### PR TITLE
 Allow "presets_xyz.sav" files that contain locked presets.

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -502,7 +502,7 @@ def guiMain(settings=None):
             return
 
         settings = guivars_to_settings(guivars)
-        preset = {setting.name: settings.__dict__[setting.name] for setting in 
+        preset = {setting.name: settings.__dict__[setting.name] for setting in
             filter(lambda s: s.shared and s.bitwidth > 0, setting_infos)}
 
         presets[preset_name] = preset
@@ -564,7 +564,7 @@ def guiMain(settings=None):
             if guivars['logic_rules'].get() == 'Glitchless':
                 notebook.tab(2, state="normal")
             else:
-                notebook.tab(2, state="disabled")               
+                notebook.tab(2, state="disabled")
             notebook.tab(3, state="normal")
             toggle_widget(widgets['world_count'], check_dependency('world_count'))
             toggle_widget(widgets['create_spoiler'], check_dependency('create_spoiler'))
@@ -682,16 +682,18 @@ def guiMain(settings=None):
         settings_to_guivars(settings, guivars)
 
         presets = {}
-        try:
-            with open(data_path('presets_default.json')) as f:
-                presets.update(json.load(f))
-        except:
-            pass
-        try:
-            with open(local_path('presets.sav')) as f:
-                presets.update(json.load(f))
-        except:
-            pass           
+        for file in [data_path('presets_default.json')] \
+                  + [local_path(f) for f in os.listdir(local_path()) if f.startswith('presets_') and f.endswith('.sav')] \
+                  + [local_path('presets.sav')]:
+            try:
+                with open(file) as f:
+                    presets_temp = json.load(f)
+                    if file != local_path('presets.sav'):
+                        for preset in presets_temp.values():
+                            preset['locked'] = True
+                    presets.update(presets_temp)
+            except:
+                pass
         update_preset_dropdown()
 
     show_settings()

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -37,18 +37,11 @@
         "tokensanity": "off",
         "mq_dungeons_random": false,
         "mq_dungeons": 0,
-        "logic_skulltulas": 50,
         "logic_no_night_tokens_without_suns_song": false,
-        "logic_no_big_poes": false,
-        "logic_no_child_fishing": false,
-        "logic_no_adult_fishing": false,
-        "logic_no_trade_skull_mask": false,
-        "logic_no_trade_mask_of_truth": true,
-        "logic_no_1500_archery": false,
-        "logic_no_memory_game": false,
-        "logic_no_second_dampe_race": false,
-        "logic_no_trade_biggoron": false,
         "logic_earliest_adult_trade": "prescription",
+        "disabled_locations": [
+            "Deku Theater Mask of Truth"
+        ],
         "logic_latest_adult_trade": "claim_check",
         "logic_tricks": false,
         "logic_man_on_roof": false,
@@ -68,7 +61,6 @@
         "hint_dist": "balanced",
         "text_shuffle": "none",
         "item_pool_value": "balanced",
-        "damage_multiplier": "normal",
-        "locked": true
+        "damage_multiplier": "normal"
     }
 }


### PR DESCRIPTION
The idea being that people can distribute their presets as a separate file and the user can just drop it into their randomizer directory instead of doing something awful like manually editing JSON.