### PR TITLE
Add option to prevent minigame rewards from containing required items

### DIFF
--- a/LocationList.py
+++ b/LocationList.py
@@ -786,3 +786,14 @@ business_scrubs = [
     (0x77, 40,   0x10DC, ["enable you to pick up more\x01\x05\x41Deku Sticks", "sell you a \x05\x42mysterious item"]),
     (0x79, 40,   0x10DD, ["enable you to pick up more \x05\x41Deku\x01Nuts", "sell you a \x05\x42mysterious item"]),
 ]
+
+game_location_names = [
+    'Horseback Archery 1000 Points',
+    'Horseback Archery 1500 Points',
+    'Child Shooting Gallery',
+    'Adult Shooting Gallery',
+    'Frog Ocarina Game',
+    'Ocarina Memory Game',
+    'Diving Minigame',
+    'Treasure Chest Game'
+]

--- a/Rules.py
+++ b/Rules.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 from Location import DisableType
+from LocationList import game_location_names
 
 
 def set_rules(world):
@@ -45,6 +46,10 @@ def set_rules(world):
         if location.name == 'Forest Temple MQ First Chest' and world.shuffle_bosskeys == 'dungeon' and world.shuffle_smallkeys == 'dungeon' and world.tokensanity == 'off':
             # This location needs to be a small key. Make sure the boss key isn't placed here.
             forbid_item(location, 'Boss Key (Forest Temple)')
+
+        if not world.can_require_games:
+            if location.name in game_location_names:
+                add_item_rule(location, lambda location, item: not item.advancement)
 
     for location in world.disabled_locations:
         try:

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -991,6 +991,21 @@ setting_infos = [
             default        = True,
             shared         = True,
             ),
+    Checkbutton(
+        name               = 'can_require_games',
+        args_help          = '''\
+                             If disabled game rewards, such as those from the shooting, 
+                             galleries will not be required to advance.
+                             ''',
+        gui_text           = 'Require game rewards',
+        gui_group          = 'shuffle',
+        gui_tooltip        = '''\
+                             If disabled game rewards, such as those from the shooting, 
+                             galleries will not be required to advance.
+                             ''',
+        default            = True,
+        shared             = True,
+    ),
     Combobox(
             name           = 'shuffle_scrubs',
             default        = 'off',


### PR DESCRIPTION
After playing through my first run I worked on this because I hate (read: suck at) all of the mini-games. This adds an option to exclude mini-game locations for required items so that any other equally mini-game-inept folks out there can easily skip them.

Tested by generating 20 random spoiler logs and verifying that none of the mini-game locations contained necessary items, and one actual game to validate that it started up and ran properly.