### PR TITLE
Difficulty settings

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -7,9 +7,9 @@ from Items import ItemFactory
 #This file sets the item pools for various modes. Timed modes and triforce hunt are enforced first, and then extra items are specified per mode to fill in the remaining space.
 #Some basic items that various modes require are placed here, including pendants and crystals. Medallion requirements for the two relevant entrances are also decided.
 
-alwaysitems = (['Kokiri Sword', 'Biggoron Sword', 'Boomerang', 'Lens of Truth', 'Hammer', 'Iron Boots', 'Goron Tunic', 'Zora Tunic', 'Hover Boots', 'Mirror Shield', 'Stone of Agony', 'Fire Arrows', 'Ice Arrows', 'Light Arrows', 'Dins Fire', 'Farores Wind', 'Nayrus Love', 'Rupee (1)'] + ['Progressive Hookshot'] * 2 + ['Deku Shield'] * 4 +  ['Hylian Shield'] * 2 + 
-              ['Progressive Strength Upgrade'] * 3 + ['Progressive Scale'] * 2 + ['Piece of Heart'] * 35 + ['Recovery Heart'] * 11 + ['Rupees (5)'] * 17 + ['Rupees (20)'] * 5 + ['Rupees (50)'] * 7 + ['Rupees (200)'] * 6 + ['Bow'] * 3 + ['Slingshot'] * 3 + ['Bomb Bag'] * 3 + ['Bottle with Letter'] + ['Heart Container'] * 8 + ['Piece of Heart (Treasure Chest Game)'] +
-              ['Bombs (5)'] * 2 + ['Bombs (10)'] * 2 + ['Bombs (20)'] * 2 + ['Arrows (5)'] + ['Arrows (10)'] * 6 + ['Arrows (30)'] * 6 + ['Deku Nuts (5)'] + ['Deku Nuts (10)'] + ['Progressive Wallet'] * 2 + ['Deku Stick Capacity'] * 2 + ['Deku Nut Capacity'] * 2 + ['Magic Meter'] * 2 + ['Double Defense'])
+alwaysitems = (['Kokiri Sword', 'Biggoron Sword', 'Boomerang', 'Lens of Truth', 'Hammer', 'Iron Boots', 'Goron Tunic', 'Zora Tunic', 'Hover Boots', 'Mirror Shield', 'Stone of Agony', 'Fire Arrows', 'Ice Arrows', 'Light Arrows', 'Dins Fire', 'Farores Wind', 'Rupee (1)'] + ['Progressive Hookshot'] * 2 + ['Deku Shield'] * 4 +  ['Hylian Shield'] * 2 + 
+              ['Progressive Strength Upgrade'] * 3 + ['Progressive Scale'] * 2 + ['Recovery Heart'] * 11 + ['Rupees (5)'] * 17 + ['Rupees (20)'] * 5 + ['Rupees (50)'] * 7 + ['Rupees (200)'] * 6 + ['Bow'] * 3 + ['Slingshot'] * 3 + ['Bomb Bag'] * 3 + ['Bottle with Letter'] +
+              ['Bombs (5)'] * 2 + ['Bombs (10)'] * 2 + ['Bombs (20)'] * 2 + ['Arrows (5)'] + ['Arrows (10)'] * 6 + ['Arrows (30)'] * 6 + ['Deku Nuts (5)'] + ['Deku Nuts (10)'] + ['Progressive Wallet'] * 2 + ['Deku Stick Capacity'] * 2 + ['Deku Nut Capacity'] * 2 + ['Magic Meter'])
 # normal_bottles = ['Bottle', 'Bottle with Milk', 'Bottle with Red Potion', 'Bottle with Green Potion', 'Bottle with Blue Potion', 'Bottle with Fairy', 'Bottle with Fish', 'Bottle with Blue Fire', 'Bottle with Bugs', 'Bottle with Poe']
 normal_bottles = ['Bottle', 'Bottle with Milk', 'Bottle with Red Potion', 'Bottle with Green Potion', 'Bottle with Blue Potion', 'Bottle with Fairy', 'Bottle with Fish', 'Bottle with Bugs', 'Bottle with Poe']
 normal_bottle_count = 3
@@ -23,6 +23,7 @@ skulltulla_locations = (['GS Kokiri Know It All House', 'GS Kokiri Bean Patch', 
                        ['GS Forest Temple Lobby', 'GS Forest Temple Outdoor East', 'GS Forest Temple Outdoor West', 'GS Forest Temple Basement', 'GS Fire Temple Song of Time Room', 'GS Fire Temple Unmarked Bomb Wall', 'GS Fire Temple East Tower Climb', 'GS Fire Temple East Tower Top', 'GS Fire Temple Basement', 'GS Ice Cavern Spinning Scythe Room', 'GS Ice Cavern Heart Piece Room', 'GS Ice Cavern Push Block Room', 'GS Water Temple South Basement', 'GS Water Temple Serpent River', 'GS Water Temple Falling Platform Room', 'GS Water Temple Central Room', 'GS Water Temple Near Boss Key Chest', 'GS Well West Inner Room', 'GS Well East Inner Room', 'GS Well Like Like Cage'] +
                        ['GS Shadow Temple Like Like Room', 'GS Shadow Temple Crusher Room', 'GS Shadow Temple Single Giant Pot', 'GS Shadow Temple Near Ship', 'GS Shadow Temple Tripple Giant Pot', 'GS Gerudo Valley Small Bridge', 'GS Gerudo Valley Bean Patch', 'GS Gerudo Valley Behind Tent', 'GS Gerudo Valley Pillar', 'GS Gerudo Fortress Archery Range', 'GS Gerudo Fortress Top Floor', 'GS Wasteland Ruins', 'GS Desert Colossus Bean Patch', 'GS Desert Colossus Tree', 'GS Desert Colossus Hill', 'GS Spirit Temple Metal Fence', 'GS Spirit Temple Bomb for Light Room', 'GS Spirit Temple Hall to West Iron Knuckle', 'GS Spirit Temple Boulder Room', 'GS Spirit Temple Lobby'])
 tradeitems = ['Pocket Egg', 'Pocket Cucco', 'Cojiro', 'Odd Mushroom', 'Poachers Saw', 'Broken Sword', 'Prescription', 'Eyeball Frog', 'Eyedrops', 'Claim Check']
+
 
 eventlocations = {
     'Ganon': 'Triforce',
@@ -99,6 +100,15 @@ def get_pool_core(world):
         pool.extend(['Recovery Heart'] * 6)
     else:
         pool.extend(['Ice Trap'] * 6)
+        
+    if world.difficulty == 'hard' or world.difficulty == 'very_hard':
+        pool.extend(['Rupees (5)'] * 10)
+    else:
+        pool.extend(['Magic Meter', 'Double Defense'] + ['Heart Container'] * 8)
+    if world.difficulty == 'very_hard':
+        pool.extend(['Rupees (5)'] * 37)
+    else:
+        pool.extend(['Nayrus Love', 'Piece of Heart (Treasure Chest Game)'] + ['Piece of Heart'] * 35)
 
     if world.gerudo_fortress == 'open':
         placed_items['Gerudo Fortress North F1 Carpenter'] = 'Recovery Heart'

--- a/Settings.py
+++ b/Settings.py
@@ -943,6 +943,30 @@ setting_infos = [
                 'All text shuffled': 'complete',
             },
         }),
+    Setting_Info('difficulty', str, 2, True, 
+        {
+            'default': 'normal',
+            'const': 'normal',
+            'nargs': '?',
+            'choices': ['normal', 'hard', 'very_hard'],
+            'help': '''\
+                    Choose how hard the game will be.
+                    normal:         Default items
+                    hard:           Double defense, double magic, and all 8 heart containers are removed
+                    very_hard:      Double defense, double magic, Nayru's Love, and all health upgrades are removed
+                    '''
+        },
+        {
+            'text': 'Difficulty',
+            'group': 'other',
+            'widget': 'Combobox',
+            'default': 'Normal',
+            'options': {
+                'Normal': 'normal',
+                'Hard': 'hard',
+                'Very Hard': 'very_hard',
+            },
+        }),
     Setting_Info('default_targeting', str, 1, False, 
         {
             'default': 'hold',


### PR DESCRIPTION
The Ocarina of Time Randomizer feels very easy in terms of combat because you naturally run across a lot of health upgrades and defensive items like Nayru's Love, double defense, and double magic.

To counteract this, the following options are added:
- normal: Default items
- hard: Double defense, double magic, and all 8 heart containers are removed
- very_hard: Double defense, double magic, Nayru's Love, and all health upgrades are removed

The hard difficulty still leaves the heart pieces in the pool, so the player can gain up to 12 hearts total, likely a few less though. It also doesn't remove NL, but still takes away double magic so it can't be spammed for multiple minutes of invulnerability.
The very_hard difficulty just takes it all away, meaning the player will stay at 3 hearts without double defense or Nayru's Love.

The removed items just get replaced by blue rupees for now. I'm not sure how that would feel, probably fine for hard, but might get excessive for very_hard (increases number of blue rupees from 17 to 64).