### PR TITLE
added adult_trade_option

### DIFF
--- a/ItemList.py
+++ b/ItemList.py
@@ -350,7 +350,7 @@ skulltulla_locations = ([
     'GS Spirit Temple Boulder Room',
     'GS Spirit Temple Lobby'])
     
-tradeitems = [
+tradeitems = (
     'Pocket Egg',
     'Pocket Cucco', 
     'Cojiro', 
@@ -360,7 +360,19 @@ tradeitems = [
     'Prescription', 
     'Eyeball Frog', 
     'Eyedrops', 
-    'Claim Check']
+    'Claim Check')
+
+tradeitemoptions = (
+    'pocket_egg',
+    'pocket_cucco', 
+    'cojiro', 
+    'odd_mushroom', 
+    'poachers_saw', 
+    'broken_sword', 
+    'prescription', 
+    'eyeball_frog', 
+    'eyedrops', 
+    'claim_check')
 
 
 eventlocations = {
@@ -548,7 +560,7 @@ def get_pool_core(world):
     for _ in range(normal_bottle_count):
         bottle = random.choice(normal_bottles)
         pool.append(bottle)
-    tradeitem = random.choice(tradeitems)
+    tradeitem = random.choice(tradeitems[tradeitemoptions.index(world.logic_earliest_adult_trade):])
     pool.append(tradeitem)
     pool.extend(songlist)
 

--- a/ItemList.py
+++ b/ItemList.py
@@ -557,11 +557,18 @@ def get_pool_core(world):
         pool.extend(DC_MQ)
     else:
         pool.extend(DC_vanilla)
+
     for _ in range(normal_bottle_count):
         bottle = random.choice(normal_bottles)
         pool.append(bottle)
-    tradeitem = random.choice(tradeitems[tradeitemoptions.index(world.logic_earliest_adult_trade):])
+
+    earliest_trade = tradeitemoptions.index(world.logic_earliest_adult_trade)
+    latest_trade = tradeitemoptions.index(world.logic_latest_adult_trade)
+    if earliest_trade > latest_trade:
+        earliest_trade, latest_trade = latest_trade, earliest_trade
+    tradeitem = random.choice(tradeitems[earliest_trade:latest_trade+1])
     pool.append(tradeitem)
+    
     pool.extend(songlist)
 
     if world.shuffle_mapcompass == 'remove':

--- a/Settings.py
+++ b/Settings.py
@@ -1169,22 +1169,6 @@ setting_infos = [
                       Spiritual Stones.
                       '''
         }),
-    Setting_Info('logic_no_trade_biggoron', bool, 1, True, 
-        {
-            'help': '''\
-                    You will not be expected to trade for biggoron's reward.
-                    ''',
-            'action': 'store_true'
-        },
-        {
-            'text': 'No Biggoron reward',
-            'group': 'rewards',
-            'widget': 'Checkbutton',
-            'default': 'unchecked',
-            'tooltip':'''\
-                      Adult trade sequence is time consuming.
-                      '''
-        }),
     Setting_Info('logic_no_1500_archery', bool, 1, True, 
         {
             'help': '''\
@@ -1234,6 +1218,22 @@ setting_infos = [
                       Racing twice is repetitive.
                       '''
         }),
+    Setting_Info('logic_no_trade_biggoron', bool, 1, True, 
+        {
+            'help': '''\
+                    You will not be expected to trade for biggoron's reward.
+                    ''',
+            'action': 'store_true'
+        },
+        {
+            'text': 'No Biggoron reward',
+            'group': 'rewards',
+            'widget': 'Checkbutton',
+            'default': 'unchecked',
+            'tooltip':'''\
+                      Adult trade sequence is time consuming.
+                      '''
+        }),
     Setting_Info('logic_earliest_adult_trade', str, 2, True, 
         {
             'default': 'pocket_egg',
@@ -1268,20 +1268,71 @@ setting_infos = [
             'text': 'Adult Trade Sequence',
             'group': 'rewards',
             'widget': 'Combobox',
+            'dependency': lambda guivar: not guivar['logic_no_trade_biggoron'].get(),
             'default': 'Pocket Egg',
             'options': {
-                'Pocket Egg': 'pocket_egg',
-                'Pocket Cucco': 'pocket_cucco', 
-                'Cojiro': 'cojiro', 
-                'Odd Mushroom': 'odd_mushroom', 
-                'Poachers Saw': 'poachers_saw', 
-                'Broken Sword': 'broken_sword', 
-                'Prescription': 'prescription', 
-                'Eyeball Frog': 'eyeball_frog', 
-                'Eyedrops': 'eyedrops', 
-                'Claim Check': 'claim_check'},
+                'Earliest: Pocket Egg': 'pocket_egg',
+                'Earliest: Pocket Cucco': 'pocket_cucco', 
+                'Earliest: Cojiro': 'cojiro', 
+                'Earliest: Odd Mushroom': 'odd_mushroom', 
+                'Earliest: Poachers Saw': 'poachers_saw', 
+                'Earliest: Broken Sword': 'broken_sword', 
+                'Earliest: Prescription': 'prescription', 
+                'Earliest: Eyeball Frog': 'eyeball_frog', 
+                'Earliest: Eyedrops': 'eyedrops', 
+                'Earliest: Claim Check': 'claim_check'},
             'tooltip':'''\
                       Select the earliest item that will appear in the adult trade sequence.
+                      '''
+        }),
+    Setting_Info('logic_latest_adult_trade', str, 2, True, 
+        {
+            'default': 'claim_check',
+            'const': 'always',
+            'nargs': '?',
+            'choices': [
+                'pocket_egg',
+                'pocket_cucco', 
+                'cojiro', 
+                'odd_mushroom', 
+                'poachers_saw', 
+                'broken_sword', 
+                'prescription', 
+                'eyeball_frog', 
+                'eyedrops', 
+                'claim_check'],
+            'help': '''\
+                    Select the latest item that will appear in the adult trade sequence:
+                    'pocket_egg'
+                    'pocket_cucco'
+                    'cojiro'
+                    'odd_mushroom'
+                    'poachers_saw'
+                    'broken_sword'
+                    'prescription'
+                    'eyeball_frog'
+                    'eyedrops'
+                    'claim_check'
+                    '''
+        },
+        {
+            'group': 'rewards',
+            'widget': 'Combobox',
+            'dependency': lambda guivar: not guivar['logic_no_trade_biggoron'].get(),
+            'default': 'Claim Check',
+            'options': {
+                'Latest: Pocket Egg': 'pocket_egg',
+                'Latest: Pocket Cucco': 'pocket_cucco', 
+                'Latest: Cojiro': 'cojiro', 
+                'Latest: Odd Mushroom': 'odd_mushroom', 
+                'Latest: Poachers Saw': 'poachers_saw', 
+                'Latest: Broken Sword': 'broken_sword', 
+                'Latest: Prescription': 'prescription', 
+                'Latest: Eyeball Frog': 'eyeball_frog', 
+                'Latest: Eyedrops': 'eyedrops', 
+                'Latest: Claim Check': 'claim_check'},
+            'tooltip':'''\
+                      Select the latest item that will appear in the adult trade sequence.
                       '''
         }),
     Setting_Info('logic_man_on_roof', bool, 1, True, 

--- a/Settings.py
+++ b/Settings.py
@@ -1234,6 +1234,56 @@ setting_infos = [
                       Racing twice is repetitive.
                       '''
         }),
+    Setting_Info('logic_earliest_adult_trade', str, 2, True, 
+        {
+            'default': 'pocket_egg',
+            'const': 'always',
+            'nargs': '?',
+            'choices': [
+                'pocket_egg',
+                'pocket_cucco', 
+                'cojiro', 
+                'odd_mushroom', 
+                'poachers_saw', 
+                'broken_sword', 
+                'prescription', 
+                'eyeball_frog', 
+                'eyedrops', 
+                'claim_check'],
+            'help': '''\
+                    Select the earliest item that will appear in the adult trade sequence:
+                    'pocket_egg'
+                    'pocket_cucco'
+                    'cojiro'
+                    'odd_mushroom'
+                    'poachers_saw'
+                    'broken_sword'
+                    'prescription'
+                    'eyeball_frog'
+                    'eyedrops'
+                    'claim_check'
+                    '''
+        },
+        {
+            'text': 'Adult Trade Sequence',
+            'group': 'rewards',
+            'widget': 'Combobox',
+            'default': 'Pocket Egg',
+            'options': {
+                'Pocket Egg': 'pocket_egg',
+                'Pocket Cucco': 'pocket_cucco', 
+                'Cojiro': 'cojiro', 
+                'Odd Mushroom': 'odd_mushroom', 
+                'Poachers Saw': 'poachers_saw', 
+                'Broken Sword': 'broken_sword', 
+                'Prescription': 'prescription', 
+                'Eyeball Frog': 'eyeball_frog', 
+                'Eyedrops': 'eyedrops', 
+                'Claim Check': 'claim_check'},
+            'tooltip':'''\
+                      Select the earliest item that will appear in the adult trade sequence.
+                      '''
+        }),
     Setting_Info('logic_man_on_roof', bool, 1, True, 
         {
             'help': '''\


### PR DESCRIPTION
This PR adds a setting called `logic_earliest_adult_trade` that allows to set which item is the earliest in the adult trade sequence that will show up.
It mainly aims to give users a setting to reduce variance between seeds where Biggoron is required and one either has to do barely anything or almost the entire adult trading sequence.

I'm not sure what the default setting of this should be, so I just set it to Pocket Egg to mimic the seeds that were created before the option got added.

Created a bunch of test seeds and it worked as expected.

Since I'm a dummy and have no clue how to use command line arguments for the rando, I'm not sure if the help would look good.