### PR TITLE
Fix some minor Scarecrow Song logic issues

### DIFF
--- a/State.py
+++ b/State.py
@@ -341,7 +341,8 @@ class State(object):
 
 
     def has_scarecrow_song(self):
-        return self.world.free_scarecrow or self.can_reach('Lake Hylia', age='both')
+        return self.world.free_scarecrow or (self.has_ocarina() and self.can_reach('Lake Hylia', age='both'))
+
 
     def can_use_projectile(self):
         return self.has_explosives() or \

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -40,7 +40,7 @@
         },
         "exits": {
             "Water Temple Basement Gated Areas": "
-                can_use(Dins_Fire) and (Hover_Boots or has_ocarina)"
+                can_use(Dins_Fire) and (Hover_Boots or can_use(Scarecrow))"
         }
     },
     {


### PR DESCRIPTION
Logic changes related to scarecrow song:
- Fix a scarecrow check in Water Temple MQ not actually testing if the player could have scarecrow song.
- Add has_ocarina to the recently added has_scarecrow_song method to avoid potential issues with it.