### PR TITLE
Added fast chickens

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -24,6 +24,10 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
 
     shop_locations = [location for world in worlds for location in world.get_unfilled_locations() if location.type == 'Shop' and location.price == None]
 
+    # Place Ganon's Tower Boss Key at LACS if playing on medallions open or all dungeons open
+    # if worlds[0].bridge == 'med-open' or worlds[0].bridge == 'ad-open':
+    #     worlds[0].get_location('Zelda').push_item(location, 'Boss Key (Ganons Castle)')
+
     # If not passed in, then get a shuffled list of locations to fill in
     if not fill_locations:
         fill_locations = [location for world in worlds for location in world.get_unfilled_locations() \
@@ -412,6 +416,7 @@ def fast_fill(window, locations, itempool):
     while itempool and locations:
         spot_to_fill = locations.pop()
         item_to_place = itempool.pop()
+        # type(spot_to_fill)
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)
         window.fillcount += 1
         window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))

--- a/Patches.py
+++ b/Patches.py
@@ -26,13 +26,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             rom.write_int32(address, value)
     rom.scan_dmadata_update()
 
-    # Fast Chickens (Spawn all but 3 chickens in the pen to start)
-    # offsets = [0x02016206, 0x02016216, 0x02016226, 0x02016236, 0x02016246, 0x02016256, 0x02016266]
-    offsets = [0x02016216, 0x02016236, 0x02016256, 0x02016266]
-    position = [0x01, 0x38, 0x00, 0x50, 0x05, 0xED]
-    for offset in offsets:
-        rom.write_bytes(offset, position)
-
     # Write Randomizer title screen logo
     with open(data_path('title.bin'), 'rb') as stream:
         titleBytes = stream.read()
@@ -97,6 +90,15 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     if world.bombchus_in_logic:
         rom.write_int32(rom.sym('BOMBCHUS_IN_LOGIC'), 1)
+
+    if world.fast_chickens:
+        # All chickens
+        # offsets = [0x02016206, 0x02016216, 0x02016226, 0x02016236, 0x02016246, 0x02016256, 0x02016266]
+        offsets = [0x02016246, 0x02016256, 0x02016266]
+        position = [0x01, 0x38, 0x00, 0x50, 0x05, 0xED]
+        for offset in offsets:
+            rom.write_bytes(offset, position)
+
 
     # Change graveyard graves to not allow grabbing on to the ledge
     rom.write_byte(0x0202039D, 0x20)
@@ -877,6 +879,18 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_int32(symbol, 4)
     elif world.bridge == 'tokens':
         rom.write_int32(symbol, 5)
+    elif world.bridge == 'med-open':
+        rom.write_int32(symbol, 0)
+        rom.write_int32(0x00ACCE20, 0x2009003F) # ADDI T1, R0, 0x003F
+        rom.write_bytes(0x00ACCE2C, 0x1549001B) # BNE  T2, T1, 0x80056F3C
+        # Set LACS to GT boss key
+    elif world.bridge == 'ad-open':
+        rom.write_int32(symbol, 0)
+        rom.write_int32(0x00ACCE20, 0x2009003F) # ADDI T1, R0, 0x003F
+        rom.write_bytes(0x00ACCE2C, 0x1549001B) # BNE  T2, T1, 0x80056F3C
+        rom.write_bytes(0x00ACCE34, 0x3C0B001C) # LUI  T3, 0x001C
+        rom.write_bytes(0x00ACCE3C, 0x158B0017) # BNE  T4, T3, 0x80056F3C
+        # Set LACS to GT boss key
 
     if world.open_forest:
         save_context.write_bits(0xED5, 0x10) # "Showed Mido Sword & Shield"

--- a/Patches.py
+++ b/Patches.py
@@ -26,6 +26,13 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             rom.write_int32(address, value)
     rom.scan_dmadata_update()
 
+    # Fast Chickens (Spawn all but 3 chickens in the pen to start)
+    # offsets = [0x02016206, 0x02016216, 0x02016226, 0x02016236, 0x02016246, 0x02016256, 0x02016266]
+    offsets = [0x02016216, 0x02016236, 0x02016256, 0x02016266]
+    position = [0x01, 0x38, 0x00, 0x50, 0x05, 0xED]
+    for offset in offsets:
+        rom.write_bytes(offset, position)
+
     # Write Randomizer title screen logo
     with open(data_path('title.bin'), 'rb') as stream:
         titleBytes = stream.read()

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -681,7 +681,9 @@ setting_infos = [
             'stones':	  'All Spiritual Stones',
             'medallions': 'All Medallions',
             'dungeons':   'All Dungeons',
-            'tokens':     '100 Gold Skulltula Tokens'
+            'tokens':     '100 Gold Skulltula Tokens',
+            'med-open':   'Medallions + Open',
+            'ad-open':    'All Dungeons + Open'
         },
         gui_text       = 'Rainbow Bridge Requirement',
         gui_group      = 'open',
@@ -692,6 +694,8 @@ setting_infos = [
             'All Medallions': All 6 Medallions.
             'All Dungeons': All Medallions and Spiritual Stones.
             '100 Gold Skulltula Tokens': All 100 Gold Skulltula Tokens.
+            'All Dungeons + Open': Open bridge, Ganon Tower boss key at Light Arrows, Light Arrow cutscene requires Medallions/Stones.
+            'Medallions + Open': Open bridge, Ganon Tower Boss Key at Light Arrows, Light Arrow cutscene requires all Medallions.
         ''',
         shared         = True,
         gui_params     = {
@@ -935,6 +939,15 @@ setting_infos = [
             Start the game with 10 Deku sticks and 20 Deku nuts.
             Additionally, start the game with a Deku shield equipped,
             unless playing with the Shopsanity setting.
+        ''',
+        shared         = True,
+    ),
+    Checkbutton(
+        name           = 'fast_chickens',
+        gui_text       = 'Fast Chickens',
+        gui_group      = 'convenience',
+        gui_tooltip    = '''\
+            Move 3 of the cuccos in child Kakariko into the pen.
         ''',
         shared         = True,
     ),

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -458,6 +458,8 @@
             "Ganons Castle Fairy": "can_use(Golden_Gauntlets)",
             "Ganons Castle Lobby": "
                 (bridge == 'open')
+                or (bridge == 'med-open')
+                or (bridge == 'ad-open')
                 or ((bridge == 'medallions') and
                     Forest_Medallion and Fire_Medallion and Water_Medallion and
                     Shadow_Medallion and Spirit_Medallion and Light_Medallion)


### PR DESCRIPTION
This isn't meant to be a real change, as this would apply to every seed. I don't know how all of the gui stuff works, so I just put in the basic code for it. This places chickens 2, 4, 6, and 7 in the pen to when the player loads Kakariko so that they don't have to collect them. The commented "offsets" is a list of all of the chicken's positions, so if you want to change it, or allow the player to remove specific chickens, those are in the same order as this list

Chicken 1: Near Entrance
Chiekcn 2: Near Bazaar
Chicken 3: Near Pen
Chiekcn 4: Near Windmill
Chiekcn 5: Box Chicken
Chiekcn 6: Near Spider House
Chiekcn 7: Near Hole