### PR TITLE
Possible fix for Spirit Temple compass chest if "Chest Size Matches Contents"

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1293,6 +1293,17 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
         if not world.dungeon_mq['Ganons Castle']:
             rom.write_int16(0x321B176, 0xFC40) # original 0xFC48
 
+        #Move spirit temple compass chest if it is a small chest so it is reachable with hookshot 
+        spirit_compass_item = [l for l in world.get_locations() if 'Spirit Temple' in l.name and 'Compass Chest' in l.name][0].item
+        if 'Small Key' in spirit_compass_item.name or not spirit_compass_item.advancement:
+            if not world.dungeon_mq['Spirit Temple']:
+                chest_address = 0x2B6B07C
+            else:
+                chest_address = 0x2B6FCDC
+
+            rom.write_int16(chest_address + 2, 0x0190) #X pos
+            rom.write_int16(chest_address + 6, 0xFABC) #Z pos
+
     # give dungeon items the correct messages
     add_item_messages(messages, shop_items, world)
     if world.enhance_map_compass:


### PR DESCRIPTION
Potential fix for #457 
Instead of forcing the chest to always be large, I feel it makes more sense to move the chest a little bit to the side if it is a small chest so that it is hookshotable. If it is a large chest, the chest will remain in the same spot. 

![img1](https://user-images.githubusercontent.com/12127808/51065317-d0f77980-15c9-11e9-90bb-b8259d6d92d9.png)

![image](https://user-images.githubusercontent.com/12127808/51065325-d81e8780-15c9-11e9-93b2-73923359f8dd.png)

![image](https://user-images.githubusercontent.com/12127808/51065331-dd7bd200-15c9-11e9-97c4-e8b1b117ddd0.png)
