### PR TITLE
Logic Fixes

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -1164,7 +1164,9 @@ def dung_rules_fit0(world):
     set_rule(world.get_location('Fire Temple Compass Chest'), lambda state: state.has('Small Key (Fire Temple)', 7))
     set_rule(
         world.get_location('Fire Temple Highest Goron Chest'),
-        lambda state: (state.can_play('Song of Time') or world.logic_tricks) and state.can_use('Hammer'))
+        lambda state: state.can_use('Hammer') and
+                      (state.can_play('Song of Time') or
+                          (world.logic_tricks and (state.can_use('Hover Boots') or state.has_explosives()))))
     set_rule(world.get_location('Fire Temple Megaton Hammer Chest'), lambda state: state.has_explosives())
 
     # Boss
@@ -1404,7 +1406,8 @@ def dung_rules_spt0(world):
         lambda state: state.has('Small Key (Spirit Temple)', 4) and state.can_use('Silver Gauntlets'))
     set_rule(
         world.get_entrance('Spirit Temple Final Locked Door'),
-        lambda state: state.has('Small Key (Spirit Temple)', 5) and state.has_projectile('adult'))
+        lambda state: state.has('Small Key (Spirit Temple)', 5) and
+                      (state.has_projectile('adult') or state.can_use('Hammer')))
     set_rule(
         world.get_location('Spirit Temple Child Left Chest'),
         lambda state: (state.has('Boomerang') or state.has_slingshot() or (state.has_bombchus() and world.logic_tricks)) and
@@ -1558,9 +1561,18 @@ def dung_rules_spt0(world):
                       (state.can_use('Longshot') or state.can_use('Scarecrow') or state.has('Hover Boots')))
     set_rule(
         world.get_location('GS Spirit Temple Bomb for Light Room'),
-        lambda state: state.can_child_attack() or
+        lambda state: state.has_projectile('both') or
+                      state.can_use('Dins Fire') or
+                      ((world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love')) and
+                        ((state.has_sticks() or state.has('Kokiri Sword')) and state.is_adult())) or
+                      (state.can_play('Requiem of Spirit') and
+                        (state.has_projectile('child') or
+                        ((world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love')) and
+                          (state.has_sticks() or state.has('Kokiri Sword'))))) or
                       ((state.has('Small Key (Spirit Temple)', 3) or (state.has('Small Key (Spirit Temple)', 2) and world.bombchus_in_logic)) and
-                        state.can_use('Silver Gauntlets')))
+                        state.can_use('Silver Gauntlets') and
+                        (state.has_projectile('adult') or
+                          world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
 
 # Spirit Temple MQ
 def dung_rules_sptmq(world):


### PR DESCRIPTION
1. Logic trick for skipping Song of Time in the Fire Temple actually still needs song of time unless you have either Hover Boots or explosives.

2. Added Hammer as a means of dealing with the walltula before climbing the Spirit Temple Wall of Death.

3. OHKO logic for the Spirit Temple GS Bomb for Light Room. Absurdly complicated logic for a rule that didn't required any back before shopsanity and ohko. I'm pretty sure this is the new longest rule in the file.