### PR TITLE
More Logic Fixes

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -336,7 +336,7 @@ class CollectionState(object):
         return (self.world.open_forest or (self.has('Slingshot') and self.has('Kokiri Sword')))
 
     def can_finish_adult_trades(self):
-        zora_thawed = self.has_bottle() and self.has('Zeldas Lullaby') and (self.can_reach('Ice Cavern') or self.can_reach('Ganons Castle Water Trial') or self.has('Progressive Wallet', 2))
+        zora_thawed = self.has_bottle() and (self.can_play('Zeldas Lullaby') or (self.has('Hover Boots') and self.world.logic_zora_with_hovers)) and (self.can_reach('Ice Cavern') or self.can_reach('Ganons Castle Water Trial') or self.has('Progressive Wallet', 2))
         carpenter_access = self.has('Epona') or self.has('Progressive Hookshot', 2)
         return (self.has('Claim Check') or ((self.has('Eyedrops') or self.has('Eyeball Frog') or self.has('Prescription') or self.has('Broken Sword')) and zora_thawed) or ((self.has('Poachers Saw') or self.has('Odd Mushroom') or self.has('Cojiro') or self.has('Pocket Cucco') or self.has('Pocket Egg')) and zora_thawed and carpenter_access))
 
@@ -368,7 +368,7 @@ class CollectionState(object):
     def guarantee_hint(self):
         if(self.world.hints == 'mask'):
             # has the mask of truth
-            return self.has('Zeldas Letter') and self.has('Sarias Song') and self.has('Kokiri Emerald') and self.has('Goron Ruby') and self.has('Zora Sapphire')
+            return self.has('Zeldas Letter') and self.can_play('Sarias Song') and self.has('Kokiri Emerald') and self.has('Goron Ruby') and self.has('Zora Sapphire')
         elif(self.world.hints == 'agony'):
             # has the stone of agony
             return self.has('Stone of Agony')
@@ -376,7 +376,7 @@ class CollectionState(object):
 
     def nighttime(self):
         if self.world.logic_no_night_tokens_without_suns_song:
-            return self.has('Suns Song')
+            return self.can_play('Suns Song')
         return True
 
     def collect(self, item):

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -338,7 +338,7 @@ class CollectionState(object):
     def can_finish_adult_trades(self):
         zora_thawed = self.has_bottle() and (self.can_play('Zeldas Lullaby') or (self.has('Hover Boots') and self.world.logic_zora_with_hovers)) and (self.can_reach('Ice Cavern') or self.can_reach('Ganons Castle Water Trial') or self.has('Progressive Wallet', 2))
         carpenter_access = self.has('Epona') or self.has('Progressive Hookshot', 2)
-        return (self.has('Claim Check') or ((self.has('Eyedrops') or self.has('Eyeball Frog') or self.has('Prescription') or self.has('Broken Sword')) and zora_thawed) or ((self.has('Poachers Saw') or self.has('Odd Mushroom') or self.has('Cojiro') or self.has('Pocket Cucco') or self.has('Pocket Egg')) and zora_thawed and carpenter_access))
+        return (self.has('Claim Check') or ((self.has('Progressive Strength Upgrade') or self.can_blast_or_smash() or self.has('Bow')) and (((self.has('Eyedrops') or self.has('Eyeball Frog') or self.has('Prescription') or self.has('Broken Sword')) and zora_thawed) or ((self.has('Poachers Saw') or self.has('Odd Mushroom') or self.has('Cojiro') or self.has('Pocket Cucco') or self.has('Pocket Egg')) and zora_thawed and carpenter_access))))
 
     def has_bottle(self):
         is_normal_bottle = lambda item: (item.startswith('Bottle') and item != 'Bottle with Letter')

--- a/Regions.py
+++ b/Regions.py
@@ -299,7 +299,7 @@ def create_regions(world):
              'GS Shadow Temple Tripple Giant Pot']),
         create_ow_region(
             'Death Mountain', 
-            ['Death Mountain Bombable Chest', 'Biggoron', 'DM Trail Freestanding PoH', 'GS Mountain Trail Bean Patch', 
+            ['Death Mountain Bombable Chest', 'DM Trail Freestanding PoH', 'GS Mountain Trail Bean Patch', 
              'GS Mountain Trail Bomb Alcove', 'GS Mountain Trail Path to Crater', 
              'GS Mountain Trail Above Dodongo\'s Cavern'], 
             ['Death Mountain Exit', 'Goron City Entrance', 'Mountain Crater Entrance', 'Mountain Summit Fairy', 
@@ -321,7 +321,7 @@ def create_regions(world):
         create_ow_region('Darunias Chamber', ['Darunias Joy'], ['Darunias Chamber Exit']),
         create_ow_region(
             'Death Mountain Crater Upper', 
-            ['DM Crater Wall Freestanding PoH', 'GS Death Mountain Crater Crate'], 
+            ['DM Crater Wall Freestanding PoH', 'Biggoron', 'GS Death Mountain Crater Crate'], 
             ['Crater Exit', 'Crater Hover Boots', 'Crater Scarecrow', 'Top of Crater Grotto']),
         create_ow_region(
             'Death Mountain Crater Lower', 

--- a/Rules.py
+++ b/Rules.py
@@ -435,7 +435,7 @@ def dung_rules_sht0(world):
     set_rule(world.get_location('Shadow Temple Falling Spikes Upper Chest'), lambda state: state.has('Progressive Strength Upgrade'))
     set_rule(world.get_location('Shadow Temple Falling Spikes Switch Chest'), lambda state: state.has('Progressive Strength Upgrade'))
     set_rule(world.get_location('Shadow Temple Invisible Spikes Chest'), lambda state: state.has('Small Key (Shadow Temple)', 2))
-    set_rule(world.get_location('Shadow Temple Freestanding Key'), lambda state: state.has('Small Key (Shadow Temple)', 2) and state.has('Progressive Hookshot'))
+    set_rule(world.get_location('Shadow Temple Freestanding Key'), lambda state: state.has('Small Key (Shadow Temple)', 2) and state.has('Progressive Hookshot') and (state.has('Bomb Bag') or state.has('Progressive Strength Upgrade')))
 
     # boss rules
     set_rule(world.get_location('Bongo Bongo'), lambda state: state.has('Small Key (Shadow Temple)', 5) and (state.has('Bow') or state.has('Progressive Hookshot', 2)) and state.has('Boss Key (Shadow Temple)'))

--- a/Rules.py
+++ b/Rules.py
@@ -101,7 +101,7 @@ def global_rules(world):
     set_rule(world.get_entrance('Death Mountain Entrance'), lambda state: state.has('Zeldas Letter') or state.is_adult() or world.open_kakariko)
     set_rule(world.get_location('DM Trail Freestanding PoH'), lambda state: world.open_kakariko or (world.difficulty != 'ohko') or state.has('Zeldas Letter') or state.can_blast_or_smash() or ((state.has('Dins Fire') or state.has('Nayrus Love')) and state.has('Magic Meter')) or state.has('Bow') or state.has('Progressive Strength Upgrade') or state.has_bottle() or state.has('Hover Boots'))
     set_rule(world.get_location('Death Mountain Bombable Chest'), lambda state: state.can_blast_or_smash())
-    set_rule(world.get_location('Biggoron'), lambda state: (not world.logic_no_trade_biggoron) and (state.has('Progressive Strength Upgrade') or state.can_blast_or_smash() or state.has('Bow')) and state.is_adult() and state.can_finish_adult_trades() and state.guarantee_hint())
+    set_rule(world.get_location('Biggoron'), lambda state: (not world.logic_no_trade_biggoron) and state.is_adult() and state.can_finish_adult_trades() and state.guarantee_hint())
     set_rule(world.get_location('Goron City Leftmost Maze Chest'), lambda state: state.is_adult() and (state.has('Progressive Strength Upgrade', 2) or state.has('Hammer')))
     set_rule(world.get_location('Goron City Left Maze Chest'), lambda state: state.can_blast_or_smash() or (state.has('Progressive Strength Upgrade', 2) and state.is_adult()))
     set_rule(world.get_location('Goron City Right Maze Chest'), lambda state: state.can_blast_or_smash() or (state.has('Progressive Strength Upgrade', 2) and state.is_adult()))

--- a/Rules.py
+++ b/Rules.py
@@ -251,6 +251,7 @@ def global_rules(world):
     set_rule(world.get_location('GS Mountain Trail Path to Crater'), lambda state: state.has('Hammer') and state.is_adult() and state.nighttime())
     set_rule(world.get_location('GS Mountain Trail Above Dodongo\'s Cavern'), lambda state: state.has('Hammer') and state.is_adult() and state.nighttime())
     set_rule(world.get_location('GS Goron City Boulder Maze'), lambda state: state.has_explosives())
+    set_rule(world.get_location('GS Death Mountain Crater Crate'), lambda state: state.can_blast_or_smash())
     set_rule(world.get_location('GS Goron City Center Platform'), lambda state: state.is_adult())
     set_rule(world.get_location('GS Mountain Crater Bean Patch'), lambda state: state.can_play('Bolero of Fire') and state.has_bottle())
     set_rule(world.get_location('GS Dodongo\'s Cavern Alcove Above Stairs'), lambda state: (state.has('Progressive Hookshot') and state.is_adult()) or (state.has('Boomerang') and (state.has_explosives() or state.has('Progressive Strength Upgrade'))))


### PR DESCRIPTION
For all three of these fixes, songs were using "has" and that was changed to "can_play".

Biggoron was also missing the full access requirement for Zora's Domain, which could potentially include Hover Boots now, instead of just Zelda's Lullaby.

Since the original creation of the PR it was realized that Biggoron had further issues in the case of the Claim Check item. Since that item does not need to be delivered on a timer, Bolero (along with Hookshot, Hover Boots, or Magic Bean) can be used to reach Biggoron instead of needing one of the requirements that won't expire the timer.

And it was noticed that the Shadow Temple Freestanding Key was in logic with bombchus. While that's definitely possible, it was not intentional.

And somebody got an impossible seed because the Death Mountain Crater Crate GS was not checking for child access, so it would think you could get the GS as adult as long as you could get there somehow.