### PR TITLE
Add Tricks

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -210,7 +210,6 @@ logic_tricks = {
                     Silver Rupee Chest. May need to make multiple
                     trips.
                     '''},
-
     'Child Deadhand without Kokiri Sword': {
         'name'    : 'logic_child_deadhand',
         'tooltip' : '''\
@@ -283,6 +282,12 @@ logic_tricks = {
                     near Goron City and walk up the
                     very steep slope.
                     '''},
+    'Zora\'s Domain Entry with Cucco': {
+        'name'    : 'logic_zora_with_cucco',
+        'tooltip' : '''\
+                    Can fly behind the waterfall with
+                    a cucco as child.
+                    '''},
     'Gerudo Training Grounds MQ Left Side Silver Rupees with Hookshot': {
         'name'    : 'logic_gtg_mq_with_hookshot',
         'tooltip' : '''\
@@ -338,6 +343,62 @@ logic_tricks = {
                     shot is to first spawn a Song of Time block, and then
                     stand on the very edge of it.
                     '''},
+    'Spirit Temple Shifting Wall with No Additional Items': {
+        'name'    : 'logic_spirit_wall',
+        'tooltip' : '''\
+                    The logic normally guarantees a way of dealing with both
+                    the Beamos and the Walltula before climbing the wall.
+                    '''},
+    'Spirit Temple Main Room GS with Boomerang': {
+        'name'    : 'logic_spirit_lobby_gs',
+        'tooltip' : '''\
+                    Standing on the highest part of the arm of the statue, a
+                    precise Boomerang throw can kill and obtain this Gold
+                    Skulltula. You must throw the Boomerang slightly off to
+                    the side so that it curves into the Skulltula, as aiming
+                    directly at it will clank off of the wall in front.
+                    '''},
+    'Spirit Temple MQ Sun Block Room GS with Boomerang': {
+        'name'    : 'logic_spirit_mq_sun_block_gs',
+        'tooltip' : '''\
+                    Throw the Boomerang in such a way that it
+                    curves through the side of the glass block
+                    to hit the Gold Skulltula.
+                    '''},
+    'Jabu MQ Song of Time Block GS with Boomerang': {
+        'name'    : 'logic_jabu_mq_sot_gs',
+        'tooltip' : '''\
+                    Allow the Boomerang to return to you through
+                    the Song of Time block to grab the token.
+                    '''},
+    'Bottom of the Well MQ Dead Hand Freestanding Key with Boomerang': {
+        'name'    : 'logic_botw_mq_dead_hand_key',
+        'tooltip' : '''\
+                    Boomerang can fish the item out of the rubble without
+                    needing explosives to blow it up.
+                    '''},
+    'Fire Temple Flame Wall Maze Skip': {
+        'name'    : 'logic_fire_flame_maze',
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of
+                    a flame wall before it can rise up to block you.
+                    To do it without taking damage is more precise.
+                    '''},
+    'Fire Temple MQ Chest Near Boss without Breaking Crate': {
+        'name'    : 'logic_fire_mq_near_boss',
+        'tooltip' : '''\
+                    The hitbox for the torch extends a bit outside of the crate.
+                    Shoot a flaming arrow at the side of the crate to light the
+                    torch without needing to get over there and break the crate.
+                    '''},
+    'Fire Temple MQ Boulder Maze Side Room without Box': {
+        'name'    : 'logic_fire_mq_maze_side_room',
+        'tooltip' : '''\
+                    You can walk from the blue switch to the door and
+                    quickly open the door before the bars reclose. This
+                    skips needing the Hookshot in order to reach a box
+                    to place on the switch.
+                    '''},
     'Fire Temple MQ Boss Key Chest without Bow': {
         'name'    : 'logic_fire_mq_bk_chest',
         'tooltip' : '''\
@@ -346,11 +407,24 @@ logic_tricks = {
                     oversight in the way the game counts how many
                     torches have been lit.
                     '''},
-    'Zora\'s Domain Entry with Cucco': {
-        'name'    : 'logic_zora_with_cucco',
+    'Zora\'s River Lover Freestanding PoH as Adult with Nothing': {
+        'name'    : 'logic_zora_river_lower',
         'tooltip' : '''\
-                    Can fly behind the waterfall with
-                    a cucco as child.
+                    Adult can reach this PoH with a precise jump,
+                    no Hover Boots required.
+                    '''},
+    'Water Temple Cracked Wall with Hover Boots': {
+        'name'    : 'logic_water_cracked_wall_hovers',
+        'tooltip' : '''\
+                    With a midair side-hop while wearing the Hover
+                    Boots, you can reach the cracked wall without
+                    needing to raise the water up to the middle level.
+                    '''},
+    'Shadow Temple Freestanding Key with Bombchu': {
+        'name'    : 'logic_shadow_freestanding_key',
+        'tooltip' : '''\
+                    Release the Bombchu with good timing so that
+                    it explodes near the bottom of the pot.
                     '''},
     'Zora\'s Domain Entry with Hover Boots': {
         'name'    : 'logic_zora_with_hovers',

--- a/data/World/Bottom of the Well MQ.json
+++ b/data/World/Bottom of the Well MQ.json
@@ -10,7 +10,8 @@
             "Bottom of the Well MQ Lens Chest": "
                 has_explosives and 
                 (Small_Key_Bottom_of_the_Well, 2)",
-            "Bottom of the Well MQ Dead Hand Freestanding Key": "has_explosives",
+            "Bottom of the Well MQ Dead Hand Freestanding Key": "
+                has_explosives or (logic_botw_mq_dead_hand_key and Boomerang)",
             "Bottom of the Well MQ East Inner Room Freestanding Key": "
                 can_play(Zeldas_Lullaby) or has_explosives",
             "GS Well MQ Basement": "can_child_attack",

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -5,7 +5,7 @@
         "locations": {
             "Fire Temple MQ Entrance Hallway Small Chest": "True",
             "Fire Temple MQ Chest Near Boss": "
-                (Hover_Boots and has_fire_source) or 
+                ((Hover_Boots or (logic_fire_mq_near_boss and has_bow)) and has_fire_source) or 
                 (Progressive_Hookshot and (can_use(Fire_Arrows) or 
                     (can_use(Dins_Fire) and 
                     ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or has_GoronTunic or 
@@ -50,7 +50,9 @@
         "region_name": "Fire Lower Maze",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple MQ Maze Lower Chest": "True"
+            "Fire Temple MQ Maze Lower Chest": "True",
+            "Fire Temple MQ Maze Side Room": "
+                has_explosives and (logic_fire_mq_maze_side_room or can_use(Hookshot))"
         },
         "exits": {
             "Fire Upper Maze": "
@@ -62,7 +64,6 @@
         "dungeon": "Fire Temple",
         "locations": {
             "Fire Temple MQ Maze Upper Chest": "True",
-            "Fire Temple MQ Maze Side Room": "has_explosives",
             "Fire Temple MQ Compass Chest": "has_explosives",
             "GS Fire Temple MQ East Tower Top": "
                 can_play(Song_of_Time) or can_use(Longshot)"

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -52,7 +52,8 @@
         "exits": {
             "Fire Temple Upper": "
                 (Small_Key_Fire_Temple, 8) or 
-                ((Small_Key_Fire_Temple, 7) and can_use(Hover_Boots) and can_use(Hammer))"
+                ((Small_Key_Fire_Temple, 7) and
+                    ((can_use(Hover_Boots) and can_use(Hammer)) or logic_fire_flame_maze))"
         }
     },
     {

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -21,7 +21,8 @@
             "Jabu Jabus Belly MQ Basement North Chest": "True",
             "Jabu Jabus Belly MQ Boomerang Room Small Chest": "True",
             "MQ Boomerang Chest": "True",
-            "GS Jabu Jabu MQ Boomerang Room": "can_play(Song_of_Time)"
+            "GS Jabu Jabu MQ Boomerang Room": "
+                can_play(Song_of_Time) or (logic_jabu_mq_sot_gs and Boomerang)"
         },
         "exits": {
             "Jabu Jabus Belly Beginning": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -259,7 +259,7 @@
             "Hyrule Field": "True",
             "Lake Hylia": "True",
             "Gerudo Valley Far Side": "
-                Epona or can_use(Longshot) or ((gerudo_fortress == 'open') and is_adult)"
+                is_adult and (Epona or can_use(Longshot) or (gerudo_fortress == 'open'))"
         }
     },
     {
@@ -293,7 +293,7 @@
             "GS Gerudo Fortress Archery Range": "
                 can_use(Hookshot) and Carpenter_Rescue and nighttime",
             "GS Gerudo Fortress Top Floor": "
-                nighttime and (can_use(Bow) or can_use(Hookshot) or 
+                nighttime and (Carpenter_Rescue or can_use(Bow) or can_use(Hookshot) or 
                     can_use(Hover_Boots) or logic_gerudo_kitchen)"
         },
         "exits": {
@@ -962,7 +962,8 @@
         "region_name": "Zora River Shared",
         "locations": {
             "Zora River Lower Freestanding PoH": "
-                has_explosives or can_dive or can_use(Hover_Boots)",
+                has_explosives or can_dive or
+                    (is_adult and (logic_zora_river_lower or Hover_Boots))",
             "Zora River Upper Freestanding PoH": "
                 has_explosives or can_dive or can_use(Hover_Boots)"
         },

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -34,7 +34,8 @@
             "Shadow Temple Invisible Spikes Chest": "(Small_Key_Shadow_Temple, 2)",
             "Shadow Temple Freestanding Key": "
                 (Small_Key_Shadow_Temple, 2) and Progressive_Hookshot and 
-                (has_bombs or Progressive_Strength_Upgrade)",
+                (has_bombs or Progressive_Strength_Upgrade or
+                    (logic_shadow_freestanding_key and has_bombchus))",
             "GS Shadow Temple Like Like Room": "Progressive_Hookshot",
             "GS Shadow Temple Crusher Room": "Progressive_Hookshot",
             "GS Shadow Temple Single Giant Pot": "(Small_Key_Shadow_Temple, 2) and Progressive_Hookshot"

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -52,7 +52,6 @@
                 (Small_Key_Spirit_Temple, 5) and can_play(Song_of_Time)",
             "Spirit Temple MQ Boss Key Chest": "
                 (Small_Key_Spirit_Temple, 5) and can_play(Song_of_Time) and Mirror_Shield",
-            "GS Spirit Temple MQ Sun Block Room": "True",
             "GS Spirit Temple MQ Iron Knuckle West": "(Small_Key_Spirit_Temple, 7)",
             "GS Spirit Temple MQ Iron Knuckle North": "(Small_Key_Spirit_Temple, 7)"
         },
@@ -77,6 +76,9 @@
                 (has_slingshot and has_bow)",
             "Spirit Temple MQ Sun Block Room Chest": "
                 can_play(Song_of_Time) or 
+                (can_use(Longshot) and can_use(Silver_Gauntlets))",
+            "GS Spirit Temple MQ Sun Block Room": "
+                (logic_spirit_mq_sun_block_gs and can_play(Song_of_time) and Boomerang) or
                 (can_use(Longshot) and can_use(Silver_Gauntlets))"
         },
         "exits": {

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -121,8 +121,10 @@
                     ((Small_Key_Spirit_Temple, 3) or 
                         ((Small_Key_Spirit_Temple, 2) and Boomerang and bombchus_in_logic)))",
             "GS Spirit Temple Lobby": "
-                can_use(Silver_Gauntlets) and (Small_Key_Spirit_Temple, 3) and 
-                (Progressive_Hookshot or Hover_Boots)"
+                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
+                    logic_spirit_lobby_gs and Boomerang and (Progressive_Hookshot or Hover_Boots)) or
+                (logic_spirit_lobby_gs and (Small_Key_Spirit_Temple, 5) and has_explosives and can_play(Requiem_of_Spirit) and Boomerang) or
+                ((Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and (Progressive_Hookshot or Hover_Boots))"
         },
         "exits": {
             "Spirit Temple Outdoor Hands": "True",
@@ -152,7 +154,7 @@
         "exits": {
             "Spirit Temple Beyond Final Locked Door": "
                 (Small_Key_Spirit_Temple, 5) and 
-                (can_use(Longshot) or has_bombchus or 
+                (logic_spirit_wall or can_use(Longshot) or has_bombchus or 
                     ((has_bombs or has_nuts or can_use(Dins_Fire)) and 
                         (has_bow or can_use(Hookshot) or Hammer)))"
         }

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -5,6 +5,10 @@
         "locations": {
             "Water Temple Map Chest": "Iron_Boots",
             "Water Temple Compass Chest": "Iron_Boots",
+            "Water Temple Cracked Wall Chest": "
+                Iron_Boots and can_play(Zeldas_Lullaby) and has_explosives and
+                    ((logic_water_cracked_wall_hovers and Hover_Boots) or
+                    (has_bow or can_use(Dins_Fire) or (Small_Key_Water_Temple, 5)))",
             "Water Temple Torches Chest": "
                 (has_bow or can_use(Dins_Fire)) and 
                 can_play(Zeldas_Lullaby) and Iron_Boots",
@@ -48,7 +52,6 @@
         "dungeon": "Water Temple",
         "locations": {
             "Water Temple Central Pillar Chest": "has_ZoraTunic",
-            "Water Temple Cracked Wall Chest": "has_explosives",
             "GS Water Temple Central Room": "can_use(Longshot) or can_use(Farores_Wind)"
         }
     },


### PR DESCRIPTION
I'm working my way through all the tricks and I think these are some of the easiest ones that currently didn't have options.

Changes:
- Gerudo Fortress top floor GS now in logic with Carpenter Rescue instead of just Bow/Hook/Hovers. I also changed how gerudo valley far side was written because I thought it was strange.
- Added Tricks:
1. Spirit Temple Shifting Wall with No Additional Items
2. Spirit Temple Main Room GS with Boomerang
3. Spirit Temple MQ Sun Block Room GS with Boomerang
4. Jabu MQ Song of Time Block GS with Boomerang
5. Bottom of the Well MQ Deadhand Freestanding Key with Boomerang
6. Fire Temple Flame Wall Maze Skip
7. Fire Temple MQ Near Boss Chest without Destroying Crate
8. Fire Temple MQ Boss Key Chest without Bow
9. Fire Temple MQ Boulder Maze Side Room without Hookshot
10. Zora's River Lover Freestanding PoH as Adult with Nothing
11. Water Temple Cracked Wall Chest with Hover Boots
12. Shadow Temple Freestanding Key with Bombchu