### PR TITLE
Fix incorrect hints for fortress keys

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -117,6 +117,7 @@ hintTable = {'Hammer':                                                ("the drag
              'Compass':                                               ("a treasure tracker", 'item'),
              'BossKey':                                               ("a master of unlocking", 'item'),
              'SmallKey':                                              ("a tool for unlocking", 'item'),
+             'FortressSmallKey':                                      ("a get out of jail free card", 'item'),
              'useless':                                               ("something worthless", 'item'),
              'Arrows (5)':                                            ("danger darts", 'item'),
              'Arrows (10)':                                           ("danger darts", 'item'),

--- a/Hints.py
+++ b/Hints.py
@@ -45,7 +45,7 @@ def buildHintString(hintString):
 
 
 def getItemGenericName(item):
-    if item.type == 'Map' or item.type == 'Compass' or item.type == 'BossKey' or item.type == 'SmallKey':
+    if item.type == 'Map' or item.type == 'Compass' or item.type == 'BossKey' or item.type == 'SmallKey' or item.type == 'FortressSmallKey':
         return item.type
     else:
         return item.name


### PR DESCRIPTION
Gerudo Fortress keys have a unique item type `FortressSmallKey` that is different from the generic `SmallKey` type. This item type lacks an entry in the hints table, causing the hint to fall back to the entry for `useless`. We add an entry to the table to properly account for this case.

Here is an example seed/settings combination that exhibits the issue:
* Settings: RJDU9VUBAAUB
* Seed: BZURYLQVEG

In this seed, there is a Gerudo Fortress key in the Fire Temple which is granted a hint. Before this change, the hint reads `something worthless`. After this change, it reads `a get out of jail free card`.

Before:
```sh
$ python3.6 -m pdb OoTRandomizer.py --rom './Output/ZOOTDEC.z64' --settings_string RJDU9VUBAAUB --seed BZURYLQVEG --create_spoiler
> /mnt/d/scratch/OoT-Randomizer/OoTRandomizer.py(2)<module>()
-> import argparse
(Pdb) b Hints.py:59, text.startswith('They say that a high')
Breakpoint 1 at /mnt/d/scratch/OoT-Randomizer/Hints.py:59
(Pdb) continue
OoT Randomizer Version 2.15.20 f.LUM  -  Seed: BZURYLQVEG


Generating World 0.
Creating Overworld
Creating Dungeons
Linking Entrances
Calculating Access Rules.
Generating Item Pool.
Fill the world.
Calculating playthrough.
Patching ROM.
> /mnt/d/scratch/OoT-Randomizer/Hints.py(59)update_hint()
-> update_message_by_id(messages, id, get_raw_text(text))
(Pdb) p text
'They say that a high mountain&hoards something worthless.'
(Pdb)
```

After:
```sh
$ python3.6 -m pdb OoTRandomizer.py --rom './Output/ZOOTDEC.z64' --settings_string RJDU9VUBAAUB --seed BZURYLQVEG --create_spoiler
> /mnt/d/scratch/OoT-Randomizer/OoTRandomizer.py(2)<module>()
-> import argparse
(Pdb) b Hints.py:59, text.startswith('They say that a high')
Breakpoint 1 at /mnt/d/scratch/OoT-Randomizer/Hints.py:59
(Pdb) continue
OoT Randomizer Version 2.15.20 f.LUM  -  Seed: BZURYLQVEG


Generating World 0.
Creating Overworld
Creating Dungeons
Linking Entrances
Calculating Access Rules.
Generating Item Pool.
Fill the world.
Calculating playthrough.
Patching ROM.
> /mnt/d/scratch/OoT-Randomizer/Hints.py(59)update_hint()
-> update_message_by_id(messages, id, get_raw_text(text))
(Pdb) p text
'They say that a high mountain&hoards a get out of jail free card.'
(Pdb)
```

And in the spoiler log, we see that this item is a Gerudo Fortress key:

`Fire Temple Big Lava Room Open Chest: Small Key (Gerudo Fortress)`