### PR TITLE
Logic Update

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -317,8 +317,9 @@ logic_tricks = {
                     and Longshot, the chest can be reached with no additional
                     items aside from Small Keys. Stand on the blue switch
                     with the Iron Boots, wait for the water to rise all the
-                    way up, and then quickly swim up to the exit. You will
-                    grab the ledge as you surface.
+                    way up, and then swim straight to the exit. You should
+                    grab the ledge as you surface. It works best if you don't
+                    mash B.
                     '''},
     'Adult Kokiri Forest GS with Hover Boots': {
         'name'    : 'logic_adult_kokiri_gs',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -183,151 +183,15 @@ def logic_tricks_list_tooltip(widget, pos):
 
 
 logic_tricks = {
-    'Bottom of the Well Basement Chest with Strength & Sticks': {
-        'name'    : 'logic_botw_basement',
+    'Morpha with Gold Scale': {
+        'name'    : 'logic_morpha_with_scale',
         'tooltip' : '''\
-                    The chest in the basement can be reached with
-                    strength by doing a jump slash with a lit
-                    stick to access the bomb flowers.
-                    '''},
-    'Deku Tree Basement Vines GS with Jump Slash': {
-        'name'    : 'logic_deku_basement_gs',
-        'tooltip' : '''\
-                    Can be defeated by doing a precise jump slash.
-                    '''},
-    'Dodongo\'s Cavern Staircase with Bow': {
-        'name'    : 'logic_dc_staircase',
-        'tooltip' : '''\
-                    The Bow can be used to knock down the stairs
-                    with two well-timed shots.
-                    '''},
-    'Fire Temple MQ Boss Key Chest without Bow': {
-        'name'    : 'logic_fire_mq_bk_chest',
-        'tooltip' : '''\
-                    Din\'s alone can be used to unbar the door to
-                    the boss key chest's room thanks to an
-                    oversight in the way the game counts how many
-                    torches have been lit.
-                    '''},
-    'Fire Temple MQ Upper Maze without Explosives': {
-        'name'    : 'logic_fire_mq_upper_maze',
-        'tooltip' : '''\
-                    The switch to spawn the hookshot targets can
-                    be hammered through the bombable wall.
-                    '''},
-    'Fire Temple Highest Goron without Song of Time': {
-        'name'    : 'logic_fire_highest_goron',
-        'tooltip' : '''\
-                    The switch to free the highest Goron can
-                    be hammered through the Song of Time block.
-                    '''},
-    'Skip Forest Temple MQ Block Puzzle with Bombchu': {
-        'name'    : 'logic_forest_mq_block_puzzle',
-        'tooltip' : '''\
-                    Send the Bombchu straight up the center of the
-                    wall directly to the left upon entering the room.
-                    '''},
-    'Swim Through Forest Temple Well with Hookshot': {
-        'name'    : 'logic_forest_well_swim',
-        'tooltip' : '''\
-                    Shoot the vines in the well as low and as far to
-                    the right as possible, and then immediately swim
-                    under the ceiling to the right. This can only be
-                    required if Forest Temple is in its Master Quest
-                    form.
-                    '''},
-    'Forest Temple East Courtyard Vines with Hookshot': {
-        'name'    : 'logic_forest_vines',
-        'tooltip' : '''\
-                    The vines in Forest Temple leading to where the well
-                    drain switch is in the standard form can be barely
-                    reached with just the Hookshot.
-                    '''},
-    'Ganon\'s Castle MQ Spirit Trial First Room without Bow': {
-        'name'    : 'logic_ganon_mq_spirit_trial',
-        'tooltip' : '''\
-                    The switch to unbar the door can be hammered through
-                    the thrones.
-                    '''},
-    'Gerudo Training Grounds MQ Left Side Silver Rupees with Hookshot': {
-        'name'    : 'logic_gtg_mq_with_hookshot',
-        'tooltip' : '''\
-                    The highest silver rupee can be obtained by
-                    hookshotting the target and then immediately jump
-                    slashing toward the rupee.
-                    '''},
-    'Adult Kokiri Forest GS with Hover Boots': {
-        'name'    : 'logic_adult_kokiri_gs',
-        'tooltip' : '''\
-                    Can be obtained without Hookshot by using the Hover
-                    Boots off of one of the roots.
-                    '''},
-    'Gerudo Fortress "Kitchen" with Nothing': {
-        'name'    : 'logic_gerudo_kitchen',
-        'tooltip' : '''\
-                    The logic normally guarantees one of Bow, Hookshot,
-                    or Hover Boots.
-                    '''},
-    'Death Mountain Trail Bombable Chest with Strength': {
-        'name'    : 'logic_dmt_bombable',
-        'tooltip' : '''\
-                    Child Link can blow up the wall using a nearby bomb
-                    flower. You must backwalk with the flower and then
-                    quickly throw it toward the wall.
-                    '''},
-    'Spirit Temple MQ Frozen Eye Switch without Fire': {
-        'name'    : 'logic_spirit_mq_frozen_eye',
-        'tooltip' : '''\
-                    You can melt the ice by shooting an arrow through a
-                    torch. The only way to find a line of sight for this
-                    shot is to first spawn a Song of Time block, and then
-                    stand on the very edge of it.
-                    '''},
-    'Spirit Temple Child Side Bridge with Bombchu': {
-        'name'    : 'logic_spirit_child_bombchu',
-        'tooltip' : '''\
-                    A carefully-timed Bombchu can hit the switch.
-                    '''},
-    'Man on Roof without Hookshot': {
-        'name'    : 'logic_man_on_roof',
-        'tooltip' : '''\
-                    Can be reached by side-hopping off
-                    the watchtower.
-                    '''},
-    'Child Deadhand without Kokiri Sword': {
-        'name'    : 'logic_child_deadhand',
-        'tooltip' : '''\
-                    Requires 9 sticks or 5 jump slashes.
-                    '''},
-    'Dodongo\'s Cavern Spike Trap Room Jump without Hover Boots': {
-        'name'    : 'logic_dc_jump',
-        'tooltip' : '''\
-                    Jump is adult only.
-                    '''},
-    'Windmill PoH as Adult with Nothing': {
-        'name'    : 'logic_windmill_poh',
-        'tooltip' : '''\
-                    Can jump up to the spinning platform from
-                    below as adult.
-                    '''},
-    'Crater\'s Bean PoH with Hover Boots': {
-        'name'    : 'logic_crater_bean_poh_with_hovers',
-        'tooltip' : '''\
-                    Hover from the base of the bridge
-                    near Goron City and walk up the
-                    very steep slope.
-                    '''},
-    'Zora\'s Domain Entry with Cucco': {
-        'name'    : 'logic_zora_with_cucco',
-        'tooltip' : '''\
-                    Can fly behind the waterfall with
-                    a cucco as child.
-                    '''},
-    'Zora\'s Domain Entry with Hover Boots': {
-        'name'    : 'logic_zora_with_hovers',
-        'tooltip' : '''\
-                    Can hover behind the waterfall as adult.
-                    This is very difficult.
+                    Allows entering Water Temple and beating
+                    Morpha with Gold Scale instead of Iron Boots.
+                    Only applicable for keysanity and keysy due
+                    to the logic always seeing every chest in
+                    Water Temple that could contain the Boss Key
+                    as requiring Iron Boots.
                     '''},
     'Fewer Tunic Requirements': {
         'name'    : 'logic_fewer_tunic_requirements',
@@ -343,15 +207,152 @@ logic_tricks = {
                     Silver Rupee Chest. May need to make multiple
                     trips.
                     '''},
-    'Morpha with Gold Scale': {
-        'name'    : 'logic_morpha_with_scale',
+
+    'Child Deadhand without Kokiri Sword': {
+        'name'    : 'logic_child_deadhand',
         'tooltip' : '''\
-                    Allows entering Water Temple and beating
-                    Morpha with Gold Scale instead of Iron Boots.
-                    Only applicable for keysanity and keysy due
-                    to the logic always seeing every chest in
-                    Water Temple that could contain the Boss Key
-                    as requiring Iron Boots.
+                    Requires 9 sticks or 5 jump slashes.
+                    '''},
+    'Man on Roof without Hookshot': {
+        'name'    : 'logic_man_on_roof',
+        'tooltip' : '''\
+                    Can be reached by side-hopping off
+                    the watchtower.
+                    '''},
+    'Dodongo\'s Cavern Staircase with Bow': {
+        'name'    : 'logic_dc_staircase',
+        'tooltip' : '''\
+                    The Bow can be used to knock down the stairs
+                    with two well-timed shots.
+                    '''},
+    'Dodongo\'s Cavern Spike Trap Room Jump without Hover Boots': {
+        'name'    : 'logic_dc_jump',
+        'tooltip' : '''\
+                    Jump is adult only.
+                    '''},
+    'Gerudo Fortress "Kitchen" with No Additional Items': {
+        'name'    : 'logic_gerudo_kitchen',
+        'tooltip' : '''\
+                    The logic normally guarantees one of Bow, Hookshot,
+                    or Hover Boots.
+                    '''},
+    'Deku Tree Basement Vines GS with Jump Slash': {
+        'name'    : 'logic_deku_basement_gs',
+        'tooltip' : '''\
+                    Can be defeated by doing a precise jump slash.
+                    '''},
+    'Hammer Rusted Switches Through Walls': {
+        'name'    : 'logic_rusted_switches',
+        'tooltip' : '''\
+                    Applies to:
+                    - Fire Temple Highest Goron Chest.
+                    - MQ Fire Temple Lizalfos Maze.
+                    - MQ Spirit Trial.
+                    '''},
+    'Bottom of the Well Basement Chest with Strength & Sticks': {
+        'name'    : 'logic_botw_basement',
+        'tooltip' : '''\
+                    The chest in the basement can be reached with
+                    strength by doing a jump slash with a lit
+                    stick to access the bomb flowers.
+                    '''},
+    'Skip Forest Temple MQ Block Puzzle with Bombchu': {
+        'name'    : 'logic_forest_mq_block_puzzle',
+        'tooltip' : '''\
+                    Send the Bombchu straight up the center of the
+                    wall directly to the left upon entering the room.
+                    '''},
+    'Spirit Temple Child Side Bridge with Bombchu': {
+        'name'    : 'logic_spirit_child_bombchu',
+        'tooltip' : '''\
+                    A carefully-timed Bombchu can hit the switch.
+                    '''},
+    'Windmill PoH as Adult with Nothing': {
+        'name'    : 'logic_windmill_poh',
+        'tooltip' : '''\
+                    Can jump up to the spinning platform from
+                    below as adult.
+                    '''},
+    'Crater\'s Bean PoH with Hover Boots': {
+        'name'    : 'logic_crater_bean_poh_with_hovers',
+        'tooltip' : '''\
+                    Hover from the base of the bridge
+                    near Goron City and walk up the
+                    very steep slope.
+                    '''},
+    'Gerudo Training Grounds MQ Left Side Silver Rupees with Hookshot': {
+        'name'    : 'logic_gtg_mq_with_hookshot',
+        'tooltip' : '''\
+                    The highest silver rupee can be obtained by
+                    hookshotting the target and then immediately jump
+                    slashing toward the rupee.
+                    '''},
+    'Forest Temple East Courtyard Vines with Hookshot': {
+        'name'    : 'logic_forest_vines',
+        'tooltip' : '''\
+                    The vines in Forest Temple leading to where the well
+                    drain switch is in the standard form can be barely
+                    reached with just the Hookshot.
+                    '''},
+    'Swim Through Forest Temple MQ Well with Hookshot': {
+        'name'    : 'logic_forest_well_swim',
+        'tooltip' : '''\
+                    Shoot the vines in the well as low and as far to
+                    the right as possible, and then immediately swim
+                    under the ceiling to the right. This can only be
+                    required if Forest Temple is in its Master Quest
+                    form.
+                    '''},
+    'Death Mountain Trail Bombable Chest with Strength': {
+        'name'    : 'logic_dmt_bombable',
+        'tooltip' : '''\
+                    Child Link can blow up the wall using a nearby bomb
+                    flower. You must backwalk with the flower and then
+                    quickly throw it toward the wall.
+                    '''},
+    'Water Temple Boss Key Chest with No Additional Items': {
+        'name'    : 'logic_water_bk_chest',
+        'tooltip' : '''\
+                    After reaching the Boss Key chest's area with Iron Boots
+                    and Longshot, the chest can be reached with no additional
+                    items aside from Small Keys. Stand on the blue switch
+                    with the Iron Boots, wait for the water to rise all the
+                    way up, and then quickly swim up to the exit. You will
+                    grab the ledge as you surface.
+                    '''},
+    'Adult Kokiri Forest GS with Hover Boots': {
+        'name'    : 'logic_adult_kokiri_gs',
+        'tooltip' : '''\
+                    Can be obtained without Hookshot by using the Hover
+                    Boots off of one of the roots.
+                    '''},
+    'Spirit Temple MQ Frozen Eye Switch without Fire': {
+        'name'    : 'logic_spirit_mq_frozen_eye',
+        'tooltip' : '''\
+                    You can melt the ice by shooting an arrow through a
+                    torch. The only way to find a line of sight for this
+                    shot is to first spawn a Song of Time block, and then
+                    stand on the very edge of it.
+                    '''},
+    'Fire Temple MQ Boss Key Chest without Bow': {
+        'name'    : 'logic_fire_mq_bk_chest',
+        'tooltip' : '''\
+                    Din\'s alone can be used to unbar the door to
+                    the boss key chest's room thanks to an
+                    oversight in the way the game counts how many
+                    torches have been lit.
+                    '''},
+    'Zora\'s Domain Entry with Cucco': {
+        'name'    : 'logic_zora_with_cucco',
+        'tooltip' : '''\
+                    Can fly behind the waterfall with
+                    a cucco as child.
+                    '''},
+    'Zora\'s Domain Entry with Hover Boots': {
+        'name'    : 'logic_zora_with_hovers',
+        'tooltip' : '''\
+                    Can hover behind the waterfall as adult.
+                    This is very difficult.
                     '''},
 }
 

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -54,7 +54,7 @@
         },
         "exits": {
             "Fire Upper Maze": "
-                (has_explosives or logic_fire_mq_upper_maze) and can_use(Hookshot)"
+                (has_explosives or logic_rusted_switches) and can_use(Hookshot)"
         }
     },
     {

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -61,7 +61,7 @@
         "locations": {
             "Fire Temple Highest Goron Chest": "
                 can_use(Hammer) and 
-                (can_play(Song_of_Time) or (logic_fire_highest_goron and 
+                (can_play(Song_of_Time) or (logic_rusted_switches and 
                     (can_use(Hover_Boots) or has_explosives)))",
             "Fire Temple Megaton Hammer Chest": "has_explosives"
         }

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -78,9 +78,9 @@
         "region_name": "Ganons Castle Spirit Trial",
         "dungeon": "Ganons Castle",
         "locations": {
-            "Ganons Castle MQ Spirit Trial First Chest": "(has_bow or logic_ganon_mq_spirit_trial) and Hammer",
+            "Ganons Castle MQ Spirit Trial First Chest": "(has_bow or logic_rusted_switches) and Hammer",
             "Ganons Castle MQ Spirit Trial Second Chest": "
-                (has_bow or logic_ganon_mq_spirit_trial) and Hammer and 
+                (has_bow or logic_rusted_switches) and Hammer and 
                 has_bombchus and can_see_with_lens",
             "Ganons Castle MQ Spirit Trial Sun Front Left Chest": "
                 Hammer and has_bombchus and 

--- a/data/World/Gerudo Training Grounds MQ.json
+++ b/data/World/Gerudo Training Grounds MQ.json
@@ -58,7 +58,7 @@
         },
         "exits": {
             "Gerudo Training Grounds Central Maze Right": "Hammer",
-            "Gerudo Training Grounds Right Side": "True"
+            "Gerudo Training Grounds Right Side": "can_use(Longshot)"
         }
     },
     {
@@ -69,6 +69,9 @@
             "Gerudo Training Grounds MQ Maze Right Side Chest": "True",
             "Gerudo Training Grounds MQ Ice Arrows Chest": "
                 (Small_Key_Gerudo_Training_Grounds, 3)"
+        },
+        "exits": {
+            "Gerudo Training Grounds Right Side": "True"
         }
     }
 ]

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -40,7 +40,7 @@
             "Shadow Temple MQ Falling Spikes Switch Chest": "Progressive_Strength_Upgrade",
             "Shadow Temple MQ Invisible Spikes Chest": "Hover_Boots and (Small_Key_Shadow_Temple, 3)",
             "Shadow Temple MQ Stalfos Room Chest": "
-                Hover_Boots and (Small_Key_Shadow_Temple, 3) and can_use(Longshot)",
+                Hover_Boots and (Small_Key_Shadow_Temple, 3) and Progressive_Hookshot",
             "GS Shadow Temple MQ Crusher Room": "Progressive_Hookshot"
         },
         "exits": {

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -122,7 +122,7 @@
                         ((Small_Key_Spirit_Temple, 2) and Boomerang and bombchus_in_logic)))",
             "GS Spirit Temple Lobby": "
                 can_use(Silver_Gauntlets) and (Small_Key_Spirit_Temple, 3) and 
-                (can_use(Longshot) or can_use(Scarecrow) or Hover_Boots)"
+                (Progressive_Hookshot or Hover_Boots)"
         },
         "exits": {
             "Spirit Temple Outdoor Hands": "True",
@@ -163,7 +163,7 @@
         "locations": {
             "Spirit Temple Boss Key Chest": "
                 can_play(Zeldas_Lullaby) and has_bow and 
-                Progressive_Hookshot and can_blast_or_smash",
+                Progressive_Hookshot",
             "Spirit Temple Topmost Chest": "Mirror_Shield",
             "Twinrova Heart": "
                 Mirror_Shield and has_explosives and 

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -19,7 +19,7 @@
             "Water Temple Boss Key Chest": "
                 (Small_Key_Water_Temple, 6) and Iron_Boots and 
                 (can_play(Zeldas_Lullaby) or keysanity) and 
-                ((has_explosives and Progressive_Strength_Upgrade) or Hover_Boots) and 
+                (logic_water_bk_chest or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots) and 
                 can_use(Longshot)",
             # If the player leaves the dungeon without collecting the item at Morpha Heart,
             # they won't be able to come back without Iron Boots.


### PR DESCRIPTION
1. Fixed bug with Gerudo Training Grounds MQ Left Side Silver Rupees without Hookshot option.
2. Removed need to destroy door to hit eye switch in Spirit Temple BK room. Just shoot the door once to make it fall, then you can shoot the switch behind it.
3. Shadow Temple MQ Redead Silver Rupees does not require Longshot.
4. Renamed "Gerudo Fortress Kitchen With Nothing" to "Gerudo Fortress Kitchen with No Additional Items".
5. Reordered trick list in approximate order of difficulty. (I'm not sure this actually accomplished anything.)
6. Combined three tricks into a single trick, Hammer Rusted Switches Through Walls.
7. Removed scarecrow from logic for Spirit Lobby GS. If you walk up the arm you can get a good line of sight with just the Hookshot.
8. Added "Water Temple Boss Key Chest with No Additional Items".