### PR TITLE
Compress ROM by default

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -85,10 +85,13 @@ def main(settings):
             logger.info('Compressing ROM.')
             if platform.system() == 'Windows':
                 subprocess.call(["Compress\\Compress.exe", rom_path, os.path.join(output_dir, '%s-comp.z64' % outfilebase)])
+                os.remove(rom_path)
             elif platform.system() == 'Linux':
                 subprocess.call(["Compress/Compress", rom_path])
+                os.remove(rom_path)
             elif platform.system() == 'Darwin':
                 subprocess.call(["Compress/Compress.out", rom_path])
+                os.remove(rom_path)
             else:
                 logger.info('OS not supported for compression')
 

--- a/Settings.py
+++ b/Settings.py
@@ -214,7 +214,7 @@ setting_infos = [
             'text': 'Compress Rom. Improves stability but will take longer to generate',
             'group': 'rom_tab',
             'widget': 'Checkbutton',
-            'default': 'unchecked'
+            'default': 'checked'
         }),
     Setting_Info('open_forest', bool, 1, True, 
         {


### PR DESCRIPTION
This changes the Compress ROM option to be selected by default. Anyone who needs the uncompressed rom probably already knows what they're doing. It also deletes the uncompressed rom from the output directory after compressing it. The uncompressed rom is useless for most people and 99% of the time it's opened, it's user error.