### PR TITLE
Prevent fill progress overshoot

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -28,7 +28,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
                location.type != 'GossipStone']
     world_states = [world.state for world in worlds]
 
-    window.locationcount = len(fill_locations) + len(song_locations)
+    window.locationcount = len(fill_locations) + len(song_locations) + len(shop_locations)
     window.fillcount = 0
 
     # Generate the itempools


### PR DESCRIPTION
The shop items were not accounted for it the total locations to fill,
however ther are accounted for incremental progress. Fix by adding
shops to the total. This avoids the progress bar from jumping
backwards.