### PR TITLE
Fixes Compress Args for Mac/Linux

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -80,9 +80,9 @@ def main(settings):
             if platform.system() == 'Windows':
                 subprocess.call(["Compress\\Compress.exe", rom_path, os.path.join(output_dir, '%s-comp.z64' % outfilebase)])
             elif platform.system() == 'Linux':
-                subprocess.call(["Compress/Compress", ('%s.z64' % outfilebase)])
+                subprocess.call(["Compress/Compress", rom_path])
             elif platform.system() == 'Darwin':
-                subprocess.call(["Compress/Compress.out", ('%s.z64' % outfilebase)])
+                subprocess.call(["Compress/Compress.out", rom_path])
             else:
                 logger.info('OS not supported for compression')
 


### PR DESCRIPTION
Compress for Mac and Linux take only one argument and it automatically appends `-comp` to the compressed ROM.  The previous argument does not respect `output_dir`, looking for the uncompressed output ROM in the base dir causing a file not found error if an output directory is specified.  This change uses `rom_path` as to respect the user's set `output_dir`.