### PR TITLE
Allow full customization of Navi colors.

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -42,7 +42,7 @@ tunic_colors = {
 
 
 NaviColors = {          # Inner Core Color         Outer Glow Color
-    "Custom Color":      (Color(0x00, 0x00, 0x00), Color(0x00, 0x00, 0x00)),
+    "Custom Navi Color": (Color(0x00, 0x00, 0x00), Color(0x00, 0x00, 0x00)),
     "Gold":              (Color(0xFE, 0xCC, 0x3C), Color(0xFE, 0xC0, 0x07)),
     "White":             (Color(0xFF, 0xFF, 0xFF), Color(0x00, 0x00, 0xFF)),
     "Green":             (Color(0x00, 0xFF, 0x00), Color(0x00, 0xFF, 0x00)),
@@ -173,7 +173,6 @@ def patch_navi_colors(rom, settings, log, symbols):
     ]
     navi_color_list = get_navi_colors()
     for navi_action, navi_option, navi_addresses in navi:
-        inner = navi_action in [action[0] for action in navi[0:4]]
         # choose a random choice for the whole group
         if navi_option == 'Random Choice':
             navi_option = random.choice(navi_color_list)
@@ -191,8 +190,12 @@ def patch_navi_colors(rom, settings, log, symbols):
                 colors = list(NaviColors[navi_option][0]), list(NaviColors[navi_option][1])
             # build color from hex code
             else:
-                base_color = list(int(navi_option[i:i+2], 16) for i in (0, 2 ,4))
-                colors = (base_color, base_color)
+                inner_color = list(int(navi_option[i:i+2], 16) for i in (0, 2 ,4))
+                if len(navi_option) / 6 == 1:
+                    outer_color = inner_color
+                else:
+                    outer_color = list(int(navi_option[i:i+2], 16) for i in (6, 8 ,10))
+                colors = (inner_color, outer_color)
                 custom_color = True
 
             color = colors[0] + [0xFF] + colors[1] + [0xFF]

--- a/Gui.py
+++ b/Gui.py
@@ -40,7 +40,9 @@ def settings_to_guivars(settings, guivars):
                 guivar.set('')
             else:
                 if 'Custom Color' in info.choices and re.match(r'^[A-Fa-f0-9]{6}$', value):
-                    guivar.set('Custom (#' + value + ')')
+                    guivar.set('Custom (#%s)' % value)
+                elif 'Custom Navi Color' in info.choices and re.match(r'^[A-Fa-f0-9]{12}$', value):
+                    guivar.set('Custom (#%s #%s)' % (value[0:6], value[6:12]))
                 else:
                     try:
                         value = info.choices[value]
@@ -75,8 +77,8 @@ def guivars_to_settings(guivars):
         # Dropdown/radiobox
         if info.type == str:
             # Set guivar to hexcode if custom color
-            if 'Custom Color' in info.choices and re.match(r'^Custom \(#[A-Fa-f0-9]{6}\)$', guivar.get()):
-                result[name] = re.findall(r'[A-Fa-f0-9]{6}', guivar.get())[0]
+            if ('Custom Color' in info.choices or 'Custom Navi Color' in info.choices) and re.match(r'^Custom \((?: ?#[A-Fa-f0-9]{6})+\)$', guivar.get()):
+                result[name] = ''.join(re.findall(r'[A-Fa-f0-9]{6}', guivar.get()))
             else:
                 try:
                     value = info.reverse_choices[guivar.get()]
@@ -201,6 +203,16 @@ def guiMain(settings=None):
                 if color == (None, None):
                     color = ((0,0,0),'#000000')
                 guivars[info.name].set('Custom (' + color[1] + ')')
+
+            if info.type != list and info.name in guivars and guivars[info.name].get() == 'Custom Navi Color':
+                innerColor = colorchooser.askcolor(title='Pick an Inner Core color.')
+                if innerColor == (None, None):
+                    innerColor = ((0,0,0),'#000000')
+                outerColor = colorchooser.askcolor(title='Pick an Outer Glow color.')
+                if outerColor == (None, None):
+                    outerColor = ((0,0,0),'#000000')
+                guivars[info.name].set('Custom (%s %s)' % (innerColor[1], outerColor[1]))
+
         update_generation_type()
 
 


### PR DESCRIPTION
~~The cosmetic log was changed in the Navi color refactoring but not reverted when that refactoring was scrapped. This makes it properly show both colors as well as all Completely Random colors for each action.~~

Instead of splitting each Navi color into two options, this changes the GUI to launch two color pickers, one for each part of the color.