### PR TITLE
remove /build path from ,gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ output/*
 *.pyo
 *.spec
 dist/
-build/


### PR DESCRIPTION
Two reasons: 

* build.py is dependent on the c_symbols.txt file in order to generate symbol data that is accessible to the main program, and build.asm is dependent on the bundle.o file in order to import the compiled C code. If the folder is removed entirely from the repo, the build script will now require you to recompile the C source in order to make changes to the ASM source or risk corrupting the rom, which is a bit cumbersome.
* Keeping symbol data/bundle.o in the repo makes it much easier to track down bugs without having to know the exact version of gcc/armips used.