### PR TITLE
Fix some small issues related to shop access rules

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -27,7 +27,7 @@ from Utils import default_output_path, is_bundled, subprocess_args, data_path
 from version import __version__
 from N64Patch import create_patch_file, apply_patch_file
 from SettingsList import setting_infos, logic_tricks
-from Rules import set_rules
+from Rules import set_rules, set_shop_rules
 from Plandomizer import Distribution
 from Playthrough import Playthrough
 from EntranceShuffle import set_entrances
@@ -121,6 +121,7 @@ def main(settings, window=dummy_window()):
         window.update_progress(0 + 5*(id + 1)/settings.world_count)
         logger.info('Generating Item Pool.')
         generate_itempool(world)
+        set_shop_rules(world)
 
     logger.info('Setting Entrances.')
     set_entrances(worlds)

--- a/Rules.py
+++ b/Rules.py
@@ -34,9 +34,9 @@ def set_rules(world):
                 add_item_rule(location, lambda location, item: item.type != 'Shop')
                 location.price = world.shop_prices[location.name]
                 if location.price > 200:
-                    set_rule(location, lambda state: state.has('Progressive Wallet', 2))
+                    add_rule(location, lambda state: state.has('Progressive Wallet', 2))
                 elif location.price > 99:
-                    set_rule(location, lambda state: state.has('Progressive Wallet'))
+                    add_rule(location, lambda state: state.has('Progressive Wallet'))
             else:
                 add_item_rule(location, lambda location, item: item.type == 'Shop' and item.world.id == location.world.id)
 


### PR DESCRIPTION
- Wallet requirements in shopsanity no longer override existing location access rules.
- Entrance shuffling now accounts for vanilla shop location rules. This prevents some placement issues like having the Goron Shop/Zora Shop potentially placed behind a child only entrance even if shopsanity is off and ALR is enabled.