### PR TITLE
Fix starting time of day not being copied in the World instance

### DIFF
--- a/World.py
+++ b/World.py
@@ -90,6 +90,7 @@ class World(object):
         new_world.skipped_trials = copy.copy(self.skipped_trials)
         new_world.dungeon_mq = copy.copy(self.dungeon_mq)
         new_world.big_poe_count = copy.copy(self.big_poe_count)
+        new_world.starting_tod = self.starting_tod
         new_world.starting_age = self.starting_age
         new_world.can_take_damage = self.can_take_damage
         new_world.shop_prices = copy.copy(self.shop_prices)


### PR DESCRIPTION
This resulted in the time of day setting property being randomized again every World copy when the starting time of day option was set to "random".