### PR TITLE
Fix child fire big lava room

### DIFF
--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -31,8 +31,8 @@
         "dungeon": "Fire Temple",
         "locations": {
             "Fire Temple Big Lava Room Open Chest": "True",
-            "Fire Temple Big Lava Room Bombable Chest": "has_explosives",
-            "GS Fire Temple Song of Time Room": "can_play(Song_of_Time)"
+            "Fire Temple Big Lava Room Bombable Chest": "is_adult and has_explosives",
+            "GS Fire Temple Song of Time Room": "is_adult and can_play(Song_of_Time)"
         },
         "exits": {
             "Fire Temple Lower":  "True",


### PR DESCRIPTION
Interim Support Information:

Only affects closed door of time or Non-ALR settings. Also has a ground jump
workaround.

I had this at one stage but lost it if code refactoring. This is definately
tested as needing adult height.