### PR TITLE
Bug Fix for removing keys with Gerudo Fortress

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -482,7 +482,7 @@ def get_pool_core(world):
         placed_items['Gerudo Fortress North F2 Carpenter'] = 'Recovery Heart'
         placed_items['Gerudo Fortress South F1 Carpenter'] = 'Recovery Heart'
         placed_items['Gerudo Fortress South F2 Carpenter'] = 'Recovery Heart'
-    elif world.keysanity:
+    elif world.shuffle_smallkeys == 'keysanity':
         if world.gerudo_fortress == 'fast':
             pool.append('Small Key (Gerudo Fortress)')
             placed_items['Gerudo Fortress North F2 Carpenter'] = 'Recovery Heart'


### PR DESCRIPTION
Due to the change to the meaning of world.keysanity, gerudo fortress keys were being world shuffled instead of left alone, when small keys are removed.