### PR TITLE
Fix Playthrough issues.

### DIFF
--- a/Playthrough.py
+++ b/Playthrough.py
@@ -84,6 +84,7 @@ class Playthrough(object):
     # Not safe to call during iteration.
     def reset(self):
         self.cached_spheres[1:] = []
+        self.cached_spheres[0]['visited_locations'].clear()
         self.location_in_sphere.clear()
         self.item_in_sphere.clear()
 

--- a/State.py
+++ b/State.py
@@ -106,7 +106,8 @@ class State(object):
             return False
 
         if self.tod == None and self.playthrough != None:
-            return self.playthrough.can_reach(spot, age=age_type)
+            if self.playthrough.can_reach(spot, age=age_type):
+                return True
 
         # The normal cache can't be used while checking for reachability with a specific time of day
         if self.tod == None and spot in self.region_cache[age_type]:


### PR DESCRIPTION
- Remove old location cache on reset.
- In State.can_reach, use Playthrough cache as positive-only cache for now.

This fixes issues where a playthrough could have never-required items (multiple Buy Bombchu, Ice Arrows, etc) or fail to reach Ganon.