### PR TITLE
Fix Multi-World Playthroughs

### DIFF
--- a/Item.py
+++ b/Item.py
@@ -16,13 +16,29 @@ class Item(object):
         self.world = world
 
 
+    item_worlds_to_fix = {}
+
     def copy(self, new_world=None):
+        if new_world is not None and self.world is not None and new_world.id != self.world.id:
+            new_world = None
+
         new_item = Item(self.name, self.advancement, self.priority, self.type, self.index, self.object, self.model, self.special)
         new_item.world = new_world
         new_item.price = self.price
 
+        if new_world is None and self.world is not None:
+            Item.item_worlds_to_fix[new_item] = self.world.id
+
         return new_item
 
+    @classmethod
+    def fix_worlds_after_copy(cls, worlds):
+        items_fixed = []
+        for item, world_id in cls.item_worlds_to_fix.items():
+            item.world = worlds[world_id]
+            items_fixed.append(item)
+        for item in items_fixed:
+            del cls.item_worlds_to_fix[item]
 
     @property
     def key(self):

--- a/Main.py
+++ b/Main.py
@@ -18,6 +18,7 @@ from Rom import LocalRom
 from Patches import patch_rom, patch_cosmetics
 from DungeonList import create_dungeons
 from Fill import distribute_items_restrictive
+from Item import Item
 from ItemPool import generate_itempool
 from Hints import buildGossipHints
 from Utils import default_output_path, is_bundled, subprocess_args, data_path
@@ -306,12 +307,18 @@ def run_process(window, logger, args):
             break
 
 
+def copy_worlds(worlds):
+    worlds = [world.copy() for world in worlds]
+    Item.fix_worlds_after_copy(worlds)
+    return worlds
+
+
 def create_playthrough(worlds):
     if worlds[0].check_beatable_only and not State.can_beat_game([world.state for world in worlds]):
         raise RuntimeError('Uncopied is broken too.')
     # create a copy as we will modify it
     old_worlds = worlds
-    worlds = [world.copy() for world in worlds]
+    worlds = copy_worlds(worlds)
 
     # if we only check for beatable, we can do this sanity check first before writing down spheres
     if worlds[0].check_beatable_only and not State.can_beat_game([world.state for world in worlds]):


### PR DESCRIPTION
When a location was copied, it set its item's world to the world of the location. This is bad if there are more than one world!