### PR TITLE
Closed Forest logic specification

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -588,7 +588,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     # Change Pokey to check DT complete flag
     rom.write_bytes(0xE5400A, [0x8C, 0x4C])
     rom.write_bytes(0xE5400E, [0xB4, 0xA4])
-    if world.open_forest:
+    if (world.open_forest == 'open'):
         rom.write_bytes(0xE5401C, [0x14, 0x0B])
 
     # Fix Shadow Temple to check for different rewards for scene
@@ -797,7 +797,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     elif world.bridge == 'tokens':
         rom.write_int32(symbol, 5)
 
-    if world.open_forest:
+    # "open Deku Tree"
+    if ((world.open_forest == 'open') or (world.open_forest == 'deku') or (world.open_forest == 'dekuLogic')):
         write_bits_to_save(0xED5, 0x10) # "Showed Mido Sword & Shield"
 
     if world.open_door_of_time:

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -484,11 +484,11 @@ setting_infos = [
                 },
             args_help      = '''\
                              Select how to exit Kokiri Forest/access Deku Tree (default: %(default)s)
-                             Open:      Deku Tree and Forest exit are open from the start.
-                             Closed:    Follow the vanilla logic for Kokiri Forest, guaranteed required item in Forest.
-                             Deku:      Same as previous, but with Deku Tree open from the start.
-                             More:      Exit with vanilla requirement, but song and Lost Wood exits included in Logic.
-                             DekuLogic: Same as previous, but Deku Tree is open from the start.
+                             Open:        Deku Tree and Forest exit are open from the start.
+                             Closed:      Follow the vanilla logic for Kokiri Forest, guaranteed required item in Forest.
+                             Deku:        Same as previous, but with Deku Tree open from the start.
+                             Escape:      Exit with vanilla requirement, but song and Lost Wood exits included in Logic.
+                             Deku_escape: Same as previous, but Deku Tree is open from the start.
                              ''',
             gui_text       = 'Kokiri Forest / Deku Tree',
             gui_group      = 'open',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -472,24 +472,46 @@ setting_infos = [
         },
         shared=False,
     ),
-    Checkbutton(
+    Combobox(
             name           = 'open_forest',
+            default        = 'open',
+            choices        = {
+                'open':      'Open Forest',
+                'vanilla':   'Vanilla closed',
+                'deku':      'Open Deku Tree',
+                'more':      'Closed in logic',
+                'dekuLogic': 'Closed in logic w/ Deku Tree open'
+                },
             args_help      = '''\
-                             Mido no longer blocks the path to the Deku Tree, and
-                             the Kokiri boy no longer blocks the path out of the forest.
+                             Select how to exit Kokiri Forest/access Deku Tree (default: %(default)s)
+                             Open:      Deku Tree and Forest exit are open from the start.
+                             Vanilla:   Follow the vanilla requirement for Kokiri Forest, guaranteed required item in Forest.
+                             Deku:      Same as previous, but with Deku Tree open from the start.
+                             More:      Exit with vanilla requirement, but song and Lost Wood exits included in Logic.
+                             DekuLogic: Same as previous, but Deku Tree is open from the start.
                              ''',
-            gui_text       = 'Open Forest',
+            gui_text       = 'Kokiri Forest / Deku Tree',
             gui_group      = 'open',
             gui_tooltip    = '''\
-                             Mido no longer blocks the path to the Deku Tree,
-                             and the Kokiri boy no longer blocks the path out
-                             of the forest.
-
-                             When this option is off, the Kokiri Sword and
-                             Slingshot are always available somewhere
+                             'Open Forest': Mido no longer blocks the path to the Deku Tree, and
+                             the Kokiri boy no longer blocks the path out of the forest.
+                             
+                             'Vanilla closed': Mido blocks the path to the Deku Tree, and
+                             the Kokiri boy blocks the path out of the forest. The Kokiri Sword,
+                             Kokiri shield and Slingshot are always available somewhere
                              in the forest.
+                             
+                             'Open Deku Tree': Same as previous, but Mido no longer blocks the path
+                             to the Deku Tree.
+                             
+                             'Closed in logic': Mido blocks the path to the Deku Tree, and
+                             the Kokiri boy blocks the path out of the forest. You might be expected
+                             to exit using a warp song or one of the Lost Wood exits. Might need to
+                             save-warp back in.
+                             
+                             'Closed in logic w/ Deku Tree open': Same as previous, but Mido no longer
+                             blocks the path to the Deku Tree.
                              ''',
-            default        = True,
             shared         = True,
             ),
     Checkbutton(
@@ -568,7 +590,7 @@ setting_infos = [
             choices        = {
                 'open':       'Always Open',
                 'vanilla':    'Vanilla Requirements',
-                'stones':	  'All Spiritual Stones',
+                'stones':     'All Spiritual Stones',
                 'medallions': 'All Medallions',
                 'dungeons':   'All Dungeons',
                 'tokens':     '100 Gold Skulltula Tokens'

--- a/State.py
+++ b/State.py
@@ -234,7 +234,18 @@ class State(object):
 
 
     def can_leave_forest(self):
-        return self.world.open_forest or self.can_reach(self.world.get_location('Queen Gohma'))
+        if self.world.open_forest == 'open':
+            return True
+        elif ((self.world.open_forest == 'vanilla') or (self.world.open_forest == 'deku')):
+            return self.can_reach(self.world.get_location('Queen Gohma'))
+        else:
+            can_teleport = self.can_play('Prelude of Light') or self.can_play('Serenade of Water') or self.can_play('Nocturne of Shadow')
+            lost_wood_exit = self.has_explosives() or self.can_use('Dins Fire') or self.can_dive()
+            return self.can_reach(self.world.get_location('Queen Gohma')) or lost_wood_exit or can_teleport
+
+
+    def open_deku(self):
+        return (self.has('Kokiri Sword') and self.has('Buy Deku Shield')) or self.world.open_forest == 'open' or self.world.open_forest == 'deku' or self.world.open_forest == 'dekuLogic'
 
 
     def can_finish_adult_trades(self):

--- a/State.py
+++ b/State.py
@@ -245,7 +245,7 @@ class State(object):
 
 
     def open_deku(self):
-        return (self.has('Kokiri Sword') and self.has('Buy Deku Shield')) or self.world.open_forest == 'open' or self.world.open_forest == 'deku' or self.world.open_forest == 'dekuLogic'
+        return (self.has('Kokiri Sword') and self.has('Buy Deku Shield')) or (self.world.open_forest == 'open') or (self.world.open_forest == 'deku') or (self.world.open_forest == 'dekuLogic') or (self.has('Zeldas Letter'))
 
 
     def can_finish_adult_trades(self):

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -7,12 +7,10 @@
             "Deku Tree MQ Slingshot Chest": "can_child_attack",
             "Deku Tree MQ Slingshot Room Back Chest": "has_sticks or can_use(Dins_Fire)",
             "Deku Tree MQ Basement Chest": "has_sticks or can_use(Dins_Fire)",
-            "GS Deku Tree MQ Lobby": "can_child_attack",
-            "Deku Tree Gossip Stone (Left)": "True",
-            "Deku Tree Gossip Stone (Right)": "True"
+            "GS Deku Tree MQ Lobby": "can_child_attack"
         },
         "exits": {
-            "Kokiri Forest": "True",
+            "Deku Tree Glade": "True",
             "Deku Tree Compass Room": "has_slingshot and (has_sticks or can_use(Dins_Fire))",
             "Deku Tree Boss Room": "has_slingshot and (has_sticks or can_use(Dins_Fire))"
         }

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -11,12 +11,10 @@
             "GS Deku Tree Basement Vines": "
                 has_slingshot or Boomerang or has_explosives or can_use(Dins_Fire) or 
                 (logic_deku_basement_gs and (has_sticks or Kokiri_Sword))",
-            "GS Deku Tree Basement Gate": "can_child_attack",
-            "Deku Tree Gossip Stone (Left)": "True",
-            "Deku Tree Gossip Stone (Right)": "True"
+            "GS Deku Tree Basement Gate": "can_child_attack"
         },
         "exits": {
-            "Kokiri Forest": "True",
+            "Deku Tree Glade": "True",
             "Deku Tree Slingshot Room": "Buy_Deku_Shield",
             "Deku Tree Boss Room": "has_slingshot and (has_sticks or can_use(Dins_Fire))"
         }

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -165,7 +165,7 @@
     {
         "region_name": "Lost Woods Bridge",
         "locations": {
-            "Gift from Saria": "True"
+            "Gift from Saria": "(open_forest == 'open') or can_reach(Queen_Gohma, Location)"
         },
         "exits": {
             "Kokiri Forest": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -13,9 +13,9 @@
             "GS Kokiri House of Twins": "
                 (can_use(Hookshot) or 
                     (logic_adult_kokiri_gs and can_use(Hover_Boots))) and nighttime",
-            "Deku Baba Sticks": "open_deku and (is_adult or Kokiri_Sword or Boomerang)",
-            "Deku Baba Nuts": "open_deku and (is_adult or has_slingshot or has_sticks or 
-                        has_explosives or Kokiri_Sword or can_use(Dins_Fire))",
+            "Deku Baba Sticks": "(open_deku and (Kokiri_Sword or Boomerang)) or is_adult",
+            "Deku Baba Nuts": "(open_deku and (has_slingshot or has_sticks or 
+                        has_explosives or Kokiri_Sword or can_use(Dins_Fire))) or is_adult",
             "Kokiri Forest Gossip Stone": "True"
         },
         "exits": {
@@ -27,7 +27,7 @@
             "Kokiri Shop": "True",
             "Deku Tree Lobby": "open_deku",
             "Lost Woods": "True",
-            "Lost Woods Bridge": "(open_forest == 'open') or can_reach(Queen_Gohma, Location)",
+            "Lost Woods Bridge": "(open_forest == 'open') or can_reach(Queen_Gohma, Location) or is_adult",
             "Kokiri Forest Storms Grotto": "can_play(Song_of_Storms)"
         }
     },
@@ -165,7 +165,7 @@
     {
         "region_name": "Lost Woods Bridge",
         "locations": {
-            "Gift from Saria": "(open_forest == 'open') or can_reach(Queen_Gohma, Location)"
+            "Gift from Saria": "(open_forest == 'open') or can_reach(Queen_Gohma, Location) or is_adult"
         },
         "exits": {
             "Kokiri Forest": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -13,9 +13,6 @@
             "GS Kokiri House of Twins": "
                 (can_use(Hookshot) or 
                     (logic_adult_kokiri_gs and can_use(Hover_Boots))) and nighttime",
-            "Deku Baba Sticks": "(open_deku and (Kokiri_Sword or Boomerang)) or is_adult",
-            "Deku Baba Nuts": "(open_deku and (has_slingshot or has_sticks or 
-                        has_explosives or Kokiri_Sword or can_use(Dins_Fire))) or is_adult",
             "Kokiri Forest Gossip Stone": "True"
         },
         "exits": {
@@ -25,10 +22,24 @@
             "House of Twins": "True",
             "Know It All House": "True",
             "Kokiri Shop": "True",
-            "Deku Tree Lobby": "open_deku",
+            "Deku Tree Glade": "open_deku or is_adult",
             "Lost Woods": "True",
             "Lost Woods Bridge": "(open_forest == 'open') or can_reach(Queen_Gohma, Location) or is_adult",
             "Kokiri Forest Storms Grotto": "can_play(Song_of_Storms)"
+        }
+    },
+    {
+        "region_name": "Deku Tree Glade",
+        "locations": {
+            "Deku Baba Sticks": "Kokiri_Sword or Boomerang or is_adult",
+            "Deku Baba Nuts": "has_slingshot or has_sticks or has_explosives
+                        or Kokiri_Sword or can_use(Dins_Fire) or is_adult",
+            "Deku Tree Gossip Stone (Left)": "True",
+            "Deku Tree Gossip Stone (Right)": "True"
+        },
+        "exits": {
+            "Kokiri Forest": "True",
+            "Deku Tree Lobby": "open_deku"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -13,14 +13,9 @@
             "GS Kokiri House of Twins": "
                 (can_use(Hookshot) or 
                     (logic_adult_kokiri_gs and can_use(Hover_Boots))) and nighttime",
-            "Deku Baba Sticks": "
-                (Kokiri_Sword and Buy_Deku_Shield) or 
-                (open_forest and (is_adult or Kokiri_Sword or Boomerang))",
-            "Deku Baba Nuts": "
-                (Kokiri_Sword and Buy_Deku_Shield) or 
-                (open_forest and 
-                    (is_adult or has_slingshot or has_sticks or 
-                        has_explosives or Kokiri_Sword or can_use(Dins_Fire)))",
+            "Deku Baba Sticks": "open_deku and (is_adult or Kokiri_Sword or Boomerang)",
+            "Deku Baba Nuts": "open_deku and (is_adult or has_slingshot or has_sticks or 
+                        has_explosives or Kokiri_Sword or can_use(Dins_Fire))",
             "Kokiri Forest Gossip Stone": "True"
         },
         "exits": {
@@ -30,9 +25,9 @@
             "House of Twins": "True",
             "Know It All House": "True",
             "Kokiri Shop": "True",
-            "Deku Tree Lobby": "(Kokiri_Sword and Buy_Deku_Shield) or open_forest",
+            "Deku Tree Lobby": "open_deku",
             "Lost Woods": "True",
-            "Lost Woods Bridge": "can_leave_forest",
+            "Lost Woods Bridge": "(open_forest == 'open') or can_reach(Queen_Gohma, Location)",
             "Kokiri Forest Storms Grotto": "can_play(Song_of_Storms)"
         }
     },
@@ -47,11 +42,11 @@
             "Forest Temple Entry Area": "can_play(Minuet_of_Forest) and is_adult",
             "Temple of Time": "can_play(Prelude_of_Light) and can_leave_forest",
             "Death Mountain Crater Central": "
-                can_play(Bolero_of_Fire) and can_leave_forest",
+                can_play(Bolero_of_Fire) and (open_forest != 'vanilla' and open_forest != 'deku')",
             "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
             "Shadow Temple Warp Region": "
                 can_play(Nocturne_of_Shadow) and can_leave_forest",
-            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+            "Desert Colossus": "can_play(Requiem_of_Spirit) and (open_forest != 'vanilla' and open_forest != 'deku')"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -42,11 +42,11 @@
             "Forest Temple Entry Area": "can_play(Minuet_of_Forest) and is_adult",
             "Temple of Time": "can_play(Prelude_of_Light) and can_leave_forest",
             "Death Mountain Crater Central": "
-                can_play(Bolero_of_Fire) and (open_forest != 'closed' and open_forest != 'deku')",
+                can_play(Bolero_of_Fire) and ((open_forest == 'escape' or open_forest == 'deku_escape')or can_leave_forest)",
             "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
             "Shadow Temple Warp Region": "
                 can_play(Nocturne_of_Shadow) and can_leave_forest",
-            "Desert Colossus": "can_play(Requiem_of_Spirit) and (open_forest != 'closed' and open_forest != 'deku')"
+            "Desert Colossus": "can_play(Requiem_of_Spirit) and ((open_forest == 'escape' or open_forest == 'deku_escape')or can_leave_forest)"
         }
     },
     {


### PR DESCRIPTION
This is a compilation of many things surrounding the closed forest option:

1-Specified the logic surrounding closed forest by adding a open_deku state to logic, changed Kokiri exit toward LW bridge as open forest setting or completing Deku tree, and added the same check to Saria's gift as it require to enter. Open as an adult.

2- Added a "Forest Escape", as well as a combination of the newly added "Open Deku" with both "Forest Escape" and "Closed Forest", making 3 new option in total
     -Open Deku remove Mido's check for sword and shield, but the Kokiri kid (Pokey) stays.
     -Forest Escape change logic so other forest exit than the LW bridge one are considered in logic:
           >Din's fire or explosive for Goron City
           >Progressive scale for Zora river
           >Serenade of Water, Prelude of Light or Nocturne of Shadow with ocarina for warp
        All those option give indirect access to Hyrule field, and as such now trigger the can_leave_forest flag

3- Considered the quirk of the new logic, namely:
     -Zelda's letter causes Mido to vanish, and is considered in logic for now. Said in tooltip.
     -Entering Kokiri forest from LW bridge put you past Pokey, preventing the ppossibility to turn arround      
         and trigger Saria's gift. Solved as an adult.
     -Minuet of Forest lead back to the forest confine, logic left unaltered.
     -Both Bolero of Fire and Requiem of spirit lead to enclosed space, as such they now only check if they   
          can be used in logic by adding a check to see if an "escape" forest type is prensent, keeping them 
          out of the can_leave_forest logic, but may be required check to escape.
     -Many check for the option open forest or (shield and sword) have been replaced by the state   
          "open_deku" when logical

4- Changed the graphical interface to replace the "open_forest" checkbox with a list of the five existing
       Setting:
            -Open (default)
            -Closed
            -Open Deku Tree
            -Forest Escape
            -Forest Escape + open Decu Tree
      Updated the name to "Kokiri Forest / Deku Tree" to represent more closely the founction.

5- Maybe some other small change here and there