### PR TITLE
Fix accidentally skipping adult in some cases.

### DIFF
--- a/Playthrough.py
+++ b/Playthrough.py
@@ -116,11 +116,13 @@ class Playthrough(object):
             child_failed = Playthrough._expand_regions(
                     child_queue, child_regions, validate_child,
                     adult_queue, adult_regions)
-            # If child reached BDoT, we'll have added BDoT for adult,
-            # but until the state collects MS, there's no point expanding
-            # the sphere given that we check for MS in determining adult accessibility.
-            # So we do it next time.
-            adult_failed.extend(adult_queue)
+            # If child reached BDoT, we'll have added BDoT for adult.
+            # We always have to expand again before checking locations,
+            # since we could have collected all in child before running this.
+            if adult_queue:
+                adult_failed.extend(Playthrough._expand_regions(
+                        adult_queue, adult_regions, validate_adult,
+                        child_failed, child_regions))
 
             # 2. Get all locations in accessible_regions that aren't collected,
             #    and check if they can be reached. Collect them.


### PR DESCRIPTION
I suspect tokensanity results in child collecting all of its locations in an initial pass before keys are placed, triggering the observed issue.

Another fix may come later, where the fill algorithm uses playthroughs to reuse the caches there.