### PR TITLE
Import required HTTP errors

### DIFF
--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -5,6 +5,7 @@ import logging
 import random
 import textwrap
 import sys
+from urllib.error import HTTPError, URLError
 
 from Gui import guiMain
 from Main import main


### PR DESCRIPTION
This prevents the randomizer from crashing when run offline.