### PR TITLE
Use a unique root in logic and fix playthrough inconsistencies

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -198,7 +198,7 @@ def shuffle_entrance_pool(worlds, entrance_pool, already_unreachable_locations):
         restrictive_entrances, soft_entrances = split_entrances_by_requirements(worlds, entrances_to_shuffle)
 
         # Assumed Fill: Unplace, and assume we have access to entrances by connecting them to the root of reachability
-        root = world.get_region("Links House")
+        root = world.get_region('Root')
         target_regions = [entrance.disconnect() for entrance in entrances_to_shuffle]
         target_entrances = []
         for target_region in target_regions:

--- a/ItemList.py
+++ b/ItemList.py
@@ -138,7 +138,7 @@ item_table = {
     'Small Key (Ganons Castle)':        ('SmallKey', True,  0xB7, {'progressive': True}),
     'Double Defense':                   ('Item',     True,  0xB8, None),
     'Zeldas Letter':                    ('Item',     True,  None, None),
-    'Master Sword':                     ('Item',     True,  None, None),
+    'Time Travel':                      ('Event',    True,  None, None),
     'Epona':                            ('Event',    True,  None, None),
     'Deku Stick Drop':                  ('Event',    True,  None, None),
     'Deku Nut Drop':                    ('Event',    True,  None, None),

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -488,7 +488,7 @@ eventlocations = {
     "Sell 2 Big Poe": 'Sell Big Poe',
     "Sell 3 Big Poe": 'Sell Big Poe',
     "Sell 4 Big Poe": 'Sell Big Poe',
-    'Master Sword Pedestal': 'Master Sword',
+    'Master Sword Pedestal': 'Time Travel',
     'Epona': 'Epona',
     'Deku Baba Sticks': 'Deku Stick Drop',
     'Forest Temple Deku Baba Sticks': 'Deku Stick Drop',

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -40,15 +40,12 @@ class Playthrough(object):
                     region_set.add(exit.connected_region)
                     exit_queue.extend(filter(new_exit, exit.connected_region.exits))
                     # This will put all accessible cross-age regions into the current sphere,
-                    # but for child->adult, the state will not yet have Master Sword,
-                    # so adult locations will not yet be accessible.
+                    # but the state will not yet have Time Travel yet,
+                    # so cross-age locations will not be accessible.
                     if exit.connected_region.name == 'Beyond Door of Time':
-                        cross_age_set.add(exit.connected_region)
-                        cross_age_queue.extend(exit.connected_region.exits)
-                        # Adult savewarp point is Temple of Time, which is
-                        # always accessible from BDoT, so we can skip adding it specially
-                        # Child savewarp point is Links House, which is
-                        # always accessible from BDoT -> ToT -> CT -> HF -> LWB -> KF, so we can skip adding it specially
+                        root = exit.world.get_region('Root')
+                        cross_age_set.add(root)
+                        cross_age_queue.extend(root.exits)
                 else:
                     failed.append(exit)
         return failed
@@ -98,10 +95,10 @@ class Playthrough(object):
                 adult_queue = copy.copy(self.cached_spheres[-1]['adult_queue'])
             else:
                 child_starting_regions = [
-                        state.world.get_region('Links House') for state in self.state_list
+                        state.world.get_region('Root') for state in self.state_list
                         if state.world.starting_age == 'child']
                 adult_starting_regions = [
-                        state.world.get_region('Temple of Time') for state in self.state_list
+                        state.world.get_region('Root') for state in self.state_list
                         if state.world.starting_age == 'adult']
                 child_queue = deque(exit for region in child_starting_regions for exit in region.exits)
                 adult_queue = deque(exit for region in adult_starting_regions for exit in region.exits)
@@ -116,7 +113,7 @@ class Playthrough(object):
             child_failed = Playthrough._expand_regions(
                     child_queue, child_regions, validate_child,
                     adult_queue, adult_regions)
-            # If child reached BDoT, we'll have added BDoT for adult.
+            # If child reached BDoT, we'll have added the root region for adult.
             # We always have to expand again before checking locations,
             # since we could have collected all in child before running this.
             if adult_queue:

--- a/Rules.py
+++ b/Rules.py
@@ -10,12 +10,8 @@ def set_rules(world):
     # ganon can only carry triforce
     world.get_location('Ganon').item_rule = lambda location, item: item.name == 'Triforce'
 
-    # these are default save&quit points and always accessible in their corresponding age
-    old_can_reach = world.get_region('Links House').can_reach
-    world.get_region('Links House').can_reach = lambda state: state.is_child() or old_can_reach(state)
-
-    old_can_reach = world.get_region('Temple of Time').can_reach
-    world.get_region('Temple of Time').can_reach = lambda state: state.is_adult() or old_can_reach(state)
+    # the root of the world graph is always considered reachable because the player can save&quit
+    world.get_region('Root').can_reach = lambda state: True
 
     for location in world.get_locations():
 

--- a/State.py
+++ b/State.py
@@ -233,11 +233,11 @@ class State(object):
 
 
     def can_become_adult(self):
-        return self.world.starting_age == 'adult' or self.has('Master Sword')
+        return self.world.starting_age == 'adult' or self.has('Time Travel')
 
 
     def can_become_child(self):
-        return self.world.starting_age == 'child' or self.can_reach('Beyond Door of Time', age='adult')
+        return self.world.starting_age == 'child' or self.has('Time Travel')
 
 
     def is_adult(self):
@@ -246,6 +246,10 @@ class State(object):
 
     def is_child(self):
         return not self.adult
+
+
+    def is_starting_age(self):
+        return self.adult == (self.world.starting_age == 'adult')
 
 
     def can_child_attack(self):
@@ -415,8 +419,7 @@ class State(object):
 
 
     def can_leave_forest(self):
-        return self.world.open_forest or self.can_reach(self.world.get_location('Queen Gohma'), age='either') \
-            or self.is_glitched
+        return self.world.open_forest or self.is_adult() or self.is_glitched or self.can_reach(self.world.get_location('Queen Gohma'), age='either')
 
 
     def can_finish_adult_trades(self):

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1,5 +1,29 @@
 [
     {
+        "region_name": "Root",
+        "hint": "Link's Pocket",
+        "locations": {
+            "Links Pocket": "True"
+        },
+        "exits": {
+            "Root Exits": "is_starting_age or Time_Travel"
+        }
+    },
+    {
+        "region_name": "Root Exits",
+        "exits": {
+            "Links House": "is_child",
+            "Temple of Time": "
+                is_adult or 
+                (can_play(Prelude_of_Light) and can_leave_forest)",
+            "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
+            "Death Mountain Crater Central": "can_play(Bolero_of_Fire) and can_leave_forest",
+            "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
+            "Shadow Temple Warp Region": "can_play(Nocturne_of_Shadow) and can_leave_forest",
+            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+        }
+    },
+    {
         "region_name": "Kokiri Forest",
         "hint": "Kokiri Forest",
         "locations": {
@@ -48,19 +72,10 @@
         "region_name": "Links House",
         "hint": "Kokiri Forest",
         "locations": {
-            "Links Pocket": "True",
             "Links House Cow": "is_adult and Epona"
         },
         "exits": {
-            "Kokiri Forest": "True",
-            "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
-            "Temple of Time": "can_play(Prelude_of_Light) and can_leave_forest",
-            "Death Mountain Crater Central": "
-                can_play(Bolero_of_Fire) and can_leave_forest",
-            "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
-            "Shadow Temple Warp Region": "
-                can_play(Nocturne_of_Shadow) and can_leave_forest",
-            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+            "Kokiri Forest": "True"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1,5 +1,29 @@
 [
     {
+        "region_name": "Root",
+        "hint": "Link's Pocket",
+        "locations": {
+            "Links Pocket": "True"
+        },
+        "exits": {
+            "Root Exits": "is_starting_age or Time_Travel"
+        }
+    },
+    {
+        "region_name": "Root Exits",
+        "exits": {
+            "Links House": "is_child",
+            "Temple of Time": "
+                is_adult or 
+                (can_play(Prelude_of_Light) and can_leave_forest)",
+            "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
+            "Death Mountain Crater Central": "can_play(Bolero_of_Fire) and can_leave_forest",
+            "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
+            "Shadow Temple Warp Region": "can_play(Nocturne_of_Shadow) and can_leave_forest",
+            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+        }
+    },
+    {
         "region_name": "Kokiri Forest",
         "hint": "Kokiri Forest",
         "locations": {
@@ -51,19 +75,10 @@
         "region_name": "Links House",
         "hint": "Kokiri Forest",
         "locations": {
-            "Links Pocket": "True",
             "Links House Cow": "is_adult and Epona"
         },
         "exits": {
-            "Kokiri Forest": "True",
-            "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
-            "Temple of Time": "can_play(Prelude_of_Light) and can_leave_forest",
-            "Death Mountain Crater Central": "
-                can_play(Bolero_of_Fire) and can_leave_forest",
-            "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
-            "Shadow Temple Warp Region": "
-                can_play(Nocturne_of_Shadow) and can_leave_forest",
-            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+            "Kokiri Forest": "True"
         }
     },
     {
@@ -410,7 +425,7 @@
             "Sheik at Temple": "Forest_Medallion and is_adult"
         },
         "exits": {
-            "Temple of Time": "Master_Sword"
+            "Temple of Time": "True"
         }
     },
     {


### PR DESCRIPTION
Mostly internal logic changes, shouldn't change anything other than making generation slightly faster and fixing some playthrough issues in the spoiler.

- Change Link's House and Temple of Time save&quit points to be children of a common Root region.
- Update the playthrough algorithm to support a unique common root, and remove assumptions about Beyond Door of Time always having a path to Link's House.
- Change the Master Sword Pedestal event item to "Time Travel" to make the playthrough consistent between child and adult start.

I had to make some changes to the new playthrough algorithm so I'm curious to hear what @Zannick thinks about it and if he knows a better way to handle having a common root. I think this is good enough as it is but there might be some possible improvements.