### PR TITLE
Add Tricks Part 2

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -389,6 +389,102 @@ logic_tricks = {
                     Release the Bombchu with good timing so that
                     it explodes near the bottom of the pot.
                     '''},
+    'Adult Meadow Access without Saria\'s or Minuet': {
+        'name'    : 'logic_adult_meadow_access',
+        'tooltip' : '''\
+                    With a specific position and angle, you can
+                    backflip over Mido.
+                    '''},
+    'Reach Volvagia without Hover Boots or Pillar': {
+        'name'    : 'logic_volvagia_jump',
+        'tooltip' : '''\
+                    The Fire Temple Boss Door can be reached with a precise
+                    jump. You must be touching the side wall of the room so
+                    so that Link will grab the ledge from farther away than
+                    is normally possible.
+                    '''},
+    'Diving in the Lab without Gold Scale': {
+        'name'    : 'logic_lab_diving',
+        'tooltip' : '''\
+                    Remove the Iron Boots in the midst of
+                    Hookshotting the underwater crate.
+                    '''},
+    'Deliver Eye Drops with Bolero of Fire': {
+        'name'    : 'logic_biggoron_bolero',
+        'tooltip' : '''\
+                    If you do not wear the Goron Tunic, the heat timer
+                    inside the crater will override the trade item's timer.
+                    When you exit to Death Mountain Trail you will have
+                    one second to deliver the Eye Drops before the timer
+                    expires. It works best if you play Bolero as quickly as
+                    possible upon receiving the Eye Drops. If you have few
+                    hearts, there is enough time to dip Goron City to
+                    refresh the heat timer as long as you've already
+                    pulled the block.
+                    '''},
+    'Wasteland Crossing without Hover Boots or Longshot': {
+        'name'    : 'logic_wasteland_crossing',
+        'tooltip' : '''\
+                    You can beat the quicksand by backwalking across it
+                    in a specific way.
+                    '''},
+    'Desert Colossus Hill GS with Hookshot': {
+        'name'    : 'logic_colossus_gs',
+        'tooltip' : '''\
+                    Somewhat precise. If you kill enough Leevers
+                    you can get enough of a break to take some time
+                    to aim more carefully.
+                    '''},
+    'Dodongo\'s Cavern Scarecrow GS with Armos Statue': {
+        'name'    : 'logic_dc_scarecrow_gs',
+        'tooltip' : '''\
+                    You can jump off an Armos Statue to reach the
+                    alcove with the Gold Skulltula. It takes quite
+                    a long time to pull the statue the entire way.
+                    The jump to the alcove can be a pit picky when
+                    done as child.
+                    '''},
+    'Kakariko Tower GS with Jump Slash': {
+        'name'    : 'logic_kakariko_tower_gs',
+        'tooltip' : '''\
+                    Climb the tower as high as you can without
+                    touching the Gold Skulltula, then let go and
+                    jump slash immediately. You will take fall
+                    damage.
+                    '''},
+    'Lake Hylia Lab Wall GS with Jump Slash': {
+        'name'    : 'logic_lab_wall_gs',
+        'tooltip' : '''\
+                    The jump slash to actually collect the
+                    token is somewhat precise.
+                    '''},
+    'Spirit Temple MQ Lower Adult without Fire Arrows': {
+        'name'    : 'logic_spirit_mq_lower_adult',
+        'tooltip' : '''\
+                    It can be done with Din\'s Fire and Bow.
+                    Whenever an arrow passes through a lit torch, it
+                    resets the timer. It's finicky but it's also
+                    possible to stand on the pillar next to the center
+                    torch, which makes it easier.
+                    '''},
+    'Spirit Temple Map Chest with Bow': {
+        'name'    : 'logic_spirit_map_chest',
+        'tooltip' : '''\
+                    To get a line of sight from the upper torch to
+                    the map chest torches, you must pull an Armos
+                    statue all the way up the stairs.
+                    '''},
+    'Spirit Temple Sun Block Room Chest with Bow': {
+        'name'    : 'logic_spirit_sun_chest',
+        'tooltip' : '''\
+                    Using the blocks in the room as platforms you can
+                    get lines of sight to all three torches. The timer
+                    on the torches is quite short so you must move
+                    quickly in order to light all three.
+                    '''},
+
+
+
     'Zora\'s Domain Entry with Hover Boots': {
         'name'    : 'logic_zora_with_hovers',
         'tooltip' : '''\
@@ -924,6 +1020,7 @@ setting_infos = [
 
             The Gerudo Card is required to enter the Gerudo Training Grounds,
             however it does not prevent the guards throwing you in jail.
+            This has no effect if the option to Start with Gerudo Card is set.
         ''',
         shared         = True,
         gui_params     = {

--- a/State.py
+++ b/State.py
@@ -231,8 +231,8 @@ class State(object):
 
     def can_finish_adult_trades(self):
         zora_thawed = (self.can_play('Zeldas Lullaby') or (self.has('Hover Boots') and self.world.logic_zora_with_hovers)) and self.has_blue_fire()
-        carpenter_access = self.has('Epona') or self.has('Progressive Hookshot', 2)
-        return (self.has('Claim Check') or ((self.has('Progressive Strength Upgrade') or self.can_blast_or_smash() or self.has_bow()) and (((self.has('Eyedrops') or self.has('Eyeball Frog') or self.has('Prescription') or self.has('Broken Sword')) and zora_thawed) or ((self.has('Poachers Saw') or self.has('Odd Mushroom') or self.has('Cojiro') or self.has('Pocket Cucco') or self.has('Pocket Egg')) and zora_thawed and carpenter_access))))
+        carpenter_access = self.can_reach('Gerudo Valley Far Side')
+        return (self.has('Claim Check') or ((self.has('Progressive Strength Upgrade') or self.can_blast_or_smash() or self.has_bow() or self.world.logic_biggoron_bolero) and (((self.has('Eyedrops') or self.has('Eyeball Frog') or self.has('Prescription') or self.has('Broken Sword')) and zora_thawed) or ((self.has('Poachers Saw') or self.has('Odd Mushroom') or self.has('Cojiro') or self.has('Pocket Cucco') or self.has('Pocket Egg')) and zora_thawed and carpenter_access))))
 
 
     def has_bottle(self):

--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -18,7 +18,8 @@
             "GS Dodongo's Cavern East Side Room": "
                 has_explosives or is_adult or has_slingshot or 
                 Boomerang or has_sticks or Kokiri_Sword",
-            "GS Dodongo's Cavern Scarecrow": "can_use(Scarecrow) or can_use(Longshot)",
+            "GS Dodongo's Cavern Scarecrow": "
+                can_use(Scarecrow) or can_use(Longshot) or logic_dc_scarecrow_gs",
             "DC Deku Scrub Deku Sticks": "
                 is_adult or has_slingshot or has_sticks or 
                 has_explosives or Kokiri_Sword",

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -14,8 +14,8 @@
         "exits": {
             "Death Mountain Crater Central": "True",
             "Fire Boss Room": "
-                has_fire_source and has_GoronTunic and Hammer and 
-                Boss_Key_Fire_Temple and (Hover_Boots or can_reach(Fire_Temple_Upper))",
+                has_fire_source and has_GoronTunic and Hammer and Boss_Key_Fire_Temple and
+                (logic_volvagia_jump or Hover_Boots or can_reach(Fire_Temple_Upper))",
             "Fire Lower Locked Door": "
                 (Small_Key_Fire_Temple, 5) and 
                 (has_explosives or Hammer or Progressive_Hookshot)",

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -1,40 +1,31 @@
 [    
-    {
+	{
         "region_name": "Fire Temple Lower",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple Chest Near Boss" : "logic_fewer_tunic_requirements or has_GoronTunic",
+            "Fire Temple Chest Near Boss": "True",
             "Fire Temple Fire Dancer Chest": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)",
             "Fire Temple Boss Key Chest": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)",
+            "Fire Temple Big Lava Room Bombable Chest": "
+                (Small_Key_Fire_Temple, 2) and has_explosives",
+            "Fire Temple Big Lava Room Open Chest": "(Small_Key_Fire_Temple, 2)",
             "Volvagia Heart": "
                 has_GoronTunic and can_use(Hammer) and Boss_Key_Fire_Temple and 
-                (Hover_Boots or (can_reach(Fire_Temple_Upper) and 
+                (logic_volvagia_jump or Hover_Boots or (can_reach(Fire_Temple_Upper) and 
                     (can_play(Song_of_Time) or has_explosives)))",
             "Volvagia": "
                 has_GoronTunic and can_use(Hammer) and Boss_Key_Fire_Temple and 
-                (Hover_Boots or (can_reach(Fire_Temple_Upper) and 
+                (logic_volvagia_jump or Hover_Boots or (can_reach(Fire_Temple_Upper) and 
                     (can_play(Song_of_Time) or has_explosives)))",
+            "GS Fire Temple Song of Time Room": "
+                (Small_Key_Fire_Temple, 2) and can_play(Song_of_Time)",
             "GS Fire Temple Basement": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)"
         },
         "exits": {
-            "Fire Temple Big Lava Room":"
-                (Small_Key_Fire_Temple, 2) and
-                (logic_fewer_tunic_requirements or has_GoronTunic)"
-        }
-    },
-    {
-        "region_name": "Fire Temple Big Lava Room",
-        "dungeon": "Fire Temple",
-        "locations": {
-            "Fire Temple Big Lava Room Open Chest": "True",
-            "Fire Temple Big Lava Room Bombable Chest": "has_explosives",
-            "GS Fire Temple Song of Time Room": "can_play(Song_of_Time)"
-        },
-        "exits": {
-            "Fire Temple Lower":  "True",
+            "Death Mountain Crater Central": "True",
             "Fire Temple Middle": "
                 has_GoronTunic and (Small_Key_Fire_Temple, 4) and Progressive_Strength_Upgrade and 
                 (has_explosives or ((has_bow or Progressive_Hookshot) and is_adult))"

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -1,11 +1,11 @@
 [    
-    {
+	{
         "region_name": "Forest Temple Lobby",
         "dungeon": "Forest Temple",
         "locations": {
             "Forest Temple First Chest": "True",
             "Forest Temple Chest Behind Lobby": "True",
-            "GS Forest Temple First Room": "can_use(Dins_Fire) or has_projectile(adult)",
+            "GS Forest Temple First Room": "can_use(Hookshot) or can_use(Bow) or can_use(Dins_Fire)",
             "GS Forest Temple Lobby": "can_use(Hookshot)"
         },
         "exits": {
@@ -33,13 +33,8 @@
         "region_name": "Forest Temple NE Outdoors",
         "dungeon": "Forest Temple",
         "locations": {
-            "Forest Temple Outside Hookshot Chest": "
-                can_use(Hookshot) or
-                can_reach(Forest_Temple_Falling_Room)",
-            "GS Forest Temple Outdoor East": "
-                can_use(Hookshot) or 
-                (can_reach(Forest_Temple_Falling_Room) and 
-                 (can_use(Bow) or can_use(Dins_Fire) or has_explosives))"
+            "Forest Temple Outside Hookshot Chest": "True",
+            "GS Forest Temple Outdoor East": "can_use(Hookshot)"
         },
         "exits": {
             "Forest Temple NW Outdoors": "

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -30,21 +30,10 @@
             "House of Twins": "True",
             "Know It All House": "True",
             "Kokiri Shop": "True",
-            "Outside Deku Tree": "(Kokiri_Sword and Buy_Deku_Shield) or open_forest",
+            "Deku Tree Lobby": "(Kokiri_Sword and Buy_Deku_Shield) or open_forest",
             "Lost Woods": "True",
             "Lost Woods Bridge": "can_leave_forest",
             "Kokiri Forest Storms Grotto": "can_play(Song_of_Storms)"
-        }
-    },
-    {
-        "region_name": "Outside Deku Tree",
-        "locations": {
-            "Deku Tree Gossip Stone (Left)": "True",
-            "Deku Tree Gossip Stone (Right)": "True"
-        },
-        "exits": {
-            "Deku Tree Lobby": "True",
-            "Kokiri Forest" : "True"
         }
     },
     {
@@ -137,12 +126,12 @@
             "Sacred Forest Meadow Entryway": "True",
             "Goron City Woods Warp": "True",
             "Zora River Child": "can_dive and can_leave_forest",
-            "Forest Temple Entry Area": "can_play(Sarias_Song) and is_adult",
+            "Forest Temple Entry Area": "(logic_adult_meadow_access or can_play(Sarias_Song)) and is_adult",
             "Lost Woods Generic Grotto": "can_blast_or_smash",
             "Deku Theater": "True",
             "Lost Woods Sales Grotto": "
                 has_explosives or (can_use(Hammer) and 
-                    (can_play(Minuet_of_Forest) or can_play(Sarias_Song)))"
+                    (logic_adult_meadow_access or can_play(Minuet_of_Forest) or can_play(Sarias_Song)))"
         }
     },
     {
@@ -154,7 +143,7 @@
                 Kokiri_Sword or can_use(Dins_Fire)",
             "Front of Meadow Grotto": "
                 has_explosives or (can_use(Hammer) and 
-                    (can_play(Minuet_of_Forest) or can_play(Sarias_Song)))"
+                    (logic_adult_meadow_access or can_play(Minuet_of_Forest) or can_play(Sarias_Song)))"
         }
     },
     {
@@ -225,7 +214,9 @@
                 can_use(Bow)",
             "Lake Hylia Freestanding PoH": "can_use(Scarecrow) or can_use(Magic_Bean)",
             "GS Lake Hylia Bean Patch": "has_bottle and can_child_attack",
-            "GS Lake Hylia Lab Wall": "Boomerang and nighttime",
+            "GS Lake Hylia Lab Wall": "
+                (Boomerang or
+                    (logic_lab_wall_gs and (has_sticks or Kokiri_Sword))) and nighttime",
             "GS Lake Hylia Small Island": "nighttime and can_child_attack",
             "GS Lake Hylia Giant Tree": "can_use(Longshot)",
             "Lake Hylia Lab Gossip Stone": "True",
@@ -246,7 +237,9 @@
     {
         "region_name": "Lake Hylia Lab",
         "locations": {
-            "Diving in the Lab": "(Progressive_Scale, 2)",
+            "Diving in the Lab": "
+                (Progressive_Scale, 2) or
+                (logic_lab_diving and Iron_Boots and can_use(Hookshot))",
             "GS Lab Underwater Crate": "Iron_Boots and can_use(Hookshot)"
         }
     },
@@ -311,7 +304,7 @@
         },
         "exits": {
             "Haunted Wasteland": "
-                Carpenter_Rescue and (can_use(Hover_Boots) or can_use(Longshot))",
+                Carpenter_Rescue and (logic_wasteland_crossing or can_use(Hover_Boots) or can_use(Longshot))",
             "Gerudo Training Grounds Lobby": "
                 Carpenter_Rescue and Gerudo_Membership_Card and is_adult"
         }
@@ -337,8 +330,8 @@
                 has_bottle and can_play(Requiem_of_Spirit) and can_child_attack",
             "GS Desert Colossus Tree": "can_use(Hookshot) and nighttime",
             "GS Desert Colossus Hill": "
-                ((can_use(Magic_Bean) and can_play(Requiem_of_Spirit)) or 
-                    can_use(Longshot)) and nighttime"
+                ((can_use(Magic_Bean) and can_play(Requiem_of_Spirit)) or can_use(Longshot) or
+                    (logic_colossus_gs and can_use(Hookshot))) and nighttime"
         },
         "exits": {
             "Colossus Fairy": "has_explosives",
@@ -559,7 +552,10 @@
             "GS Kakariko Skulltula House": "nighttime",
             "GS Kakariko Guard's House": "nighttime",
             "GS Kakariko Tree": "nighttime",
-            "GS Kakariko Watchtower": "(has_slingshot or has_bombchus) and nighttime",
+            "GS Kakariko Watchtower": "
+                (has_slingshot or has_bombchus or
+                    (logic_kakariko_tower_gs and (has_sticks or Kokiri_Sword) and
+                    (damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love)))) and nighttime",
             "GS Kakariko Above Impa's House": "can_use(Hookshot) and nighttime"
         },
         "exits": {
@@ -571,7 +567,9 @@
             "Windmill": "True",
             "Kakariko Bazaar": "is_adult",
             "Kakariko Shooting Gallery": "True",
-            "Bottom of the Well": "can_play(Song_of_Storms)",
+            "Bottom of the Well": "
+                can_play(Song_of_Storms) and 
+                (dungeon_mq[Bottom_of_the_Well] or can_child_attack or has_nuts)",
             "Kakariko Potion Shop Front": "is_adult",
             "Kakariko Potion Shop Back": "is_adult",
             "Odd Medicine Building": "True",
@@ -715,7 +713,9 @@
         },
         "exits": {
             "Graveyard": "True",
-            "Shadow Temple Entryway": "can_use(Dins_Fire)"
+            "Shadow Temple Beginning": "
+                can_use(Dins_Fire) and can_see_with_lens and 
+                (can_use(Hover_Boots) or can_use(Hookshot))"
         }
     },
     {
@@ -1208,9 +1208,9 @@
             "GS Hyrule Field Near Gerudo Valley": "
                 (Hammer and has_fire_source and can_use(Hookshot)) or 
                 (Boomerang and has_explosives and can_use(Dins_Fire))",
-             "HF Grotto Cow": "
-                can_play(Eponas_Song) and ((can_use(Hammer) and has_fire_source) or
-                (has_explosives and can_use(Dins_Fire)))"
+             "HF Grotto Cow":
+           "(can_use(Hammer) and has_fire_source) or
+              (has_explosives and can_use(Dins_Fire))"
         },
         "exits": {
             "Field Valley Grotto Gossip Stone": "

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -56,7 +56,9 @@
             "GS Spirit Temple MQ Iron Knuckle North": "(Small_Key_Spirit_Temple, 7)"
         },
         "exits": {
-            "Lower Adult Spirit Temple": "can_use(Fire_Arrows) and Mirror_Shield",
+            "Lower Adult Spirit Temple": "
+                (can_use(Fire_Arrows) or
+                    (logic_spirit_mq_lower_adult and can_use(Dins_Fire) and has_bow)) and Mirror_Shield",
             "Spirit Temple Shared": "True",
             "Spirit Temple Boss Area": "
                 (Small_Key_Spirit_Temple, 6) and can_play(Zeldas_Lullaby) and Hammer",

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -90,22 +90,22 @@
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Map Chest": "
-                ((has_explosives or (Small_Key_Spirit_Temple, 3) or 
-                    ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
-                Magic_Meter and (Dins_Fire or 
-                    (Fire_Arrows and has_bow and has_sticks))) or 
-                ((Small_Key_Spirit_Temple, 5) and has_explosives and 
+                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
+                    (can_use(Dins_Fire) or
+                        (((Magic_Meter and Fire_Arrows) or logic_spirit_map_chest) and has_bow and has_sticks))) or 
+                ((Small_Key_Spirit_Temple, 5) and has_explosives and
                     can_play(Requiem_of_Spirit) and has_sticks) or 
-                ((Small_Key_Spirit_Temple, 3) and can_use(Fire_Arrows) and 
+                ((Small_Key_Spirit_Temple, 3) and
+                    (can_use(Fire_Arrows) or (logic_spirit_map_chest and has_bow)) and 
                     can_use(Silver_Gauntlets))",
             "Spirit Temple Sun Block Room Chest": "
-                ((has_explosives or (Small_Key_Spirit_Temple, 3) or 
-                    ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
-                Magic_Meter and (Dins_Fire or 
-                    (Fire_Arrows and has_bow and has_sticks))) or 
-                ((Small_Key_Spirit_Temple, 5) and has_explosives and 
+                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
+                    (can_use(Dins_Fire) or
+                        (((Magic_Meter and Fire_Arrows) or logic_spirit_sun_chest) and has_bow and has_sticks))) or 
+                ((Small_Key_Spirit_Temple, 5) and has_explosives and
                     can_play(Requiem_of_Spirit) and has_sticks) or 
-                ((Small_Key_Spirit_Temple, 3) and can_use(Fire_Arrows) and 
+                ((Small_Key_Spirit_Temple, 3) and
+                    (can_use(Fire_Arrows) or (logic_spirit_sun_chest and has_bow)) and 
                     can_use(Silver_Gauntlets))",
             "Spirit Temple Statue Hand Chest": "
                 (Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and 


### PR DESCRIPTION
Changes:
- Fixed bug with can_finish_adult_trades not considering open gerudo fortress.
- Added tricks:
1. Adult Meadow Access without Saria's or Minuet
2. Reach Volvagia without Hover Boots or Pillar
3. Diving in the Lab without Gold Scale
4. Deliver Eye Drops with Bolero of Fire
5. Wasteland Crossing without Hover Boots or Longshot
6. Desert Colossus Hill GS with Hookshot
7. Dodongo's Cavern Scarecrow GS with Armos Statue
8. Kakariko Tower GS with Jump Slash
9. Lake Hylia Lab Wall GS with Jump Slash
10. Spirit Temple MQ Lower Adult without Fire Arrows
11. Spirit Temple Map Chest with Bow
12. Spirit Temple Sun Block Room Chest with Bow