### PR TITLE
Fix random starting time of day setting not working

### DIFF
--- a/World.py
+++ b/World.py
@@ -41,7 +41,7 @@ class World(object):
             self.big_poe_count = random.randint(1, 10)
         if self.starting_tod == 'random':
             setting_info = get_setting_info('starting_tod')
-            choices = [ch for ch in setting_info.args_params['choices'] if ch not in ['default', 'random']]
+            choices = [ch for ch in setting_info.choices if ch not in ['default', 'random']]
             self.starting_tod = random.choice(choices)
 
         # rename a few attributes...


### PR DESCRIPTION
Fix for Issue #561.
The SettingsList rework had broken this since Setting_Info doesn't have a args_params property anymore.