### PR TITLE
Add default values for co-op settings

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -172,6 +172,7 @@ setting_infos = [
                     ''',
             'type': int}),
     Setting_Info('world_count', int, 0, False, {
+            'default': 1,
             'help': '''\
                     Use to create a multi-world generation for co-op seeds.
                     World count is the number of players. Warning: Increasing
@@ -179,6 +180,7 @@ setting_infos = [
                     ''',
             'type': int}),
     Setting_Info('player_num', int, 0, False, {
+            'default': 1,
             'help': '''\
                     Use to select world to generate when there are multiple worlds.
                     ''',


### PR DESCRIPTION
default `world_count` and `player_num` arguments to a value of `1` to match the Gui and to continue to make it possible to generate a seed with only the `rom` argument