### PR TITLE
Make Morpha Heart have the same rules as Morpha

### DIFF
--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -7,8 +7,7 @@
             "Water Temple MQ Central Pillar Chest": "
                 has_ZoraTunic and Iron_Boots and 
                 (can_use(Fire_Arrows) or (can_use(Dins_Fire) and can_play(Song_of_Time)))",
-            "Morpha Heart": "
-                Boss_Key_Water_Temple and can_use(Longshot) and Iron_Boots",
+            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot)",
             "Morpha": "Boss_Key_Water_Temple and can_use(Longshot)"
         },
         "exits": {

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -21,7 +21,7 @@
                 (can_play(Zeldas_Lullaby) or keysanity) and 
                 ((has_explosives and Progressive_Strength_Upgrade) or Hover_Boots) and 
                 can_use(Longshot)",
-            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot) and Iron_Boots",
+            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot)",
             "Morpha": "Boss_Key_Water_Temple and can_use(Longshot)",
             "GS Water Temple South Basement": "has_explosives and can_play(Zeldas_Lullaby) and Iron_Boots",
             "GS Water Temple Near Boss Key Chest": "


### PR DESCRIPTION
If the "Gold Scale to Morpha" trick enables Morpha's stone/medallion to be reached without Iron Boots, I see no reason why it shouldn't also apply to Morpha's heart?

([absolutely not trying to put IB in a location only reachable after beating Morpha in a plando…](https://tvtropes.org/pmwiki/pmwiki.php/Main/SuspiciouslySpecificDenial))