### PR TITLE
Fix No Logic not using the correct data files

### DIFF
--- a/DungeonList.py
+++ b/DungeonList.py
@@ -102,16 +102,17 @@ def create_dungeons(world):
         name = dungeon_info['name']
         hint = dungeon_info['hint'] if 'hint' in dungeon_info else name
         
-        if world.settings.logic_rules == 'glitchless':
-            if not world.dungeon_mq[name]:
-                dungeon_json = os.path.join(data_path('World'), name + '.json')
-            else:
-                dungeon_json = os.path.join(data_path('World'), name + ' MQ.json')
-        else:
+        if world.settings.logic_rules == 'glitched':
             if not world.dungeon_mq[name]:
                 dungeon_json = os.path.join(data_path('Glitched World'), name + '.json')
             else:
                 dungeon_json = os.path.join(data_path('Glitched World'), name + ' MQ.json')
+        else:
+            if not world.dungeon_mq[name]:
+                dungeon_json = os.path.join(data_path('World'), name + '.json')
+            else:
+                dungeon_json = os.path.join(data_path('World'), name + ' MQ.json')
+
         
         world.load_regions_from_json(dungeon_json)
 


### PR DESCRIPTION
In No Logic, the overworld was recently changed to default to glitchless data files, but dungeons weren't updated to match that so some issues could still appear in MQ or ER settings.