### PR TITLE
Faster collect_locations and playthrough generation

### DIFF
--- a/Entrance.py
+++ b/Entrance.py
@@ -24,8 +24,8 @@ class Entrance(object):
         return new_entrace
 
 
-    def can_reach(self, state):
-        return state.with_spot(self.access_rule, spot=self) and state.can_reach(self.parent_region)
+    def can_reach(self, state, noparent=False):
+        return state.with_spot(self.access_rule, spot=self) and (noparent or state.can_reach(self.parent_region))
 
 
     def connect(self, region, addresses=None, target=None, vanilla=None):

--- a/Location.py
+++ b/Location.py
@@ -59,11 +59,11 @@ class Location(object):
         return (self.parent_region.can_fill(item, manual) and self.item_rule(self, item))
 
 
-    def can_reach(self, state):
+    def can_reach(self, state, noparent=False):
         if self.is_disabled():
             return False
 
-        return state.with_spot(self.access_rule, spot=self) and state.can_reach(self.parent_region)
+        return state.with_spot(self.access_rule, spot=self) and (noparent or state.can_reach(self.parent_region))
 
 
     def is_disabled(self):

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -32,7 +32,7 @@ def start():
         sys.exit(0)
 
     # ToDo: Validate files further than mere existance
-    if not os.path.isfile(settings.rom):
+    if settings.compress_rom != 'None' and not os.path.isfile(settings.rom):
         input('Could not find valid base rom for patching at expected path %s. Please run with -h to see help for further information. \nPress Enter to exit.' % settings.rom)
         sys.exit(1)
 

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -71,9 +71,9 @@ class Playthrough(object):
         validate_child = lambda exit: self.state_list[exit.parent_region.world.id].as_child(lambda s: s.with_spot(exit.access_rule, exit))
         validate_adult = lambda exit: self.state_list[exit.parent_region.world.id].as_adult(lambda s: s.with_spot(exit.access_rule, exit))
 
-        # simplified loc.can_reach(state), minus the disable check
+        # simplified loc.can_reach(state)
         # Check adult first; it's the most likely.
-        accessible = lambda loc: (
+        accessible = lambda loc: not loc.is_disabled() and (
                 loc.parent_region in adult_regions
                 and self.state_list[loc.world.id].as_adult(lambda s: s.with_spot(loc.access_rule, loc))
                 or (loc.parent_region in child_regions

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -81,11 +81,10 @@ class Playthrough(object):
             loc not in collected_set
             and not loc.is_disabled()
             # Check adult first; it's the most likely.
-            # calling as_adult checks for MS to keep it required.
             and (loc.parent_region in adult_regions
-                 and self.state_list[loc.world.id].as_adult(lambda state: loc.can_reach(state, noparent=True))
+                 and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'adult')
                  or (loc.parent_region in child_regions
-                     and self.state_list[loc.world.id].as_child(lambda state: loc.can_reach(state, noparent=True)))))
+                     and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'child'))))
 
         had_reachable_locations = True
         # will loop as long as any collections were made, and at least once

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -1,0 +1,151 @@
+import copy
+from collections import deque, defaultdict
+import itertools
+
+
+class Playthrough(object):
+
+    def __init__(self, state_list):
+        self.state_list = state_list  # reference, not a copy
+        # Each region sphere is a pair (child_regions, adult_regions)
+        self.region_spheres = []
+        # Mapping from location to sphere index. 0-based.
+        self.location_in_sphere = defaultdict(int)
+
+    # Truncates the region sphere cache based on which sphere a location is in.
+    # Doesn't forget which sphere locations are in as an optimization, so be careful
+    # to only uncollect locations in descending sphere order, or locations that
+    # have been revisited in the most recent iteration.
+    # Locations never visited in this Playthrough are assumed to be in sphere 0, so
+    # uncollecting them will discard everything above sphere 0.
+    # Not safe to call during iteration.
+    def uncollect(self, location):
+        self.region_spheres[self.location_in_sphere[location]+1:] = []
+
+    # Yields every reachable location, by iteratively deepening explored sets of
+    # regions (one as child, one as adult) and invoking access rules without
+    # calling the recursive can_reach.
+    # item_locations is a set of Location objects from state_list that the caller
+    # has prefiltered (eg. by whether they contain advancement items).
+    #
+    # Inside the loop, the caller usually wants to collect items at these
+    # locations to see if the game is beatable. This function does not alter provided state.
+    def iter_reachable_locations(self, item_locations):
+        if not self.region_spheres:
+            self.region_spheres = [
+                ({state.world.get_region('Links House') for state in self.state_list
+                    if state.world.starting_age == 'child'},
+                 {state.world.get_region('Temple of Time') for state in self.state_list
+                    if state.world.starting_age == 'adult'})
+            ]
+        collected_set = set(itertools.chain.from_iterable(
+            map(state.world.get_location, state.collected_locations)
+            for id, state in enumerate(self.state_list)))
+        # set of Region.
+        child_regions, adult_regions = self.region_spheres[-1]
+        # simplified exit.can_reach(self)
+        new_child_exit = lambda exit: exit.connected_region not in child_regions and self.state_list[exit.parent_region.world.id].as_child(lambda s: s.with_spot(exit.access_rule, exit))
+        new_adult_exit = lambda exit: exit.connected_region not in adult_regions and self.state_list[exit.parent_region.world.id].as_adult(lambda s: s.with_spot(exit.access_rule, exit))
+
+        # simplified loc.can_reach(self), minus the disable check
+        child_accessible = lambda loc: loc.parent_region in child_regions and self.state_list[loc.world.id].as_child(lambda s: s.with_spot(loc.access_rule, loc))
+        adult_accessible = lambda loc: loc.parent_region in adult_regions and self.state_list[loc.world.id].as_adult(lambda s: s.with_spot(loc.access_rule, loc))
+
+        reachable_locations = True
+        # will loop as long as any collections were made, and at least once
+        while reachable_locations:
+            # 1. Use a queue to iteratively add regions to the accessed set,
+            #    until we are stuck or out of regions.
+            # queue of (is_child, Entrance)
+            exit_queue = deque(itertools.chain(
+                ((True, exit) for region in child_regions
+                    for exit in region.exits if new_child_exit(exit)),
+                ((False, exit) for region in adult_regions
+                    for exit in region.exits if new_adult_exit(exit))))
+            while exit_queue:
+                child, exit = exit_queue.popleft()
+                if child:
+                    if exit.connected_region not in child_regions:
+                        child_regions.add(exit.connected_region)
+                        exit_queue.extend(
+                            (True, exit) for exit in exit.connected_region.exits
+                            if new_child_exit(exit))
+                        if exit.connected_region.name == 'Beyond Door of Time':
+                            adult_regions.add(exit.connected_region)
+                            exit_queue.extend(
+                                (False, exit) for exit in exit.connected_region.exits
+                                if new_adult_exit(exit))
+                            # Adult savewarp point is Temple of Time, which is
+                            # always accessible from BDoT, so we can skip adding it specially
+                else:
+                    # mostly the same but for adult
+                    if exit.connected_region not in adult_regions:
+                        adult_regions.add(exit.connected_region)
+                        exit_queue.extend(
+                            (False, exit) for exit in exit.connected_region.exits
+                            if new_adult_exit(exit))
+                        if exit.connected_region.name == 'Beyond Door of Time':
+                            child_regions.add(exit.connected_region)
+                            exit_queue.extend(
+                                (True, exit) for exit in exit.connected_region.exits
+                                if new_adult_exit(exit))
+                            # Child savewarp point is Links House, which is
+                            # always accessible from BDoT -> ToT -> CT -> HF -> LWB -> KF, so we can skip adding it specially
+            # 2. Get all locations in accessible_regions that aren't collected,
+            #    and check if they can be reached. Collect them.
+            reachable_locations = [
+                location for location in item_locations - collected_set
+                # Put the more likely one first
+                if adult_accessible(location) or child_accessible(location)]
+            for location in reachable_locations:
+                yield location
+                # Mark it collected for this algorithm
+                collected_set.add(location)
+                self.location_in_sphere[location] = len(self.region_spheres) - 1
+            # 3. Save the current region sphere in the cache, duplicate to make a new one to modify
+            self.region_spheres.append((copy.copy(child_regions), copy.copy(adult_regions)))
+            child_regions, adult_regions = self.region_spheres[-1]
+
+    # This collects all item locations available in the state list given that
+    # the states have collected items. The purpose is that it will search for
+    # all new items that become accessible with a new item set.
+    # Alters provided state.
+    def collect_locations(self):
+        # Get all item locations in the worlds
+        item_locations = {location for state in self.state_list for location in state.world.get_filled_locations() if location.item.advancement}
+        collected_locations = [s.collected_locations for s in self.state_list]
+        for location in self.iter_reachable_locations(item_locations):
+            # Mark the location collected in the state world it exists in
+            collected_locations[location.world.id][location.name] = True
+            # Collect the item for the state world it is for
+            self.state_list[location.item.world.id].collect(location.item)
+
+    # This returns True if every state is beatable. It's important to ensure
+    # all states beatable since items required in one world can be in another.
+    def can_beat_game(self, scan_for_items=True):
+        if scan_for_items:
+            # Check if already beaten
+            game_beaten = True
+            for state in self.state_list:
+                if not state.has('Triforce'):
+                    game_beaten = False
+                    break
+            if game_beaten:
+                return True
+
+            # collect all available items
+            # make a new playthrough since we might be iterating over one already
+            playthrough = Playthrough([state.copy() for state in self.state_list])
+            # we only need to copy the top sphere since that's what we're starting with and we don't go back
+            if self.region_spheres:
+                playthrough.region_spheres = [tuple(map(copy.copy, self.region_spheres[-1]))]
+            playthrough.collect_locations()
+        else:
+            playthrough = self
+
+        # if the every state got the Triforce, then return True
+        for state in playthrough.state_list:
+            if not state.has('Triforce'):
+                return False
+        return True
+

--- a/State.py
+++ b/State.py
@@ -1,7 +1,10 @@
-from Region import Region
 from collections import Counter, defaultdict
 import copy
+import itertools
+
 from Item import ItemInfo
+from Playthrough import Playthrough
+from Region import Region
 
 
 class State(object):
@@ -495,55 +498,20 @@ class State(object):
                 if item.world.id == base_state.world.id: # Check world
                     new_state.collect(item)
             new_state_list.append(new_state)
-        State.collect_locations(new_state_list)
+        Playthrough(new_state_list).collect_locations()
         return new_state_list
 
-
-    # This collected all item locations available in the state list given that
+    # This collects all item locations available in the state list given that
     # the states have collected items. The purpose is that it will search for
     # all new items that become accessible with a new item set
     @staticmethod
     def collect_locations(state_list):
-        # Get all item locations in the worlds
-        item_locations = [location for state in state_list for location in state.world.get_filled_locations() if location.item.advancement]
-
-        # will loop if there is more items opened up in the previous iteration. Always run once
-        reachable_items_locations = True
-        while reachable_items_locations:
-            # get reachable new items locations
-            reachable_items_locations = [location for location in item_locations if location.name not in state_list[location.world.id].collected_locations and state_list[location.world.id].can_reach(location)]
-            for location in reachable_items_locations:
-                # Mark the location collected in the state world it exists in
-                state_list[location.world.id].collected_locations[location.name] = True
-                # Collect the item for the state world it is for
-                state_list[location.item.world.id].collect(location.item)
+        Playthrough(state_list).collect_locations()
 
 
-    # This returns True is every state is beatable. It's important to ensure
-    # all states beatable since items required in one world can be in another.
     @staticmethod
     def can_beat_game(state_list, scan_for_items=True):
-        if scan_for_items:
-            # Check if already beaten
-            game_beaten = True
-            for state in state_list:
-                if not state.has('Triforce'):
-                    game_beaten = False
-                    break
-            if game_beaten:
-                return True
-
-            # collect all available items
-            new_state_list = [state.copy() for state in state_list]
-            State.collect_locations(new_state_list)
-        else:
-            new_state_list = state_list
-
-        # if the every state got the Triforce, then return True
-        for state in new_state_list:
-            if not state.has('Triforce'):
-                return False
-        return True
+        return Playthrough(state_list).can_beat_game(scan_for_items)
 
 
     @staticmethod
@@ -552,38 +520,39 @@ class State(object):
         state_list = [world.state for world in worlds]
 
         # get list of all of the progressive items that can appear in hints
-        all_locations = [location for world in worlds for location in world.get_filled_locations()]
-        item_locations = [location for location in all_locations if location.item.majoritem and not location.locked]
+        # all_locations: all progressive items. have to collect from these
+        # item_locations: only the ones that should appear as "required"/WotH
+        all_locations = {location for world in worlds for location in world.get_filled_locations()}
+        item_locations = {location for location in all_locations if location.item.majoritem and not location.locked}
 
         # if the playthrough was generated, filter the list of locations to the
         # locations in the playthrough. The required locations is a subset of these
         # locations. Can't use the locations directly since they are location to the
         # copied spoiler world, so must try to find the matching locations by name
         if spoiler.playthrough:
-            spoiler_locations = defaultdict(lambda: [])
-            for location in [location for _,sphere in spoiler.playthrough.items() for location in sphere]:
+            spoiler_locations = defaultdict(list)
+            for location in itertools.chain.from_iterable(spoiler.playthrough.values()):
                 spoiler_locations[location.name].append(location.world.id)
-            item_locations = list(filter(lambda location: location.world.id in spoiler_locations[location.name], item_locations))
+            item_locations = set(filter(lambda location: location.world.id in spoiler_locations[location.name], item_locations))
 
         required_locations = []
-        reachable_items_locations = True
-        while (item_locations and reachable_items_locations):
-            reachable_items_locations = [location for location in all_locations if location.name not in state_list[location.world.id].collected_locations and state_list[location.world.id].can_reach(location)]
-            for location in reachable_items_locations:
-                # Try to remove items one at a time and see if the game is still beatable
-                if location in item_locations:
-                    old_item = location.item
-                    location.item = None
-                    if not State.can_beat_game(state_list):
-                        required_locations.append(location)
-                    location.item = old_item
-                    item_locations.remove(location)
-                state_list[location.world.id].collected_locations[location.name] = True
-                state_list[location.item.world.id].collect(location.item)
+
+        playthrough = Playthrough(state_list)
+        for location in playthrough.iter_reachable_locations(all_locations):
+            # Try to remove items one at a time and see if the game is still beatable
+            if location in item_locations:
+                old_item = location.item
+                location.item = None
+                # copies state! This is very important as we're in the middle of a playthrough
+                # already, but beneficially, has playthrough it can start from
+                if not playthrough.can_beat_game():
+                    required_locations.append(location)
+                location.item = old_item
+            state_list[location.world.id].collected_locations[location.name] = True
+            state_list[location.item.world.id].collect(location.item)
 
         # Filter the required location to only include location in the world
         required_locations_dict = {}
         for world in worlds:
             required_locations_dict[world.id] = list(filter(lambda location: location.world.id == world.id, required_locations))
         spoiler.required_locations = required_locations_dict
-

--- a/State.py
+++ b/State.py
@@ -522,7 +522,8 @@ class State(object):
         # get list of all of the progressive items that can appear in hints
         # all_locations: all progressive items. have to collect from these
         # item_locations: only the ones that should appear as "required"/WotH
-        all_locations = {location for world in worlds for location in world.get_filled_locations()}
+        all_locations = [location for world in worlds for location in world.get_filled_locations()]
+        # Set to test inclusion against
         item_locations = {location for location in all_locations if location.item.majoritem and not location.locked}
 
         # if the playthrough was generated, filter the list of locations to the

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -387,7 +387,7 @@
             "Sheik at Temple": "Forest_Medallion and is_adult"
         },
         "exits": {
-            "Temple of Time": "True"
+            "Temple of Time": "Master_Sword"
         }
     },
     {


### PR DESCRIPTION
This implements a BFS simulation of a playthrough, tracking the regions accessed in each sphere and caching those regions and the exits to new regions that can't yet be taken, rather than use the can_reach inward DFS (inward because it starts at the goal location and searches backward until it finds an accessed region). This cuts generation time down nearly 50% depending on settings, and hopefully it's easier to understand. There may be more room for the Fill algorithm to take advantage of the new Playthrough caching, but the majority of time spent is in create_playthrough so that was what I was focusing on.

Experimental times on my laptop:
- Accessible, count=10:  33s -> 19s
- Accessible, worlds=5: 2m16s -> 1m10s
- Sanity (ocarina/egg/songs/cows/scrubs/shops/tokens/keys/maps+compasses): 5.5s -> 2.8s
- Sanity x10 with custom script to skip playthrough generation: 34s -> 18s