### PR TITLE
Fix some logic typos and add an exception thrown when rule parsing fails

### DIFF
--- a/RuleParser.py
+++ b/RuleParser.py
@@ -45,7 +45,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                 keywords=[])
 
         else:
-            return ast.Str(node.id.replace('_', ' '))
+            raise Exception('Parse Error: invalid node name %s', node.id)
 
 
     def visit_Tuple(self, node):

--- a/data/Glitched World/Deku Tree.json
+++ b/data/Glitched World/Deku Tree.json
@@ -17,7 +17,7 @@
                  as_either_here(can_use(Hookshot) or can_use(Boomerang) or can_hover)) or
                 (is_child and (has_explosives or has_blue_fire) and
                  (can_use(Boomerang) or can_hover) and has_fire_source_with_torch) or
-                (is_adult and has_explosives and Hookshot and Hover_Boots and can_live_dmg(0.5) and
+                (is_adult and has_explosives and Progressive_Hookshot and Hover_Boots and can_live_dmg(0.5) and
                     (Bow or has_fire_source))"
         },
         "exits": {

--- a/data/Glitched World/Forest Temple.json
+++ b/data/Glitched World/Forest Temple.json
@@ -143,7 +143,7 @@
             "GS Forest Temple Basement": "can_use(Hookshot) or can_use(Boomerang) or can_hover"
         },
         "exits":{
-            "Forest Temple Boss Room": "Forest_Temple_Boss_Key"
+            "Forest Temple Boss Room": "Boss_Key_Forest_Temple"
         }
     },
     {

--- a/data/Glitched World/Ganons Castle.json
+++ b/data/Glitched World/Ganons Castle.json
@@ -75,11 +75,12 @@
         "locations": {
             "Ganons Castle Spirit Trial First Chest": "True",
             #// include req for silver rupees here
-            "Ganons Castle Spirit Trial Second Chest": "has_bombchus or (can_shield and (Longshot or Bow))",
+            "Ganons Castle Spirit Trial Second Chest": "
+                has_bombchus or (can_shield and (can_use(Longshot) or Bow))",
             #// previous 2 reqs here
             "Ganons Castle Spirit Trial Clear": "
                 can_use(Light_Arrows) and Mirror_Shield and 
-                (has_bombchus or (can_shield and (Longshot or Bow)))"
+                (has_bombchus or (can_shield and (can_use(Longshot) or Bow)))"
         }
     },
     {

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -120,7 +120,7 @@
         "locations": {
             "LW Deku Scrub Deku Nuts": "is_child and can_stun_deku",
             "LW Deku Scrub Deku Sticks": "is_child and can_stun_deku",
-            "GS Lost Woods Above Stage": "is_adult and nighttime and (can_use(Magic_Bean) or Longshot or (has_bombchus and Hookshot) or can_hover)",
+            "GS Lost Woods Above Stage": "is_adult and nighttime and (can_use(Magic_Bean) or can_use(Longshot) or (has_bombchus and Progressive_Hookshot) or can_hover)",
             "GS Lost Woods Bean Patch Near Stage": "
                 can_plant_bugs and 
                 (can_child_attack or (shuffle_scrubs == 'off' and Buy_Deku_Shield))"
@@ -305,7 +305,7 @@
         },
         "exits": {
             "Haunted Wasteland": "is_child or
-                (is_adult and (Carpenter_Rescue or (Hookshot and (Hover_Boots or can_mega)) or (can_isg and has_bombs) ) )",
+                (is_adult and (Carpenter_Rescue or (Progressive_Hookshot and (Hover_Boots or can_mega)) or (can_isg and has_bombs) ) )",
             "Gerudo Training Grounds Lobby": "True"
         }
     },
@@ -315,7 +315,7 @@
         "locations": {
             "Haunted Wasteland Structure Chest": "has_fire_source",
             "Haunted Wasteland Bombchu Salesman": "Progressive_Wallet and can_jumpslash",
-            "GS Wasteland Ruins": "can_use(Boomerang) or (is_adult and (Hookshot or (has_bombs and can_shield)))"
+            "GS Wasteland Ruins": "can_use(Boomerang) or (is_adult and (Progressive_Hookshot or (has_bombs and can_shield)))"
         },
         "exits": {
             "Desert Colossus": "True",
@@ -945,7 +945,7 @@
             "Zora River Lower Freestanding PoH": "True",
             "Zora River Upper Freestanding PoH": "True",
             "GS Zora River Ladder": "is_child and nighttime and can_child_attack",
-            "GS Zora River Near Raised Grottos": "is_adult and (Hookshot or can_hover) and nighttime",
+            "GS Zora River Near Raised Grottos": "is_adult and (Progressive_Hookshot or can_hover) and nighttime",
             "GS Zora River Above Bridge": "can_use(Hookshot) and nighttime",
             "Zoras River Plateau Gossip Stone": "True",
             "Zoras River Waterfall Gossip Stone": "True"

--- a/data/Glitched World/Spirit Temple MQ.json
+++ b/data/Glitched World/Spirit Temple MQ.json
@@ -79,7 +79,7 @@
                 can_play(Song_of_Time) or 
                 (can_use(Longshot) and can_use(Silver_Gauntlets))",
             "GS Spirit Temple MQ Sun Block Room": "
-                (logic_spirit_mq_sun_block_gs and can_play(Song_of_time) and Boomerang) or
+                (logic_spirit_mq_sun_block_gs and can_play(Song_of_Time) and Boomerang) or
                 (can_use(Longshot) and can_use(Silver_Gauntlets))"
         },
         "exits": {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -19,7 +19,7 @@
                     ( (has_nuts or can_use(Boomerang)) and 
                         (can_use(Kokiri_Sword) or has_slingshot) ) ))",
             "Spirit Temple Child Right Chest": "(is_adult and has_fire_source) or 
-                (has_fire_source_with_torch and (as_adult_here(True) or
+                (has_fire_source_with_torch and (as_adult_here or
                 (
                 (can_use(Boomerang) or has_slingshot or has_bombchus or can_mega) and 
                 (has_sticks or has_explosives or 
@@ -75,8 +75,8 @@
         "region_name": "Spirit Temple Central Chamber",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Map Chest": "can_use(Bow) or has_fire_with_torch",
-            "Spirit Temple Sun Block Room Chest": "has_fire_with_torch or can_use(Bow)",
+            "Spirit Temple Map Chest": "can_use(Bow) or has_fire_source_with_torch",
+            "Spirit Temple Sun Block Room Chest": "has_fire_source_with_torch or can_use(Bow)",
             "Spirit Temple Statue Hand Chest": "can_play(Zeldas_Lullaby)
                 and can_jumpslash",
             "Spirit Temple NE Main Room Chest": "can_play(Zeldas_Lullaby) and can_jumpslash and

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -61,7 +61,7 @@
         "locations": {
             "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
                 (can_use(Hookshot) or can_hover) and has_projectile",
-            "Spirit Temple Early Adult Right Chest": "has(projectile)", 
+            "Spirit Temple Early Adult Right Chest": "has_projectile", 
             "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 2)",
             "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 2)",
             "GS Spirit Temple Boulder Room": "has_projectile and

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -63,13 +63,13 @@
             "Water Temple Map Chest": "is_adult or can_child_damage",
             "Water Temple Cracked Wall Chest": "(can_use(Hookshot) and Iron_Boots) or
                 (can_play(Zeldas_Lullaby) and (can_use(Hookshot) or has_explosives)) ",
-            "Water Temple Torches Chest": "(as_child_here(can_use(sticks)) or has_fire_source or can_use(Bow))
+            "Water Temple Torches Chest": "(as_child_here(can_use(Sticks)) or has_fire_source or can_use(Bow))
                 and can_play(Zeldas_Lullaby)"
         },
         "exits": {
             "Central Pillar": "can_play(Zeldas_Lullaby) and 
                 ( (((Small_Key_Water_Temple, 5) and not keysanity) or (Small_Key_Water_Temple,6))
-                or as_child_here(can_use(sticks)) or has_fire_source or can_use(Bow))",
+                or as_child_here(can_use(Sticks)) or has_fire_source or can_use(Bow))",
             "Boss Key Area": "(((Small_Key_Water_Temple, 4) and not keysanity) or (Small_Key_Water_Temple,5)) and
                 (can_use(Longshot) or can_hover or can_use(Hover_Boots)) and can_play(Zeldas_Lullaby)",
             "Dragon Head Area": "Progressive_Strength_Upgrade and (is_adult or can_child_attack) and can_play(Zeldas_Lullaby)",

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -13,17 +13,17 @@
                 (logic_deku_basement_gs and (is_adult or has_sticks or Kokiri_Sword))",
             "GS Deku Tree Basement Gate": "is_adult or can_child_attack",
             "GS Deku Tree Basement Back Room": "
-                (as_either_here(has_fire_source_with_torch()) and
+                (as_either_here(has_fire_source_with_torch) and
                  as_either_here(can_use(Slingshot) or can_use(Bow)) and
                  as_either_here(can_blast_or_smash) and
                  as_either_here(can_use(Hookshot) or can_use(Boomerang))) or
-                (as_adult_here(True) and is_child and has_explosives and
+                (as_adult_here and is_child and has_explosives and
                  can_use(Boomerang) and (has_sticks or can_use(Dins_Fire)))"
         },
         "exits": {
             "Deku Tree Slingshot Room": "as_either_here(has_shield)",
             "Deku Tree Boss Room": "
-                as_either_here(has_fire_source_with_torch()) and
+                as_either_here(has_fire_source_with_torch) and
                 as_either_here(is_adult or can_use(Slingshot))"
         }
     },

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -78,7 +78,7 @@
                 can_play(Song_of_Time) or 
                 (can_use(Longshot) and can_use(Silver_Gauntlets))",
             "GS Spirit Temple MQ Sun Block Room": "
-                (logic_spirit_mq_sun_block_gs and can_play(Song_of_time) and Boomerang) or
+                (logic_spirit_mq_sun_block_gs and can_play(Song_of_Time) and Boomerang) or
                 (can_use(Longshot) and can_use(Silver_Gauntlets))"
         },
         "exits": {

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -98,7 +98,7 @@
                     (can_use(Fire_Arrows) or (logic_spirit_map_chest and has_bow)) and 
                     can_use(Silver_Gauntlets))",
             "Spirit Temple Sun Block Room Chest": "
-                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrance)) and 
+                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
                     (can_use(Dins_Fire) or
                         (((Magic_Meter and Fire_Arrows) or logic_spirit_sun_chest) and has_bow and has_sticks))) or 
                 ((Small_Key_Spirit_Temple, 5) and has_explosives and


### PR DESCRIPTION
The rule parser was accepting unknown conditions instead of throwing an error, which resulted in conditions being incorrectly defaulted to True. 
I changed that behavior so the parser throws an exception in this case and fixed a bunch of typos in the current logic that were being incorrectly parsed, in both glitchless and glitched logic (@dotzo).