### PR TITLE
Remove entry assumptions from water temple

### DIFF
--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -1,58 +1,80 @@
 [    
-	{
+    {
         "region_name": "Water Temple Lobby",
         "dungeon": "Water Temple",
         "locations": {
-            "Water Temple Map Chest": "Iron_Boots",
-            "Water Temple Compass Chest": "Iron_Boots",
+            "Morpha": "Boss_Key_Water_Temple and can_use(Longshot)"
+        },
+        "exits": {
+            "Water Temple Highest Water Level":"Iron_Boots"
+        }
+    },
+    {
+        "region_name": "Water Temple Highest Water Level",
+        "dungeon":  "Water Temple",
+        "locations": {
+            # If the player leaves the dungeon without collecting the item at Morpha Heart,
+            # they won't be able to come back without Iron Boots.
+            # If it is the Iron Boots or an item required to get them, it means a soft-lock.
+            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot)"
+        },
+        "exits": {
+            "Water Temple Dark Link Region": "
+                (Small_Key_Water_Temple, 5) and 
+                ((Iron_Boots and can_play(Zeldas_Lullaby)) or keysanity) and can_use(Hookshot)",
+            #A trick about longshotting torches might go here
+            "Water Temple Dive": "(has_ZoraTunic or logic_fewer_tunic_requirements) and Iron_Boots"
+        }
+    },
+    {
+        "region_name": "Water Temple Dive",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple Map Chest": "True",
+            "Water Temple Compass Chest": "
+                (can_play(Zeldas_Lullaby) or Iron_Boots) and can_use(Hookshot)",
             "Water Temple Cracked Wall Chest": "
-                Iron_Boots and can_play(Zeldas_Lullaby) and has_explosives and
-                    ((logic_water_cracked_wall_hovers and Hover_Boots) or
-                    (has_bow or can_use(Dins_Fire) or (Small_Key_Water_Temple, 5)))",
+                can_play(Zeldas_Lullaby) and has_explosives and
+                    ((logic_water_cracked_wall_hovers and Hover_Boots) or can_reach(Water_Temple_Middle_Water_Level))",
             "Water Temple Torches Chest": "
-                (has_bow or can_use(Dins_Fire)) and 
-                can_play(Zeldas_Lullaby) and Iron_Boots",
+                (has_bow or can_use(Dins_Fire)) and can_play(Zeldas_Lullaby)",
             "Water Temple Dragon Chest": "
-                Iron_Boots and 
+                Iron_Boots and can_use(Hookshot) and
                 ((Progressive_Strength_Upgrade and can_play(Zeldas_Lullaby)) or 
                     ((Small_Key_Water_Temple, 6) and (can_play(Zeldas_Lullaby) or keysanity) and 
                         can_play(Song_of_Time) and has_bow))",
             "Water Temple Central Bow Target Chest": "
-                has_bow and Iron_Boots and Progressive_Strength_Upgrade and 
+                has_bow and Progressive_Strength_Upgrade and 
                 can_play(Zeldas_Lullaby) and (Hover_Boots or can_use(Longshot))",
             "Water Temple Boss Key Chest": "
-                (Small_Key_Water_Temple, 6) and Iron_Boots and 
+                (Small_Key_Water_Temple, 6) and 
                 (can_play(Zeldas_Lullaby) or keysanity) and 
-                (logic_water_bk_chest or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots) and 
+                ((logic_water_bk_chest and Iron_Boots) or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots) and 
                 can_use(Longshot)",
-            # If the player leaves the dungeon without collecting the item at Morpha Heart,
-            # they won't be able to come back without Iron Boots.
-            # If it is the Iron Boots or an item required to get them, it means a soft-lock.
-            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot) and Iron_Boots",
-            "Morpha": "Boss_Key_Water_Temple and can_use(Longshot)",
-            "GS Water Temple South Basement": "has_explosives and can_play(Zeldas_Lullaby) and Iron_Boots",
+            "GS Water Temple South Basement": "
+                (can_use(Hookshot) or can_use(Hover_Boots)) and 
+                has_explosives and can_play(Zeldas_Lullaby)",
             "GS Water Temple Near Boss Key Chest": "
-                can_use(Longshot) and Iron_Boots and 
+                can_use(Longshot) and 
                 (can_play(Zeldas_Lullaby) or keysanity) and 
                 (Small_Key_Water_Temple, 5)" 
                 # Longshot just reaches without the need to actually go near
         },
         "exits": {
-            "Lake Hylia": "True",
             "Water Temple Middle Water Level": "
-                (has_bow or can_use(Dins_Fire) or (Small_Key_Water_Temple, 5)) and 
-                can_play(Zeldas_Lullaby) and Iron_Boots",
-            "Water Temple Dark Link Region": "
-                (Small_Key_Water_Temple, 5) and Iron_Boots and 
-                (can_play(Zeldas_Lullaby) or keysanity)"
+                (has_bow or can_use(Dins_Fire) or
+                 ((Small_Key_Water_Temple, 5) and can_use(Hookshot))) and 
+                can_play(Zeldas_Lullaby)"
         }
     },
     {
         "region_name": "Water Temple Middle Water Level",
         "dungeon": "Water Temple",
         "locations": {
-            "Water Temple Central Pillar Chest": "has_ZoraTunic",
-            "GS Water Temple Central Room": "can_use(Longshot) or can_use(Farores_Wind)"
+            "Water Temple Central Pillar Chest": "
+                Iron_Boots and has_ZoraTunic and can_use(Hookshot)",
+            "GS Water Temple Central Room": "
+                can_use(Longshot) or (can_use(Farores_Wind) and can_use(Hookshot))"
         }
     },
     {
@@ -66,7 +88,7 @@
                 (Small_Key_Water_Temple, 6) and can_play(Song_of_Time) and 
                 has_bow and (can_play(Zeldas_Lullaby) or keysanity)",
             "GS Water Temple Serpent River": "
-                can_play(Song_of_Time) and (Small_Key_Water_Temple, 6)",
+                can_play(Song_of_Time) and (Small_Key_Water_Temple, 6) and Iron_Boots",
             "GS Water Temple Falling Platform Room": "can_use(Longshot)"
         }
     }


### PR DESCRIPTION
No hook, irons or tunic assumptions. Also prepare for the definition
of a trick to longshot the torch without irons which is logically ok
in ER (as water temple might not be at the lake anymore).

Regression tested with 5000 all-sanity seeds as no logic diff to current (non-ER).