### PR TITLE
Fix open bridge logic

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -6,40 +6,6 @@ from Location import DisableType
 def set_rules(world):
     logger = logging.getLogger('')
 
-    if world.bridge == 'medallions':
-        # require all medallions to form the bridge
-        set_rule(
-            world.get_entrance('Ganons Castle Grounds -> Ganons Castle Lobby'),
-            lambda state: (
-                state.has('Forest Medallion') and 
-                state.has('Fire Medallion') and 
-                state.has('Water Medallion') and 
-                state.has('Shadow Medallion') and 
-                state.has('Spirit Medallion') and 
-                state.has('Light Medallion')))
-    elif world.bridge == 'vanilla':
-        # require only what vanilla did to form the bridge
-        set_rule(
-            world.get_entrance('Ganons Castle Grounds -> Ganons Castle Lobby'),
-            lambda state: (
-                state.has('Light Arrows') and 
-                state.has('Shadow Medallion') and 
-                state.has('Spirit Medallion')))
-    elif world.bridge == 'dungeons':
-        # require all medallions and stones to form the bridge
-        set_rule(
-            world.get_entrance('Ganons Castle Grounds -> Ganons Castle Lobby'),
-            lambda state: (
-                state.has('Forest Medallion') and 
-                state.has('Fire Medallion') and 
-                state.has('Water Medallion') and 
-                state.has('Shadow Medallion') and
-                state.has('Spirit Medallion') and 
-                state.has('Light Medallion') and 
-                state.has('Kokiri Emerald') and 
-                state.has('Goron Ruby') and 
-                state.has('Zora Sapphire')))
-
     # ganon can only carry triforce
     world.get_location('Ganon').item_rule = lambda location, item: item.name == 'Triforce'
 

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -431,7 +431,19 @@
         "exits": {
             "Castle Town": "True",
             "Ganons Castle Fairy": "can_use(Golden_Gauntlets)",
-            "Ganons Castle Lobby": "True"
+            "Ganons Castle Lobby": "
+                (bridge == 'open')
+                or ((bridge == 'medallions') and
+                    Forest_Medallion and Fire_Medallion and Water_Medallion and
+                    Shadow_Medallion and Spirit_Medallion and Light_Medallion)
+                or ((bridge == 'vanilla') and
+                    Light_Arrows and Shadow_Medallion and Spirit_Medallion)
+                or ((bridge == 'dungeons') and
+                    Forest_Medallion and Fire_Medallion and Water_Medallion and 
+                    Shadow_Medallion and Spirit_Medallion and Light_Medallion and
+                    Kokiri_Emerald and Goron_Ruby and Zora_Sapphire)
+                or ((bridge == 'stones') and
+                    Kokiri_Emerald and Goron_Ruby and Zora_Sapphire)"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -431,9 +431,7 @@
         "exits": {
             "Castle Town": "True",
             "Ganons Castle Fairy": "can_use(Golden_Gauntlets)",
-            "Ganons Castle Lobby": "
-                Forest_Medallion and Fire_Medallion and Water_Medallion and 
-                Shadow_Medallion and Spirit_Medallion and Light_Medallion"
+            "Ganons Castle Lobby": "True"
         }
     },
     {


### PR DESCRIPTION
I think this is required because in Rules.py only the requirements for meds/ad/vanilla get set. So if it "defaults" to meds and open doesn't overwrite it with `True`, there could never be early progression in GC for open bridge, right?