### PR TITLE
Add convenience settings for faster start

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -3,6 +3,8 @@ import logging
 from State import State
 from Rules import set_shop_rules
 from Location import DisableType
+from ItemPool import songlist, get_junk_item
+from Item import ItemFactory
 
 
 class FillError(RuntimeError):
@@ -33,6 +35,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     shopitempool = [item for world in worlds for item in world.itempool if item.type == 'Shop']
     songitempool = [item for world in worlds for item in world.itempool if item.type == 'Song']
     itempool =     [item for world in worlds for item in world.itempool if item.type != 'Shop' and item.type != 'Song']
+    
     if worlds[0].shuffle_song_items:
         itempool.extend(songitempool)
         fill_locations.extend(song_locations)
@@ -45,6 +48,15 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     progitempool = [item for item in itempool if item.advancement]
     prioitempool = [item for item in itempool if not item.advancement and item.priority]
     restitempool = [item for item in itempool if not item.advancement and not item.priority]
+
+    # handle start with fast travel (removes songs)
+    if not worlds[0].shuffle_song_items and worlds[0].start_with_fast_travel:
+        for song in songlist:
+            if not any(song == item.name for item in songitempool):
+                # move one non-advancement/priority item into song pool
+                songitempool.append(restitempool[-1])
+                del restitempool[-1]
+                
 
 
     # We place all the shop items first. Like songs, they have a more limited

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -827,6 +827,10 @@ def get_pool_core(world):
         placed_items.update(vanilla_deku_scrubs)
 
     pool.extend(alwaysitems)
+    if world.start_with_fast_travel:
+        pool.remove('Farores Wind')
+        pool.extend(get_junk_item())
+    
     if world.dungeon_mq['Deku Tree']:
         pool.extend(DT_MQ)
     else:
@@ -882,6 +886,11 @@ def get_pool_core(world):
     pool.append(tradeitem)
 
     pool.extend(songlist)
+    if world.start_with_fast_travel:
+        pool.remove('Prelude of Light')
+        pool.extend(get_junk_item())
+        pool.remove('Serenade of Water')
+        pool.extend(get_junk_item())
 
     if world.shuffle_mapcompass == 'remove' or world.shuffle_mapcompass == 'startwith':
         for item in [item for dungeon in world.dungeons for item in dungeon.dungeon_items]:

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -829,6 +829,7 @@ def get_pool_core(world):
     pool.extend(alwaysitems)
     if world.start_with_fast_travel:
         pool.remove('Farores Wind')
+        world.state.collect(ItemFactory('Farores Wind'))
         pool.extend(get_junk_item())
     
     if world.dungeon_mq['Deku Tree']:
@@ -888,8 +889,10 @@ def get_pool_core(world):
     pool.extend(songlist)
     if world.start_with_fast_travel:
         pool.remove('Prelude of Light')
+        world.state.collect(ItemFactory('Prelude of Light'))
         pool.extend(get_junk_item())
         pool.remove('Serenade of Water')
+        world.state.collect(ItemFactory('Serenade of Water'))
         pool.extend(get_junk_item())
 
     if world.shuffle_mapcompass == 'remove' or world.shuffle_mapcompass == 'startwith':

--- a/Patches.py
+++ b/Patches.py
@@ -258,23 +258,26 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     Block_code = [0x00, 0x00, 0x00, 0x01, 0x00, 0x21, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02]
     rom.write_bytes(0x1FC0CF8, Block_code)
 
+    # songs as items flag
+    songs_as_items = world.shuffle_song_items or world.start_with_fast_travel
+    
     # Speed learning Zelda's Lullaby
     rom.write_int32s(0x02E8E90C, [0x000003E8, 0x00000001]) # Terminator Execution
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0x0073, 0x001, 0x0002, 0x0002]) # ID, start, end, end
     else:
         rom.write_int16s(None, [0x0073, 0x003B, 0x003C, 0x003C]) # ID, start, end, end
 
 
     rom.write_int32s(0x02E8E91C, [0x00000013, 0x0000000C]) # Textbox, Count
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
     else:
         rom.write_int16s(None, [0x0017, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x00D4, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
 
     # Speed learning Sun's Song
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x0332A4A4, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x0332A4A4, 0x0000003C) # Header: frame_count
@@ -284,7 +287,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int16s(None, [0x00D3, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
 
     # Speed learning Saria's Song
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x020B1734, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x020B1734, 0x0000003C) # Header: frame_count
@@ -302,13 +305,13 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
 
     # Speed learning Epona's Song
     rom.write_int32s(0x029BEF60, [0x000003E8, 0x00000001]) # Terminator Execution
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0x005E, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
     else:
         rom.write_int16s(None, [0x005E, 0x000A, 0x000B, 0x000B]) # ID, start, end, end
 
     rom.write_int32s(0x029BECB0, [0x00000013, 0x00000002]) # Textbox, Count
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0xFFFF, 0x0000, 0x0009, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
     else:
         rom.write_int16s(None, [0x00D2, 0x0000, 0x0009, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
@@ -316,13 +319,13 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
 
     # Speed learning Song of Time
     rom.write_int32s(0x0252FB98, [0x000003E8, 0x00000001]) # Terminator Execution
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0x0035, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
     else:
         rom.write_int16s(None, [0x0035, 0x003B, 0x003C, 0x003C]) # ID, start, end, end
 
     rom.write_int32s(0x0252FC80, [0x00000013, 0x0000000C]) # Textbox, Count
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
     else:
         rom.write_int16s(None, [0x0019, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
@@ -331,7 +334,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int32(0x01FC3B84, 0xFFFFFFFF) # Other Header?: frame_count
 
     # Speed learning Song of Storms
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x03041084, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x03041084, 0x0000000A) # Header: frame_count
@@ -341,7 +344,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int16s(None, [0xFFFF, 0x00BE, 0x00C8, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
 
     # Speed learning Minuet of Forest
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x020AFF84, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x020AFF84, 0x0000003C) # Header: frame_count
@@ -361,7 +364,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int16s(None, [0x0004, 0x0000, 0x0000, 0x0000]) #action, start, end, ????
 
     # Speed learning Bolero of Fire
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x0224B5D4, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x0224B5D4, 0x0000003C) # Header: frame_count
@@ -381,7 +384,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int16s(0x0224B888, [0x0000]) #action
 
     # Speed learning Serenade of Water
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x02BEB254, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x02BEB254, 0x0000003C) # Header: frame_count
@@ -410,14 +413,14 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int32(0x01FFFDF4, 0x0000003C) # Header: frame_count
 
     rom.write_int32s(0x02000FD8, [0x00000013, 0x0000000E]) # Textbox, Count
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
     else:
         rom.write_int16s(None, [0x0013, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x0077, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x02000128, [0x000003E8, 0x00000001]) # Terminator Execution
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0x0032, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
     else:
         rom.write_int16s(None, [0x0032, 0x003A, 0x003B, 0x003B]) # ID, start, end, end
@@ -426,14 +429,14 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int32(0x0218AF14, 0x0000003C) # Header: frame_count
 
     rom.write_int32s(0x0218C574, [0x00000013, 0x00000008]) # Textbox, Count
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
     else:
         rom.write_int16s(None, [0x0012, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x0076, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x0218B478, [0x000003E8, 0x00000001]) # Terminator Execution
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int16s(None, [0x0030, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
     else:
         rom.write_int16s(None, [0x0030, 0x003A, 0x003B, 0x003B]) # ID, start, end, end
@@ -447,7 +450,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int16s(0x0218AF50, [0x003E, 0x0011, 0x0020, 0x0000]) #action, start, end, ????
 
     # Speed learning Prelude of Light
-    if world.shuffle_song_items:
+    if songs_as_items:
         rom.write_int32(0x0252FD24, 0xFFFFFFFF) # Header: frame_count
     else:
         rom.write_int32(0x0252FD24, 0x0000003C) # Header: frame_count
@@ -829,7 +832,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
 
         table_len = len(initial_save_table)
         if table_len > 0x400:
-            raise Exception("The Initial Save Table has exceeded it's maximum capacity: 0x%03X/0x400" % table_len)
+            raise Exception("The Initial Save Table has exceeded its maximum capacity: 0x%03X/0x400" % table_len)
         rom.write_bytes(0x3481800, initial_save_table)
 
 
@@ -974,6 +977,23 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
         write_bits_to_save(0x00AE, 0x06) # "Spirit Map/Compass"
         write_bits_to_save(0x00B0, 0x06) # "BotW Map/Compass"
         write_bits_to_save(0x00B1, 0x06) # "Ice Map/Compass"
+        
+    if world.start_with_rupees:
+        write_byte_to_save(0x0035, 0x63) # start with 99 rupees
+
+    if world.start_with_deku_equipment:
+        if world.shopsanity == "off":
+            write_bits_to_save(0x009D, 0x10) # start with Deku Shield
+            write_bits_to_save(0x0071, 0x10) # equip Deku Shield
+        write_byte_to_save(0x0074, 0x00) # Deku stick in 1st inventory slot
+        write_byte_to_save(0x008C, 0x0A) # start with 10 Deku sticks
+        write_byte_to_save(0x0075, 0x01) # Deku nut in 2nd inventory slot
+        write_byte_to_save(0x008D, 0x14) # start with 20 Deku nuts
+        write_bits_to_save(0x00A1, 0x12) # enable Deku stick/nut base capacity
+
+    if world.start_with_fast_travel:
+        write_bits_to_save(0x00A6, 0x09) # start with Prelude of Light & Serenade of Water
+        write_byte_to_save(0x007F, 0x0D) # Farore's Wind in 12th inventory slot
 
     # Revert change that Skips the Epona Race
     if not world.no_epona_race:
@@ -1104,7 +1124,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_byte(0x03481C00, world.id + 1) # Write player ID
 
     # Revert Song Get Override Injection
-    if not world.shuffle_song_items:
+    if not songs_as_items:
         # general get song
         rom.write_int32(0xAE5DF8, 0x240200FF)
         rom.write_int32(0xAE5E04, 0xAD0F00A4)
@@ -1144,7 +1164,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
         locationaddress = location.address
         secondaryaddress = location.address2
 
-        if location.type == 'Song' and not world.shuffle_song_items:
+        if location.type == 'Song' and not songs_as_items:
             bit_mask_pointer = 0x8C34 + ((special['item_id'] - 0x65) * 4)
             rom.write_byte(locationaddress, special['song_id'])
             next_song_id = special['song_id'] + 0x0D

--- a/Rules.py
+++ b/Rules.py
@@ -50,7 +50,11 @@ def set_rules(world):
 
         if not world.shuffle_song_items:
             if location.type == 'Song':
-                add_item_rule(location, lambda location, item: item.type == 'Song' and item.world.id == location.world.id)
+                if not world.start_with_fast_travel:
+                    add_item_rule(location, lambda location, item: item.type == 'Song' and item.world.id == location.world.id)
+                else:
+                    # allow junk items, but songs must still have matching world
+                    add_item_rule(location, lambda location, item: item.type != 'Song' or (item.type == 'Song' and item.world.id == location.world.id))
             else:
                 add_item_rule(location, lambda location, item: item.type != 'Song')
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -599,6 +599,46 @@ setting_infos = [
             shared         = True,
             ),
     Checkbutton(
+            name           = 'start_with_rupees',
+            args_help      = '''\
+                             Start with 99 rupees.
+                             ''',
+            gui_text       = 'Start with max rupees',
+            gui_group      = 'convenience',
+            gui_tooltip    = '''\
+                             Start the game with 99 rupees.
+                             ''',
+            shared         = True,
+            ),
+    Checkbutton(
+            name           = 'start_with_deku_equipment',
+            args_help      = '''\
+                             Start with full Deku sticks, nuts, and a shield.
+                             ''',
+            gui_text       = 'Start with Deku equipment',
+            gui_group      = 'convenience',
+            gui_tooltip    = '''\
+                             Start the game with 10 Deku sticks and 20 Deku nuts.
+                             Additionally, start the game with a Deku shield equipped,
+                             unless playing with the Shopsanity setting.
+                             ''',
+            shared         = True,
+            ),
+    Checkbutton(
+            name           = 'start_with_fast_travel',
+            args_help      = '''\
+                             Start with two warp songs and Farore's Wind.
+                             ''',
+            gui_text       = 'Start with fast travel',
+            gui_group      = 'convenience',
+            gui_tooltip    = '''\
+                             Start the game with knowledge of the Prelude of Light
+                             and Serenade of Water songs. Also start the game with
+                             Farore's Wind in inventory.
+                             ''',
+            shared         = True,
+            ),            
+    Checkbutton(
             name           = 'shuffle_kokiri_sword',
             args_help      = '''\
                              Shuffles the Kokiri Sword into the pool.


### PR DESCRIPTION
This branch adds the following settings:

1. "Start with max rupees" - The player begins the game with 99 rupees.
2. "Start with Deku equipment" - The player begins the game with 10 Deku sticks and 20 Deku nuts (which normally can be bought or obtained by killing enemies in the starting area). Additionally, if playing without shopsanity, the player begins with a Deku shield equipped (which can also be bought).
3. "Start with fast travel" - The player begins the game with the Prelude of Light and Serenade of Water songs learned (but no ocarina) and the Farore's Wind spell (but no magic meter). These three items increase Link's mobility around the map, but don't actually unlock any new items or areas.

The "start with fast travel" option required some minor rework of the ItemPool logic (to remove the three mentioned items and replace them with junk items) and of the Fill logic (to place minor items in the songlist to compensate for its smaller size if not shuffling songs). Additionally, the song cutscenes are disabled, since two song locations will now provide an item instead of a song.