### PR TITLE
Fix default equipped child items when starting as adult

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -849,7 +849,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
     if world.starting_age == 'adult':
         save_context.addresses['link_age'].value = False                    # Set link's age to adult
         save_context.addresses['scene_index'].value = 0x43                  # Set the scene index to Temple of Time
-        save_context.addresses['equip_items']['master_sword'].value = True  # Equip Master Sword
+        save_context.addresses['equip_items']['master_sword'].value = True  # Equip Master Sword by default
+        save_context.addresses['equip_items']['kokiri_tunic'].value = True  # Equip Kokiri Tunic & Kokiri Boots by default
+        save_context.addresses['equip_items']['kokiri_boots'].value = True  # (to avoid issues when going back child for the first time)
 
     # Revert change that Skips the Epona Race
     if not world.no_epona_race:
@@ -1370,7 +1372,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:LocalRom):
 
     # actually write the save table to rom
     world.distribution.give_items(save_context)
-    save_context.equip_items(world.starting_age)
+    if world.starting_age == 'adult':
+        # When starting as adult, the pedestal doesn't handle child default equips when going back child the first time, so we have to equip them ourselves
+        save_context.equip_default_items('child')
+    save_context.equip_current_items(world.starting_age)
     save_context.write_save_table(rom)
 
     return rom

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -254,9 +254,20 @@ class SaveContext():
             raise ValueError("Cannot give unknown starting item %s" % item)
 
 
-    def equip_items(self, age):
+    def equip_default_items(self, age):
+        self.equip_items(age, 'equips_' + age)
+
+
+    def equip_current_items(self, age):
+        self.equip_items(age, 'equips')
+
+
+    def equip_items(self, age, equip_type):
         if age not in ['child', 'adult']:
             raise ValueError("Age must be 'adult' or 'child', not %s" % age)
+
+        if equip_type not in ['equips', 'equips_child', 'equips_adult']:
+            raise ValueError("Equip type must be 'equips', 'equips_child' or 'equips_adult', not %s" % equip_type)
 
         age = 'equips_' + age
         c_buttons = list(self.addresses[age]['button_slots'].keys())
@@ -264,8 +275,8 @@ class SaveContext():
             item = self.addresses['item_slot'][item_slot].get_value('none')
             if item != 'none':
                 c_button = c_buttons.pop()
-                self.addresses['equips']['button_slots'][c_button].value = item_slot
-                self.addresses['equips']['button_items'][c_button].value = item
+                self.addresses[equip_type]['button_slots'][c_button].value = item_slot
+                self.addresses[equip_type]['button_items'][c_button].value = item
                 if not c_buttons:
                     break
 
@@ -273,9 +284,9 @@ class SaveContext():
             for item in SaveContext.equipable_items[age][equip_item]:
                 if self.addresses['equip_items'][item].get_value():
                     item_value = self.addresses['equip_items'][item].get_value_raw()
-                    self.addresses['equips']['equips'][equip_item].set_value_raw(item_value)
+                    self.addresses[equip_type]['equips'][equip_item].set_value_raw(item_value)
                     if equip_item == 'sword':
-                        self.addresses['equips']['button_items']['b'].value = item
+                        self.addresses[equip_type]['button_items']['b'].value = item
                     break
 
 
@@ -910,8 +921,10 @@ class SaveContext():
             'tunic' : [
                 'goron_tunic',
                 'zora_tunic',
+                'kokiri_tunic',
             ],
             'boots' : [
+                'kokiri_boots'
             ],
         },
         'equips_child' : {
@@ -941,8 +954,10 @@ class SaveContext():
                 'hylian_shield',
             ],
             'tunic' : [
+                'kokiri_tunic',
             ],
             'boots' : [
+                'kokiri_boots',
             ],
         }
     }


### PR DESCRIPTION
Child items weren't automatically equipped when starting as adult and going back child for the first time, this is now fixed.