### PR TITLE
Fix shadow entrance not using the proper hint area

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -732,6 +732,7 @@
     },
     {
         "region_name": "Shadow Temple Warp Region",
+        "hint": "the Graveyard",
         "locations": {
             "Graveyard Gossip Stone": "True"
         },


### PR DESCRIPTION
Shadow Temple entrance could end up with the Kokiri Forest hint area because of the warp song entrance, instead of the expected graveyard hint area, this is now fixed.