### PR TITLE
Fixed 0 trials not dispelling barrier

### DIFF
--- a/Rom.py
+++ b/Rom.py
@@ -1073,7 +1073,7 @@ def patch_rom(world, rom):
         write_bits_to_save(0x0EEA, 0x20) # "Completed Shadow Trial"
     if world.skipped_trials['Light']:
         write_bits_to_save(0x0EEA, 0x80) # "Completed Light Trial"
-    if world.trials == '0':
+    if world.trials == 0:
         write_bits_to_save(0x0EED, 0x08) # "Dispelled Ganon's Tower Barrier"
 
     # open gerudo fortress


### PR DESCRIPTION
Seems there was an integer to string comparison being made causing the barrier to never be dispelled when 0 trials was selected in the generator. It now dispels barrier on 0 trials and doesn't affect the barrier on 1-6 trials.