### PR TITLE
Fix tournament hint distribution to only fail when out of random hints

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -553,7 +553,7 @@ def buildGossipHints(spoiler, world):
         if hint == None:
             index = hint_types.index(hint_type)
             hint_prob[index] = 0
-            if world.hint_dist == "tournament":
+            if world.hint_dist == "tournament" and hint_type == 'random':
                 raise Exception('Not enough valid %s hints for tournament distribution' % hint_type)
         else:
             gossip_text, location = hint


### PR DESCRIPTION
The tournament hint distribution was failing if any of the hint categories didn't have enough hints to generate the fixed number of hint types. For example, if only one area in the seed was barren, it couldn't generate 2 different barren hints so it ended up failing. It could also not generate entrance hints when entrances weren't shuffled so it would fail in this case for every seed.

With this it will only fail if there aren't enough valid random hints to fill the gap caused by hints missing in other types.