### PR TITLE
Small: Fix Multiworld Gold Skulltula get item text

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -170,7 +170,7 @@ ITEM_MESSAGES = {
     0x00AD: "\x08\x13\x05You got \x05\x41Din's Fire\x05\x40!\x01Its fireball engulfs everything!",
     0x00AE: "\x08\x13\x0DYou got \x05\x42Farore's Wind\x05\x40!\x01This is warp magic you can use!",
     0x00AF: "\x08\x13\x13You got \x05\x43Nayru's Love\x05\x40!\x01Cast this to create a powerful\x01protective barrier.",
-    0x00B4: "\x08You got a \x05\x41Gold Skulltula Token\x05\x40!\x01You've collected \x05\x41\x19\x05\x40 in total.",
+    0x00B4: "\x08You got a \x05\x41Gold Skulltula Token\x05\x40!\x01You[expl]'ve collected \x05\x41\x19\x05\x40 tokens in total.",
     0x00B5: "\x08You destroyed a \x05\x41Gold Skulltula\x05\x40.\x01You got a token proving you \x01destroyed it!", #Unused
     0x00C2: "\x08\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01Collect four pieces total to get\x01another Heart Container.",
     0x00C3: "\x08\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01So far, you've collected two \x01pieces.",
@@ -178,7 +178,7 @@ ITEM_MESSAGES = {
     0x00C5: "\x08\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01You've completed another Heart\x01Container!",
     0x00C6: "\x08\x13\x72You got a \x05\x41Heart Container\x05\x40!\x01Your maximum life energy is \x01increased by one heart.",
     0x00C7: "\x08\x13\x74You got the \x05\x41Boss Key\x05\x40!\x01Now you can get inside the \x01chamber where the Boss lurks.",
-	0x9002: "\x08You are a \x05\x43FOOL\x05\x40!",
+    0x9002: "\x08You are a \x05\x43FOOL\x05\x40!",
     0x00CC: "\x08You got a \x05\x43Blue Rupee\x05\x40!\x01That's \x05\x43five Rupees\x05\x40!",
     0x00CD: "\x08\x13\x53You got the \x05\x43Silver Scale\x05\x40!\x01You can dive deeper than you\x01could before.",
     0x00CE: "\x08\x13\x54You got the \x05\x43Golden Scale\x05\x40!\x01Now you can dive much\x01deeper than you could before!",
@@ -673,35 +673,35 @@ def move_shop_item_messages(messages, shop_items):
             shop.purchase_message |= 0x8000
 
 def make_player_message(text):
-    player_text_U = '\x05\x42\x0F\x05\x40'
-    player_text_L = '\x05\x42\x0F\x05\x40'
+    player_text = '\x05\x42\x0F\x05\x40'
     pronoun_mapping = {
-        'You have ': player_text_U + ' ',
-        'You\'ve ':  player_text_U + ' ',
-        'Your ':     player_text_U + '\'s ',
-        'You ':      player_text_U + ' ',
+        "You have ": player_text + " ",
+        "You've ":   player_text + " ",
+        "Your ":     player_text + "'s ",
+        "You ":      player_text + " ",
+        "You[expl]":               "You",
 
-        'you have ': player_text_L + ' ',
-        'you\'ve ':  player_text_L + ' ',
-        'your ':     player_text_L + '\'s ',
-        'you ':      player_text_L + ' ',
+        "you have ": player_text + " ",
+        "you've ":   player_text + " ",
+        "your ":     player_text + "'s ",
+        "you ":      player_text + " ",
+        "you[expl]":               "you",
     }
 
     verb_mapping = {
         'obtained ': 'got ',
         'received ': 'got ',
-        'learned ': 'got ',
+        'learned ':  'got ',
         'borrowed ': 'got ',
-        'found ': 'got ',
+        'found ':    'got ',
     }
 
     new_text = text
-    for find_text, replace_text in pronoun_mapping.items():
-        if find_text in text:
-            new_text = new_text.replace(find_text, replace_text, 1)
-            break
-    for find_text, replace_text in verb_mapping.items():
-        new_text = new_text.replace(find_text, replace_text)
+    for search, replacement in pronoun_mapping.items():
+        if search in text:
+            new_text = new_text.replace(search, replacement)
+    for search, replacement in verb_mapping.items():
+        new_text = new_text.replace(search, replacement)
     return new_text
 
 

--- a/Messages.py
+++ b/Messages.py
@@ -672,20 +672,30 @@ def move_shop_item_messages(messages, shop_items):
         if is_in_item_range(shop.purchase_message):
             shop.purchase_message |= 0x8000
 
-def make_player_message(text):
+def update_for_single(text):
+    string_mapping = {
+        "You[expl]": "You",
+        "you[expl]": "you",
+    }
+
+    new_text = text
+    for search, replacement in string_mapping.items():
+        if search in text:
+            new_text = new_text.replace(search, replacement)
+    return new_text
+
+def update_for_multi(text):
     player_text = '\x05\x42\x0F\x05\x40'
     pronoun_mapping = {
         "You have ": player_text + " ",
         "You've ":   player_text + " ",
         "Your ":     player_text + "'s ",
         "You ":      player_text + " ",
-        "You[expl]":               "You",
 
         "you have ": player_text + " ",
         "you've ":   player_text + " ",
         "your ":     player_text + "'s ",
         "you ":      player_text + " ",
-        "you[expl]":               "you",
     }
 
     verb_mapping = {
@@ -702,7 +712,7 @@ def make_player_message(text):
             new_text = new_text.replace(search, replacement)
     for search, replacement in verb_mapping.items():
         new_text = new_text.replace(search, replacement)
-    return new_text
+    return update_for_single(new_text)
 
 
 # reduce item message sizes and add new item messages
@@ -712,9 +722,9 @@ def update_item_messages(messages, world):
     new_item_messages.update(KEYSANITY_MESSAGES)
     for id, text in new_item_messages.items():
         if world.world_count > 1:
-            update_message_by_id(messages, id, make_player_message(text), 0x23)
+            update_message_by_id(messages, id, update_for_multi(text), 0x23)
         else:
-            update_message_by_id(messages, id, text, 0x23)
+            update_message_by_id(messages, id, update_for_single(text), 0x23)
 
 
 # run all keysanity related patching to add messages for dungeon specific items

--- a/Patches.py
+++ b/Patches.py
@@ -10,7 +10,7 @@ from Hints import writeGossipStoneHints, buildBossRewardHints, \
         buildGanonText, getSimpleHintNoPrefix
 from Utils import data_path
 from Messages import read_messages, update_message_by_id, read_shop_items, \
-        write_shop_items, remove_unused_messages, make_player_message, \
+        write_shop_items, remove_unused_messages, update_for_multi, \
         add_item_messages, repack_messages, shuffle_messages
 from OcarinaSongs import replace_songs
 from MQ import patch_files, File, update_dmadata, insert_space, add_relocations
@@ -1358,7 +1358,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     rom.write_int16(0xB6EC52, 999)
     tycoon_message = "\x08\x13\x57You got a \x05\x43Tycoon's Wallet\x05\x40!\x01Now you can hold\x01up to \x05\x46999\x05\x40 \x05\x46Rupees\x05\x40."
     if world.world_count > 1:
-       tycoon_message = make_player_message(tycoon_message)
+       tycoon_message = update_for_multi(tycoon_message)
     update_message_by_id(messages, 0x00F8, tycoon_message, 0x23)
 
     repack_messages(rom, messages)


### PR DESCRIPTION
Before it would say something like "You got a token, Player X has {your gs count} in total."
Now it should say the reverse. "Player X got the token, you have {your gs count} in total."

Also changed some unrelated aspects of the `make_player_message` function a little. I figure I'm removing redundancies, but maybe not. Testing it on Multi World wouldn't be a bad idea.