### PR TITLE
Logic Fixes

### DIFF
--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -6,7 +6,7 @@
             "Deku Tree Lobby Chest": "True",
             "Deku Tree Compass Chest": "True",
             "Deku Tree Compass Room Side Chest": "True",
-            "Deku Tree Basement Chest": "True",
+            "Deku Tree Basement Chest": "can_child_attack or has_nuts",
             "GS Deku Tree Compass Room": "can_child_attack",
             "GS Deku Tree Basement Vines": "
                 has_slingshot or Boomerang or has_explosives or can_use(Dins_Fire) or 

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -8,7 +8,7 @@
                 (Hover_Boots and has_fire_source) or 
                 (Progressive_Hookshot and (can_use(Fire_Arrows) or 
                     (can_use(Dins_Fire) and 
-                    (damage_multiplier != 'ohko' or has_GoronTunic or 
+                    ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or has_GoronTunic or 
                         has_bow or (Progressive_Hookshot, 2)))))"
         },
         "exits": {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -778,8 +778,8 @@
             "Goron City Grotto": "
                 is_adult and 
                 ((can_play(Song_of_Time) and 
-                    (damage_multiplier != 'ohko' or has_GoronTunic or 
-                        can_use(Longshot) or can_use(Nayrus_Love))) or 
+                    ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
+                        has_GoronTunic or can_use(Longshot) or can_use(Nayrus_Love))) or 
                 (damage_multiplier != 'ohko' and has_GoronTunic and can_use(Hookshot)) or 
                 (can_use(Nayrus_Love) and can_use(Hookshot)))",
             "Goron City Maze Gossip Stone": "
@@ -848,7 +848,9 @@
         "exits": {
             "Death Mountain": "True",
             "Death Mountain Crater Lower": "can_use(Hover_Boots)",
-            "Death Mountain Crater Central": "can_use(Distant_Scarecrow)",
+            "Death Mountain Crater Central": "has_GoronTunic and can_use(Distant_Scarecrow) and 
+                ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
+                    has_bottle or can_use(Nayrus_Love))",
             "Top of Crater Grotto": "can_blast_or_smash",
             "Death Mountain Crater Gossip Stone": "has_explosives",
             "Death Mountain Trail Gossip Stone": "


### PR DESCRIPTION
1. Added means of dealing with the Skulltula to reach the basement chest in Deku Tree.
2. There was a lava run in Fire Temple MQ that couldn't be reasonably done on 3 hearts in quad damage.
3. There was a lava run in Goron City that couldn't be reasonably done on 3 hearts in quad damage.
4. The scarecrow route into central crater can't be done in time with 3 hearts without Goron Tunic. It also takes a full heart of fall damage and so can't be done on ohko or in 3 hearts with quad damage, without a fairy or Nayru's.