### PR TITLE
Change No Logic to default to Glitchless world data instead of Glitched

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -104,10 +104,10 @@ def main(settings, window=dummy_window()):
             for dung in mqd_picks:
                 world.dungeon_mq[dung] = True
 
-        if settings.logic_rules == 'glitchless':
-            overworld_data = os.path.join(data_path('World'), 'Overworld.json')
-        else:
+        if settings.logic_rules == 'glitched':
             overworld_data = os.path.join(data_path('Glitched World'), 'Overworld.json')
+        else:
+            overworld_data = os.path.join(data_path('World'), 'Overworld.json')
         world.load_regions_from_json(overworld_data)
 
         create_dungeons(world)


### PR DESCRIPTION
Glitched logic currently doesn't support some settings like MQ dungeons and Entrance Rando, so No Logic should default to the Glitchless world structure to avoid issues when using it with MQ and ER.