### PR TITLE
Change closed forest logic to allow for more varied escapes

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -595,10 +595,6 @@ setting_infos = [
             and the Kokiri boy no longer blocks the path out
             of the forest.
 
-            When this option is off, the Kokiri Sword and
-            Slingshot are always available somewhere
-            in the forest.
-
             This is incompatible with start as adult.
         ''',
         default        = True,

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -118,7 +118,7 @@
         "exits": {
             "Kokiri Forest": "True",
             "Goron City Woods Warp": "True",
-            "Zora River": "can_dive and can_leave_forest",
+            "Zora River": "can_dive",
             "Lost Woods Beyond Mido": "is_child or logic_adult_meadow_access or can_play(Sarias_Song)",
             "Lost Woods Generic Grotto": "can_blast_or_smash"
         }
@@ -796,8 +796,7 @@
         "region_name": "Goron City Woods Warp",
         "exits": {
             "Goron City": "
-                can_leave_forest and 
-                (as_either_here(can_blast_or_smash or can_use(Dins_Fire)) or 
+                 as_either_here(can_blast_or_smash or can_use(Dins_Fire) or 
                     can_reach('Goron City -> Goron City Woods Warp', Entrance, either))",
             "Lost Woods": "True"
         }

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -5,7 +5,7 @@
             "Kokiri Sword Chest": "is_child",
             "GS Kokiri Know It All House": "
                 is_child and nighttime and 
-                (had_night_start or can_leave_forest or can_play(Suns_Song)) and can_child_attack",
+                (had_night_start or can_play(Suns_Song)) and can_child_attack",
             "GS Kokiri Bean Patch": "
                 can_plant_bugs and can_child_attack",
             "GS Kokiri House of Twins": "
@@ -50,13 +50,13 @@
         "exits": {
             "Kokiri Forest": "True",
             "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
-            "Temple of Time": "can_play(Prelude_of_Light) and can_leave_forest",
+            "Temple of Time": "can_play(Prelude_of_Light)",
             "Death Mountain Crater Central": "
-                can_play(Bolero_of_Fire) and can_leave_forest",
-            "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
+                can_play(Bolero_of_Fire)",
+            "Lake Hylia": "can_play(Serenade_of_Water)",
             "Shadow Temple Warp Region": "
-                can_play(Nocturne_of_Shadow) and can_leave_forest",
-            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+                can_play(Nocturne_of_Shadow)",
+            "Desert Colossus": "can_play(Requiem_of_Spirit)"
         }
     },
     {
@@ -170,7 +170,7 @@
     {
         "region_name": "Lost Woods Bridge",
         "locations": {
-            "Gift from Saria": "True"
+            "Gift from Saria": "can_leave_forest or is_adult"
         },
         "exits": {
             "Kokiri Forest": "True",


### PR DESCRIPTION
Allows for more ways to exit the forest other than killing Gohma.  Zora scale, Explosives, and warp songs all allow for forest escapes.  Escaping in such a way does not let you access Saria's gift until you open the forest properly, or become an adult.