### PR TITLE
Exempt text id error from text shuffle, some cleanup

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -823,7 +823,8 @@ def shuffle_messages(rom, except_hints=True, always_allow_skip=True):
     def is_not_exempt(m):
         exempt_as_id = m.is_id_message()
         exempt_as_hint = ( except_hints and m.id in (GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES + LIGHT_ARROW_HINT + list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages ) )
-        return not ( exempt_as_id or exempt_as_hint )
+        exempt_as_error = ( m.id == 0x0001 )
+        return not ( exempt_as_id or exempt_as_hint or exempt_as_error )
 
     have_goto =         list( filter( lambda m: is_not_exempt(m) and m.has_goto, messages) )
     have_keep_open =    list( filter( lambda m: is_not_exempt(m) and m.has_keep_open, messages) )

--- a/Messages.py
+++ b/Messages.py
@@ -64,6 +64,7 @@ GOSSIP_STONE_MESSAGES += [0x2053, 0x2054] # shared initial stone messages
 TEMPLE_HINTS_MESSAGES = [0x7057, 0x707A] # dungeon reward hints from the temple of time pedestal
 LIGHT_ARROW_HINT = [0x70CC] # ganondorf's light arrow hint line
 GS_TOKEN_MESSAGES = [0x00B4, 0x00B5] # Get Gold Skulltula Token messages
+ERROR_MESSAGE = 0x0001
 
 # messages for shorter item messages
 # ids are in the space freed up by move_shop_item_messages()
@@ -178,7 +179,7 @@ ITEM_MESSAGES = {
     0x00C5: "\x08\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01You've completed another Heart\x01Container!",
     0x00C6: "\x08\x13\x72You got a \x05\x41Heart Container\x05\x40!\x01Your maximum life energy is \x01increased by one heart.",
     0x00C7: "\x08\x13\x74You got the \x05\x41Boss Key\x05\x40!\x01Now you can get inside the \x01chamber where the Boss lurks.",
-	0x9002: "\x08You are a \x05\x43FOOL\x05\x40!",
+    0x9002: "\x08You are a \x05\x43FOOL\x05\x40!",
     0x00CC: "\x08You got a \x05\x43Blue Rupee\x05\x40!\x01That's \x05\x43five Rupees\x05\x40!",
     0x00CD: "\x08\x13\x53You got the \x05\x43Silver Scale\x05\x40!\x01You can dive deeper than you\x01could before.",
     0x00CE: "\x08\x13\x54You got the \x05\x43Golden Scale\x05\x40!\x01Now you can dive much\x01deeper than you could before!",
@@ -820,20 +821,23 @@ def shuffle_messages(rom, except_hints=True, always_allow_skip=True):
 
     permutation = [i for i, _ in enumerate(messages)]
 
-    def is_not_exempt(m):
-        exempt_as_id = m.is_id_message()
-        exempt_as_hint = ( except_hints and m.id in (GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES + LIGHT_ARROW_HINT + list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages ) )
-        exempt_as_error = ( m.id == 0x0001 )
-        return not ( exempt_as_id or exempt_as_hint or exempt_as_error )
+    def is_exempt(m):
+        hint_ids = (
+            GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES + LIGHT_ARROW_HINT +
+            list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages
+        )
+        is_hint = (except_hints and m.id in hint_ids)
+        is_error_message = (m.id == ERROR_MESSAGE)
+        return (is_hint or is_error_message or m.is_id_message())
 
-    have_goto =         list( filter( lambda m: is_not_exempt(m) and m.has_goto, messages) )
-    have_keep_open =    list( filter( lambda m: is_not_exempt(m) and m.has_keep_open, messages) )
-    have_event =        list( filter( lambda m: is_not_exempt(m) and m.has_event, messages) )
-    have_fade =         list( filter( lambda m: is_not_exempt(m) and m.has_fade, messages) )
-    have_ocarina =      list( filter( lambda m: is_not_exempt(m) and m.has_ocarina, messages) )
-    have_two_choice =   list( filter( lambda m: is_not_exempt(m) and m.has_two_choice, messages) )
-    have_three_choice = list( filter( lambda m: is_not_exempt(m) and m.has_three_choice, messages) )
-    basic_messages =    list( filter( lambda m: is_not_exempt(m) and m.is_basic(), messages) )
+    have_goto         = list( filter(lambda m: not is_exempt(m) and m.has_goto,         messages) )
+    have_keep_open    = list( filter(lambda m: not is_exempt(m) and m.has_keep_open,    messages) )
+    have_event        = list( filter(lambda m: not is_exempt(m) and m.has_event,        messages) )
+    have_fade         = list( filter(lambda m: not is_exempt(m) and m.has_fade,         messages) )
+    have_ocarina      = list( filter(lambda m: not is_exempt(m) and m.has_ocarina,      messages) )
+    have_two_choice   = list( filter(lambda m: not is_exempt(m) and m.has_two_choice,   messages) )
+    have_three_choice = list( filter(lambda m: not is_exempt(m) and m.has_three_choice, messages) )
+    basic_messages    = list( filter(lambda m: not is_exempt(m) and m.is_basic(),       messages) )
 
 
     def shuffle_group(group):


### PR DESCRIPTION
The default error message was being shuffled into the text pool. This _should be enough_ to fix it.

Closes TestRunnerSRL#516