### PR TITLE
Fix MQ Forest Temple Key Placement (Issue #354)

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -44,6 +44,10 @@ def set_rules(world):
         elif not 'Deku Scrub' in location.name:
             add_item_rule(location, lambda location, item: item.type != 'Shop')
 
+        if location.name == 'Forest Temple MQ First Chest' and world.shuffle_bosskeys == 'dungeon' and world.shuffle_smallkeys == 'dungeon' and world.tokensanity == 'off':
+            # This location needs to be a small key. Make sure the boss key isn't placed here.
+            forbid_item(location, 'Boss Key (Forest Temple)')
+
     for location in world.disabled_locations:
         try:
             world.get_location(location).disabled = DisableType.PENDING


### PR DESCRIPTION
Forest Temple MQ has a chest that can be only viable for a small key, so we need to make sure the boss key isn't placed there in those cases.