### PR TITLE
Option to generate all files for multi world at once

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -422,6 +422,10 @@ def guiMain(settings=None):
     countLabel.pack(side=LEFT)
     countSpinbox.pack(side=LEFT, padx=2)
     playerNumFrame.pack(side=LEFT, anchor=N, padx=10, pady=(1,5))
+
+    guivars['generate_all'] = IntVar()
+    generateAllCheckbox = Checkbutton(multiworldFrame, text='Generate All', variable=guivars['generate_all'], justify=LEFT, wraplength=190)
+    generateAllCheckbox.pack(side=LEFT, anchor=N, padx=10, pady=(1,5))
     multiworldFrame.pack(side=TOP, anchor=W, padx=5, pady=(1,1))
 
 

--- a/Settings.py
+++ b/Settings.py
@@ -227,6 +227,12 @@ setting_infos = [
                     Use to select world to generate when there are multiple worlds.
                     ''',
             'type': int}),
+    Setting_Info('generate_all', int, 0, False, {
+            'default': 0,
+            'help': '''\
+                    Use to generate all worlds when there are multiple worlds.
+                    ''',
+            'type': int}),
     Setting_Info('create_spoiler', bool, 1, True, 
         {
             'help': 'Output a Spoiler File',


### PR DESCRIPTION
This PR adds a `Generate All` button next to the player id and generates all seeds (1 to world count) at once.

I think there was talk about this before, but I was recently trying to look at a few multi world spoilers, and generating those was a giant pain. So I decided to add this :)

I wanted the player id field to be greyed out, but didn't get it to work. So that could/should be improved I guess.

