### PR TITLE
Require longshot to open water with no boots

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -238,7 +238,7 @@
             "Fishing Hole": "
                 is_child or can_use(Scarecrow) or can_use(Magic_Bean) or can_reach(Morpha, Location)",
             "Water Temple Lobby": "
-                as_adult_here(can_use(Hookshot)) and
+                as_adult_here((can_use(Hookshot) and can_use(Iron_Boots)) or can_use(Longshot)) and
                 ((as_adult(can_reach(Morpha, Location)) and child_lake_hylia_control) or is_adult) and
                 ((Progressive_Scale, 2) or can_use(Iron_Boots))",
             "Lake Hylia Grotto": "can_stun_deku"


### PR DESCRIPTION
The setup for water with hookshot and scale is a little on the harsh
side. Kick it out of logic as this has already come up in the support
channels with suggestion by support it should be out. Could be trick
level in the future.