### PR TITLE
Create Settings Log is Spoiler Log is Disabled / Use Partial Hash of Settings String for Filenames

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -9,6 +9,7 @@ import sys
 import struct
 import zipfile
 import io
+import hashlib
 
 from World import World
 from State import State
@@ -126,10 +127,11 @@ def main(settings, window=dummy_window()):
 
     logger.info('Patching ROM.')
 
+    settings_string_hash = hashlib.sha1(worlds[0].settings_string.encode('utf-8')).hexdigest().upper()[:5]
     if settings.world_count > 1:
-        outfilebase = 'OoT_%s_%s_W%d' % (worlds[0].settings_string, worlds[0].seed, settings.world_count)
+        outfilebase = 'OoT_%s_%s_W%d' % (settings_string_hash, worlds[0].seed, settings.world_count)
     else:
-        outfilebase = 'OoT_%s_%s' % (worlds[0].settings_string, worlds[0].seed)
+        outfilebase = 'OoT_%s_%s' % (settings_string_hash, worlds[0].seed)
 
     output_dir = default_output_path(settings.output_dir)
 

--- a/Main.py
+++ b/Main.py
@@ -214,6 +214,9 @@ def main(settings, window=dummy_window()):
     if settings.create_spoiler:
         window.update_status('Creating Spoiler Log')
         spoiler.to_file(os.path.join(output_dir, '%s_Spoiler.txt' % outfilebase))
+    else:
+        window.update_status('Creating Settings Log')
+        spoiler.to_file(os.path.join(output_dir, '%s_Settings.txt' % outfilebase))
 
     window.update_progress(100)
     window.update_status('Success: Rom patched successfully')

--- a/Spoiler.py
+++ b/Spoiler.py
@@ -70,42 +70,53 @@ class Spoiler(object):
     def to_file(self, filename):
         self.parse_data()
         with open(filename, 'w') as outfile:
-            outfile.write('OoT Randomizer Version %s  -  Seed: %s\n\n' % (__version__, self.settings.seed))
+            output = self.settings_output()
+            if (self.settings.create_spoiler):
+                output += self.spoiler_output()
+            outfile.write(output)
+            
+    def settings_output(self):
+        output = ''
+        output += 'OoT Randomizer Version %s  -  Seed: %s\n\n' % (__version__, self.settings.seed)
 
-            outfile.write('File Select Hash:\n')
-            outfile.write('\n'.join(['    %s' % HASH_ICONS[icon] for icon in self.file_hash]))
-            outfile.write('\n\n')
+        output += 'File Select Hash:\n'
+        output += '\n'.join(['    %s' % HASH_ICONS[icon] for icon in self.file_hash])
+        output += '\n\n'
 
-            outfile.write('Settings (%s):\n%s' % (self.settings.get_settings_string(), self.settings.get_settings_display()))
+        output += 'Settings (%s):\n%s' % (self.settings.get_settings_string(), self.settings.get_settings_display())
+        return output
 
-            extra_padding = 1 if self.settings.world_count < 2 else 6 if self.settings.world_count < 10 else 7
-            if self.settings.world_count > 1:
-                header_world_string = '\n\n{header} [World {world}]:\n\n'
-                header_player_string = '\n\n{header} [Player {player}]:\n\n'
-                location_string = '{location} [W{world}]:'
-                item_string = '{item} [Player {player}]{cost}'
-            else:
-                header_world_string = '\n\n{header}:\n\n'
-                header_player_string = '\n\n{header}:\n\n'
-                location_string = '{location}:'
-                item_string = '{item}{cost}'
+    def spoiler_output(self):
+        output = ''
+        extra_padding = 1 if self.settings.world_count < 2 else 6 if self.settings.world_count < 10 else 7
+        if self.settings.world_count > 1:
+            header_world_string = '\n\n{header} [World {world}]:\n\n'
+            header_player_string = '\n\n{header} [Player {player}]:\n\n'
+            location_string = '{location} [W{world}]:'
+            item_string = '{item} [Player {player}]{cost}'
+        else:
+            header_world_string = '\n\n{header}:\n\n'
+            header_player_string = '\n\n{header}:\n\n'
+            location_string = '{location}:'
+            item_string = '{item}{cost}'
 
-            location_padding = len(max(self.locations[0].keys(), key=len)) + extra_padding
+        location_padding = len(max(self.locations[0].keys(), key=len)) + extra_padding
+        for world in self.worlds:
+            output += header_world_string.format(header="Locations", world=world.id+1)
+            output += '\n'.join(['{:{width}} {}'.format(location_string.format(location=location, world=world.id+1), item_string.format(item=item.name, player=item.world.id+1, cost=' [Costs %d Rupees]' % item.price if item.price is not None else ''), width=location_padding) for (location, item) in self.locations[world.id].items()])
+
+        output += '\n\nPlaythrough:\n\n'
+        output += '\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(['  {:{width}} {}'.format(location_string.format(location=location.name, world=location.world.id+1), item_string.format(item=item.name, player=item.world.id+1, cost=' [Costs %d Rupees]' % item.price if item.price is not None else ''), width=location_padding) for (location, item) in sphere.items()])) for (sphere_nr, sphere) in self.playthrough.items()])
+
+        if len(self.hints) > 0:
             for world in self.worlds:
-                outfile.write(header_world_string.format(header="Locations", world=world.id+1))
-                outfile.write('\n'.join(['{:{width}} {}'.format(location_string.format(location=location, world=world.id+1), item_string.format(item=item.name, player=item.world.id+1, cost=' [Costs %d Rupees]' % item.price if item.price is not None else ''), width=location_padding) for (location, item) in self.locations[world.id].items()]))
+                output += header_player_string.format(header="Way of the Hero", player=world.id+1)
+                output += '\n'.join(['{:{width}} {}'.format(location_string.format(location=location.name, world=location.world.id+1), item_string.format(item=location.item.name, player=location.item.world.id+1, cost=' [Costs %d Rupees]' % location.item.price if location.item.price is not None else ''), width=location_padding) for location in self.required_locations[world.id]])
 
-            outfile.write('\n\nPlaythrough:\n\n')
-            outfile.write('\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(['  {:{width}} {}'.format(location_string.format(location=location.name, world=location.world.id+1), item_string.format(item=item.name, player=item.world.id+1, cost=' [Costs %d Rupees]' % item.price if item.price is not None else ''), width=location_padding) for (location, item) in sphere.items()])) for (sphere_nr, sphere) in self.playthrough.items()]))
+            gossip_padding = len(max([stone.name for stone in gossipLocations.values()], key=len)) + extra_padding
+            for world in self.worlds:
+                hint_ids = sorted(list(self.hints[world.id].keys()), key=lambda id: gossipLocations[id].name)
+                output += header_player_string.format(header="Gossip Stone Hints", player=world.id+1)
+                output += '\n'.join(['{:{width}} {}'.format(location_string.format(location=gossipLocations[id].name, world=world.id+1), re.sub('\x05[\x40\x41\x42\x43\x44\x45\x46\x47]', '', self.hints[world.id][id].replace('&', ' ').replace('^', ' ')), width=gossip_padding) for id in hint_ids])
 
-            if len(self.hints) > 0:
-                for world in self.worlds:
-                    outfile.write(header_player_string.format(header="Way of the Hero", player=world.id+1))
-                    outfile.write('\n'.join(['{:{width}} {}'.format(location_string.format(location=location.name, world=location.world.id+1), item_string.format(item=location.item.name, player=location.item.world.id+1, cost=' [Costs %d Rupees]' % location.item.price if location.item.price is not None else ''), width=location_padding) for location in self.required_locations[world.id]]))
-
-                gossip_padding = len(max([stone.name for stone in gossipLocations.values()], key=len)) + extra_padding
-                for world in self.worlds:
-                    hint_ids = sorted(list(self.hints[world.id].keys()), key=lambda id: gossipLocations[id].name)
-                    outfile.write(header_player_string.format(header="Gossip Stone Hints", player=world.id+1))
-                    outfile.write('\n'.join(['{:{width}} {}'.format(location_string.format(location=gossipLocations[id].name, world=world.id+1), re.sub('\x05[\x40\x41\x42\x43\x44\x45\x46\x47]', '', self.hints[world.id][id].replace('&', ' ').replace('^', ' ')), width=gossip_padding) for id in hint_ids]))
-
+        return output


### PR DESCRIPTION
Two changes designed to account for the fact that a long, long settings string should not be in a filename, and yet it is nice to be able to keep a log of what settings were used to generate a particular seed for reference or troubleshooting / debugging purposes.