### PR TITLE
Skip "caught by gerudo" cutscene

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -924,6 +924,7 @@ def patch_rom(world, rom):
     write_bits_to_save(0x0EE7, 0x10) # "Spoke to Nabooru in Spirit Temple"
     write_bits_to_save(0x0EED, 0x20) # "Sheik, Spawned at Master Sword Pedestal as Adult"
     write_bits_to_save(0x0EED, 0x01) # "Nabooru Ordered to Fight by Twinrova"
+    write_bits_to_save(0x0EED, 0x80) # "Watched Ganon's Tower Collapse / Caught by Gerudo"
     write_bits_to_save(0x0EF9, 0x01) # "Greeted by Saria"
     write_bits_to_save(0x0F0A, 0x04) # "Spoke to Ingo Once as Adult"
     write_bits_to_save(0x0F1A, 0x04) # "Met Darunia in Fire Temple"


### PR DESCRIPTION
Sets the flag that you got caught by the guards in Gerudo Fortress. Prevents short cutscene from playing.
This flag is shared with the flag for the tower collapse cs at the end of the game, but that cutscene is skipped already anyway.