### PR TITLE
 Separate 'OHKO' mode from Difficulty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ARCHIVE.bin
 *.spec
 /dist/
 /build/
+/.idea/

--- a/ItemList.py
+++ b/ItemList.py
@@ -872,7 +872,7 @@ def get_pool_core(world):
         pool.extend(normal_items)
 
     max_items = dict(item_difficulty_max[world.difficulty])
-    if world.combat_difficulty == 'ohko':
+    if world.damage_multiplier == 'ohko':
         max_items['Ice Trap'] = 0
         if 'Nayrus Love' in max_items and max_items['Nayrus Love'] == 0:
             max_items['Nayrus Love'] = 1

--- a/ItemList.py
+++ b/ItemList.py
@@ -115,22 +115,6 @@ item_difficulty_max = {
         'Heart Container': 0,
         'Piece of Heart': 0,
     },
-    'ohko': {
-        'Ice Trap': 0,
-        'Bombchu': 1,
-        'Bombchu (5)': 1,
-        'Bombchu (10)': 0,
-        'Bombchu (20)': 0,
-        'Magic Meter': 1, 
-        'Double Defense': 0, 
-        'Deku Stick Capacity': 0, 
-        'Deku Nut Capacity': 0, 
-        'Bow': 1, 
-        'Slingshot': 1, 
-        'Bomb Bag': 1,
-        'Heart Container': 0,
-        'Piece of Heart': 0,
-    },
 }
 
 
@@ -887,7 +871,13 @@ def get_pool_core(world):
     else:
         pool.extend(normal_items)
 
-    for item,max in item_difficulty_max[world.difficulty].items():
+    max_items = dict(item_difficulty_max[world.difficulty])
+    if world.combat_difficulty == 'ohko':
+        max_items['Ice Trap'] = 0
+        if 'Nayrus Love' in max_items and max_items['Nayrus Love'] == 0:
+            max_items['Nayrus Love'] = 1
+
+    for item,max in max_items.items():
         replace_max_item(pool, item, max)
 
     return (pool, placed_items)

--- a/Patches.py
+++ b/Patches.py
@@ -1197,7 +1197,7 @@ def patch_rom(world, rom):
         rom.write_int32(0xDB532C, 0x24050003)
 
     # Set OHKO mode
-    if world.difficulty == 'ohko':
+    if world.combat_difficulty == 'ohko':
         rom.write_int32(0xAE80A8, 0xA4A00030) # sh  zero,48(a1)
         rom.write_int32(0xAE80B4, 0x06000003) # bltz s0, +0003
 

--- a/Patches.py
+++ b/Patches.py
@@ -1197,7 +1197,7 @@ def patch_rom(world, rom):
         rom.write_int32(0xDB532C, 0x24050003)
 
     # Set OHKO mode
-    if world.combat_difficulty == 'ohko':
+    if world.damage_multiplier == 'ohko':
         rom.write_int32(0xAE80A8, 0xA4A00030) # sh  zero,48(a1)
         rom.write_int32(0xAE80B4, 0x06000003) # bltz s0, +0003
 

--- a/README.html
+++ b/README.html
@@ -217,8 +217,12 @@
 <p>Heart Containers, Double Defense, and the second Magic Upgrade are replaced with junk items. One each of the ammo expansions (Quiver, Bullet Bag, Bomb Bag Deku Stick Capacity, Deku Nut Capacity) will also be replaced with junk items, and all Bombchu pick-ups other than three will similarly be replaced with junk.</p>
 <h3 id="very-hard">Very Hard</h3>
 <p>In addition to the items from Hard, Pieces of Heart and Nayru's Love are also replaced with junk items. One more of each ammo expansion is removed resulting in zero extra ammo capacity for those item types, and only one Bombchu pick-up can be found.</p>
+<h2 id="combat_difficulty">Combat Difficulty</h2>
+<p>This setting changes the amount of damage taken.</p>
+<h3 id="combat_difficulty_normal">Normal</h3>
+<p>Link takes normal damage.</p>
 <h3 id="ohko">OHKO</h3>
-<p>In addition to the item changes from Very Hard, Link dies in one hit. Ice Traps are replaced with Recovery Hearts.</p>
+<p>Link dies in one hit. Ice Traps are removed, and at least one Nayru's Love is in the item pool.</p>
 <h1 id="cosmetics">Cosmetics</h1>
 <h2 id="background-music">Background Music</h2>
 <h3 id="normal-1">Normal</h3>
@@ -402,8 +406,10 @@
 <p>Enable hints from Gossip Stones and select the condition to read them (default: agony)</p>
 <pre><code>--text_shuffle [{none,except_hints,complete}]</code></pre>
 <p>Shuffle the chosen text randomly (default: none)</p>
-<pre><code>--difficulty [{normal,hard,very_hard,ohko}]</code></pre>
-<p>Alter the item pool to increase difficulty. The ohko option also causes Link to die in one hit. (default: normal)</p>
+<pre><code>--difficulty [{normal,hard,very_hard}]</code></pre>
+<p>Alter the item pool to increase difficulty. (default: normal)</p>
+<pre><code>--combat_difficulty [{normal,ohko}]</code></pre>
+<p>Alters the amount of damage taken. The ohko option causes Link to die in one hit. (default: normal)</p>
 <pre><code>--default_targeting [{hold,switch}]</code></pre>
 <p>Set the default Z-targeting setting. It can still be changed in the game's options menu. (default: hold)</p>
 <pre><code>--background_music [{normal,off,random}]</code></pre>

--- a/README.html
+++ b/README.html
@@ -217,7 +217,7 @@
 <p>Heart Containers, Double Defense, and the second Magic Upgrade are replaced with junk items. One each of the ammo expansions (Quiver, Bullet Bag, Bomb Bag Deku Stick Capacity, Deku Nut Capacity) will also be replaced with junk items, and all Bombchu pick-ups other than three will similarly be replaced with junk.</p>
 <h3 id="very-hard">Very Hard</h3>
 <p>In addition to the items from Hard, Pieces of Heart and Nayru's Love are also replaced with junk items. One more of each ammo expansion is removed resulting in zero extra ammo capacity for those item types, and only one Bombchu pick-up can be found.</p>
-<h2 id="combat_difficulty">Combat Difficulty</h2>
+<h2 id="combat_difficulty">Damage Multiplier</h2>
 <p>This setting changes the amount of damage taken.</p>
 <h3 id="combat_difficulty_normal">Normal</h3>
 <p>Link takes normal damage.</p>
@@ -408,7 +408,7 @@
 <p>Shuffle the chosen text randomly (default: none)</p>
 <pre><code>--difficulty [{normal,hard,very_hard}]</code></pre>
 <p>Alter the item pool to increase difficulty. (default: normal)</p>
-<pre><code>--combat_difficulty [{normal,ohko}]</code></pre>
+<pre><code>--damage_multiplier [{normal,ohko}]</code></pre>
 <p>Alters the amount of damage taken. The ohko option causes Link to die in one hit. (default: normal)</p>
 <pre><code>--default_targeting [{hold,switch}]</code></pre>
 <p>Set the default Z-targeting setting. It can still be changed in the game's options menu. (default: hold)</p>

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ In addition to the items from Hard, Pieces of Heart and Nayru's Love are also re
 One more of each ammo expansion is removed resulting in zero extra ammo capacity for those item types,
 and only one Bombchu pick-up can be found.
 
-## Combat Difficulty
+## Damage Multiplier
 
 This setting changes the amount of damage taken.
 
@@ -1217,7 +1217,7 @@ Shuffle the chosen text randomly (default: none)
 Alter the item pool to increase difficulty. (default: normal)
 
 ```
---combat_difficulty [{normal,ohko}]
+--damage_multiplier [{normal,ohko}]
 ```
 
 Alters the amount of damage taken. The ohko option causes Link to die in one hit. (default: normal)

--- a/README.md
+++ b/README.md
@@ -666,9 +666,17 @@ In addition to the items from Hard, Pieces of Heart and Nayru's Love are also re
 One more of each ammo expansion is removed resulting in zero extra ammo capacity for those item types,
 and only one Bombchu pick-up can be found.
 
+## Combat Difficulty
+
+This setting changes the amount of damage taken.
+
+### Normal
+
+Link takes normal damage.
+
 ### OHKO
 
-In addition to the item changes from Very Hard, Link dies in one hit. Ice Traps are replaced with Recovery Hearts.
+Link dies in one hit. Ice Traps are removed, and at least one Nayru's Love is in the item pool.
 
 # Cosmetics
 
@@ -1203,10 +1211,16 @@ Enable hints from Gossip Stones and select the condition to read them (default: 
 Shuffle the chosen text randomly (default: none)
 
 ```
---difficulty [{normal,hard,very_hard,ohko}]
+--difficulty [{normal,hard,very_hard}]
 ```
 
-Alter the item pool to increase difficulty. The ohko option also causes Link to die in one hit. (default: normal)
+Alter the item pool to increase difficulty. (default: normal)
+
+```
+--combat_difficulty [{normal,ohko}]
+```
+
+Alters the amount of damage taken. The ohko option causes Link to die in one hit. (default: normal)
 
 ```
 --default_targeting [{hold,switch}]

--- a/Rules.py
+++ b/Rules.py
@@ -215,7 +215,7 @@ def global_rules(world):
     set_rule(
         world.get_location('DM Trail Freestanding PoH'),
         lambda state: world.open_kakariko or
-                      (world.combat_difficulty != 'ohko') or
+                      (world.damage_multiplier != 'ohko') or
                       state.has('Zeldas Letter') or
                       state.can_blast_or_smash() or
                       state.can_use('Dins Fire') or
@@ -749,8 +749,8 @@ def global_rules(world):
         world.get_entrance('Goron City Grotto'),
         lambda state: state.is_adult() and
                       ((state.can_play('Song of Time') and
-                        (world.combat_difficulty != 'ohko' or state.has_GoronTunic() or state.can_use('Longshot') or state.can_use('Nayrus Love'))) or
-                        (world.combat_difficulty != 'ohko' and state.has_GoronTunic() and state.can_use('Hookshot')) or
+                        (world.damage_multiplier != 'ohko' or state.has_GoronTunic() or state.can_use('Longshot') or state.can_use('Nayrus Love'))) or
+                        (world.damage_multiplier != 'ohko' and state.has_GoronTunic() and state.can_use('Hookshot')) or
                         (state.can_use('Nayrus Love') and state.can_use('Hookshot'))))
     set_rule(
         world.get_entrance('Lon Lon Grotto'),
@@ -978,7 +978,7 @@ def dung_rules_dcmq(world):
                       (state.has_slingshot() and
                         (state.has_explosives() or
                             ((state.has_sticks() or state.can_use('Dins Fire')) and
-                                (world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))
+                                (world.damage_multiplier != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))
     set_rule(world.get_location('DC MQ Deku Scrub Deku Sticks'), lambda state: state.can_stun_deku())
     set_rule(world.get_location('DC MQ Deku Scrub Deku Seeds'), lambda state: state.can_stun_deku())
     set_rule(world.get_location('DC MQ Deku Scrub Deku Shield'), lambda state: state.can_stun_deku())
@@ -987,7 +987,7 @@ def dung_rules_dcmq(world):
         lambda state: state.is_adult() or
                       state.has_explosives() or
                       ((state.has_sticks() or state.can_use('Dins Fire')) and
-                        (world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
+                        (world.damage_multiplier != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
 
     # Boss
     set_rule(
@@ -1016,7 +1016,7 @@ def dung_rules_dcmq(world):
                             (state.has('Progressive Strength Upgrade') and
                                 (state.can_use('Hammer') or
                                     ((state.has_sticks() or state.can_use('Dins Fire') or (state.is_adult() and (world.logic_dc_jump or state.has('Hover Boots')))) and
-                                        (world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))) or
+                                        (world.damage_multiplier != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))) or
                       (state.can_use('Hookshot') and (state.has_explosives() or state.has('Progressive Strength Upgrade') or state.has_bow() or state.can_use('Dins Fire'))))
 
 # Jabu Jabu's Belly Vanilla
@@ -1253,7 +1253,7 @@ def dung_rules_fitmq(world):
                       (state.has('Progressive Hookshot') and
                         (state.can_use('Fire Arrows') or
                             (state.can_use('Dins Fire') and
-                                (world.combat_difficulty != 'ohko' or
+                                (world.damage_multiplier != 'ohko' or
                                     state.has_GoronTunic() or
                                     state.has_bow() or
                                     state.has('Progressive Hookshot', 2))))))
@@ -1597,14 +1597,14 @@ def dung_rules_spt0(world):
         world.get_location('GS Spirit Temple Bomb for Light Room'),
         lambda state: state.has_projectile('both') or
                       state.can_use('Dins Fire') or
-                      ((world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love')) and
+                      ((world.damage_multiplier != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love')) and
                         (state.has_sticks() or state.has('Kokiri Sword') or state.has_projectile('child'))) or
                       (state.can_play('Requiem of Spirit') and state.has('Small Key (Spirit Temple)', 5) and
                         state.has_projectile('child')) or
                       ((state.has('Small Key (Spirit Temple)', 3) or (state.has('Small Key (Spirit Temple)', 2) and world.bombchus_in_logic)) and
                         state.can_use('Silver Gauntlets') and
                         (state.has_projectile('adult') or
-                          world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
+                          world.damage_multiplier != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
 
 # Spirit Temple MQ
 def dung_rules_sptmq(world):
@@ -2063,7 +2063,7 @@ def dung_rules_gtgmq(world):
                       state.has_fire_source() and
                       state.has('Iron Boots') and
                       (world.logic_fewer_tunic_requirements or state.has_ZoraTunic()) and
-                      (world.combat_difficulty != 'ohko' or (state.has_bottle() or state.can_use('Nayrus Love'))))
+                      (world.damage_multiplier != 'ohko' or (state.has_bottle() or state.can_use('Nayrus Love'))))
     set_rule(
         world.get_location('Gerudo Training Grounds MQ Heavy Block Chest'),
         lambda state: state.can_use('Silver Gauntlets'))

--- a/Rules.py
+++ b/Rules.py
@@ -215,7 +215,7 @@ def global_rules(world):
     set_rule(
         world.get_location('DM Trail Freestanding PoH'),
         lambda state: world.open_kakariko or
-                      (world.difficulty != 'ohko') or
+                      (world.combat_difficulty != 'ohko') or
                       state.has('Zeldas Letter') or
                       state.can_blast_or_smash() or
                       state.can_use('Dins Fire') or
@@ -749,8 +749,8 @@ def global_rules(world):
         world.get_entrance('Goron City Grotto'),
         lambda state: state.is_adult() and
                       ((state.can_play('Song of Time') and
-                        (world.difficulty != 'ohko' or state.has_GoronTunic() or state.can_use('Longshot') or state.can_use('Nayrus Love'))) or
-                        (world.difficulty != 'ohko' and state.has_GoronTunic() and state.can_use('Hookshot')) or
+                        (world.combat_difficulty != 'ohko' or state.has_GoronTunic() or state.can_use('Longshot') or state.can_use('Nayrus Love'))) or
+                        (world.combat_difficulty != 'ohko' and state.has_GoronTunic() and state.can_use('Hookshot')) or
                         (state.can_use('Nayrus Love') and state.can_use('Hookshot'))))
     set_rule(
         world.get_entrance('Lon Lon Grotto'),
@@ -978,7 +978,7 @@ def dung_rules_dcmq(world):
                       (state.has_slingshot() and
                         (state.has_explosives() or
                             ((state.has_sticks() or state.can_use('Dins Fire')) and
-                                (world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))
+                                (world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))
     set_rule(world.get_location('DC MQ Deku Scrub Deku Sticks'), lambda state: state.can_stun_deku())
     set_rule(world.get_location('DC MQ Deku Scrub Deku Seeds'), lambda state: state.can_stun_deku())
     set_rule(world.get_location('DC MQ Deku Scrub Deku Shield'), lambda state: state.can_stun_deku())
@@ -987,7 +987,7 @@ def dung_rules_dcmq(world):
         lambda state: state.is_adult() or
                       state.has_explosives() or
                       ((state.has_sticks() or state.can_use('Dins Fire')) and
-                        (world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
+                        (world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
 
     # Boss
     set_rule(
@@ -1016,7 +1016,7 @@ def dung_rules_dcmq(world):
                             (state.has('Progressive Strength Upgrade') and
                                 (state.can_use('Hammer') or
                                     ((state.has_sticks() or state.can_use('Dins Fire') or (state.is_adult() and (world.logic_dc_jump or state.has('Hover Boots')))) and
-                                        (world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))) or
+                                        (world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))))) or
                       (state.can_use('Hookshot') and (state.has_explosives() or state.has('Progressive Strength Upgrade') or state.has_bow() or state.can_use('Dins Fire'))))
 
 # Jabu Jabu's Belly Vanilla
@@ -1253,7 +1253,7 @@ def dung_rules_fitmq(world):
                       (state.has('Progressive Hookshot') and
                         (state.can_use('Fire Arrows') or
                             (state.can_use('Dins Fire') and
-                                (world.difficulty != 'ohko' or
+                                (world.combat_difficulty != 'ohko' or
                                     state.has_GoronTunic() or
                                     state.has_bow() or
                                     state.has('Progressive Hookshot', 2))))))
@@ -1597,14 +1597,14 @@ def dung_rules_spt0(world):
         world.get_location('GS Spirit Temple Bomb for Light Room'),
         lambda state: state.has_projectile('both') or
                       state.can_use('Dins Fire') or
-                      ((world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love')) and
+                      ((world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love')) and
                         (state.has_sticks() or state.has('Kokiri Sword') or state.has_projectile('child'))) or
                       (state.can_play('Requiem of Spirit') and state.has('Small Key (Spirit Temple)', 5) and
                         state.has_projectile('child')) or
                       ((state.has('Small Key (Spirit Temple)', 3) or (state.has('Small Key (Spirit Temple)', 2) and world.bombchus_in_logic)) and
                         state.can_use('Silver Gauntlets') and
                         (state.has_projectile('adult') or
-                          world.difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
+                          world.combat_difficulty != 'ohko' or state.has_bottle() or state.can_use('Nayrus Love'))))
 
 # Spirit Temple MQ
 def dung_rules_sptmq(world):
@@ -2063,7 +2063,7 @@ def dung_rules_gtgmq(world):
                       state.has_fire_source() and
                       state.has('Iron Boots') and
                       (world.logic_fewer_tunic_requirements or state.has_ZoraTunic()) and
-                      (world.difficulty != 'ohko' or (state.has_bottle() or state.can_use('Nayrus Love'))))
+                      (world.combat_difficulty != 'ohko' or (state.has_bottle() or state.can_use('Nayrus Love'))))
     set_rule(
         world.get_location('Gerudo Training Grounds MQ Heavy Block Chest'),
         lambda state: state.can_use('Silver Gauntlets'))

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1749,7 +1749,7 @@ setting_infos = [
                       pack is available.
                       '''
         }),
-    Setting_Info('combat_difficulty', str, 3, True,
+    Setting_Info('damage_multiplier', str, 3, True,
         {
             'default': 'normal',
             'const': 'normal',
@@ -1761,7 +1761,7 @@ setting_infos = [
                     '''
         },
         {
-            'text': 'Combat Difficulty',
+            'text': 'Damage Multiplier',
             'group': 'other',
             'widget': 'Combobox',
             'default': 'Normal',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1715,7 +1715,6 @@ setting_infos = [
                                     for each type can only be expanded once and you can only find three Bombchu packs.
                     very_hard:      Double defense, double magic, Nayru's Love, and all health upgrades are removed.
                                     No ammo expansions are available and you can only find one Bombchu pack.
-                    ohko:           Same as very hard, and Link will die in one hit.
                     '''
         },
         {
@@ -1727,8 +1726,7 @@ setting_infos = [
                 'Easy': 'easy',
                 'Normal': 'normal',
                 'Hard': 'hard',
-                'Very Hard': 'very_hard',
-                'OHKO': 'ohko'
+                'Very Hard': 'very_hard'
             },
             'tooltip':'''\
                       Makes health less available, reduces
@@ -1749,8 +1747,37 @@ setting_infos = [
                       Deku Stick and Deku Nut Capacity Upgrades
                       will be available. Only one Bombchu
                       pack is available.
+                      '''
+        }),
+    Setting_Info('combat_difficulty', str, 3, True,
+        {
+            'default': 'normal',
+            'const': 'normal',
+            'nargs': '?',
+            'help': '''\
+                    Change the amount of damage taken.
+                    normal:         Normal damage values.
+                    ohko:           Link will die in one hit. Ice Traps are removed and at least one Nayru's Love is available.
+                    '''
+        },
+        {
+            'text': 'Combat Difficulty',
+            'group': 'other',
+            'widget': 'Combobox',
+            'default': 'Normal',
+            'options': {
+                'Normal': 'normal',
+                'OHKO': 'ohko'
+            },
+            'tooltip':'''\
+                      Changes the amount of damage taken.
 
-                      'OHKO': Link dies in one hit.
+                      'Normal': Normal damage taken.
+                      
+                      'OHKO': Link dies in one hit. Ice Traps are
+                      removed and at least one Nayru's Love is
+                      available to allow all locations to be
+                      accessible logically.
                       '''
         }),
     Setting_Info('default_targeting', str, 1, False,


### PR DESCRIPTION
Difficulty is now about item distribution in general, whereas OHKO should be possible with any general item distribution difficulty. It makes sense for the two to be separate options now.

In the future this option could be used to set a damage multiplier or something, but implementing that is outside of my abilities.