### PR TITLE
Add option for starting with Tycoon wallet

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -922,6 +922,11 @@ def get_pool_core(world):
     for item,max in item_difficulty_max[world.item_pool_value].items():
         replace_max_item(pool, item, max)
 
+    if world.start_with_wallet:
+        replace_max_item(pool, 'Progressive Wallet', 0)
+        for i in [1, 2, 3]: # collect wallets
+            world.state.collect(ItemFactory('Progressive Wallet'))
+
     return (pool, placed_items)
 
 

--- a/Patches.py
+++ b/Patches.py
@@ -833,7 +833,14 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
         write_bits_to_save(0x00B1, 0x06) # "Ice Map/Compass"
 
     if world.start_with_rupees:
-        write_byte_to_save(0x0035, 0x63) # start with 99 rupees
+        if world.start_with_wallet:
+            write_byte_to_save(0x0034, 0x03) # start with 999 rupees if tycoon, first byte
+            write_byte_to_save(0x0035, 0xE7) # second byte
+        else:
+            write_byte_to_save(0x0035, 0x63) # start with 99 rupees
+
+    if world.start_with_wallet:
+        write_bits_to_save(0x00A2, 0x30) # tycoon's wallet
 
     if world.start_with_deku_equipment:
         if world.shopsanity == "off":

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -819,6 +819,18 @@ setting_infos = [
                              Start the game with 99 rupees.
                              ''',
             shared         = True,
+            ),         
+    Checkbutton(
+            name           = 'start_with_wallet',
+            args_help      = '''\
+                             Start with Tycoon's Wallet.
+                             ''',
+            gui_text       = 'Start with Tycoon\'s Wallet',
+            gui_group      = 'convenience',
+            gui_tooltip    = '''\
+                             Start the game with the largest wallet (999 max).
+                             ''',
+            shared         = True,
             ),
     Checkbutton(
             name           = 'start_with_deku_equipment',


### PR DESCRIPTION
I find it frustrating to open chests containing purple or larger rupees and be unable to hold them, plus wallets are kind of an annoying gate to attaining items. This option starts Link with the largest wallet.

Also if combined with "Start with Max rupees" it accounts for the increased capacity.