### PR TITLE
Rework child/adult logic by adding an age parameter to can_reach

### DIFF
--- a/Entrance.py
+++ b/Entrance.py
@@ -7,7 +7,7 @@ class Entrance(object):
         self.target = None
         self.addresses = None
         self.spot_type = 'Entrance'
-        self.recursion_count = 0
+        self.recursion_count = { 'child': 0, 'adult': 0 }
         self.vanilla = None
         self.access_rule = lambda state: True
 
@@ -25,10 +25,7 @@ class Entrance(object):
 
 
     def can_reach(self, state):
-        if self.access_rule(state) and state.can_reach(self.parent_region):
-            return True
-
-        return False
+        return state.with_spot(self.access_rule, spot=self) and state.can_reach(self.parent_region)
 
 
     def connect(self, region, addresses=None, target=None, vanilla=None):

--- a/Fill.py
+++ b/Fill.py
@@ -331,7 +331,7 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
                         while parent_region:
                             try:
                                 source_region = item_to_place.world.get_region(parent_region.name)
-                                can_reach = source_region.can_reach(maximum_exploration_state_list[item_to_place.world.id])
+                                can_reach = maximum_exploration_state_list[item_to_place.world.id].can_reach(source_region)
                                 break
                             except KeyError:
                                 parent_region = parent_region.entrances[0].parent_region

--- a/Location.py
+++ b/Location.py
@@ -15,7 +15,7 @@ class Location(object):
         self.scene = scene
         self.hint = hint
         self.spot_type = 'Location'
-        self.recursion_count = 0
+        self.recursion_count = { 'child': 0, 'adult': 0 }
         self.staleness_count = 0
         self.access_rule = lambda state: True
         self.item_rule = lambda location, item: True
@@ -60,11 +60,11 @@ class Location(object):
 
 
     def can_reach(self, state):
-        if not self.is_disabled() and \
-           self.access_rule(state) and \
-           state.can_reach(self.parent_region):
-            return True
-        return False
+        if self.is_disabled():
+            return False
+
+        return state.with_spot(self.access_rule, spot=self) and state.can_reach(self.parent_region)
+
 
     def is_disabled(self):
         return (self.disabled == DisableType.DISABLED) or \

--- a/Region.py
+++ b/Region.py
@@ -27,7 +27,7 @@ class Region(object):
         self.dungeon = None
         self.world = None
         self.spot_type = 'Region'
-        self.recursion_count = 0
+        self.recursion_count = { 'child': 0, 'adult': 0 }
         self.price = None
         self.world = None
 
@@ -51,6 +51,7 @@ class Region(object):
         for entrance in self.entrances:
             if entrance.can_reach(state):
                 return True
+
         return False
 
 

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -8,6 +8,9 @@ escaped_items = {}
 for item in item_table:
     escaped_items[re.sub(r'[\'()[\]]', '', item.replace(' ', '_'))] = item
 
+lambda_methods = ['as_either', 'as_both', 'as_adult', 'as_child', 
+                  'as_either_here', 'as_both_here', 'as_adult_here', 'as_child_here']
+
 
 class Rule_AST_Transformer(ast.NodeTransformer):
 
@@ -84,6 +87,15 @@ class Rule_AST_Transformer(ast.NodeTransformer):
 
 
     def visit_Call(self, node):
+        if node.func.id in lambda_methods:
+            node.args = [ast.Lambda(
+                            args=ast.arguments(
+                                args=[ast.arg(arg='state')],
+                                defaults=[],
+                                kwonlyargs=[], 
+                                kw_defaults=[]),
+                            body=node.args[0])]
+
         new_args = []
         for child in node.args:
             if isinstance(child, ast.Name):
@@ -99,6 +111,8 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                     child = ast.Str(escaped_items[child.id])
                 else:
                     child = ast.Str(child.id.replace('_', ' '))
+            else:
+                self.visit(child)
             new_args.append(child)
 
         if isinstance(node.func, ast.Name):

--- a/Rules.py
+++ b/Rules.py
@@ -50,6 +50,9 @@ def set_rules(world):
             # This location needs to be a small key. Make sure the boss key isn't placed here.
             forbid_item(location, 'Boss Key (Forest Temple)')
 
+        if location.type == 'GossipStone' and world.hints == 'mask':
+            add_rule(location, lambda state: state.is_child())
+
     for location in world.disabled_locations:
         try:
             world.get_location(location).disabled = DisableType.PENDING
@@ -106,16 +109,7 @@ def set_shop_rules(world):
 
             # Add adult only checks
             if location.item.name in ['Buy Goron Tunic', 'Buy Zora Tunic']:
-                if location.parent_region.name == 'Goron Shop':
-                    add_rule(
-                        location,
-                        lambda state: state.is_adult() and (state.has_explosives() or state.has('Progressive Strength Upgrade') or state.has_bow()))
-                elif location.parent_region.name == 'Zora Shop':
-                    add_rule(location, lambda state: state.can_reach('Zoras Domain Frozen -> Zora Shop', 'Entrance'))
-                elif location.parent_region.name in ['Castle Town Bombchu Shop', 'Castle Town Potion Shop', 'Castle Town Bazaar']:
-                    set_rule(location, lambda state: False)
-                else:
-                    add_rule(location, lambda state: state.is_adult())
+                add_rule(location, lambda state: state.is_adult())
 
             # Add item prerequisit checks
             if location.item.name in ['Buy Blue Fire',

--- a/Rules.py
+++ b/Rules.py
@@ -9,9 +9,13 @@ def set_rules(world):
     # ganon can only carry triforce
     world.get_location('Ganon').item_rule = lambda location, item: item.name == 'Triforce'
 
-    # these are default save&quit points and always accessible
-    world.get_region('Links House').can_reach = lambda state: True
-    
+    # these are default save&quit points and always accessible in their corresponding age
+    old_can_reach = world.get_region('Links House').can_reach
+    world.get_region('Links House').can_reach = lambda state: state.is_child() or old_can_reach(state)
+
+    old_can_reach = world.get_region('Temple of Time').can_reach
+    world.get_region('Temple of Time').can_reach = lambda state: state.is_adult() or old_can_reach(state)
+
     for location in world.get_locations():
 
         if not world.shuffle_song_items:

--- a/State.py
+++ b/State.py
@@ -194,19 +194,20 @@ class State(object):
 
 
     def can_child_attack(self):
-        return  self.has_slingshot() or \
-                self.has('Boomerang') or \
-                self.has_sticks() or \
-                self.has_explosives() or \
-                self.has('Kokiri Sword') or \
-                (self.has('Dins Fire') and self.has('Magic Meter'))
+        return  self.is_child() and \
+                   (self.has_slingshot() or \
+                    self.has('Boomerang') or \
+                    self.has_sticks() or \
+                    self.has_explosives() or \
+                    self.has('Kokiri Sword') or \
+                    self.can_use('Dins Fire'))
 
 
     def can_stun_deku(self):
         return  self.is_adult() or \
                 self.can_child_attack() or \
                 self.has_nuts() or \
-                self.has('Buy Deku Shield')
+                self.can_use('Deku Shield')
 
 
     def has_nuts(self):
@@ -231,10 +232,10 @@ class State(object):
 
     def has_blue_fire(self):
         return self.has_bottle() and \
-                (self.can_reach('Ice Cavern')
-                or self.can_reach('Ganons Castle Water Trial')
+                (self.can_reach('Ice Cavern', age='either')
+                or self.can_reach('Ganons Castle Water Trial', age='either')
                 or self.has('Buy Blue Fire')
-                or (self.world.dungeon_mq['Gerudo Training Grounds'] and self.can_reach('Gerudo Training Grounds Stalfos Room')))
+                or (self.world.dungeon_mq['Gerudo Training Grounds'] and self.can_reach('Gerudo Training Grounds Stalfos Room', age='either')))
 
 
     def has_ocarina(self):
@@ -247,14 +248,21 @@ class State(object):
 
     def can_use(self, item):
         magic_items = ['Dins Fire', 'Farores Wind', 'Nayrus Love', 'Lens of Truth']
-        adult_items = ['Bow', 'Hammer', 'Iron Boots', 'Hover Boots', 'Magic Bean']
+        adult_items = ['Bow', 'Hammer', 'Iron Boots', 'Hover Boots', 'Epona']
+        child_items = ['Slingshot', 'Boomerang', 'Kokiri Sword']
         magic_arrows = ['Fire Arrows', 'Light Arrows']
         if item in magic_items:
             return self.has(item) and self.has('Magic Meter')
+        elif item in child_items:
+            return self.has(item) and self.is_child()
         elif item in adult_items:
             return self.has(item) and self.is_adult()
         elif item in magic_arrows:
             return self.has(item) and self.is_adult() and self.has_bow() and self.has('Magic Meter')
+        elif item == 'Sticks':
+            return self.has_sticks() and self.is_child()
+        elif item == 'Deku Shield':
+            return self.has('Buy Deku Shield') and self.is_child()
         elif item == 'Hookshot':
             return self.has('Progressive Hookshot') and self.is_adult()
         elif item == 'Longshot':
@@ -267,6 +275,9 @@ class State(object):
             return self.has('Progressive Hookshot') and self.is_adult() and self.has_ocarina()
         elif item == 'Distant Scarecrow':
             return self.has('Progressive Hookshot', 2) and self.is_adult() and self.has_ocarina()
+        elif item == 'Magic Bean':
+            # Magic Bean usability automatically checks for reachability as child to the current spot's parent region (with as_child_here)
+            return self.as_child_here(lambda state: state.has('Magic Bean')) and self.is_adult()
         else:
             return self.has(item)
 
@@ -275,8 +286,8 @@ class State(object):
         return self.has('Buy Bombchu (5)') or \
                self.has('Buy Bombchu (10)') or \
                self.has('Buy Bombchu (20)') or \
-               self.can_reach('Castle Town Bombchu Bowling') or \
-               self.can_reach('Haunted Wasteland Bombchu Salesman', 'Location')
+               self.can_reach('Castle Town Bombchu Bowling', age='either') or \
+               self.can_reach('Haunted Wasteland Bombchu Salesman', 'Location', age='either')
 
 
     def has_bombchus(self):
@@ -290,7 +301,7 @@ class State(object):
     def has_bombchus_item(self):
         return (self.world.bombchus_in_logic and \
                 (self.has_any(lambda pritem: pritem.startswith('Bombchus')) \
-                or (self.has('Progressive Wallet') and self.can_reach('Haunted Wasteland')))) \
+                or (self.has('Progressive Wallet') and self.can_reach('Haunted Wasteland', age='either')))) \
             or (not self.world.bombchus_in_logic and self.has('Bomb Bag'))
 
 
@@ -308,6 +319,16 @@ class State(object):
 
     def can_see_with_lens(self):
         return ((self.has('Magic Meter') and self.has('Lens of Truth')) or self.world.logic_lens != 'all')
+
+
+    def can_plant_bugs(self):
+        return self.is_child() and self.has_bugs()
+
+
+    def has_bugs(self):
+        return self.has_bottle() and \
+            (self.can_leave_forest() or self.has_sticks() or self.has('Kokiri Sword') or 
+             self.has('Boomerang') or self.has_explosives() or self.has('Buy Bottle Bug'))
 
 
     def has_projectile(self, age='either'):
@@ -330,13 +351,18 @@ class State(object):
 
 
     def can_leave_forest(self):
-        return self.world.open_forest or self.can_reach(self.world.get_location('Queen Gohma'))
+        return self.world.open_forest or self.can_reach(self.world.get_location('Queen Gohma'), age='either')
 
 
     def can_finish_adult_trades(self):
         zora_thawed = (self.can_play('Zeldas Lullaby') or (self.has('Hover Boots') and self.world.logic_zora_with_hovers)) and self.has_blue_fire()
         carpenter_access = self.can_reach('Gerudo Valley Far Side')
         return (self.has('Claim Check') or ((self.has('Progressive Strength Upgrade') or self.can_blast_or_smash() or self.has_bow() or self.world.logic_biggoron_bolero) and (((self.has('Eyedrops') or self.has('Eyeball Frog') or self.has('Prescription') or self.has('Broken Sword')) and zora_thawed) or ((self.has('Poachers Saw') or self.has('Odd Mushroom') or self.has('Cojiro') or self.has('Pocket Cucco') or self.has('Pocket Egg')) and zora_thawed and carpenter_access))))
+
+
+    def has_mask_of_truth(self):
+        # Must befriend Skull Kid to sell Skull Mask, all stones to spawn running man.
+        return self.has('Zeldas Letter') and self.can_play('Sarias Song') and self.has('Kokiri Emerald') and self.has('Goron Ruby') and self.has('Zora Sapphire')
 
 
     def has_bottle(self):
@@ -369,7 +395,7 @@ class State(object):
     def guarantee_hint(self):
         if(self.world.hints == 'mask'):
             # has the mask of truth
-            return self.has('Zeldas Letter') and self.can_play('Sarias Song') and self.has('Kokiri Emerald') and self.has('Goron Ruby') and self.has('Zora Sapphire')
+            return self.has_mask_of_truth()
         elif(self.world.hints == 'agony'):
             # has the Stone of Agony
             return self.has('Stone of Agony')

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -10,7 +10,7 @@
             "GS Deku Tree MQ Lobby": "can_child_attack"
         },
         "exits": {
-            "Kokiri Forest": "True",
+            "Outside Deku Tree": "True",
             "Deku Tree Compass Room": "has_slingshot and (has_sticks or can_use(Dins_Fire))",
             "Deku Tree Boss Room": "has_slingshot and (has_sticks or can_use(Dins_Fire))"
         }

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -14,7 +14,7 @@
             "GS Deku Tree Basement Gate": "can_child_attack"
         },
         "exits": {
-            "Kokiri Forest": "True",
+            "Outside Deku Tree": "True",
             "Deku Tree Slingshot Room": "Buy_Deku_Shield",
             "Deku Tree Boss Room": "has_slingshot and (has_sticks or can_use(Dins_Fire))"
         }

--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -13,11 +13,9 @@
         "locations": {
             "Dodongos Cavern MQ Map Chest": "True",
             "Dodongos Cavern MQ Compass Chest": "is_adult or can_child_attack or has_nuts",
-            "Dodongos Cavern MQ Larva Room Chest": "
-                (has_sticks and (has_explosives or Progressive_Strength_Upgrade)) or 
-                has_fire_source",
+            "Dodongos Cavern MQ Larva Room Chest": "can_use(Sticks) or has_fire_source",
             "Dodongos Cavern MQ Torch Puzzle Room Chest": "
-                can_blast_or_smash or has_sticks or can_use(Dins_Fire) or 
+                can_blast_or_smash or can_use(Sticks) or can_use(Dins_Fire) or 
                 (is_adult and (logic_dc_jump or Hover_Boots or Progressive_Hookshot))",
             "Dodongos Cavern MQ Bomb Bag Chest": "
                 is_adult or 
@@ -27,15 +25,14 @@
                             (damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love)))))",
             "GS Dodongo's Cavern MQ Song of Time Block Room": "
                 can_play(Song_of_Time) and (can_child_attack or is_adult)",
-            "GS Dodongo's Cavern MQ Larva Room": "
-                (has_sticks and (has_explosives or Progressive_Strength_Upgrade)) or has_fire_source",
+            "GS Dodongo's Cavern MQ Larva Room": "can_use(Sticks) or has_fire_source",
             "GS Dodongo's Cavern MQ Lizalfos Room": "can_blast_or_smash",
             "GS Dodongo's Cavern MQ Scrub Room": "
-                (Boomerang and (has_slingshot or (is_adult and has_explosives)) and 
+                (can_use(Boomerang) and (has_slingshot or (can_become_adult and has_explosives)) and 
                     (has_explosives or (Progressive_Strength_Upgrade and 
-                        (can_use(Hammer) or 
+                        (Hammer or 
                             ((has_sticks or can_use(Dins_Fire) or 
-                                (is_adult and (logic_dc_jump or Hover_Boots))) and 
+                                (can_become_adult and (logic_dc_jump or Hover_Boots))) and 
                             (damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love))))))) or 
                 (can_use(Hookshot) and (has_explosives or Progressive_Strength_Upgrade or 
                     has_bow or can_use(Dins_Fire)))",
@@ -45,19 +42,11 @@
             "DC MQ Deku Scrub Red Potion": "
                 is_adult or has_explosives or 
                 ((has_sticks or can_use(Dins_Fire)) and 
-                    (damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love)))"
+                    (damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love)))",
+            "Dodongos Cavern Gossip Stone": "True"
         },
         "exits": {
-            "Dodongos Cavern Boss Area": "has_explosives",
-            "Dodongos Gossip Stone": "
-                hints != 'mask' or has_explosives or Progressive_Strength_Upgrade"
-        }
-    },
-    {
-        "region_name": "Dodongos Gossip Stone",
-        "dungeon": "Dodongos Cavern",
-        "locations": {
-            "Dodongos Cavern Gossip Stone": "True"
+            "Dodongos Cavern Boss Area": "has_explosives"
         }
     },
     {

--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -23,24 +23,18 @@
             "DC Deku Scrub Deku Sticks": "
                 is_adult or has_slingshot or has_sticks or 
                 has_explosives or Kokiri_Sword",
-            "DC Deku Scrub Deku Shield": "True"
+            "DC Deku Scrub Deku Shield": "True",
+            "Dodongos Cavern Gossip Stone": "True"
         },
         "exits": {
             "Dodongos Cavern Beginning": "True",
             "Dodongos Cavern Climb": "
-                (is_adult or 
-                    ((has_sticks or can_use(Dins_Fire)) and 
-                        (has_slingshot or has_sticks or has_explosives or Kokiri_Sword))) and 
-                (has_explosives or Progressive_Strength_Upgrade or 
-                    can_use(Dins_Fire) or (logic_dc_staircase and can_use(Bow)))",
-            "Dodongos Gossip Stone": "
-                hints != 'mask' or has_explosives or Progressive_Strength_Upgrade"
-        }
-    },
-    {
-        "region_name": "Dodongos Gossip Stone",
-        "locations": {
-            "Dodongos Cavern Gossip Stone": "True"
+                as_either_here(
+                    (is_adult or 
+                        ((has_sticks or can_use(Dins_Fire)) and 
+                            (has_slingshot or has_sticks or has_explosives or Kokiri_Sword))) and 
+                    (has_explosives or Progressive_Strength_Upgrade or 
+                        can_use(Dins_Fire) or (logic_dc_staircase and can_use(Bow))))"
         }
     },
     {
@@ -55,9 +49,8 @@
         "exits": {
             "Dodongos Cavern Lobby": "True",
             "Dodongos Cavern Far Bridge": "
-                (has_slingshot and (has_explosives or Progressive_Strength_Upgrade)) or 
-                ((has_bow or Hover_Boots or (Progressive_Hookshot, 2) or logic_dc_jump) and 
-                    is_adult)"
+                as_child_here(has_slingshot) or 
+                as_adult_here(has_bow or Hover_Boots or can_use(Longshot) or logic_dc_jump)"
         }
     },
     {
@@ -66,9 +59,7 @@
         "locations": {
             "Dodongos Cavern Bomb Bag Chest": "True",
             "Dodongos Cavern End of Bridge Chest": "can_blast_or_smash",
-            "GS Dodongo's Cavern Alcove Above Stairs": "
-                can_use(Hookshot) or 
-                (Boomerang and (has_explosives or Progressive_Strength_Upgrade))"
+            "GS Dodongo's Cavern Alcove Above Stairs": "can_use(Hookshot) or can_use(Boomerang)"
         },
         "exits": {
             "Dodongos Cavern Boss Area": "has_explosives",

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -7,7 +7,7 @@
             "GS Forest Temple MQ First Hallway": "True"
         },
         "exits": {
-            "Forest Temple Entry Area": "True",
+            "Sacred Forest Meadow": "True",
             "Forest Temple Central Area": "(Small_Key_Forest_Temple, 1)"
         }
     },

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -9,7 +9,7 @@
             "GS Forest Temple Lobby": "can_use(Hookshot)"
         },
         "exits": {
-            "Forest Temple Entry Area": "True",
+            "Sacred Forest Meadow": "True",
             "Forest Temple NW Outdoors": "can_play(Song_of_Time)",
             "Forest Temple NE Outdoors": "can_use(Bow)",
             "Forest Temple Block Push Room": "(Small_Key_Forest_Temple, 1)"

--- a/data/World/Ice Cavern MQ.json
+++ b/data/World/Ice Cavern MQ.json
@@ -3,7 +3,7 @@
         "region_name": "Ice Cavern",
         "dungeon": "Ice Cavern",
         "exits": {
-            "Outside Ice Cavern": "True",
+            "Zoras Fountain": "True",
             "Ice Cavern Interior": "has_bottle"
         }
     },

--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -13,7 +13,7 @@
             "GS Ice Cavern Push Block Room": "has_blue_fire and can_use(Hookshot)"
         },
         "exits": {
-            "Outside Ice Cavern": "True"
+            "Zoras Fountain": "True"
         }
     }
 ]

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2,25 +2,15 @@
     {
         "region_name": "Kokiri Forest",
         "locations": {
-            "Kokiri Sword Chest": "True",
+            "Kokiri Sword Chest": "is_child",
             "GS Kokiri Know It All House": "
-                nighttime and (had_night_start or can_leave_forest or can_play(Suns_Song)) and 
-                can_child_attack",
+                is_child and nighttime and 
+                (had_night_start or can_leave_forest or can_play(Suns_Song)) and can_child_attack",
             "GS Kokiri Bean Patch": "
-                has_bottle and can_child_attack and 
-                (can_leave_forest or Kokiri_Sword or has_sticks or 
-                    Boomerang or has_explosives or Buy_Bottle_Bug)",
+                can_plant_bugs and can_child_attack",
             "GS Kokiri House of Twins": "
-                (can_use(Hookshot) or 
-                    (logic_adult_kokiri_gs and can_use(Hover_Boots))) and nighttime",
-            "Deku Baba Sticks": "
-                (Kokiri_Sword and Buy_Deku_Shield) or 
-                (open_forest and (is_adult or Kokiri_Sword or Boomerang))",
-            "Deku Baba Nuts": "
-                (Kokiri_Sword and Buy_Deku_Shield) or 
-                (open_forest and 
-                    (is_adult or has_slingshot or has_sticks or 
-                        has_explosives or Kokiri_Sword or can_use(Dins_Fire)))",
+                is_adult and nighttime and 
+                (can_use(Hookshot) or (logic_adult_kokiri_gs and can_use(Hover_Boots)))",
             "Kokiri Forest Gossip Stone": "True"
         },
         "exits": {
@@ -30,7 +20,7 @@
             "House of Twins": "True",
             "Know It All House": "True",
             "Kokiri Shop": "True",
-            "Outside Deku Tree": "(Kokiri_Sword and Buy_Deku_Shield) or open_forest",
+            "Outside Deku Tree": "(Kokiri_Sword and Buy_Deku_Shield) or is_adult or open_forest",
             "Lost Woods": "True",
             "Lost Woods Bridge": "can_leave_forest",
             "Kokiri Forest Storms Grotto": "can_play(Song_of_Storms)"
@@ -39,24 +29,27 @@
     {
         "region_name": "Outside Deku Tree",
         "locations": {
+            "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
+            "Deku Baba Nuts": "
+                is_adult or has_slingshot or has_sticks or 
+                has_explosives or Kokiri_Sword or can_use(Dins_Fire)",
             "Deku Tree Gossip Stone (Left)": "True",
             "Deku Tree Gossip Stone (Right)": "True"
         },
         "exits": {
-            "Deku Tree Lobby": "True",
-            "Kokiri Forest" : "True"
+            "Deku Tree Lobby": "is_child",
+            "Kokiri Forest": "True"
         }
     },
     {
         "region_name": "Links House",
         "locations": {
             "Links Pocket": "True",
-            "Links House Cow": "Epona"
+            "Links House Cow": "is_adult and Epona"
         },
         "exits": {
             "Kokiri Forest": "True",
             "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
-            "Forest Temple Entry Area": "can_play(Minuet_of_Forest) and is_adult",
             "Temple of Time": "can_play(Prelude_of_Light) and can_leave_forest",
             "Death Mountain Crater Central": "
                 can_play(Bolero_of_Fire) and can_leave_forest",
@@ -115,68 +108,63 @@
     {
         "region_name": "Lost Woods",
         "locations": {
-            "Skull Kid": "can_play(Sarias_Song)",
-            "Ocarina Memory Game": "has_ocarina",
-            "Target in Woods": "has_slingshot",
-            "LW Deku Scrub Deku Stick Upgrade": "can_stun_deku",
-            "GS Lost Woods Bean Patch Near Bridge": "
-                has_bottle and can_child_attack and 
-                (can_leave_forest or Kokiri_Sword or has_sticks or 
-                    Boomerang or has_explosives or Buy_Bottle_Bug)",
-            "GS Lost Woods Bean Patch Near Stage": "
-                has_bottle and 
-                (can_child_attack or (shuffle_scrubs == 'off' and Buy_Deku_Shield)) and 
-                (can_leave_forest or Kokiri_Sword or has_sticks or 
-                    Boomerang or has_explosives or Buy_Bottle_Bug)",
-            "LW Deku Scrub Deku Nuts": "can_stun_deku",
-            "LW Deku Scrub Deku Sticks": "can_stun_deku",
+            "Skull Kid": "is_child and can_play(Sarias_Song)",
+            "Ocarina Memory Game": "is_child and has_ocarina",
+            "Target in Woods": "can_use(Slingshot)",
+            "LW Deku Scrub Deku Stick Upgrade": "is_child and can_stun_deku",
+            "GS Lost Woods Bean Patch Near Bridge": "can_plant_bugs and can_child_attack",
             "Lost Woods Gossip Stone": "True"
         },
         "exits": {
             "Kokiri Forest": "True",
-            "Sacred Forest Meadow Entryway": "True",
             "Goron City Woods Warp": "True",
-            "Zora River Child": "can_dive and can_leave_forest",
-            "Forest Temple Entry Area": "(logic_adult_meadow_access or can_play(Sarias_Song)) and is_adult",
-            "Lost Woods Generic Grotto": "can_blast_or_smash",
+            "Zora River": "can_dive and can_leave_forest",
+            "Lost Woods Beyond Mido": "is_child or logic_adult_meadow_access or can_play(Sarias_Song)",
+            "Lost Woods Generic Grotto": "can_blast_or_smash"
+        }
+    },
+    {
+        "region_name": "Lost Woods Beyond Mido",
+        "locations": {
+            "LW Deku Scrub Deku Nuts": "is_child and can_stun_deku",
+            "LW Deku Scrub Deku Sticks": "is_child and can_stun_deku",
+            "GS Lost Woods Above Stage": "can_use(Magic_Bean) and nighttime",
+            "GS Lost Woods Bean Patch Near Stage": "
+                can_plant_bugs and 
+                (can_child_attack or (shuffle_scrubs == 'off' and Buy_Deku_Shield))"
+        },
+        "exits": {
+            "Lost Woods": "True",
+            "Sacred Forest Meadow Entryway": "True",
             "Deku Theater": "True",
-            "Lost Woods Sales Grotto": "
-                has_explosives or (can_use(Hammer) and 
-                    (logic_adult_meadow_access or can_play(Minuet_of_Forest) or can_play(Sarias_Song)))"
+            "Lost Woods Sales Grotto": "can_blast_or_smash"
         }
     },
     {
         "region_name": "Sacred Forest Meadow Entryway",
         "exits": {
-            "Lost Woods": "True",
+            "Lost Woods Beyond Mido": "True",
             "Sacred Forest Meadow": "
-                has_slingshot or has_sticks or has_explosives or 
+                is_adult or has_slingshot or has_sticks or has_explosives or 
                 Kokiri_Sword or can_use(Dins_Fire)",
-            "Front of Meadow Grotto": "
-                has_explosives or (can_use(Hammer) and 
-                    (logic_adult_meadow_access or can_play(Minuet_of_Forest) or can_play(Sarias_Song)))"
+            "Front of Meadow Grotto": "can_blast_or_smash"
         }
     },
     {
         "region_name": "Sacred Forest Meadow",
         "locations": {
-            "Song from Saria": "Zeldas_Letter"
-        },
-        "exits": {
-            "Sacred Forest Meadow Entryway": "True",
-            "Meadow Fairy Grotto": "True",
-            "Meadow Storms Grotto": "
-                can_play(Song_of_Storms) and 
-                (can_child_attack or has_nuts or Buy_Deku_Shield)",
-            "Sacred Forest Meadow Gossip Stones": "True"
-        }
-    },
-    {
-        "region_name": "Sacred Forest Meadow Gossip Stones",
-        "locations": {
+            "Song from Saria": "is_child and Zeldas_Letter",
+            "Sheik Forest Song": "is_adult",
+            "GS Sacred Forest Meadow": "can_use(Hookshot) and nighttime",
             "Sacred Forest Meadow Maze Gossip Stone (Lower)": "True",
             "Sacred Forest Meadow Maze Gossip Stone (Upper)": "True",
             "Sacred Forest Meadow Saria Gossip Stone": "True"
+        },
+        "exits": {
+            "Sacred Forest Meadow Entryway": "True",
+            "Forest Temple Lobby": "can_use(Hookshot)",
+            "Meadow Fairy Grotto": "True",
+            "Meadow Storms Grotto": "can_play(Song_of_Storms) and can_stun_deku"
         }
     },
     {
@@ -193,9 +181,9 @@
         "region_name": "Hyrule Field",
         "locations": {
             "Ocarina of Time": "
-                Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
+                is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
             "Song from Ocarina of Time": "
-                Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
+                is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
             "Generic Grotto Gossip Stone": "True"
         },
         "exits": {
@@ -209,7 +197,8 @@
             "Remote Southern Grotto": "can_blast_or_smash",
             "Field Near Lake Outside Fence Grotto": "True",
             "Field Near Lake Inside Fence Grotto": "can_blast_or_smash",
-            "Field Valley Grotto": "can_blast_or_smash",
+            "Field Valley Grotto": "
+                can_use(Hammer) or (is_child and has_explosives)",
             "Field West Castle Town Grotto": "can_blast_or_smash",
             "Field Far West Castle Town Grotto": "can_blast_or_smash",
             "Field Kakariko Grotto": "can_blast_or_smash",
@@ -219,16 +208,16 @@
     {
         "region_name": "Lake Hylia",
         "locations": {
-            "Underwater Bottle": "can_dive",
+            "Underwater Bottle": "is_child and can_dive",
             "Lake Hylia Sun": "
-                (can_use(Distant_Scarecrow) or can_reach(Morpha, Location)) and 
-                can_use(Bow)",
+                is_adult and 
+                (can_use(Distant_Scarecrow) or can_reach(Morpha, Location)) and can_use(Bow)",
             "Lake Hylia Freestanding PoH": "can_use(Scarecrow) or can_use(Magic_Bean)",
-            "GS Lake Hylia Bean Patch": "has_bottle and can_child_attack",
+            "GS Lake Hylia Bean Patch": "can_plant_bugs and can_child_attack",
             "GS Lake Hylia Lab Wall": "
-                (Boomerang or
+                is_child and (Boomerang or 
                     (logic_lab_wall_gs and (has_sticks or Kokiri_Sword))) and nighttime",
-            "GS Lake Hylia Small Island": "nighttime and can_child_attack",
+            "GS Lake Hylia Small Island": "is_child and can_child_attack and nighttime",
             "GS Lake Hylia Giant Tree": "can_use(Longshot)",
             "Lake Hylia Lab Gossip Stone": "True",
             "Lake Hylia Gossip Stone (Southeast)": "True",
@@ -236,9 +225,10 @@
         },
         "exits": {
             "Hyrule Field": "True",
-            "Zoras Domain": "can_dive",
+            "Zoras Domain": "is_child and can_dive",
             "Lake Hylia Lab": "True",
-            "Fishing Hole": "True",
+            "Fishing Hole": "
+                is_child or can_use(Scarecrow) or can_use(Magic_Bean) or can_reach(Morpha, Location)",
             "Water Temple Lobby": "
                 (Iron_Boots or (logic_morpha_with_scale and (Progressive_Scale, 2))) and 
                 can_use(Hookshot) and (logic_fewer_tunic_requirements or has_ZoraTunic)",
@@ -257,26 +247,25 @@
     {
         "region_name": "Fishing Hole",
         "locations": {
-            "Child Fishing": "True",
-            "Adult Fishing": "
-                (can_use(Scarecrow) or can_use(Magic_Bean) or can_reach(Morpha, Location))"
+            "Child Fishing": "is_child",
+            "Adult Fishing": "is_adult"
         }
     },
     {
         "region_name": "Gerudo Valley",
         "locations": {
             "Gerudo Valley Waterfall Freestanding PoH": "True",
-            "Gerudo Valley Crate Freestanding PoH": "True",
-            "GS Gerudo Valley Small Bridge": "Boomerang and nighttime",
-            "GS Gerudo Valley Bean Patch": "has_bottle and can_child_attack",
+            "Gerudo Valley Crate Freestanding PoH": "is_child or can_use(Longshot)",
+            "GS Gerudo Valley Small Bridge": "can_use(Boomerang) and nighttime",
+            "GS Gerudo Valley Bean Patch": "can_plant_bugs and can_child_attack",
             "Gerudo Valley Gossip Stone": "True",
-            "Gerudo Valley Cow": "can_play(Eponas_Song)"
+            "Gerudo Valley Cow": "is_child and can_play(Eponas_Song)"
         },
         "exits": {
             "Hyrule Field": "True",
             "Lake Hylia": "True",
             "Gerudo Valley Far Side": "
-                is_adult and (Epona or can_use(Longshot) or (gerudo_fortress == 'open'))"
+                is_adult and (Epona or can_use(Longshot) or gerudo_fortress == 'open')"
         }
     },
     {
@@ -334,34 +323,25 @@
     {
         "region_name": "Desert Colossus",
         "locations": {
-            "Colossus Freestanding PoH": "
-                can_play(Requiem_of_Spirit) and can_use(Magic_Bean)",
+            "Colossus Freestanding PoH": "can_use(Magic_Bean)",
             "Sheik at Colossus": "True",
-            "GS Desert Colossus Bean Patch": "
-                has_bottle and can_play(Requiem_of_Spirit) and can_child_attack",
+            "GS Desert Colossus Bean Patch": "can_plant_bugs and can_child_attack",
             "GS Desert Colossus Tree": "can_use(Hookshot) and nighttime",
             "GS Desert Colossus Hill": "
-                ((can_use(Magic_Bean) and can_play(Requiem_of_Spirit)) or can_use(Longshot) or
-                    (logic_colossus_gs and can_use(Hookshot))) and nighttime"
+                (can_use(Magic_Bean) or can_use(Longshot) or 
+                    (logic_colossus_gs and can_use(Hookshot))) and nighttime",
+            "Desert Colossus Gossip Stone": "True"
         },
         "exits": {
             "Colossus Fairy": "has_explosives",
             "Spirit Temple Lobby": "True",
-            "Desert Colossus Grotto": "can_use(Silver_Gauntlets)",
-            "Desert Colossus Gossip Stone": "
-                hints != 'mask' or can_play(Requiem_of_Spirit)"
+            "Desert Colossus Grotto": "can_use(Silver_Gauntlets)"
         }
     },
     {
         "region_name": "Colossus Fairy",
         "locations": {
             "Desert Colossus Fairy Reward": "can_play(Zeldas_Lullaby)"
-        }
-    },
-    {
-        "region_name": "Desert Colossus Gossip Stone",
-        "locations": {
-            "Desert Colossus Gossip Stone": "True"
         }
     },
     {
@@ -375,18 +355,18 @@
         "exits": {
             "Hyrule Field": "True",
             "Temple of Time": "True",
-            "Hyrule Castle Grounds": "True",
-            "Castle Town Rupee Room": "True",
-            "Castle Town Bazaar": "True",
-            "Castle Town Mask Shop": "True",
-            "Castle Town Shooting Gallery": "True",
+            "Hyrule Castle Grounds": "is_child",
             "Ganons Castle Grounds": "is_adult",
-            "Castle Town Bombchu Bowling": "True",
-            "Castle Town Potion Shop": "True",
-            "Castle Town Treasure Chest Game": "True",
-            "Castle Town Bombchu Shop": "True",
-            "Castle Town Dog Lady": "True",
-            "Castle Town Man in Green House": "True"
+            "Castle Town Rupee Room": "True",
+            "Castle Town Bazaar": "is_child",
+            "Castle Town Mask Shop": "is_child",
+            "Castle Town Shooting Gallery": "is_child",
+            "Castle Town Bombchu Bowling": "is_child",
+            "Castle Town Potion Shop": "is_child",
+            "Castle Town Treasure Chest Game": "is_child",
+            "Castle Town Bombchu Shop": "is_child",
+            "Castle Town Dog Lady": "is_child",
+            "Castle Town Man in Green House": "is_child"
         }
     },
     {
@@ -478,7 +458,7 @@
                 is_adult and 
                 ((can_use(Bow) and Epona and has_bottle and (big_poe_count <= 3 or guarantee_hint)) or 
                     (Bottle_with_Big_Poe, big_poe_count))",
-            "GS Castle Market Guard House": "True"
+            "GS Castle Market Guard House": "is_child"
         }
     },
     {
@@ -556,15 +536,15 @@
         "locations": {
             "Man on Roof": "logic_man_on_roof or can_use(Hookshot)",
             "Anju as Adult": "is_adult",
-            "Anjus Chickens": "True",
+            "Anjus Chickens": "is_child",
             "Sheik in Kakariko": "
                 is_adult and Forest_Medallion and Fire_Medallion and Water_Medallion",
-            "GS Kakariko House Under Construction": "nighttime",
-            "GS Kakariko Skulltula House": "nighttime",
-            "GS Kakariko Guard's House": "nighttime",
-            "GS Kakariko Tree": "nighttime",
+            "GS Kakariko House Under Construction": "is_child and nighttime",
+            "GS Kakariko Skulltula House": "is_child and nighttime",
+            "GS Kakariko Guard's House": "is_child and nighttime",
+            "GS Kakariko Tree": "is_child and nighttime",
             "GS Kakariko Watchtower": "
-                (has_slingshot or has_bombchus or
+                is_child and (has_slingshot or has_bombchus or 
                     (logic_kakariko_tower_gs and (has_sticks or Kokiri_Sword) and
                     (damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love)))) and nighttime",
             "GS Kakariko Above Impa's House": "can_use(Hookshot) and nighttime"
@@ -578,7 +558,7 @@
             "Windmill": "True",
             "Kakariko Bazaar": "is_adult",
             "Kakariko Shooting Gallery": "True",
-            "Bottom of the Well": "can_play(Song_of_Storms)",
+            "Bottom of the Well": "is_child and can_play(Song_of_Storms)",
             "Kakariko Potion Shop Front": "is_adult",
             "Kakariko Potion Shop Back": "is_adult",
             "Odd Medicine Building": "True",
@@ -624,7 +604,7 @@
         "locations": {
             "Windmill Freestanding PoH": "
                 (is_adult and (logic_windmill_poh or can_play(Song_of_Time))) or 
-                Boomerang",
+                can_use(Boomerang)",
             "Song at Windmill": "is_adult and has_ocarina"
         }
     },
@@ -644,7 +624,7 @@
     {
         "region_name": "Kakariko Shooting Gallery",
         "locations": {
-            "Adult Shooting Gallery": "Bow and is_adult"
+            "Adult Shooting Gallery": "can_use(Bow)"
         }
     },
     {
@@ -670,9 +650,9 @@
         "region_name": "Graveyard",
         "locations": {
             "Graveyard Freestanding PoH": "can_use(Magic_Bean) or can_use(Longshot)",
-            "Gravedigging Tour": "True",
-            "GS Graveyard Wall": "Boomerang and nighttime",
-            "GS Graveyard Bean Patch": "has_bottle and can_child_attack"
+            "Gravedigging Tour": "is_child",
+            "GS Graveyard Wall": "can_use(Boomerang) and nighttime",
+            "GS Graveyard Bean Patch": "can_plant_bugs and can_child_attack"
         },
         "exits": {
             "Shield Grave": "True",
@@ -732,12 +712,10 @@
                 can_blast_or_smash or 
                 (logic_dmt_bombable and Progressive_Strength_Upgrade)",
             "DM Trail Freestanding PoH": "
-                open_kakariko or (damage_multiplier != 'ohko') or 
-                Zeldas_Letter or can_blast_or_smash or can_use(Dins_Fire) or 
-                can_use(Nayrus_Love) or has_bow or Progressive_Strength_Upgrade or 
-                has_bottle or Hover_Boots",
+                is_child or (damage_multiplier != 'ohko') or 
+                can_use(Nayrus_Love) or has_bottle or Hover_Boots",
             "GS Mountain Trail Bean Patch": "
-                has_bottle and (has_explosives or Progressive_Strength_Upgrade)",
+                can_plant_bugs and (has_explosives or Progressive_Strength_Upgrade)",
             "GS Mountain Trail Bomb Alcove": "can_blast_or_smash",
             "GS Mountain Trail Path to Crater": "can_use(Hammer) and nighttime",
             "GS Mountain Trail Above Dodongo's Cavern": "can_use(Hammer) and nighttime"
@@ -745,7 +723,7 @@
         "exits": {
             "Kakariko Village": "True",
             "Goron City": "True",
-            "Death Mountain Crater Upper": "can_blast_or_smash",
+            "Death Mountain Crater Upper": "as_either_here(can_blast_or_smash)",
             "Mountain Summit Fairy": "can_blast_or_smash",
             "Dodongos Cavern Entryway": "
                 has_explosives or Progressive_Strength_Upgrade or is_adult",
@@ -770,52 +748,62 @@
             "Goron City Right Maze Chest": "
                 can_blast_or_smash or can_use(Silver_Gauntlets)",
             "Goron City Pot Freestanding PoH": "
+                is_child and 
                 (has_bombs or Progressive_Strength_Upgrade) and 
                 ((can_play(Zeldas_Lullaby) and has_sticks) or can_use(Dins_Fire))",
-            "Rolling Goron as Child": "has_explosives or (Progressive_Strength_Upgrade and logic_child_rolling_with_strength)",
+            "Rolling Goron as Child": "
+                is_child and 
+                (has_explosives or (Progressive_Strength_Upgrade and logic_child_rolling_with_strength))",
             "Link the Goron": "
                 is_adult and 
                 (Progressive_Strength_Upgrade or has_explosives or has_bow)",
-            "GS Goron City Boulder Maze": "has_explosives",
+            "GS Goron City Boulder Maze": "is_child and has_explosives",
             "GS Goron City Center Platform": "is_adult",
-            "Goron City Stick Pot": "
-                open_kakariko or Zeldas_Letter or 
-                has_explosives or can_use(Dins_Fire)"
+            "Goron City Stick Pot": "is_child",
+            "Goron City Maze Gossip Stone": "
+                can_blast_or_smash or can_use(Silver_Gauntlets)",
+            "Goron City Medigoron Gossip Stone": "
+                can_blast_or_smash or Progressive_Strength_Upgrade"
         },
         "exits": {
             "Death Mountain": "True",
-            "Goron City Woods Warp": "True",
-            "Darunias Chamber": "can_play(Zeldas_Lullaby)",
-            "Death Mountain Crater Lower": "
-                is_adult and 
-                (Progressive_Strength_Upgrade or has_explosives or has_bow)",
+            "Goron City Woods Warp": "
+                as_child(can_reach(Darunias_Chamber) and has_sticks) or
+                as_either_here(can_blast_or_smash or can_use(Dins_Fire) or 
+                                can_use(Bow) or Progressive_Strength_Upgrade)",
             "Goron Shop": "
-                has_explosives or Progressive_Strength_Upgrade or 
-                can_use(Bow) or can_use(Dins_Fire) or 
-                ((Zeldas_Letter or open_kakariko or can_use(Hammer)) and 
-                    (can_play(Zeldas_Lullaby) and has_sticks))",
+                has_explosives or Progressive_Strength_Upgrade or can_use(Bow) or 
+                (is_child and (can_use(Dins_Fire) or (can_play(Zeldas_Lullaby) and has_sticks)))",
+            "Darunias Chamber": "
+                    (is_child and can_play(Zeldas_Lullaby)) or 
+                    (is_adult and (Progressive_Strength_Upgrade or has_explosives or has_bow))",
             "Goron City Grotto": "
                 is_adult and 
                 ((can_play(Song_of_Time) and 
                     ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
                         has_GoronTunic or can_use(Longshot) or can_use(Nayrus_Love))) or 
                 (damage_multiplier != 'ohko' and has_GoronTunic and can_use(Hookshot)) or 
-                (can_use(Nayrus_Love) and can_use(Hookshot)))",
-            "Goron City Maze Gossip Stone": "
-                (hints == 'mask' and has_explosives) or 
-                (hints != 'mask' and (can_blast_or_smash or can_use(Silver_Gauntlets)))",
-            "Goron City Medigoron Gossip Stone": "
-                can_blast_or_smash or Progressive_Strength_Upgrade"
+                (can_use(Nayrus_Love) and can_use(Hookshot)))"
         }
     },
     {
         "region_name": "Goron City Woods Warp",
         "exits": {
             "Goron City": "
-                (can_blast_or_smash or can_use(Dins_Fire) or 
-                    ((has_bow or Progressive_Strength_Upgrade) and is_adult)) and 
-                can_leave_forest",
+                can_leave_forest and 
+                (as_either_here(can_blast_or_smash or can_use(Dins_Fire)) or 
+                    can_reach('Goron City -> Goron City Woods Warp', Entrance, either))",
             "Lost Woods": "True"
+        }
+    },
+    {
+        "region_name": "Darunias Chamber",
+        "locations": {
+            "Darunias Joy": "is_child and can_play(Sarias_Song)"
+        },
+        "exits": {
+            "Goron City": "True",
+            "Death Mountain Crater Lower": "is_adult"
         }
     },
     {
@@ -832,37 +820,17 @@
         }
     },
     {
-        "region_name": "Darunias Chamber",
-        "locations": {
-            "Darunias Joy": "can_play(Sarias_Song)"
-        },
-        "exits": {
-            "Goron City": "True"
-        }
-    },
-    {
-        "region_name": "Goron City Maze Gossip Stone",
-        "locations": {
-            "Goron City Maze Gossip Stone": "True"
-        }
-    },
-    {
-        "region_name": "Goron City Medigoron Gossip Stone",
-        "locations": {
-            "Goron City Medigoron Gossip Stone": "True"
-        }
-    },
-    {
         "region_name": "Death Mountain Crater Upper",
         "locations": {
             "DM Crater Wall Freestanding PoH": "True",
             "Biggoron": "
                 is_adult and can_finish_adult_trades and guarantee_hint",
             "GS Death Mountain Crater Crate": "
-                can_blast_or_smash and can_child_attack",
+                is_child and can_child_attack and as_either_here(can_blast_or_smash)",
             "DMC Deku Scrub Bombs": "
-                can_blast_or_smash and 
-                (can_child_attack or has_nuts or Buy_Deku_Shield)"
+                is_child and can_stun_deku and as_either_here(can_blast_or_smash)",
+            "Death Mountain Crater Gossip Stone": "has_explosives",
+            "Death Mountain Trail Gossip Stone": "True"
         },
         "exits": {
             "Death Mountain": "True",
@@ -870,16 +838,13 @@
             "Death Mountain Crater Central": "has_GoronTunic and can_use(Distant_Scarecrow) and 
                 ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
                     has_bottle or can_use(Nayrus_Love))",
-            "Top of Crater Grotto": "can_blast_or_smash",
-            "Death Mountain Crater Gossip Stone": "has_explosives",
-            "Death Mountain Trail Gossip Stone": "
-                hints != 'mask' or can_blast_or_smash"
+            "Top of Crater Grotto": "can_blast_or_smash"
         }
     },
     {
         "region_name": "Death Mountain Crater Lower",
         "exits": {
-            "Goron City": "True",
+            "Darunias Chamber": "True",
             "Crater Fairy": "can_use(Hammer)",
             "Death Mountain Crater Central": "
                 can_use(Hover_Boots) or can_use(Hookshot)",
@@ -891,29 +856,16 @@
         "region_name": "Death Mountain Crater Central",
         "locations": {
             "DM Crater Volcano Freestanding PoH": "
-                (can_use(Magic_Bean) and can_play(Bolero_of_Fire)) or 
+                can_use(Magic_Bean) or 
                 (logic_crater_bean_poh_with_hovers and can_use(Hover_Boots))",
             "Sheik in Crater": "is_adult",
-            "GS Mountain Crater Bean Patch": "
-                can_play(Bolero_of_Fire) and has_bottle and can_child_attack"
+            "GS Mountain Crater Bean Patch": "can_plant_bugs and can_child_attack"
         },
         "exits": {
             "Death Mountain Crater Lower": "
                 can_use(Hover_Boots) or can_use(Hookshot) or can_use(Magic_Bean)",
             "Fire Temple Lower": "
                 is_adult and (logic_fewer_tunic_requirements or has_GoronTunic)"
-        }
-    },
-    {
-        "region_name": "Death Mountain Crater Gossip Stone",
-        "locations": {
-            "Death Mountain Crater Gossip Stone": "True"
-        }
-    },
-    {
-        "region_name": "Death Mountain Trail Gossip Stone",
-        "locations": {
-            "Death Mountain Trail Gossip Stone": "True"
         }
     },
     {
@@ -931,123 +883,85 @@
     {
         "region_name": "Zora River Front",
         "locations": {
-            "GS Zora River Tree": "can_child_attack"
+            "GS Zora River Tree": "is_child and can_child_attack"
         },
         "exits": {
-            "Zora River Child": "has_explosives",
-            "Zora River Adult": "is_adult",
+            "Zora River": "is_adult or has_explosives",
             "Hyrule Field": "True"
         }
     },
     {
-        "region_name": "Zora River Child",
+        "region_name": "Zora River",
         "locations": {
-            "Magic Bean Salesman": "True",
+            "Magic Bean Salesman": "is_child",
             "Frog Ocarina Game": "
-                can_play(Zeldas_Lullaby) and can_play(Sarias_Song) and can_play(Suns_Song) and 
-                can_play(Eponas_Song) and can_play(Song_of_Time) and can_play(Song_of_Storms) and guarantee_hint",
-            "Frogs in the Rain": "can_play(Song_of_Storms)",
-            "GS Zora River Ladder": "nighttime and can_child_attack"
-        },
-        "exits": {
-            "Zora River Shared": "True",
-            "Zoras Domain": "can_play(Zeldas_Lullaby) or logic_zora_with_cucco",
-            "Zoras River Gossip Stone": "True"
-        }
-    },
-    {
-        "region_name": "Zora River Adult",
-        "locations": {
+                is_child and can_play(Zeldas_Lullaby) and can_play(Sarias_Song) and 
+                can_play(Suns_Song) and can_play(Eponas_Song) and 
+                can_play(Song_of_Time) and can_play(Song_of_Storms) and guarantee_hint",
+            "Frogs in the Rain": "is_child and can_play(Song_of_Storms)",
+            "Zora River Lower Freestanding PoH": "
+                is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_lower)",
+            "Zora River Upper Freestanding PoH": "
+                is_child or can_use(Hover_Boots)",
+            "GS Zora River Ladder": "is_child and nighttime and can_child_attack",
             "GS Zora River Near Raised Grottos": "can_use(Hookshot) and nighttime",
-            "GS Zora River Above Bridge": "can_use(Hookshot) and nighttime"
-        },
-        "exits": {
-            "Zoras Domain Frozen": "
-                can_play(Zeldas_Lullaby) or (Hover_Boots and logic_zora_with_hovers)",
-            "Zora River Shared": "True",
-            "Zoras River Gossip Stone": "hints != 'mask'"
-        }
-    },
-    {
-        "region_name": "Zoras River Gossip Stone",
-        "locations": {
+            "GS Zora River Above Bridge": "can_use(Hookshot) and nighttime",
             "Zoras River Plateau Gossip Stone": "True",
             "Zoras River Waterfall Gossip Stone": "True"
-        }
-    },
-    {
-        "region_name": "Zora River Shared",
-        "locations": {
-            "Zora River Lower Freestanding PoH": "
-                has_explosives or can_dive or
-                    (is_adult and (logic_zora_river_lower or Hover_Boots))",
-            "Zora River Upper Freestanding PoH": "
-                has_explosives or can_dive or can_use(Hover_Boots)"
         },
         "exits": {
             "Zora River Front": "True",
-            "Zora River Plateau Open Grotto": "has_explosives or can_dive or is_adult",
+            "Zora River Plateau Open Grotto": "True",
             "Zora River Plateau Bombable Grotto": "can_blast_or_smash",
             "Lost Woods": "can_dive",
-            "Zora River Storms Grotto": "can_play(Song_of_Storms) and can_stun_deku"
+            "Zora River Storms Grotto": "can_play(Song_of_Storms) and can_stun_deku",
+            "Zoras Domain": "
+                can_play(Zeldas_Lullaby) or
+                (can_use(Hover_Boots) and logic_zora_with_hovers) or
+                (is_child and logic_zora_with_cucco)"
         }
     },
     {
         "region_name": "Zoras Domain",
         "locations": {
-            "Diving Minigame": "True",
-            "Zoras Domain Torch Run": "has_sticks",
-            "King Zora Moves": "Bottle_with_Letter",
-            "Zoras Domain Stick Pot": "True",
-            "Zoras Domain Nut Pot": "True"
+            "Diving Minigame": "is_child",
+            "Zoras Domain Torch Run": "can_use(Sticks)",
+            "King Zora Moves": "is_child and Bottle_with_Letter",
+            "King Zora Thawed": "is_adult and has_blue_fire",
+            "Zoras Domain Stick Pot": "is_child",
+            "Zoras Domain Nut Pot": "True",
+            "GS Zora's Domain Frozen Waterfall": "
+                is_adult and nighttime and (Progressive_Hookshot or has_bow or Magic_Meter)",
+            "Zoras Domain Gossip Stone": "True"
         },
         "exits": {
-            "Zora River Child": "True",
-            "Lake Hylia": "can_dive",
-            "Zoras Fountain": "Bottle_with_Letter or open_fountain",
-            "Zora Shop": "True",
-            "Zoras Domain Gossip Stone": "True"
+            "Zora River": "True",
+            "Lake Hylia": "is_child and can_dive",
+            "Zoras Fountain": "
+                open_fountain or 
+                (can_reach(Zoras_Domain, Region, child) and Bottle_with_Letter)",
+            "Zora Shop": "is_child or has_blue_fire"
         }
     },
     {
         "region_name": "Zoras Fountain",
         "locations": {
-            "GS Zora's Fountain Tree": "True",
-            "GS Zora's Fountain Above the Log": "Boomerang and nighttime",
+            "Zoras Fountain Iceberg Freestanding PoH": "is_adult",
+            "Zoras Fountain Bottom Freestanding PoH": "
+                is_adult and Iron_Boots and (logic_fewer_tunic_requirements or has_ZoraTunic)",
+            "GS Zora's Fountain Tree": "is_child",
+            "GS Zora's Fountain Above the Log": "can_use(Boomerang) and nighttime",
+            "GS Zora's Fountain Hidden Cave": "
+                can_use(Silver_Gauntlets) and can_blast_or_smash and 
+                can_use(Hookshot) and nighttime",
             "Zoras Fountain Fairy Gossip Stone": "True",
             "Zoras Fountain Jabu Gossip Stone": "True"
         },
         "exits": {
             "Zoras Domain": "True",
-            "Jabu Jabus Belly Beginning": "has_bottle",
+            "Jabu Jabus Belly Beginning": "is_child and has_bottle",
+            "Ice Cavern": "is_adult",
             "Zoras Fountain Fairy": "has_explosives"
-        }
-    },
-    {
-        "region_name": "Zoras Domain Frozen",
-        "locations": {
-            "King Zora Thawed": "has_blue_fire",
-            "GS Zora's Domain Frozen Waterfall": "
-                nighttime and (Progressive_Hookshot or has_bow or Magic_Meter)"
-        },
-        "exits": {
-            "Outside Ice Cavern": "can_reach(Zoras_Fountain)",
-            "Zora Shop": "has_blue_fire",
-            "Zoras Domain Gossip Stone": "hints != 'mask'"
-        }
-    },
-    {
-        "region_name": "Outside Ice Cavern",
-        "locations": {
-            "Zoras Fountain Iceberg Freestanding PoH": "True",
-            "Zoras Fountain Bottom Freestanding PoH": "
-                Iron_Boots and (logic_fewer_tunic_requirements or has_ZoraTunic)",
-            "GS Zora's Fountain Hidden Cave": "
-                (Progressive_Strength_Upgrade, 2) and can_blast_or_smash and 
-                Progressive_Hookshot and nighttime"
-        },
-        "exits": {
-            "Ice Cavern": "True"
         }
     },
     {
@@ -1070,33 +984,27 @@
         }
     },
     {
-        "region_name": "Zoras Domain Gossip Stone",
-        "locations": {
-            "Zoras Domain Gossip Stone": "True"
-        }
-    },
-    {
         "region_name": "Lon Lon Ranch",
         "locations": {
             "Epona": "can_play(Eponas_Song) and is_adult",
-            "Song from Malon": "Zeldas_Letter and has_ocarina",
-            "GS Lon Lon Ranch Tree": "True",
-            "GS Lon Lon Ranch Rain Shed": "nighttime",
-            "GS Lon Lon Ranch House Window": "Boomerang and nighttime",
-            "GS Lon Lon Ranch Back Wall": "Boomerang and nighttime"
+            "Song from Malon": "is_child and Zeldas_Letter and has_ocarina",
+            "GS Lon Lon Ranch Tree": "is_child",
+            "GS Lon Lon Ranch Rain Shed": "is_child and nighttime",
+            "GS Lon Lon Ranch House Window": "can_use(Boomerang) and nighttime",
+            "GS Lon Lon Ranch Back Wall": "can_use(Boomerang) and nighttime"
         },
         "exits": {
             "Hyrule Field": "True",
             "Talon House": "True",
             "Ingo Barn": "True",
             "Lon Lon Corner Tower": "True",
-            "Lon Lon Grotto": "can_child_attack or has_nuts or Buy_Deku_Shield"
+            "Lon Lon Grotto": "is_child and can_stun_deku"
         }
     },
     {
         "region_name": "Talon House",
         "locations": {
-            "Talons Chickens": "Zeldas_Letter"
+            "Talons Chickens": "is_child and Zeldas_Letter"
         }
     },
     {
@@ -1109,23 +1017,9 @@
     {
         "region_name": "Lon Lon Corner Tower",
         "locations": {
-            "Lon Lon Tower Freestanding PoH": "True",
+            "Lon Lon Tower Freestanding PoH": "is_child",
             "LLR Tower Left Cow": "can_play(Eponas_Song)",
             "LLR Tower Right Cow": "can_play(Eponas_Song)"
-        }
-    },
-    {
-        "region_name": "Forest Temple Entry Area",
-        "locations": {
-            "Sheik Forest Song": "True",
-            "GS Lost Woods Above Stage": "can_use(Magic_Bean) and nighttime",
-            "GS Sacred Forest Meadow": "can_use(Hookshot) and nighttime"
-        },
-        "exits": {
-            "Lost Woods": "True",
-            "Forest Temple Lobby": "can_use(Hookshot)",
-            "Meadow Storms Grotto": "can_play(Song_of_Storms)",
-            "Sacred Forest Meadow Gossip Stones": "hints != 'mask'"
         }
     },
     {
@@ -1152,12 +1046,8 @@
     {
         "region_name": "Deku Theater",
         "locations": {
-            "Deku Theater Skull Mask": "
-                Zeldas_Letter",
-            "Deku Theater Mask of Truth": "
-                (Zeldas_Letter and can_play(Sarias_Song) and 
-                    Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint)" 
-                    #Must befriend Skull Kid to sell Skull Mask, all stones to spawn running man.
+            "Deku Theater Skull Mask": "is_child and Zeldas_Letter",
+            "Deku Theater Mask of Truth": "is_child and has_mask_of_truth and guarantee_hint"
         }
     },
     {
@@ -1213,22 +1103,9 @@
         "region_name": "Field Valley Grotto",
         "locations": {
             "GS Hyrule Field Near Gerudo Valley": "
-                (Hammer and has_fire_source and can_use(Hookshot)) or 
-                (Boomerang and has_explosives and can_use(Dins_Fire))",
-             "HF Grotto Cow": "
-                can_play(Eponas_Song) and ((can_use(Hammer) and has_fire_source) or
-                (has_explosives and can_use(Dins_Fire)))"
-        },
-        "exits": {
-            "Field Valley Grotto Gossip Stone": "
-                (has_explosives and can_use(Dins_Fire)) or 
-                (hints != 'mask' and can_use(Hammer) and has_fire_source)"
-        }
-    },
-    {
-        "region_name": "Field Valley Grotto Gossip Stone",
-        "locations": {
-            "Field Valley Grotto Gossip Stone": "True"
+                has_fire_source and (can_use(Hookshot) or can_use(Boomerang))",
+            "HF Grotto Cow": "has_fire_source and can_play(Eponas_Song)",
+            "Field Valley Grotto Gossip Stone": "has_fire_source"
         }
     },
     {
@@ -1243,8 +1120,7 @@
     {
         "region_name": "Field Kakariko Grotto",
         "locations": {
-            "GS Hyrule Field near Kakariko": "
-                (Boomerang and has_explosives) or can_use(Hookshot)"
+            "GS Hyrule Field near Kakariko": "can_use(Boomerang) or can_use(Hookshot)"
         }
     },
     {
@@ -1257,16 +1133,8 @@
     {
         "region_name": "Castle Storms Grotto",
         "locations": {
-            "GS Hyrule Castle Grotto": "Boomerang and has_explosives"
-        },
-        "exits": {
+            "GS Hyrule Castle Grotto": "can_use(Boomerang) and has_explosives",
             "Castle Storms Grotto Gossip Stone": "has_explosives"
-        }
-    },
-    {
-        "region_name": "Castle Storms Grotto Gossip Stone",
-        "locations": {
-            "Castle Storms Grotto Gossip Stone": "True"
         }
     },
     {

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -5,15 +5,15 @@
         "locations": {
             "Spirit Temple MQ Entrance Front Left Chest": "True",
             "Spirit Temple MQ Entrance Back Left Chest": "
-                can_blast_or_smash and 
-                ((can_play(Requiem_of_Spirit) and has_slingshot) or can_use(Bow))",
+                as_either_here(can_blast_or_smash) and 
+                (can_use(Slingshot) or can_use(Bow))",
             "Spirit Temple MQ Entrance Back Right Chest": "
                 has_bombchus or can_use(Bow) or can_use(Hookshot) or 
-                (can_play(Requiem_of_Spirit) and (has_slingshot or Boomerang))"
+                can_use(Slingshot) or can_use(Boomerang)"
         },
         "exits": {
             "Desert Colossus": "True",
-            "Child Spirit Temple": "can_play(Requiem_of_Spirit)",
+            "Child Spirit Temple": "is_child",
             "Adult Spirit Temple": "
                 has_bombchus and can_use(Longshot) and can_use(Silver_Gauntlets)"
         }
@@ -30,9 +30,9 @@
             "Spirit Temple MQ Silver Block Hallway Chest": "
                 has_bombchus and (Small_Key_Spirit_Temple, 7) and has_slingshot and 
                 (can_use(Dins_Fire) or 
-                    (can_use(Longshot) and can_use(Silver_Gauntlets) and 
-                        (can_use(Fire_Arrows) or 
-                            (logic_spirit_mq_frozen_eye and has_bow and can_play(Song_of_Time)))))"
+                    as_adult(can_use(Longshot) and can_use(Silver_Gauntlets) and 
+                                (can_use(Fire_Arrows) or 
+                                    (logic_spirit_mq_frozen_eye and has_bow and can_play(Song_of_Time)))))"
         },
         "exits": {
             "Spirit Temple Shared": "has_bombchus and (Small_Key_Spirit_Temple, 2)"
@@ -72,8 +72,7 @@
         "locations": {
             "Spirit Temple MQ Child Climb North Chest": "(Small_Key_Spirit_Temple, 6)",
             "Spirit Temple MQ Compass Chest": "
-                (can_play(Requiem_of_Spirit) and 
-                    (Small_Key_Spirit_Temple, 7) and has_slingshot) or 
+                ((Small_Key_Spirit_Temple, 7) and can_use(Slingshot)) or 
                 (can_use(Longshot) and can_use(Silver_Gauntlets) and has_bow) or 
                 (has_slingshot and has_bow)",
             "Spirit Temple MQ Sun Block Room Chest": "

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -4,7 +4,7 @@
         "dungeon": "Spirit Temple",
         "exits": {
             "Desert Colossus": "True",
-            "Child Spirit Temple": "can_play(Requiem_of_Spirit)",
+            "Child Spirit Temple": "is_child",
             "Early Adult Spirit Temple": "can_use(Silver_Gauntlets)"
         }
     },
@@ -41,20 +41,20 @@
                 (((Small_Key_Spirit_Temple, 3) or 
                     ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
                 can_use(Silver_Gauntlets) and has_projectile(adult)) or 
-                ((Small_Key_Spirit_Temple, 5) and can_play(Requiem_of_Spirit) and 
+                ((Small_Key_Spirit_Temple, 5) and is_child and 
                     has_projectile(child))",
             "Spirit Temple Child Climb North Chest": "
                 has_projectile(both) or 
                 (((Small_Key_Spirit_Temple, 3) or 
                     ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
                 can_use(Silver_Gauntlets) and has_projectile(adult)) or 
-                ((Small_Key_Spirit_Temple, 5) and can_play(Requiem_of_Spirit) and 
+                ((Small_Key_Spirit_Temple, 5) and is_child and 
                     has_projectile(child))",
             "GS Spirit Temple Bomb for Light Room": "
                 has_projectile(both) or can_use(Dins_Fire) or 
                 ((damage_multiplier != 'ohko' or has_bottle or can_use(Nayrus_Love)) and 
                     (has_sticks or Kokiri_Sword or has_projectile(child))) or 
-                (can_play(Requiem_of_Spirit) and 
+                (is_child and 
                     (Small_Key_Spirit_Temple, 5) and has_projectile(child)) or 
                 (((Small_Key_Spirit_Temple, 3) or 
                     ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
@@ -93,8 +93,8 @@
                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
                     (can_use(Dins_Fire) or
                         (((Magic_Meter and Fire_Arrows) or logic_spirit_map_chest) and has_bow and has_sticks))) or 
-                ((Small_Key_Spirit_Temple, 5) and has_explosives and
-                    can_play(Requiem_of_Spirit) and has_sticks) or 
+                ((Small_Key_Spirit_Temple, 5) and has_explosives and 
+                    can_use(Sticks)) or 
                 ((Small_Key_Spirit_Temple, 3) and
                     (can_use(Fire_Arrows) or (logic_spirit_map_chest and has_bow)) and 
                     can_use(Silver_Gauntlets))",
@@ -103,7 +103,7 @@
                     (can_use(Dins_Fire) or
                         (((Magic_Meter and Fire_Arrows) or logic_spirit_sun_chest) and has_bow and has_sticks))) or 
                 ((Small_Key_Spirit_Temple, 5) and has_explosives and
-                    can_play(Requiem_of_Spirit) and has_sticks) or 
+                    can_use(Sticks)) or 
                 ((Small_Key_Spirit_Temple, 3) and
                     (can_use(Fire_Arrows) or (logic_spirit_sun_chest and has_bow)) and 
                     can_use(Silver_Gauntlets))",
@@ -115,15 +115,14 @@
                 (Progressive_Hookshot or Hover_Boots)",
             "GS Spirit Temple Hall to West Iron Knuckle": "
                 (has_explosives and Boomerang and Progressive_Hookshot) or 
-                (Boomerang and (Small_Key_Spirit_Temple, 5) and 
-                    has_explosives and can_play(Requiem_of_Spirit)) or 
+                (can_use(Boomerang) and (Small_Key_Spirit_Temple, 5) and has_explosives) or 
                 (Progressive_Hookshot and can_use(Silver_Gauntlets) and 
                     ((Small_Key_Spirit_Temple, 3) or 
                         ((Small_Key_Spirit_Temple, 2) and Boomerang and bombchus_in_logic)))",
             "GS Spirit Temple Lobby": "
                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic)) and 
                     logic_spirit_lobby_gs and Boomerang and (Progressive_Hookshot or Hover_Boots)) or
-                (logic_spirit_lobby_gs and (Small_Key_Spirit_Temple, 5) and has_explosives and can_play(Requiem_of_Spirit) and Boomerang) or
+                (logic_spirit_lobby_gs and (Small_Key_Spirit_Temple, 5) and has_explosives and can_use(Boomerang)) or
                 ((Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and (Progressive_Hookshot or Hover_Boots))"
         },
         "exits": {


### PR DESCRIPTION
This PR is a preparation for the "Start as Adult" and Entrance Shuffle options.
It's mostly an internal change and shouldn't affect the logic other than fixing it in some instances.
Although it was regression tested on a lot of seeds and settings, some changes might be incorrect so it would be good if this was reviewed by those able to do so.

Below is a compiled summary of the commit messages for an explanation of the changes:

**1. Rework child/adult logic by adding an age parameter to can_reach**

Split reachability by age:
- can_reach is essentially redefined as can_reach(spot, 'child') OR can_reach(spot, 'adult').
- The old is_adult condition that checks if the state has master sword is renamed to can_become_adult.
- 2 new state conditions are available: is_child and is_adult. When checking for reachability as child, is_child is true and is_adult is false, and vice versa when checking for reachability as adult.
- can_reach defaults to the current age if it's defined in the state.

Store the current spot being tested in the state:
- The current spot is now stored in the state while testing the access rule
- This means it is now possible to access the spot (location/entrance) currently checked in access rules.
- can_reach also now defaults to the current spot's parent region if no spot parameter is provided

Add as_either, as_both, as_child and as_adult methods to handle cross age conditions:
- Any conditions inside those methods will be run as the targeted age.
- These methods should only be used when dealing with cross age conditions, for example when adult can open the way for child, or vice versa.

Add as_either_here, as_both_here, as_child_here and as_adult_here:
- Those methods are their equivalent without the "_here" part except they also check for reachability on the current region.

**2. Update and add state methods to use the child/adult logic**
- can_use now handles some child items like Boomerang, Slingshot or Sticks.
- can_use(Magic_Bean) now automatically checks for reachability as child.
- Add a can_plant_bugs which checks for age and bugs, and has_mask_of_truth which checks if you can get the mask.

**3. Update logic with child/adult requirements and new state methods**
- Areas previously split between child and adult are now unified: Zora River, Zoras Domain, Zoras Fountain, Sacred Forest Meadow.
- Child only locations/regions are defined as such with the new is_child.
- All hints are only reachable as child if the hints setting is set to mask of truth, that condition is now added in Rules.py to all gossip stone rules.
- Some locations are reachable as child thanks to adult opening the way (or vice versa) so the logic is adapted to handle those cases.