### PR TITLE
Complete can_leave_forest check

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -419,7 +419,7 @@ class CollectionState(object):
         return (self.has('Zora Tunic') or self.has('Buy Zora Tunic'))
 
     def can_leave_forest(self):
-        return (self.world.open_forest or (self.has_slingshot() and self.has('Kokiri Sword') and self.has('Buy Deku Shield')))
+        return (self.world.open_forest or (self.has_slingshot() and self.has('Kokiri Sword') and self.has('Buy Deku Shield') and (self.has_sticks() or (self.has('Dins Fire') and self.has('Magic Meter')))))
 
     def can_finish_adult_trades(self):
         zora_thawed = self.has_bottle() and (self.can_play('Zeldas Lullaby') or (self.has('Hover Boots') and self.world.logic_zora_with_hovers)) and (self.can_reach('Ice Cavern') or self.can_reach('Ganons Castle Water Trial') or self.has('Progressive Wallet', 2))


### PR DESCRIPTION
May bias Din's Fire to appear early in closed forest shopsanity and scrubsanity.
You can just kill the babas for sticks, but we're not currently accounting for getting sticks from that location.
The only real problem with leaving it as-is is that anything that required sticks will still be looking for a bought stick from somewhere before using them, even though we've had to use sticks already to clear deku tree.
Once sticks can be obtained from babs location, the Din's Fire check will serve no purpose and could be removed as you will always have Kokiri Sword to kill the babas with.
