### PR TITLE
Remove Assumptions from Dungeon Logic - small stuff

### DIFF
--- a/data/World/Bottom of the Well.json
+++ b/data/World/Bottom of the Well.json
@@ -2,6 +2,13 @@
 	{
         "region_name": "Bottom of the Well",
         "dungeon": "Bottom of the Well",
+        "exits": {
+            "Bottom of the Well Main Area" : "can_child_attack or has_nuts"
+        }
+    },
+    {
+        "region_name": "Bottom of the Well Main Area",
+        "dungeon": "Bottom of the Well",
         "locations": {
             "Bottom of the Well Front Left Hidden Wall": "can_see_with_lens",
             "Bottom of the Well Front Center Bombable": "has_explosives",
@@ -37,7 +44,7 @@
             "Bottom of the Well Stick Pot": "True"
         },
         "exits": {
-            "Kakariko Village": "True"
+            "Bottom of the Well" : "True"
         }
     }
 ]

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -7,9 +7,7 @@
             "Deku Tree MQ Slingshot Chest": "can_child_attack",
             "Deku Tree MQ Slingshot Room Back Chest": "has_sticks or can_use(Dins_Fire)",
             "Deku Tree MQ Basement Chest": "has_sticks or can_use(Dins_Fire)",
-            "GS Deku Tree MQ Lobby": "can_child_attack",
-            "Deku Tree Gossip Stone (Left)": "True",
-            "Deku Tree Gossip Stone (Right)": "True"
+            "GS Deku Tree MQ Lobby": "can_child_attack"
         },
         "exits": {
             "Kokiri Forest": "True",

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -11,9 +11,7 @@
             "GS Deku Tree Basement Vines": "
                 has_slingshot or Boomerang or has_explosives or can_use(Dins_Fire) or 
                 (logic_deku_basement_gs and (has_sticks or Kokiri_Sword))",
-            "GS Deku Tree Basement Gate": "can_child_attack",
-            "Deku Tree Gossip Stone (Left)": "True",
-            "Deku Tree Gossip Stone (Right)": "True"
+            "GS Deku Tree Basement Gate": "can_child_attack"
         },
         "exits": {
             "Kokiri Forest": "True",

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -1,16 +1,13 @@
 [    
-	{
+    {
         "region_name": "Fire Temple Lower",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple Chest Near Boss": "True",
+            "Fire Temple Chest Near Boss" : "logic_fewer_tunic_requirements or has_GoronTunic",
             "Fire Temple Fire Dancer Chest": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)",
             "Fire Temple Boss Key Chest": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)",
-            "Fire Temple Big Lava Room Bombable Chest": "
-                (Small_Key_Fire_Temple, 2) and has_explosives",
-            "Fire Temple Big Lava Room Open Chest": "(Small_Key_Fire_Temple, 2)",
             "Volvagia Heart": "
                 has_GoronTunic and can_use(Hammer) and Boss_Key_Fire_Temple and 
                 (Hover_Boots or (can_reach(Fire_Temple_Upper) and 
@@ -19,13 +16,25 @@
                 has_GoronTunic and can_use(Hammer) and Boss_Key_Fire_Temple and 
                 (Hover_Boots or (can_reach(Fire_Temple_Upper) and 
                     (can_play(Song_of_Time) or has_explosives)))",
-            "GS Fire Temple Song of Time Room": "
-                (Small_Key_Fire_Temple, 2) and can_play(Song_of_Time)",
             "GS Fire Temple Basement": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)"
         },
         "exits": {
-            "Death Mountain Crater Central": "True",
+            "Fire Temple Big Lava Room":"
+                (Small_Key_Fire_Temple, 2) and
+                (logic_fewer_tunic_requirements or has_GoronTunic)"
+        }
+    },
+    {
+        "region_name": "Fire Temple Big Lava Room",
+        "dungeon": "Fire Temple",
+        "locations": {
+            "Fire Temple Big Lava Room Open Chest": "True",
+            "Fire Temple Big Lava Room Bombable Chest": "has_explosives",
+            "GS Fire Temple Song of Time Room": "can_play(Song_of_Time)"
+        },
+        "exits": {
+            "Fire Temple Lower":  "True",
             "Fire Temple Middle": "
                 has_GoronTunic and (Small_Key_Fire_Temple, 4) and Progressive_Strength_Upgrade and 
                 (has_explosives or ((has_bow or Progressive_Hookshot) and is_adult))"

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -1,11 +1,11 @@
 [    
-	{
+    {
         "region_name": "Forest Temple Lobby",
         "dungeon": "Forest Temple",
         "locations": {
             "Forest Temple First Chest": "True",
             "Forest Temple Chest Behind Lobby": "True",
-            "GS Forest Temple First Room": "can_use(Hookshot) or can_use(Bow) or can_use(Dins_Fire)",
+            "GS Forest Temple First Room": "can_use(Dins_Fire) or has_projectile(adult)",
             "GS Forest Temple Lobby": "can_use(Hookshot)"
         },
         "exits": {
@@ -33,8 +33,13 @@
         "region_name": "Forest Temple NE Outdoors",
         "dungeon": "Forest Temple",
         "locations": {
-            "Forest Temple Outside Hookshot Chest": "True",
-            "GS Forest Temple Outdoor East": "can_use(Hookshot)"
+            "Forest Temple Outside Hookshot Chest": "
+                can_use(Hookshot) or
+                can_reach(Forest_Temple_Falling_Room)",
+            "GS Forest Temple Outdoor East": "
+                can_use(Hookshot) or 
+                (can_reach(Forest_Temple_Falling_Room) and 
+                 (can_use(Bow) or can_use(Dins_Fire) or has_explosives))"
         },
         "exits": {
             "Forest Temple NW Outdoors": "

--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -3,14 +3,14 @@
         "region_name": "Ice Cavern",
         "dungeon": "Ice Cavern",
         "locations": {
-            "Ice Cavern Map Chest": "has_bottle",
-            "Ice Cavern Compass Chest": "has_bottle",
-            "Ice Cavern Iron Boots Chest": "has_bottle",
-            "Ice Cavern Freestanding PoH": "has_bottle",
-            "Sheik in Ice Cavern": "has_bottle and is_adult",
+            "Ice Cavern Map Chest": "has_blue_fire",
+            "Ice Cavern Compass Chest": "has_blue_fire",
+            "Ice Cavern Iron Boots Chest": "has_blue_fire",
+            "Ice Cavern Freestanding PoH": "has_blue_fire",
+            "Sheik in Ice Cavern": "has_blue_fire and is_adult",
             "GS Ice Cavern Spinning Scythe Room": "can_use(Hookshot)",
-            "GS Ice Cavern Heart Piece Room": "can_use(Hookshot) and has_bottle",
-            "GS Ice Cavern Push Block Room": "can_use(Hookshot) and has_bottle"
+            "GS Ice Cavern Heart Piece Room": "has_blue_fire and can_use(Hookshot)",
+            "GS Ice Cavern Push Block Room": "has_blue_fire and can_use(Hookshot)"
         },
         "exits": {
             "Outside Ice Cavern": "True"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -717,9 +717,7 @@
         },
         "exits": {
             "Graveyard": "True",
-            "Shadow Temple Beginning": "
-                can_use(Dins_Fire) and can_see_with_lens and 
-                (can_use(Hover_Boots) or can_use(Hookshot))"
+            "Shadow Temple Entryway": "can_use(Dins_Fire)"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -571,9 +571,7 @@
             "Windmill": "True",
             "Kakariko Bazaar": "is_adult",
             "Kakariko Shooting Gallery": "True",
-            "Bottom of the Well": "
-                can_play(Song_of_Storms) and 
-                (dungeon_mq[Bottom_of_the_Well] or can_child_attack or has_nuts)",
+            "Bottom of the Well": "can_play(Song_of_Storms)",
             "Kakariko Potion Shop Front": "is_adult",
             "Kakariko Potion Shop Back": "is_adult",
             "Odd Medicine Building": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -30,10 +30,21 @@
             "House of Twins": "True",
             "Know It All House": "True",
             "Kokiri Shop": "True",
-            "Deku Tree Lobby": "(Kokiri_Sword and Buy_Deku_Shield) or open_forest",
+            "Outside Deku Tree": "(Kokiri_Sword and Buy_Deku_Shield) or open_forest",
             "Lost Woods": "True",
             "Lost Woods Bridge": "can_leave_forest",
             "Kokiri Forest Storms Grotto": "can_play(Song_of_Storms)"
+        }
+    },
+    {
+        "region_name": "Outside Deku Tree",
+        "locations": {
+            "Deku Tree Gossip Stone (Left)": "True",
+            "Deku Tree Gossip Stone (Right)": "True"
+        },
+        "exits": {
+            "Deku Tree Lobby": "True",
+            "Kokiri Forest" : "True"
         }
     },
     {

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -1,9 +1,18 @@
 [
     {
+        "region_name": "Shadow Temple Entryway",
+        "dungeon": "Shadow Temple",
+        "exits": {
+            "Shadow Temple Beginning": "
+                can_see_with_lens and
+                (can_use(Hover_Boots) or can_use(Hookshot))"
+        }
+    },
+    {
         "region_name": "Shadow Temple Beginning",
         "dungeon": "Shadow Temple",
         "exits": {
-            "Shadow Temple Warp Region": "True",
+            "Shadow Temple Entryway": "True",
             "Shadow Temple First Beamos": "can_use(Fire_Arrows) or Hover_Boots",
             "Shadow Temple Dead Hand Area": "has_explosives and (Small_Key_Shadow_Temple, 6)"
         }

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -1,5 +1,14 @@
 [    
-	{
+    {
+        "region_name": "Shadow Temple Entryway",
+        "dungeon": "Shadow Temple",
+        "exits": {
+            "Shadow Temple Beginning": "
+                can_see_with_lens and
+                (can_use(Hover_Boots) or can_use(Hookshot))"
+        }
+    },
+    {
         "region_name": "Shadow Temple Beginning",
         "dungeon": "Shadow Temple",
         "locations": {
@@ -7,7 +16,7 @@
             "Shadow Temple Hover Boots Chest": "True"
         },
         "exits": {
-            "Shadow Temple Warp Region": "True",
+            "Shadow Temple Entryway": "True",
             "Shadow Temple First Beamos": "Hover_Boots"
         }
     },

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -61,8 +61,8 @@
         "region_name": "Shadow Temple Beyond Boat",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Spike Walls Left Chest": "True",
-            "Shadow Temple Boss Key Chest": "True",
+            "Shadow Temple Spike Walls Left Chest": "can_use(Dins_Fire)",
+            "Shadow Temple Boss Key Chest": "can_use(Dins_Fire)",
             "Shadow Temple Hidden Floormaster Chest": "True",
             "Bongo Bongo Heart": "
                 (Small_Key_Shadow_Temple, 5) and 


### PR DESCRIPTION
Remove assumptions from dungeons about the overworld path taken to reach dungeon entrances. Few misc changes for the ice cavern blue_fire spec and the deku tree gossip stones.

Regression tested with 5000 all-sanity generations as having no impact to current (non-ER) logic.
