### PR TITLE
Fix for reverting Zelda's Letter

### DIFF
--- a/Rom.py
+++ b/Rom.py
@@ -1176,8 +1176,6 @@ def patch_rom(world, rom):
         rom.write_int32(0xD7EC1C, 0x17010010)
         # song of time
         rom.write_int32(0xDB532C, 0x24050003)
-        # saria's song
-        rom.write_int32(0xE29388, 0x24030005)
 
     # Set Default targeting option to Hold
     if world.default_targeting == 'hold':

--- a/Rom.py
+++ b/Rom.py
@@ -1176,9 +1176,6 @@ def patch_rom(world, rom):
         rom.write_int32(0xD7EC1C, 0x17010010)
         # song of time
         rom.write_int32(0xDB532C, 0x24050003)
-        # zelda's lullaby
-        rom.write_int32(0xB06400, 0x8E0F00A4)
-        rom.write_int32(0xB0640C, 0x01CFC024)
         # saria's song
         rom.write_int32(0xE29388, 0x24030005)
 


### PR DESCRIPTION
This PR fixes the issue of Zelda's Letter reverting to a Chicken, even after talking to Impa.

The vanilla game checks that Zelda's Lullaby is in your inventory when saving and resetting after receiving Zelda's Letter. If it isn't, the letter reverts to a Chicken and the "talked to Zelda in courtyard" flag resets (preventing learning Saria's Song as well). The randomizer changes this to check for the song you learned from Impa instead, by simply changing the song that it checks for.

Songsanity changes the check "song learned from Impa is in the inventory" to "talked to Impa in the courtyard". Obviously this is because Impa will not necessarily teach a song. However, the change is reverted to check for "song learned from Impa" if Songsanity is not enabled. The value telling the code which song to check for is not changed in this branch, so it will always check for Zelda's Lullaby. This change simply removes the reversion so that the Impa flag is always checked, even if Songsanity is not selected.

Also removes the vanilla check for Saria's Song to learn Song From Saria, keeping the check for the flag even outside Songsanity.