### PR TITLE
Miscellaneous Changes

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -255,7 +255,7 @@ hintTable = {
     '1044':                                                  ("They say all toasters toast toast.", None, 'junkHint'),
     '1045':                                                  ("They say that Okami is the best Zelda game.", None, 'junkHint'),
     '1046':                                                  ("They say that quest guidance can be found at a talking rock.", None, 'junkHint'),
-    '1047':                                                  ("They say that the final item you're looking for can be found somewhere in Hyrule", None, 'junkHint'),
+    '1047':                                                  ("They say that the final item you're looking for can be found somewhere in Hyrule.", None, 'junkHint'),
     '1048':                                                  ("Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.^Mweep.", None, 'junkHint'),
     '1049':                                                  ("They say that Barinade fears Deku Nuts.", None, 'junkHint'),
     '1050':                                                  ("They say that Flare Dancers do not fear Goron-crafted blades.", None, 'junkHint'),

--- a/Hints.py
+++ b/Hints.py
@@ -297,6 +297,16 @@ hint_func = {
 
 
 hint_dist_sets = {
+    'useless': {
+        'trial':    (0.0, 0),
+        'always':   (0.0, 0),
+        'woth':     (0.0, 0),
+        'loc':      (0.0, 0),
+        'item':     (0.0, 0),
+        'ow':       (0.0, 0),
+        'dungeon':  (0.0, 0),
+        'junk':     (9.0, 1),
+    },
     'balanced': {
         'trial':    (0.0, 1),
         'always':   (0.0, 1),

--- a/ItemList.py
+++ b/ItemList.py
@@ -871,9 +871,6 @@ def get_pool_core(world):
     else:
         pool.extend(normal_items)
 
-    if world.damage_multiplier == 'ohko':
-        replace_max_item(pool, 'Ice Trap', 0)
-
     for item,max in item_difficulty_max[world.item_pool_value].items():
         replace_max_item(pool, item, max)
 

--- a/Main.py
+++ b/Main.py
@@ -144,7 +144,7 @@ def main(settings, window=dummy_window()):
         for world in worlds:
             if settings.world_count > 1:
                 window.update_status('Patching ROM: Player %d' % (world.id + 1))
-                patchfilename = '%sW%dP%d.zpf' % (patchfilebase, settings.world_count, world.id + 1)
+                patchfilename = '%s_W%dP%d.zpf' % (patchfilebase, settings.world_count, world.id + 1)
             else:
                 window.update_status('Patching ROM')
                 patchfilename = '%s.zpf' % patchfilebase
@@ -163,7 +163,7 @@ def main(settings, window=dummy_window()):
 
         if settings.world_count > 1:
             window.update_status('Creating Patch Archive')
-            output_path = os.path.join(output_dir, '%sW%d.zpfz' % (patchfilebase, settings.world_count))
+            output_path = os.path.join(output_dir, '%s_W%d.zpfz' % (patchfilebase, settings.world_count))
             with zipfile.ZipFile(output_path, mode="w") as patch_archive:
                 for file in file_list:
                     file_path = os.path.join(output_dir, file)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1671,6 +1671,7 @@ setting_infos = [
             'nargs': '?',
             'help': '''\
                     Choose how Gossip Stones hints are distributed
+                    useless: Nothing but junk hints.
                     balanced: Use a balanced distribution of hint types
                     strong: Use a strong distribution of hint types
                     very_strong: Use a very strong distribution of hint types
@@ -1682,11 +1683,14 @@ setting_infos = [
             'widget': 'Combobox',
             'default': 'Balanced',
             'options': {
+                'Useless': 'useless',
                 'Balanced': 'balanced',
                 'Strong': 'strong',
                 'Very Strong': 'very_strong',
             },
             'tooltip':'''\
+                      Useless has nothing but junk
+                      hints.
                       Strong distribution has some
                       duplicate hints and no junk
                       hints.


### PR DESCRIPTION
A few minor changes.

First, fixes the file name of multi-world patch files by adding an underscore between the seed and the W#P# part of the file name.

Second, reinstates Ice Traps back into OHKO mode. Whatever softlock issue these had in the past is seemingly resolved at this point.

Finally, adds "Useless" as a hint distribution option, which is nothing but junk hints.