### PR TITLE
Balance fix - require SoS for ER well entry

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -721,6 +721,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         # Remove deku sprout and drop player at SFM after forest (SFM blue will then be rewired by ER below)
         rom.write_int16(0xAC9F96, 0x0608)
 
+        #Tell the well water we are always a child.
+        rom.write_int32(0xDD5BF4, 0x00000000)
+
         remove_entrance_blockers(rom)
         #Tell the Deku tree jaw actor we are always a child.
         rom.write_int32(0x0C72C64, 0x240E0000)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1089,6 +1089,8 @@ setting_infos = [
             Bottom of the Well are opened for both adult and child to 
             improve randomization, and accessing the Fire Temple from 
             Bolero is always in logic for child regardless of Tunic settings.
+            Child must play song of storms at the windmill to open the 
+            well for Adult.
 
             Blue warps will return link to the new dungeons entrance. 
             Lake Hylia will be filled for adult after defeating Morpha.

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -607,8 +607,8 @@
             "Kakariko Bazaar": "is_adult and at_day",
             "Kakariko Shooting Gallery": "is_adult and at_day",
             "Bottom of the Well": "
-                (is_child and can_play(Song_of_Storms)) or 
-                (is_adult and shuffle_dungeon_entrances)",
+                as_child_here(can_play(Song_of_Storms)) and
+                (is_child or shuffle_dungeon_entrances)",
             "Kakariko Potion Shop Front": "True",
             "Kakariko Potion Shop Back": "True",
             "Odd Medicine Building": "is_adult",


### PR DESCRIPTION
Walking into adult Kak for a free dungeon is OP, and the SoS is
hugely devauled in ER due to open adult well. Fix it by consistently
requiring SoS to enter the well for both adult and child.