### PR TITLE
Use Playthrough in more places

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -350,7 +350,7 @@ def fill_restrictive(window, worlds, base_playthrough, locations, itempool, coun
                         while parent_region:
                             try:
                                 source_region = item_to_place.world.get_region(parent_region.name)
-                                can_reach = max_playthrough.state_list[item_to_place.world.id].can_reach(source_region)
+                                can_reach = max_playthrough.can_reach(source_region)
                                 break
                             except KeyError:
                                 parent_region = parent_region.entrances[0].parent_region
@@ -358,7 +358,7 @@ def fill_restrictive(window, worlds, base_playthrough, locations, itempool, coun
                             continue
 
                 if location.disabled == DisableType.PENDING:
-                    if not max_playthrough.can_beat_game():
+                    if not max_playthrough.can_beat_game(False):
                         continue
                     location.disabled = DisableType.DISABLED
 

--- a/Fill.py
+++ b/Fill.py
@@ -8,6 +8,7 @@ from LocationList import location_groups
 from ItemPool import songlist, get_junk_item, junk_pool, item_groups
 from ItemList import item_table
 from Item import ItemFactory
+from Playthrough import Playthrough
 from functools import reduce
 
 
@@ -73,22 +74,28 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     worlds[0].distribution.fill(window, worlds, [shop_locations, song_locations, fill_locations], [shopitempool, dungeon_items, songitempool, progitempool, prioitempool, restitempool])
     itempool = progitempool + prioitempool + restitempool
 
+    # Start a playthrough cache here.
+    playthrough = Playthrough([world.state.copy() for world in worlds])
+
     # We place all the shop items first. Like songs, they have a more limited
     # set of locations that they can be placed in, so placing them first will
     # reduce the odds of creating unbeatable seeds. This also avoids needing
     # to create item rules for every location for whether they are a shop item
     # or not. This shouldn't have much affect on item bias.
     if shop_locations:
-        fill_ownworld_restrictive(window, worlds, shop_locations, shopitempool, itempool + songitempool + dungeon_items, "shop")
+        fill_ownworld_restrictive(window, worlds, playthrough, shop_locations, shopitempool, itempool + songitempool + dungeon_items, "shop")
     # Update the shop item access rules
     for world in worlds:
         set_shop_rules(world)
+
+    playthrough.collect_locations()
 
     # If there are dungeon items that are restricted to their original dungeon,
     # we must place them first to make sure that there is always a location to
     # place them. This could probably be replaced for more intelligent item
     # placement, but will leave as is for now
-    fill_dungeons_restrictive(window, worlds, fill_locations, dungeon_items, itempool + songitempool)
+    fill_dungeons_restrictive(window, worlds, playthrough, fill_locations, dungeon_items, itempool + songitempool)
+    playthrough.collect_locations()
 
     # places the songs into the world
     # Currently places songs only at song locations. if there's an option
@@ -97,19 +104,22 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # of failing compared to other item type. So this way we only have retry
     # the song locations only.
     if not worlds[0].shuffle_song_items:
-        fill_ownworld_restrictive(window, worlds, song_locations, songitempool, progitempool, "song")
+        fill_ownworld_restrictive(window, worlds, playthrough, song_locations, songitempool, progitempool, "song")
+        playthrough.collect_locations()
         if worlds[0].start_with_fast_travel:
             fill_locations += [location for location in song_locations if location.item is None]
 
     # Put one item in every dungeon, needs to be done before other items are
     # placed to ensure there is a spot available for them
     if worlds[0].one_item_per_dungeon:
-        fill_dungeon_unique_item(window, worlds, fill_locations, progitempool)
+        fill_dungeon_unique_item(window, worlds, playthrough, fill_locations, progitempool)
+        playthrough.collect_locations()
 
     # Place all progression items. This will include keys in keysanity.
     # Items in this group will check for reachability and will be placed
     # such that the game is guaranteed beatable.
-    fill_restrictive(window, worlds, [world.state for world in worlds], fill_locations, progitempool)
+    fill_restrictive(window, worlds, playthrough, fill_locations, progitempool)
+    playthrough.collect_locations()
 
     # Place all priority items.
     # These items are items that only check if the item is allowed to be
@@ -134,7 +144,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     if fill_locations:
         raise FillError('Not all locations have an item.')
 
-    if not State.can_beat_game(world_states, True):
+    if not playthrough.can_beat_game():
         raise FillError('Cannot beat game!')
 
     worlds[0].settings.distribution.cloak(worlds, [cloakable_locations], [all_models])
@@ -148,9 +158,11 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
 
 # Places restricted dungeon items into the worlds. To ensure there is room for them.
 # they are placed first so it will assume all other items are reachable
-def fill_dungeons_restrictive(window, worlds, shuffled_locations, dungeon_items, itempool):
+def fill_dungeons_restrictive(window, worlds, playthrough, shuffled_locations, dungeon_items, itempool):
     # List of states with all non-key items
-    all_state_base_list = State.get_states_with_items([world.state for world in worlds], itempool)
+    base_playthrough = playthrough.copy()
+    base_playthrough.collect_all(itempool)
+    base_playthrough.collect_locations()
 
     # shuffle this list to avoid placement bias
     random.shuffle(dungeon_items)
@@ -162,7 +174,7 @@ def fill_dungeons_restrictive(window, worlds, shuffled_locations, dungeon_items,
     dungeon_items.sort(key=lambda item: sort_order.get(item.type, 1))
 
     # place dungeon items
-    fill_restrictive(window, worlds, all_state_base_list, shuffled_locations, dungeon_items)
+    fill_restrictive(window, worlds, base_playthrough, shuffled_locations, dungeon_items)
 
     for world in worlds:
         world.state.clear_cached_unreachable()
@@ -171,7 +183,7 @@ def fill_dungeons_restrictive(window, worlds, shuffled_locations, dungeon_items,
 # Places items into dungeon locations. This is used when there should be exactly
 # one progression item per dungeon. This should be ran before all the progression
 # items are places to ensure there is space to place them.
-def fill_dungeon_unique_item(window, worlds, fill_locations, itempool):
+def fill_dungeon_unique_item(window, worlds, playthrough, fill_locations, itempool):
     # We should make sure that we don't count event items, shop items,
     # token items, or dungeon items as a major item. itempool at this
     # point should only be able to have tokens of those restrictions
@@ -190,7 +202,9 @@ def fill_dungeon_unique_item(window, worlds, fill_locations, itempool):
     random.shuffle(dungeons)
     random.shuffle(itempool)
 
-    all_other_item_state = State.get_states_with_items([world.state for world in worlds], minor_items)
+    base_playthrough = playthrough.copy()
+    base_playthrough.collect_all(minor_items)
+    base_playthrough.collect_locations()
     all_dungeon_locations = []
 
     # iterate of all the dungeons in a random order, placing the item there
@@ -201,7 +215,7 @@ def fill_dungeon_unique_item(window, worlds, fill_locations, itempool):
         all_dungeon_locations.extend(dungeon_locations)
 
         # place 1 item into the dungeon
-        fill_restrictive(window, worlds, all_other_item_state, dungeon_locations, major_items, 1)
+        fill_restrictive(window, worlds, base_playthrough, dungeon_locations, major_items, 1)
 
         # update the location and item pool, removing any placed items and filled locations
         # the fact that you can remove items from a list you're iterating over is python magic
@@ -219,7 +233,7 @@ def fill_dungeon_unique_item(window, worlds, fill_locations, itempool):
 
 
 # Places items restricting placement to the recipient player's own world
-def fill_ownworld_restrictive(window, worlds, locations, ownpool, itempool, description="Unknown", attempts=15):
+def fill_ownworld_restrictive(window, worlds, playthrough, locations, ownpool, itempool, description="Unknown", attempts=15):
     # get the locations for each world
 
     # look for preplaced items
@@ -236,7 +250,8 @@ def fill_ownworld_restrictive(window, worlds, locations, ownpool, itempool, desc
     for world in worlds:
         # List of states with all items
         unplaced_prizes = [item for item in unplaced_prizes if item not in prizepool_dict[world.id]]
-        all_state_base_list = State.get_states_with_items([world.state for world in worlds], itempool + unplaced_prizes)
+        base_playthrough = playthrough.copy()
+        base_playthrough.collect_all(itempool + unplaced_prizes)
 
         world_attempts = attempts
         while world_attempts:
@@ -245,7 +260,7 @@ def fill_ownworld_restrictive(window, worlds, locations, ownpool, itempool, desc
                 prizepool = list(prizepool_dict[world.id])
                 prize_locs = list(prize_locs_dict[world.id])
                 random.shuffle(prizepool)
-                fill_restrictive(window, worlds, all_state_base_list, prize_locs, prizepool)
+                fill_restrictive(window, worlds, base_playthrough, prize_locs, prizepool)
                 
                 logging.getLogger('').info("%s items placed for world %s", description, (world.id+1))
             except FillError as e:
@@ -278,8 +293,12 @@ def fill_ownworld_restrictive(window, worlds, locations, ownpool, itempool, desc
 # This function will modify the location and itempool arguments. placed items and
 # filled locations will be removed. If this returns and error, then the state of
 # those two lists cannot be guaranteed.
-def fill_restrictive(window, worlds, base_state_list, locations, itempool, count=-1):
+def fill_restrictive(window, worlds, base_playthrough, locations, itempool, count=-1):
     unplaced_items = []
+
+    # don't run over this playthrough, just keep it as an item collection
+    items_playthrough = base_playthrough.copy()
+    items_playthrough.collect_all(itempool)
 
     # loop until there are no items or locations
     while itempool and locations:
@@ -291,9 +310,11 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
         item_to_place = itempool.pop()
         random.shuffle(locations)
 
-        # generate the max states that include every remaining item
+        # generate the max playthrough with every remaining item
         # this will allow us to place this item in a reachable location
-        maximum_exploration_state_list = State.get_states_with_items(base_state_list, itempool + unplaced_items)
+        items_playthrough.uncollect(item_to_place)
+        max_playthrough = items_playthrough.copy()
+        max_playthrough.collect_locations()
 
         # perform_access_check checks location reachability
         perform_access_check = True
@@ -302,14 +323,15 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
             # then we must check for reachability no matter what.
             # This way the reachability test is monotonic. If we were to later
             # stop checking, then we could place an item needed in one world
-            # in an unreachable place in another world
-            perform_access_check = not State.can_beat_game(maximum_exploration_state_list)
+            # in an unreachable place in another world.
+            # scan_for_items would cause an unnecessary copy+collect
+            perform_access_check = not max_playthrough.can_beat_game(scan_for_items=False)
 
         # find a location that the item can be placed. It must be a valid location
         # in the world we are placing it (possibly checking for reachability)
         spot_to_fill = None
         for location in locations:
-            if location.can_fill(maximum_exploration_state_list[location.world.id], item_to_place, perform_access_check):
+            if location.can_fill(max_playthrough.state_list[location.world.id], item_to_place, perform_access_check):
                 # for multiworld, make it so that the location is also reachable
                 # in the world the item is for. This is to prevent early restrictions
                 # in one world being placed late in another world. If this is not
@@ -317,7 +339,7 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
                 if location.world.id != item_to_place.world.id:
                     try:
                         source_location = item_to_place.world.get_location(location.name)
-                        if not source_location.can_fill(maximum_exploration_state_list[item_to_place.world.id], item_to_place, perform_access_check):
+                        if not source_location.can_fill(max_playthrough.state_list[item_to_place.world.id], item_to_place, perform_access_check):
                             # location wasn't reachable in item's world, so skip it
                             continue
                     except KeyError:
@@ -328,7 +350,7 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
                         while parent_region:
                             try:
                                 source_region = item_to_place.world.get_region(parent_region.name)
-                                can_reach = maximum_exploration_state_list[item_to_place.world.id].can_reach(source_region)
+                                can_reach = max_playthrough.state_list[item_to_place.world.id].can_reach(source_region)
                                 break
                             except KeyError:
                                 parent_region = parent_region.entrances[0].parent_region
@@ -336,7 +358,7 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
                             continue
 
                 if location.disabled == DisableType.PENDING:
-                    if not State.can_beat_game(maximum_exploration_state_list):
+                    if not max_playthrough.can_beat_game():
                         continue
                     location.disabled = DisableType.DISABLED
 
@@ -350,6 +372,7 @@ def fill_restrictive(window, worlds, base_state_list, locations, itempool, count
             if count > 0:
                 # don't decrement count, we didn't place anything
                 unplaced_items.append(item_to_place)
+                items_playthrough.collect(item_to_place)
                 continue
             else:
                 # we expect all items to be placed

--- a/Hints.py
+++ b/Hints.py
@@ -8,9 +8,9 @@ import random
 from HintList import getHint, getHintGroup, Hint, hintExclusions
 from ItemPool import eventlocations
 from Messages import update_message_by_id
+from Playthrough import Playthrough
 from TextBox import lineWrap
 from Utils import random_choices
-from State import State
 
 
 class GossipStone():
@@ -141,11 +141,11 @@ def can_reach_stone(worlds, stone_location, location):
 
     old_item = location.item
     location.item = None
-    stone_states = State.get_states_with_items([world.state for world in worlds], [])
+    playthrough = Playthrough.max_explore([world.state for world in worlds])
     location.item = old_item
 
-    return stone_states[location.world.id].can_reach(stone_location, resolution_hint='Location') and \
-           stone_states[location.world.id].guarantee_hint()
+    return (playthrough.state_list[location.world.id].can_reach(stone_location, resolution_hint='Location')
+            and playthrough.state_list[location.world.id].guarantee_hint())
 
 
 def writeGossipStoneHints(spoiler, world, messages):
@@ -485,11 +485,11 @@ def buildGossipHints(spoiler, world):
 
     world.barren_dungeon = False
 
-    max_states = State.get_states_with_items([w.state for w in spoiler.worlds], [])
+    playthrough = Playthrough.max_explore([w.state for w in spoiler.worlds])
     for stone in gossipLocations.values():
-        stone.reachable = \
-            max_states[world.id].can_reach(stone.location, resolution_hint='Location') and \
-            max_states[world.id].guarantee_hint()
+        stone.reachable = (
+            playthrough.state_list[world.id].can_reach(stone.location, resolution_hint='Location')
+            and playthrough.state_list[world.id].guarantee_hint())
 
     checkedLocations = []
 

--- a/Main.py
+++ b/Main.py
@@ -511,8 +511,6 @@ def create_playthrough(spoiler):
         collected = list(playthrough.iter_reachable_locations(item_locations))
         if not collected: break
         for location in collected:
-            # Mark the location collected in the state world it exists in
-            state_list[location.world.id].collected_locations[location.name] = True
             # Collect the item for the state world it is for
             state_list[location.item.world.id].collect(location.item)
         collection_spheres.append(collected)
@@ -527,24 +525,22 @@ def create_playthrough(spoiler):
             # we remove the item at location and check if game is still beatable
             logger.debug('Checking if %s is required to beat the game.', location.item.name)
             old_item = location.item
+            location.item = None
 
             # Uncollect the item and location.
             state_list[old_item.world.id].remove(old_item)
-            playthrough.uncollect(location)
+            playthrough.unvisit(location)
 
             # Test whether the game is still beatable from here.
             if playthrough.can_beat_game():
                 # cull entries for spoiler walkthrough at end
                 sphere.remove(location)
             else:
-                # still required, so remove the entry from collected_locations
-                # so it can be collected again by other attempts.
-                del state_list[location.world.id].collected_locations[location.name]
+                # still required, so reset the item
+                location.item = old_item
                 required_locations.append(location)
 
     # Regenerate the spheres as we might not reach places the same way anymore.
-    for state in state_list:
-        state.collected_locations.clear()
     playthrough = Playthrough(state_list)
     collection_spheres = []
     while True:
@@ -552,8 +548,6 @@ def create_playthrough(spoiler):
         collected = list(playthrough.iter_reachable_locations(required_locations))
         if not collected: break
         for location in collected:
-            # Mark the location collected in the state world it exists in
-            state_list[location.world.id].collected_locations[location.name] = True
             # Collect the item for the state world it is for
             state_list[location.item.world.id].collect(location.item)
         collection_spheres.append(collected)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import logging
 import re
@@ -12,8 +13,8 @@ from Item import ItemFactory, ItemIterator, IsItem
 from ItemPool import item_groups, rewardlist, get_junk_item
 from Location import LocationIterator, LocationFactory, IsLocation
 from LocationList import location_groups
+from Playthrough import Playthrough
 from Spoiler import HASH_ICONS
-from State import State
 from version import __version__
 from Utils import random_choices
 from JSONDump import dump_obj, CollapseList, CollapseDict, AllignedDict, SortedDict
@@ -421,8 +422,8 @@ class WorldDistribution(object):
                 item.price = record.price
             location.world.push_item(location, item, True)
             if item.advancement:
-                states_after = State.get_states_with_items([world.state for world in worlds], reduce(lambda a, b: a + b, item_pools))
-                if not State.can_beat_game(states_after, True):
+                playthrough = Playthrough.max_explore([world.state for world in worlds], itertools.chain.from_iterable(item_pools))
+                if not playthrough.can_beat_game(False):
                     raise FillError('%s in world %d is not reachable without %s in world %d!' % (location.name, self.id + 1, item.name, player_id + 1))
             window.fillcount += 1
             window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))
@@ -491,8 +492,8 @@ class Distribution(object):
 
 
     def fill(self, window, worlds, location_pools, item_pools):
-        max_states = State.get_states_with_items([world.state for world in worlds], reduce(lambda a, b: a + b, item_pools))
-        if not State.can_beat_game(max_states, True):
+        playthrough = Playthrough.max_explore([world.state for world in worlds], itertools.chain.from_iterable(item_pools))
+        if not playthrough.can_beat_game(False):
             raise FillError('Item pool does not contain items required to beat game!')
 
         for world_dist in self.world_dists:

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -5,25 +5,83 @@ import itertools
 
 class Playthrough(object):
 
-    def __init__(self, state_list):
+    def __init__(self, state_list, cached_spheres=None):
         self.state_list = state_list  # reference, not a copy
-        # Each cached sphere is a dict with 4 values:
+        # Each cached sphere is a dict with 5 values:
         #  child_regions, adult_regions: sets of Region, all the regions in that sphere
         #  child_queue, adult_queue: queue of Entrance, all the exits to try next sphere
-        self.cached_spheres = []
+        #  visited_locations: set of Locations visited in or before that sphere.
+        self.cached_spheres = cached_spheres or []
 
         # Mapping from location to sphere index. 0-based.
         self.location_in_sphere = defaultdict(int)
+        # Mapping from item to sphere index, if this is tracking items. 0-based.
+        self.item_in_sphere = defaultdict(int)
+
+        # Prefill sphere 0 if not already filled.
+        if not self.cached_spheres:
+            self.next_sphere()
+
+
+    def copy(self):
+        new_state_list = [state.copy() for state in self.state_list]
+        # we only need to copy the top sphere since that's what we're starting with and we don't go back
+        new_cache = [{k: copy.copy(v) for k,v in self.cached_spheres[-1].items()}]
+        return Playthrough(new_state_list, new_cache)
+
+
+    def collect_all(self, itempool):
+        for item in itempool:
+            self.item_in_sphere[item] = len(self.cached_spheres)
+            self.state_list[item.world.id].collect(item)
+
+
+    def collect(self, item):
+        self.item_in_sphere[item] = len(self.cached_spheres)
+        self.state_list[item.world.id].collect(item)
+
 
     # Truncates the sphere cache based on which sphere a location is in.
     # Doesn't forget which sphere locations are in as an optimization, so be careful
-    # to only uncollect locations in descending sphere order, or locations that
+    # to only unvisit locations in descending sphere order, or locations that
     # have been revisited in the most recent iteration.
-    # Locations never visited in this Playthrough are assumed to be in sphere 0, so
-    # uncollecting them will discard everything above sphere 0.
+    # Locations never visited in this Playthrough are assumed to have been visited
+    # prior to sphere 0, so unvisiting them will discard the entire cache.
     # Not safe to call during iteration.
-    def uncollect(self, location):
-        self.cached_spheres[self.location_in_sphere[location]+1:] = []
+    def unvisit(self, location):
+        self.cached_spheres[self.location_in_sphere[location]:] = []
+
+
+    # Drops the item from its respective state, and truncates the sphere cache
+    # based on which sphere an item was in.
+    # Does *not* uncollect any other items in or above that sphere!
+    # Doesn't forget which sphere items are in as an optimization, so be careful
+    # to only uncollect items in descending sphere order, or only track collected
+    # items in one sphere.
+    # Items not collected in this Playthrough are assumed to have been collected
+    # prior to sphere 0, so uncollecting them will discard the entire cache.
+    # Not safe to call during iteration.
+    def uncollect(self, item):
+        self.state_list[item.world.id].remove(item)
+        self.cached_spheres[self.item_in_sphere[item]:] = []
+
+    # Resets the sphere cache to the first entry only.
+    # Does not uncollect any items!
+    # Not safe to call during iteration.
+    def reset(self):
+        self.cached_spheres[1:] = []
+
+
+    # simplified exit.can_reach(state), with_age bypasses can_become_age
+    # which we've already accounted for
+    def validate_child(self, exit):
+        return self.state_list[exit.parent_region.world.id].with_age(
+                lambda state: exit.can_reach(state, noparent=True), 'child')
+
+    def validate_adult(self, exit):
+        return self.state_list[exit.parent_region.world.id].with_age(
+                lambda state: exit.can_reach(state, noparent=True), 'adult')
+
 
     # Internal to the iteration. Modifies the exit_queue, region_set. 
     # Returns a queue of the exits whose access rule failed, 
@@ -42,6 +100,49 @@ class Playthrough(object):
                     failed.append(exit)
         return failed
 
+    # Explores available exits, based on the most recent cache entry, and pushes
+    # the result as a new entry in the cache.
+    # Returns the set of regions accessible in the new sphere as child,
+    # the set of regions accessible as adult, and the set of visited locations.
+    # These are references to the new entry in the cache, so they can be modified
+    # directly (likely only useful for visited_locations).
+    def next_sphere(self):
+        # Use cached regions and queues or initialize starting values.
+        if self.cached_spheres:
+            child_regions = copy.copy(self.cached_spheres[-1]['child_regions'])
+            adult_regions = copy.copy(self.cached_spheres[-1]['adult_regions'])
+            # queues of Entrance where the entrance is not yet validated
+            child_queue = copy.copy(self.cached_spheres[-1]['child_queue'])
+            adult_queue = copy.copy(self.cached_spheres[-1]['adult_queue'])
+            # Locations already visited
+            visited_locations = copy.copy(self.cached_spheres[-1]['visited_locations'])
+        else:
+            root_regions = [state.world.get_region('Root') for state in self.state_list]
+            child_queue = deque(exit for region in root_regions for exit in region.exits)
+            adult_queue = deque(exit for region in root_regions for exit in region.exits)
+            child_regions = set(root_regions)
+            adult_regions = set(root_regions)
+            visited_locations = set()
+
+        # Use the queue to iteratively add regions to the accessed set,
+        # until we are stuck or out of regions.
+        adult_failed = Playthrough._expand_regions(adult_queue, adult_regions, self.validate_adult)
+        child_failed = Playthrough._expand_regions(child_queue, child_regions, self.validate_child)
+
+        # Save the current data into the cache.
+        new_child_exit = lambda exit: exit.connected_region not in child_regions
+        new_adult_exit = lambda exit: exit.connected_region not in adult_regions
+
+        self.cached_spheres.append({
+            'child_regions': child_regions,
+            'adult_regions': adult_regions,
+            'visited_locations': visited_locations,
+            # Exits that didn't pass validation (and still point to new places)
+            # are the only exits we'll be interested in
+            'child_queue': deque(filter(new_child_exit, child_failed)),
+            'adult_queue': deque(filter(new_adult_exit, adult_failed)),
+        })
+        return child_regions, adult_regions, visited_locations
 
     # Yields every reachable location, by iteratively deepening explored sets of
     # regions (one as child, one as adult) and invoking access rules without
@@ -53,49 +154,21 @@ class Playthrough(object):
     # locations to see if the game is beatable.
     # This function does not alter provided state.
     def iter_reachable_locations(self, item_locations):
-        # Set keeps track of collected locations, not for iteration.
-        collected_set = set(itertools.chain.from_iterable(
-            map(state.world.get_location, state.collected_locations)
-            for id, state in enumerate(self.state_list)))
+        # tests reachability, skipping recursive can_reach region check
+        def accessible(loc):
+            return (loc not in visited_locations
+                    and not loc.is_disabled()
+                    # Check adult first; it's the most likely.
+                    and (loc.parent_region in adult_regions
+                         and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'adult')
+                     or (loc.parent_region in child_regions
+                         and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'child'))))
 
-        new_child_exit = lambda exit: exit.connected_region not in child_regions
-        new_adult_exit = lambda exit: exit.connected_region not in adult_regions
-
-        # simplified exit.can_reach(state), with_age bypasses can_become_age
-        # which we've already accounted for
-        validate_child = lambda exit: self.state_list[exit.parent_region.world.id].with_age(lambda state: exit.can_reach(state, noparent=True), 'child')
-        validate_adult = lambda exit: self.state_list[exit.parent_region.world.id].with_age(lambda state: exit.can_reach(state, noparent=True), 'adult')
-
-        accessible = lambda loc: (
-            loc not in collected_set
-            and not loc.is_disabled()
-            # Check adult first; it's the most likely.
-            and (loc.parent_region in adult_regions
-                 and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'adult')
-                 or (loc.parent_region in child_regions
-                     and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'child'))))
 
         had_reachable_locations = True
         # will loop as long as any collections were made, and at least once
         while had_reachable_locations:
-            # 0. Use cached regions and queues or initialize starting values.
-            if self.cached_spheres:
-                child_regions = copy.copy(self.cached_spheres[-1]['child_regions'])
-                adult_regions = copy.copy(self.cached_spheres[-1]['adult_regions'])
-                # queues of Entrance where the entrance is not yet validated
-                child_queue = copy.copy(self.cached_spheres[-1]['child_queue'])
-                adult_queue = copy.copy(self.cached_spheres[-1]['adult_queue'])
-            else:
-                root_regions = [state.world.get_region('Root') for state in self.state_list]
-                child_queue = deque(exit for region in root_regions for exit in region.exits)
-                adult_queue = deque(exit for region in root_regions for exit in region.exits)
-                child_regions = set(root_regions)
-                adult_regions = set(root_regions)
-
-            # 1. Use the queue to iteratively add regions to the accessed set,
-            #    until we are stuck or out of regions.
-            adult_failed = Playthrough._expand_regions(adult_queue, adult_regions, validate_adult)
-            child_failed = Playthrough._expand_regions(child_queue, child_regions, validate_child)
+            child_regions, adult_regions, visited_locations = self.next_sphere()
 
             # 2. Get all locations in accessible_regions that aren't collected,
             #    and check if they can be reached. Collect them.
@@ -105,17 +178,9 @@ class Playthrough(object):
                 had_reachable_locations = True
                 yield location
                 # Mark it collected for this algorithm
-                collected_set.add(location)
+                visited_locations.add(location)
                 self.location_in_sphere[location] = len(self.cached_spheres)
-            # 3. Save the current data into the cache.
-            self.cached_spheres.append({
-                'child_regions': child_regions,
-                'adult_regions': adult_regions,
-                # Exits that didn't pass validation (and still point to new places)
-                # are the only exits we'll be interested in
-                'child_queue': deque(filter(new_child_exit, child_failed)),
-                'adult_queue': deque(filter(new_adult_exit, adult_failed)),
-            })
+
 
     # This collects all item locations available in the state list given that
     # the states have collected items. The purpose is that it will search for
@@ -124,10 +189,7 @@ class Playthrough(object):
     def collect_locations(self):
         # Get all item locations in the worlds
         item_locations = [location for state in self.state_list for location in state.world.get_filled_locations() if location.item.advancement]
-        collected_locations = [s.collected_locations for s in self.state_list]
         for location in self.iter_reachable_locations(item_locations):
-            # Mark the location collected in the state world it exists in
-            collected_locations[location.world.id][location.name] = True
             # Collect the item for the state world it is for
             self.state_list[location.item.world.id].collect(location.item)
 
@@ -146,10 +208,7 @@ class Playthrough(object):
 
             # collect all available items
             # make a new playthrough since we might be iterating over one already
-            playthrough = Playthrough([state.copy() for state in self.state_list])
-            # we only need to copy the top sphere since that's what we're starting with and we don't go back
-            if self.cached_spheres:
-                playthrough.cached_spheres = [{k: copy.copy(v) for k,v in self.cached_spheres[-1].items()}]
+            playthrough = self.copy()
             playthrough.collect_locations()
         else:
             playthrough = self
@@ -159,4 +218,3 @@ class Playthrough(object):
             if not state.has('Triforce'):
                 return False
         return True
-

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -22,6 +22,10 @@ class Playthrough(object):
         if not self.cached_spheres:
             self.next_sphere()
 
+        # Let the states reference this playthrough.
+        for state in self.state_list:
+            state.playthrough = self
+
 
     def copy(self):
         new_state_list = [state.copy() for state in self.state_list]

--- a/Rules.py
+++ b/Rules.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 from Location import DisableType
+from Playthrough import Playthrough
 from State import State
 
 
@@ -126,13 +127,15 @@ def set_entrances_based_rules(worlds):
 
     # Use the states with all items available in the pools for this seed
     complete_itempool = [item for world in worlds for item in world.get_itempool_with_dungeon_items()]
-    all_items_state_list = State.get_states_with_items([world.state for world in worlds], complete_itempool)
+    playthrough = Playthrough([world.state.copy() for world in worlds])
+    playthrough.collect_all(complete_itempool)
+    playthrough.collect_locations()
 
     for world in worlds:
         for location in world.get_locations():
             if location.type == 'Shop':
                 # If All Locations Reachable is on, prevent shops only ever reachable as child from containing Buy Goron Tunic and Buy Zora Tunic items
                 if not world.check_beatable_only:
-                    if not all_items_state_list[world.id].can_reach(location.parent_region, age='adult'):
+                    if not playthrough.can_reach(location.parent_region, age='adult'):
                         forbid_item(location, 'Buy Goron Tunic')
                         forbid_item(location, 'Buy Zora Tunic')

--- a/State.py
+++ b/State.py
@@ -15,7 +15,6 @@ class State(object):
         self.world = parent
         self.region_cache = { 'child': {}, 'adult': {} }
         self.recursion_count = { 'child': 0, 'adult': 0 }
-        self.collected_locations = {}
         self.current_spot = None
         self.adult = None
         self.tod = None
@@ -43,7 +42,6 @@ class State(object):
         new_state = State(new_world)
         new_state.prog_items = copy.copy(self.prog_items)
         new_state.region_cache = {k: copy.copy(v) for k,v in self.region_cache.items()}
-        new_state.collected_locations = copy.copy(self.collected_locations)
         return new_state
 
 
@@ -677,7 +675,6 @@ class State(object):
                 if not playthrough.can_beat_game():
                     required_locations.append(location)
                 location.item = old_item
-            state_list[location.world.id].collected_locations[location.name] = True
             state_list[location.item.world.id].collect(location.item)
 
         # Filter the required location to only include location in the world

--- a/State.py
+++ b/State.py
@@ -18,6 +18,7 @@ class State(object):
         self.current_spot = None
         self.adult = None
         self.tod = None
+        self.playthrough = None
 
 
     ## Ensure that this will always have a value
@@ -103,6 +104,9 @@ class State(object):
 
         if spot.recursion_count[age_type] > 0:
             return False
+
+        if self.tod == None and self.playthrough != None:
+            return self.playthrough.can_reach(spot, age=age_type)
 
         # The normal cache can't be used while checking for reachability with a specific time of day
         if self.tod == None and spot in self.region_cache[age_type]:


### PR DESCRIPTION
This is more to make Playthrough the one thing used wherever the seed needs to be judged beatable than strict performance improvements. On the whole it only shaves off a few seconds from a 5-person multiworld (1m10s -> 1m4s); the next major gains are going to come from improving the algorithm itself.

Refactors the main iteration loop in Playthrough to be easier to understand.