### PR TITLE
Randomized music bug fix

### DIFF
--- a/Rom.py
+++ b/Rom.py
@@ -1788,6 +1788,9 @@ def randomize_music(rom):
         rom.write_bytes(0xB89AE0 + (bgm[1] * 0x10), bgm_sequence)
         rom.write_int16(0xB89910 + 0xDD + (bgm[1] * 2), bgm_instrument)
         
+    # Write Fairy Fountain instrument to File Select (uses same track but different instrument set pointer for some reason)
+    rom.write_int16(0xB89910 + 0xDD + (0x57 * 2), rom.read_int16(0xB89910 + 0xDD + (0x28 * 2)))
+        
 def disable_music(rom):
     # First track is no music
     blank_track = rom.read_bytes(0xB89AE0 + (0 * 0x10), 0x10)

--- a/Rom.py
+++ b/Rom.py
@@ -1756,7 +1756,6 @@ bgm_sequence_ids = [
     ('Zoras Domain', 0x50),
     ('Shop', 0x55),
     ('Chamber of the Sages', 0x56),
-    ('File Select', 0x57),
     ('Ice Cavern', 0x58),
     ('Kaepora Gaebora', 0x5A),
     ('Shadow Temple', 0x5B),


### PR DESCRIPTION
Seems to be some weirdness with the file select music that I didn't run into while testing initially. It uses the same track as the fairy fountain but a different instrument set pointer. I removed the file select track from the randomization as I'm pretty sure it's unused, and just write the fairy fountain instrument pointer over the file select one.