### PR TITLE
Bug Fixes for Spoilers/Hints

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -605,10 +605,7 @@ class CollectionState(object):
 
         required_locations = []
         for location in item_locations:
-# NOTE: DO THIS CODE BETTER
-# The item from the spoiler playthrough is a COPY, not the original, and attempting to set it to None in this place has no effect.
-# This was very frustrating because code trying to do exactly that was sitting here looking pretty like it was actually accomplishing something.
-# There's gotta be a better way than what I've done here, but I don't know Python.
+            # The item from the spoiler playthrough is a COPY, not the original, and attempting to set it to None directly has no effect. Probably could be coded better.
             for item_location in [location for state in state_list for location in state.world.get_locations()]:
                 if item_location.name == location.name and item_location.item.world.id == location.item.world.id:
                     old_item = item_location.item

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -586,21 +586,22 @@ class CollectionState(object):
     def update_required_items(worlds):
         state_list = [world.state for world in worlds]
 
-# BUG!!! Boss Keys are "keys" and so don't get excepted from always required locations with small keysy on.
         item_locations = []
         if worlds[0].spoiler.playthrough:
             item_locations = [location for _,sphere in worlds[0].spoiler.playthrough.items() for location in sphere
                 if location.item.type != 'Event' 
                 and location.item.type != 'Shop'
                  and not location.event 
-                 and (worlds[0].keysanity or not location.item.key)]
+                 and (worlds[0].shuffle_smallkeys != 'dungeon' or location.item.type != 'SmallKey') 
+                 and (worlds[0].shuffle_bosskeys != 'dungeon' or location.item.type != 'BossKey')]
         else:
             item_locations = [location for world in worlds for location in world.get_filled_locations() 
                 if location.item.advancement 
                 and location.item.type != 'Event' 
                 and location.item.type != 'Shop' 
                 and not location.event 
-                and (worlds[0].keysanity or not location.item.key)]
+                and (worlds[0].shuffle_smallkeys != 'dungeon' or location.item.type == 'SmallKey') 
+                and (worlds[0].shuffle_bosskeys != 'dungeon' or location.item.type == 'BossKey')]
 
         required_locations = []
         for location in item_locations:

--- a/Main.py
+++ b/Main.py
@@ -187,7 +187,7 @@ def create_playthrough(worlds):
     if worlds[0].check_beatable_only and not CollectionState.can_beat_game([world.state for world in worlds]):
         raise RuntimeError('Cannot beat game. Something went terribly wrong here!')
 
-    state_list = [CollectionState(world) for world in worlds]
+    state_list = [world.state for world in worlds]
 
     # Get all item locations in the worlds
     collection_spheres = []
@@ -218,16 +218,14 @@ def create_playthrough(worlds):
             # we remove the item at location and check if game is still beatable
             logging.getLogger('').debug('Checking if %s is required to beat the game.', location.item.name)
             old_item = location.item
-            old_state_list = [state.copy() for state in state_list]
 
             location.item = None
             state_list[old_item.world.id].remove(old_item)
-            CollectionState.remove_locations(state_list)
-            if CollectionState.can_beat_game(state_list, False):
+            del state_list[location.world.id].collected_locations[location.name]
+            if CollectionState.can_beat_game(state_list):
                 to_delete.append(location)
             else:
                 # still required, got to keep it around
-                state_list = old_state_list
                 location.item = old_item
 
         # cull entries in spheres for spoiler walkthrough at end


### PR DESCRIPTION
I sort-of kind-of redid the alg for generating the spoilers and the hints.
Please verify that it works correctly!

There's one dirty little section of code in baseclasses, where I had to go way out of my way to match up two copies of what should be the same object (and the old code suggests they were believed to actually be the same object) but they were not. (Previously it didn't matter that this code didn't do anything because even if it did something it wouldn't have done anything.) Please find a cleaner way to fix this little bit of nonsense? (The break was needed because it would sometimes find the same location twice. Is that normal?)

The method remove_locations is no longer in use as far as I could see?
The false branch of can_beat_game might no longer be used as well, haven't checked.
And item.key might not be used anymore either.

Fixes:
- Spoilers failing to complete due to the extra fire temple key or failing to complete on both keysy modes.
- Fix hints about always required locations for boss keys when the setting doesn't match the small key setting.
- Fix items sometimes not being included in spoilers.
- Fix always required locations, both previously not including locations that were actually required and sometimes including locations that were not actually required.
