### PR TITLE
Make 'World Count' Affect Settings String

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -494,6 +494,7 @@ setting_infos = [
         min            = 1, 
         max            = 255, 
         default        = 1,
+        shared         = True,
     ),
     Scale('player_num', 
         min            = 1, 


### PR DESCRIPTION
I think this got lost in the SettingsList.py cleanup.