### PR TITLE
Add way to not repatch cosmetics when applying patch file.

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -585,6 +585,7 @@ def guiMain(settings=None):
 
     # Create the generation menu
     def update_generation_type(event=None):
+        settings = guivars_to_settings(guivars)
         if generation_notebook.tab(generation_notebook.select())['text'] == 'Generate From Seed':
             notebook.tab(1, state="normal")
             if guivars['logic_rules'].get() == 'Glitchless':
@@ -592,8 +593,8 @@ def guiMain(settings=None):
             else:
                 notebook.tab(2, state="disabled")
             notebook.tab(3, state="normal")
-
-            settings = guivars_to_settings(guivars)
+            notebook.tab(4, state="normal")
+            notebook.tab(5, state="normal")
             toggle_widget(widgets['world_count'], settings.check_dependency('world_count'))
             toggle_widget(widgets['create_spoiler'], settings.check_dependency('create_spoiler'))
             toggle_widget(widgets['count'], settings.check_dependency('count'))
@@ -602,6 +603,14 @@ def guiMain(settings=None):
             notebook.tab(1, state="disabled")
             notebook.tab(2, state="disabled")
             notebook.tab(3, state="disabled")
+            if guivars['repatch_cosmetics'].get():
+                notebook.tab(4, state="normal")
+                notebook.tab(5, state="normal")
+                toggle_widget(widgets['create_cosmetics_log'], settings.check_dependency('create_cosmetics_log'))
+            else:
+                notebook.tab(4, state="disabled")
+                notebook.tab(5, state="disabled")
+                toggle_widget(widgets['create_cosmetics_log'], False)
             toggle_widget(widgets['world_count'], False)
             toggle_widget(widgets['create_spoiler'], False)
             toggle_widget(widgets['count'], False)
@@ -696,8 +705,14 @@ def guiMain(settings=None):
         settings = guivars_to_settings(guivars)
         BackgroundTaskProgress(mainWindow, "Generating From File %s..." % os.path.basename(settings.patch_file), from_patch_file, settings)
 
-    generateFileButton = Button(frames['gen_from_file'], text='Generate Patched ROM', command=generateFromFile)
-    generateFileButton.pack(side=BOTTOM, anchor=E, pady=(0,10), padx=(0, 10))
+    patchCosmeticsAndGenerateFrame = Frame(frames['gen_from_file'])
+    guivars['repatch_cosmetics'] = IntVar()
+    widgets['repatch_cosmetics'] = Checkbutton(patchCosmeticsAndGenerateFrame, text='Patch Cosmetics', variable=guivars['repatch_cosmetics'], justify=LEFT, wraplength=220, command=show_settings)
+    widgets['repatch_cosmetics'].pack(side=LEFT, anchor=W)
+
+    generateFileButton = Button(patchCosmeticsAndGenerateFrame, text='Generate Patched ROM', command=generateFromFile)
+    generateFileButton.pack(side=RIGHT, anchor=E)
+    patchCosmeticsAndGenerateFrame.pack(side=BOTTOM, fill=BOTH, expand=True, pady=(0,10), padx=(0, 10))
 
     generation_notebook.pack(fill=BOTH, expand=True, padx=5, pady=5)
 

--- a/Main.py
+++ b/Main.py
@@ -163,7 +163,7 @@ def main(settings, window=dummy_window()):
 
             random.setstate(rng_state)
             patch_rom(spoiler, world, rom)
-            patch_cosmetics(settings, rom)
+            cosmetics_log = patch_cosmetics(settings, rom)
             window.update_progress(65 + 20*(world.id + 1)/settings.world_count)
 
             window.update_status('Creating Patch File')
@@ -173,13 +173,23 @@ def main(settings, window=dummy_window()):
             rom.restore()
             window.update_progress(65 + 30*(world.id + 1)/settings.world_count)
 
+            if settings.create_cosmetics_log and cosmetics_log:
+                window.update_status('Creating Cosmetics Log')
+                if settings.world_count > 1:
+                    cosmetics_log_filename = "%sP%d_Cosmetics.txt" % (outfilebase, world.id + 1)
+                else:
+                    cosmetics_log_filename = '%s_Cosmetics.txt' % outfilebase
+                cosmetics_log.to_file(os.path.join(output_dir, cosmetics_log_filename))
+                file_list.append(cosmetics_log_filename)
+            cosmetics_log = None
+
         if settings.world_count > 1:
             window.update_status('Creating Patch Archive')
             output_path = os.path.join(output_dir, '%s.zpfz' % outfilebase)
             with zipfile.ZipFile(output_path, mode="w") as patch_archive:
                 for index, file in enumerate(file_list):
                     file_path = os.path.join(output_dir, file)
-                    patch_archive.write(file_path, 'P%d.zpf' % (index + 1), compress_type=zipfile.ZIP_DEFLATED)
+                    patch_archive.write(file_path, file.replace(outfilebase, ''), compress_type=zipfile.ZIP_DEFLATED)
             for file in file_list:
                 os.remove(os.path.join(output_dir, file))
         logger.info("Created patchfile at: %s" % output_path)
@@ -297,7 +307,9 @@ def from_patch_file(settings, window=dummy_window()):
         if not settings.output_file:
             output_path += 'P%d' % (settings.player_num)
     apply_patch_file(rom, settings.patch_file, subfile)
-    cosmetics_log = patch_cosmetics(settings, rom)
+    cosmetics_log = None
+    if settings.repatch_cosmetics:
+        cosmetics_log = patch_cosmetics(settings, rom)
     window.update_progress(65)
 
     window.update_status('Saving Uncompressed ROM')

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -346,6 +346,16 @@ setting_infos = [
 
     # GUI Settings
     Checkbutton(
+        name           = 'repatch_cosmetics',
+        gui_text       = 'Patch Cosmetics',
+        gui_tooltip    = '''\
+                         Enabling this will re-patch cosmetics based on current settings.
+                         Otherwise, it will utilize the cosmetics that are in the patch file.
+                         ''',
+        default        = True,
+        shared         = False,
+    ),
+    Checkbutton(
         name           = 'create_spoiler',
         gui_text       = 'Create Spoiler Log',
         gui_group      = 'rom_tab',
@@ -360,7 +370,7 @@ setting_infos = [
         gui_text       = 'Create Cosmetics Log',
         gui_group      = 'rom_tab',
         default        = True,
-        dependency     = lambda settings: False if settings.compress_rom in ['None', 'Patch'] else None,
+        dependency     = lambda settings: False if settings.compress_rom == 'None' else None,
     ),
     Setting_Info(
         name           = 'compress_rom',


### PR DESCRIPTION
Also allows generation of cosmetics log when creating patch files. For multiworld, these cosmetic logs will be embedded in the patch file archive.