### PR TITLE
Cow Shuffle Logic Fixes

### DIFF
--- a/LocationList.py
+++ b/LocationList.py
@@ -746,7 +746,6 @@ location_table = {
     "Gerudo Valley Cow":                               ("NPC",         0x5A,  0x15, "Gerudo Valley",          None,                     ("Gerudo", "Cow")),
     "DMT Grotto Cow":                                  ("NPC",         0x3E,  0x15, "Death Mountain Trail",   None,                     ("Death Mountain", "Cow")),
     "HF Grotto Cow":                                   ("NPC",         0x3E,  0x16, "Hyrule Field",           None,                     ("Cow",)),
-    "MQ JabuCow":                                      ("NPC",         0x36,  0x15, "Jabu Jabu's Belly",      None,                     ("Cow",)),
 
     # These are not actual locations, but are filler spots used for hint reachability
     "Death Mountain Crater Gossip Stone":              ("GossipStone", None,  None, None,                     None,                     None),

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -924,7 +924,6 @@ setting_infos = [
 
             The Gerudo Card is required to enter the Gerudo Training Grounds,
             however it does not prevent the guards throwing you in jail.
-            This has no effect if the option to Start with Gerudo Card is set.
         ''',
         shared         = True,
         gui_params     = {

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -47,7 +47,7 @@
         "region_name": "Jabu Jabus Belly Boss Area",
         "dungeon": "Jabu Jabus Belly",
         "locations": {
-            "Jabu Jabus Belly MQ Cow" : "True", 
+            "Jabu Jabus Belly MQ Cow" : "can_play(Eponas_Song)",
             "Jabu Jabus Belly MQ Second Room Upper Chest": "True",
             "Jabu Jabus Belly MQ Near Boss Chest": "True",
             "Barinade Heart": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1201,9 +1201,9 @@
             "GS Hyrule Field Near Gerudo Valley": "
                 (Hammer and has_fire_source and can_use(Hookshot)) or 
                 (Boomerang and has_explosives and can_use(Dins_Fire))",
-             "HF Grotto Cow":
-           "(can_use(Hammer) and has_fire_source) or
-              (has_explosives and can_use(Dins_Fire))"
+             "HF Grotto Cow": "
+                can_play(Eponas_Song) and ((can_use(Hammer) and has_fire_source) or
+                (has_explosives and can_use(Dins_Fire)))"
         },
         "exits": {
             "Field Valley Grotto Gossip Stone": "


### PR DESCRIPTION
2 cows lacked can_play(Eponas_Song) in their logic. Also removed the extra cow location that was added by accident. Also fixes the tooltip for Shuffle Gerudo Card.