### PR TITLE
rework dungeon item shuffling

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -25,7 +25,7 @@ class World(object):
         self.settings = settings
         self.__dict__.update(settings.__dict__)
         # rename a few attributes...
-        self.place_dungeon_items = not self.nodungeonitems
+        self.keysanity = self.shuffle_dungeon_items == 'keysanity'
         self.check_beatable_only = not self.all_reachable
         # group a few others
         self.tunic_colors = [self.kokiricolor, self.goroncolor, self.zoracolor]
@@ -142,8 +142,26 @@ class World(object):
     def get_items(self):
         return [loc.item for loc in self.get_filled_locations()] + self.itempool
 
-    def get_dungeon_items(self):
-        itempool = [item for dungeon in self.dungeons for item in dungeon.all_items if item.key or self.place_dungeon_items]
+    # get a list of items that should stay in their proper dungeon
+    def get_restricted_dungeon_items(self):
+        if self.shuffle_dungeon_items == 'keysanity':
+            itempool = []
+        elif self.shuffle_dungeon_items == 'leavekeys':
+            itempool = [item for dungeon in self.dungeons for item in dungeon.all_items if item.key]
+        else:
+            itempool = [item for dungeon in self.dungeons for item in dungeon.all_items]
+        for item in itempool:
+            item.world = self
+        return itempool
+
+    # get a list of items that don't have to be in their proper dungeon
+    def get_unrestricted_dungeon_items(self):
+        if self.shuffle_dungeon_items == 'keysanity':
+            itempool = [item for dungeon in self.dungeons for item in dungeon.all_items]
+        elif self.shuffle_dungeon_items == 'leavekeys':
+            itempool = [item for dungeon in self.dungeons for item in dungeon.all_items if not item.key]
+        else:
+            itempool = []
         for item in itempool:
             item.world = self
         return itempool
@@ -200,26 +218,6 @@ class World(object):
 
     def has_beaten_game(self, state):
         return state.has('Triforce')
-
-    @property
-    def option_identifier(self):
-        id_value = 0
-        id_value_max = 1
-
-        def markbool(value):
-            nonlocal id_value, id_value_max
-            id_value += id_value_max * bool(value)
-            id_value_max *= 2
-        def marksequence(options, value):
-            nonlocal id_value, id_value_max
-            id_value += id_value_max * options.index(value)
-            id_value_max *= len(options)
-        markbool(self.place_dungeon_items)
-        marksequence(['ganon', 'pedestal', 'dungeons'], self.bridge)
-        marksequence(['vanilla', 'simple'], self.shuffle)
-        markbool(self.check_beatable_only)
-        assert id_value_max <= 0xFFFFFFFF
-        return id_value
 
 
 class CollectionState(object):
@@ -509,10 +507,10 @@ class CollectionState(object):
         item_locations = []
         if worlds[0].spoiler.playthrough:
             item_locations = [location for _,sphere in worlds[0].spoiler.playthrough.items() for location in sphere
-                if location.item.type != 'Event' and not location.event and (worlds[0].settings.keysanity or not location.item.key)]
+                if location.item.type != 'Event' and not location.event and (worlds[0].keysanity or not location.item.key)]
         else:
             item_locations = [location for world in worlds for location in world.get_filled_locations() 
-                if location.item.advancement and location.item.type != 'Event' and not location.event and (worlds[0].settings.keysanity or not location.item.key)]
+                if location.item.advancement and location.item.type != 'Event' and not location.event and (worlds[0].keysanity or not location.item.key)]
 
         required_locations = []
         for location in item_locations:
@@ -564,10 +562,13 @@ class Region(object):
         return False
 
     def can_fill(self, item):
-        if self.world.keysanity:
-            return True
-        is_dungeon_item = item.key or item.map or item.compass
-        if is_dungeon_item:
+        if self.world.shuffle_dungeon_items == 'keysanity':
+            is_dungeon_restricted = False
+        elif self.world.shuffle_dungeon_items == 'leavekeys':
+            is_dungeon_restricted = item.key
+        else:
+            is_dungeon_restricted = item.key or item.map or item.compass
+        if is_dungeon_restricted:
             return self.dungeon and self.dungeon.is_dungeon_item(item)
         return True
 

--- a/Fill.py
+++ b/Fill.py
@@ -27,23 +27,20 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
         itempool.extend(songitempool)
         fill_locations.extend(song_locations)
 
+    # add unrestricted dungeon items to main item pool
+    itempool.extend([item for world in worlds for item in world.get_unrestricted_dungeon_items()])
+
     random.shuffle(itempool) # randomize item placement order. this ordering can greatly affect the location accessibility bias
     progitempool = [item for item in itempool if item.advancement]
     prioitempool = [item for item in itempool if not item.advancement and item.priority]
     restitempool = [item for item in itempool if not item.advancement and not item.priority]
 
-    # If not keysanity, we must place the dungeon items first to make sure
-    # that there is always a locations to place them. This could probably
-    # be replaced for more intelligent item placement, but will leave as is
-    # for now
-    if worlds[0].keysanity:
-        # add dungeon items to main pool
-        progitempool.extend([item for world in worlds for item in world.get_dungeon_items()])
-        random.shuffle(progitempool)
-    else:
-        # place dungeon items
-        random.shuffle(fill_locations)
-        fill_dungeons_restrictive(window, worlds, fill_locations, itempool + songitempool)
+    # If there are dungeon items that are restricted to their original dungeon,
+    # we must place them first to make sure that there is always a location to
+    # place them. This could probably be replaced for more intelligent item
+    # placement, but will leave as is for now
+    random.shuffle(fill_locations)
+    fill_dungeons_restrictive(window, worlds, fill_locations, itempool + songitempool)
 
     # I have no idea why the locations are reversed but this is how it was, 
     # so whatever. It can't hurt I guess
@@ -87,13 +84,13 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
         raise FillError('Not all locations have an item.')
 
 
-# Places all dungeon items into the worlds. To ensure there is room for them.
+# Places restricted dungeon items into the worlds. To ensure there is room for them.
 # they are placed first so it will assume all other items are reachable
 def fill_dungeons_restrictive(window, worlds, shuffled_locations, itempool):
     # List of states with all non-key items
     all_state_base_list = CollectionState.get_states_with_items([world.state for world in worlds], itempool)
     # list of all dungeon items to be placed
-    dungeon_items = [item for world in worlds for item in world.get_dungeon_items()]
+    dungeon_items = [item for world in worlds for item in world.get_restricted_dungeon_items()]
 
     # shuffle this list to avoid placement bias
     random.shuffle(dungeon_items)

--- a/ItemList.py
+++ b/ItemList.py
@@ -63,14 +63,6 @@ normal_bottles = [
     'Bottle with Poe'] # 'Bottle with Blue Fire'
 
 normal_bottle_count = 3
-# notmapcompass = ['Rupees (5)'] * 20
-notmapcompass = (
-    ['Bombs (5)'] * 4
-    + ['Arrows (5)'] * 3 
-    + ['Deku Nuts (5)'] * 3 
-    + ['Rupees (5)'] * 7 
-    + ['Rupees (20)'] * 2 
-    + ['Rupees (50)'])
 
 # 10 items get removed for hard+
 harditems = (
@@ -268,9 +260,6 @@ def generate_itempool(world):
 def get_pool_core(world):
     pool = []
     placed_items = {}
-
-    if not world.place_dungeon_items:
-        pool.extend(notmapcompass)
         
     if world.shuffle_kokiri_sword:
         pool.append('Kokiri Sword')

--- a/Settings.py
+++ b/Settings.py
@@ -686,46 +686,44 @@ setting_infos = [
                       Plays spiritually best with Keysanity.
                       '''
         }),
-    Setting_Info('nodungeonitems', bool, 1, True, 
+    Setting_Info('shuffle_dungeon_items', str, 2, True,
         {
-            'help': '''\
-                    Remove Maps and Compasses from Itempool, replacing them by
-                    empty slots.
-                    ''',
-            'action': 'store_true'
+        'default': 'leavekeys',
+        'const': 'leavekeys',
+        'nargs': '?',
+        'choices': ['off', 'leavekeys', 'keysanity'],
+        'help': '''\
+                    Dungeon items can appear outside of their
+                    respective dungeon.
+                    off:            Don't use this feature
+                    leavekeys:      All items besides keys will be shuffled
+                    keysanity:      All items will be shuffled
+                    '''
         },
         {
-            'text': 'Remove Maps and Compasses',
+            'text': 'Shuffle Dungeon Items',
             'group': 'logic',
-            'widget': 'Checkbutton',
-            'default': 'checked',
+            'widget': 'Combobox',
+            'default': 'Maps and Compasses',
+            'options': {
+                'Off': 'off',
+                'Maps and Compasses': 'leavekeys',
+                'Full Keysanity': 'keysanity'
+            },
             'tooltip':'''\
-                      Dungeons will have 2 more possible item
-                      locations. This helps make some dungeons
-                      more profitable, such as Ice Cavern and 
-                      Jabu Jabu's Belly.
-                      '''
-        }),    
-    Setting_Info('keysanity', bool, 1, True, 
-        {
-            'help': '''\
-                    Small Keys, Boss Keys, Maps, and Compasses will be shuffled into the pool at
-                    large, instead of just being restricted to their own dungeons.
-                    ''',
-            'action': 'store_true'
-        },
-        {
-            'text': 'Keysanity',
-            'group': 'logic',
-            'widget': 'Checkbutton',
-            'default': 'unchecked',
-            'tooltip':'''\
-                      Dungeon items can appear outside of their
-                      respective dungeon. Gerudo Fortress keys
-                      are also shuffled. 
+                      Dungeon items will be shuffled into the pool
+                      at large, instead of just being restricted to
+                      their own dungeon.
 
-                      A difficult mode since it it more likely
-                      to need to enter a dungeon multiple times.
+                      'Maps and Compasses': Dungeons will have
+                      2 more possible item locations. This helps
+                      make some dungeons more profitable, such as
+                      Ice Cavern and Jabu Jabu's Belly.
+
+                      'Full Keysanity': All items, including small and
+                      boss keys, will be shuffled. A difficult mode,
+                      since it is more likely to need to enter a dungeon
+                      multiple times.
                       '''
         }),
     Setting_Info('tokensanity', str, 2, True, 


### PR DESCRIPTION
Reworked dungeon item shuffling to be more consistent, as per #37. Notable effects:

- Combined two settings flags, "Remove Maps and Compasses" and "Keysanity", into a new combobox.
- Maps and compasses are no longer replaced by arbitrary junk when moved from their dungeon (this means there is no longer any option that changes the total set of items that exist, other than Gerudo key skip turning unnecessary keys into hearts)
- Keysanity behavior is preserved as before

To my knowledge we were already changing text for keys/maps/compasses even when they were left in the proper dungeon, but it's possible that I missed something there. Someone with more experience with the codebase should make sure nothing broke with the progression system, but it seems correct from what I can tell.