### PR TITLE
Multi-World Spoiler Fixes

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -908,13 +908,14 @@ class Spoiler(object):
             for world in self.worlds:
                 if self.settings.world_count > 1:
                     outfile.write('\n\nLocations [World %d]:\n\n' % (world.id + 1))
+                    outfile.write('\n'.join(['%s [W%d]: %s' % (location, world.id + 1, item) for (location, item) in self.locations[world.id].items()]))
                 else:
                     outfile.write('\n\nLocations:\n\n')
-                outfile.write('\n'.join(['%s: %s' % (location, item) for (location, item) in self.locations[world.id].items()]))
+                    outfile.write('\n'.join(['%s: %s' % (location, item) for (location, item) in self.locations[world.id].items()]))
 
             outfile.write('\n\nPlaythrough:\n\n')
             if self.settings.world_count > 1:
-                outfile.write('\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(['  %s [World %d]: %s [Player %d]' % (location.name, location.world.id + 1, item.name, item.world.id + 1) for (location, item) in sphere.items()])) for (sphere_nr, sphere) in self.playthrough.items()]))
+                outfile.write('\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(['  %s [W%d]: %s [Player %d]' % (location.name, location.world.id + 1, item.name, item.world.id + 1) for (location, item) in sphere.items()])) for (sphere_nr, sphere) in self.playthrough.items()]))
             else:
                 outfile.write('\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(['  %s: %s' % (location.name, item.name) for (location, item) in sphere.items()])) for (sphere_nr, sphere) in self.playthrough.items()]))
 
@@ -922,17 +923,17 @@ class Spoiler(object):
                 for world in self.worlds:
                     if self.settings.world_count > 1:
                         outfile.write('\n\nWay of the Hero [Player %d]:\n\n' % (world.id + 1))
-                        outfile.write('\n'.join(['%s: %s [Player %d]' % (location.name, location.item.name, location.item.world.id + 1) for location in self.required_locations[world.id]]))
+                        outfile.write('\n'.join(['%s [W%d]: %s [Player %d]' % (location.name, world.id + 1, location.item.name, location.item.world.id + 1) for location in self.required_locations[world.id]]))
                     else:
                         outfile.write('\n\nWay of the Hero:\n\n')
                         outfile.write('\n'.join(['%s: %s' % (location.name, location.item.name) for location in self.required_locations[world.id]]))
 
                 from Hints import gossipLocations
-                if self.settings.world_count > 1:
-                    outfile.write('\n\nGossip Stone Hints [Player %d]:\n\n' % self.settings.player_num)
-                else:
-                    outfile.write('\n\nGossip Stone Hints:\n')
-
-                hint_ids = sorted(list(self.hints.keys()), key=lambda id: gossipLocations[id].name)
-                for id in hint_ids:
-                    outfile.write('\n%s: %s' % (gossipLocations[id].name if id in gossipLocations else "Unknown", re.sub('\x05[\x40\x41\x42\x43\x44\x45\x46\x47]', '', self.hints[id].replace('&', ' ').replace('^', ' '))))
+                for world in self.worlds:
+                    hint_ids = sorted(list(world.spoiler.hints.keys()), key=lambda id: gossipLocations[id].name)
+                    if self.settings.world_count > 1:
+                        outfile.write('\n\nGossip Stone Hints [Player %d]:\n' % (world.id + 1))
+                    else:
+                        outfile.write('\n\nGossip Stone Hints:\n')
+                    for id in hint_ids:
+                        outfile.write('\n%s: %s' % (gossipLocations[id].name if id in gossipLocations else "Unknown", re.sub('\x05[\x40\x41\x42\x43\x44\x45\x46\x47]', '', world.spoiler.hints[id].replace('&', ' ').replace('^', ' '))))

--- a/Main.py
+++ b/Main.py
@@ -129,25 +129,23 @@ def main(settings, window=dummy_window()):
     logger.info('Patching ROM.')
 
     if settings.world_count > 1:
-        outfilebase = 'OoT_%s_%s_W%dP%d' % (worlds[0].settings_string, worlds[0].seed, settings.world_count, settings.player_num)
+        outfilebase = 'OoT_%s_%s_W%d' % (worlds[0].settings_string, worlds[0].seed, settings.world_count)
     else:
         outfilebase = 'OoT_%s_%s' % (worlds[0].settings_string, worlds[0].seed)
 
     output_dir = default_output_path(settings.output_dir)
-    output_path = os.path.join(output_dir, outfilebase)
 
     if settings.compress_rom == 'Patch':
         rng_state = random.getstate()
         file_list = []
-        patchfilebase = 'OoT_%s_%s' % (worlds[0].settings_string, worlds[0].seed)
         window.update_progress(65)
         for world in worlds:
             if settings.world_count > 1:
                 window.update_status('Patching ROM: Player %d' % (world.id + 1))
-                patchfilename = '%s_W%dP%d.zpf' % (patchfilebase, settings.world_count, world.id + 1)
+                patchfilename = '%sP%d.zpf' % (outfilebase, world.id + 1)
             else:
                 window.update_status('Patching ROM')
-                patchfilename = '%s.zpf' % patchfilebase
+                patchfilename = '%s.zpf' % outfilebase
 
             random.setstate(rng_state)
             patch_rom(world, rom)
@@ -163,7 +161,7 @@ def main(settings, window=dummy_window()):
 
         if settings.world_count > 1:
             window.update_status('Creating Patch Archive')
-            output_path = os.path.join(output_dir, '%s_W%d.zpfz' % (patchfilebase, settings.world_count))
+            output_path = os.path.join(output_dir, '%s.zpfz' % outfilebase)
             with zipfile.ZipFile(output_path, mode="w") as patch_archive:
                 for file in file_list:
                     file_path = os.path.join(output_dir, file)
@@ -179,7 +177,10 @@ def main(settings, window=dummy_window()):
         window.update_progress(65)
 
         window.update_status('Saving Uncompressed ROM')
-        output_path += '.z64'
+        if settings.world_count > 1:
+            output_path = os.path.join(output_dir, '%sP%d.z64' % (outfilebase, settings.player_num))
+        else:
+            output_path = os.path.join(output_dir, '%s.z64' % outfilebase)
         rom.write_to_file(output_path)
         if settings.compress_rom == 'True':
             window.update_status('Compressing ROM')


### PR DESCRIPTION
Gossip Stone hints for all players are now included in the spoiler log. As a result, the player number is no longer included in the filename for multi-world spoilers.

Also added [W#] next to locations in multi-world spoilers to more easily Ctrl+F the correct location/world.

Filename logic in general cleaned up a bit.

Before/After spoiler logs: http://runs.live/OoT_CRUA4ACEJSABAL3A4AAM4RHLBC_MS4BYD6FGZ_W2_Spoiler.zip