### PR TITLE
Fix some issues with entrance randomizer

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -665,9 +665,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     exit_updates = []
 
-    def write_entrance(target_index, data_index, length=4):
-        ti = target_index * 4
-        rom.write_bytes(0xB6FBF0 + data_index * 4, et_original[ti:ti+(4*length)])
+    def copy_entrance_record(source_index, destination_index, count=4):
+        ti = source_index * 4
+        rom.write_bytes(0xB6FBF0 + destination_index * 4, et_original[ti:ti+(4 * count)])
 
     def generate_exit_lookup_table():
         # Assumes that the last exit on a scene's exit list cannot be 0000
@@ -746,8 +746,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
                 # vanilla as it never took you to the exit and the lake fill is handled
                 # above by removing the cutscene completely. Child has problems with Adult
                 # blue warps, so always use the return entrance if a child.
-                write_entrance(blue_out_data + 2, new_entrance["blue_warp"] + 2, 2)
-                write_entrance(replaced_entrance["index"], new_entrance["blue_warp"], 2)
+                copy_entrance_record(blue_out_data + 2, new_entrance["blue_warp"] + 2, 2)
+                copy_entrance_record(replaced_entrance["index"], new_entrance["blue_warp"], 2)
 
     if world.shuffle_overworld_entrances:
         # Prevent the ocarina cutscene from leading straight to hyrule field
@@ -766,18 +766,18 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         ## writeback entrance updates
 
         # Change Impa escort to bring link at the hyrule castle grounds entrance from market, instead of hyrule field
-        write_entrance(0x0138, 0x0594) # After Impa escort (overridden to Hyrule Castle entrance from Market)
+        copy_entrance_record(0x0138, 0x0594) # After Impa escort (overridden to Hyrule Castle entrance from Market)
 
         # Change Getting caught cutscene as adult without hookshot to keep Link inside the Fortress
-        write_entrance(0x0129, 0x01A5 + 2, 2) # Thrown out of fortress as adult (overridden to Gerudo Fortress entrance from Valley)
+        copy_entrance_record(0x0129, 0x01A5 + 2, 2) # Thrown out of fortress as adult (overridden to Gerudo Fortress entrance from Valley)
 
         # Change Getting caught cutscene as child to always throw Link in the stream
-        write_entrance(0x01A5, 0x03B4, 2) # Captured with hookshot 1st time as child (overridden to Thrown out of fortress)
-        write_entrance(0x01A5, 0x05F8, 2) # Captured with hookshot 2nd time as child (overridden to Thrown out of fortress)
+        copy_entrance_record(0x01A5, 0x03B4, 2) # Captured with hookshot 1st time as child (overridden to Thrown out of fortress)
+        copy_entrance_record(0x01A5, 0x05F8, 2) # Captured with hookshot 2nd time as child (overridden to Thrown out of fortress)
 
         # Patch Owl Drop entrances to their new indexes
         for entrance in world.get_shuffled_entrances(type='OwlDrop'):
-            write_entrance(entrance.replaces.data['index'], entrance.data['index'])
+            copy_entrance_record(entrance.replaces.data['index'], entrance.data['index'])
 
         set_entrance_updates(world.get_shuffled_entrances(type='Overworld'))
 

--- a/Patches.py
+++ b/Patches.py
@@ -663,59 +663,71 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     et_original = rom.read_bytes(0xB6FBF0, 4 * 0x0614)
 
-    entrance_updates = []
+    exit_updates = []
 
     def write_entrance(target_index, data_index, length=4):
         ti = target_index * 4
         rom.write_bytes(0xB6FBF0 + data_index * 4, et_original[ti:ti+(4*length)])
 
-    def write_scene_exit(target_index, data_index, scene_start, scene_data):
-        start_count = 0
-        current = scene_data
-        command = 0
-        while command != 0x14:
-            command = rom.read_byte(current)
-            if command == 0x00:
-                start_count = rom.read_byte(current + 1)
-            current = current + 8
-        command = 0
-        current = scene_data
-        while command != 0x14:
-            command = rom.read_byte(current)
-            if command == 0x13:
-                entrance_list = scene_start + (rom.read_int32(current + 4) & 0x00FFFFFF)
-                for _ in range (0, start_count):
-                    entrance = rom.read_int16(entrance_list)
-                    if (entrance == data_index):
-                        entrance_updates.append((entrance_list, target_index))
-                    entrance_list = entrance_list + 2
-            if command == 0x18: # Alternate header list
-                header_list = scene_start + (rom.read_int32(current + 4) & 0x00FFFFFF)
-                for alt_id in range(0,3):
-                    header_offset = rom.read_int32(header_list) & 0x00FFFFFF
-                    if header_offset != 0:
-                        write_scene_exit(target_index, data_index, scene_start, scene_start + header_offset)
-                    header_list = header_list + 4
-            current = current + 8
+    def generate_exit_lookup_table():
+        # Assumes that the last exit on a scene's exit list cannot be 0000
+        exit_table = {}
 
-    def write_scenes_exits(target_index, data_index):
+        def add_scene_exits(scene_start, offset = 0):
+            current = scene_start + offset
+            exit_list_start_off = 0
+            exit_list_end_off = 0
+            command = 0
+
+            while command != 0x14:
+                command = rom.read_byte(current)
+                if command == 0x18: # Alternate header list
+                    header_list = scene_start + (rom.read_int32(current + 4) & 0x00FFFFFF)
+                    for alt_id in range(0,3):
+                        header_offset = rom.read_int32(header_list) & 0x00FFFFFF
+                        if header_offset != 0:
+                            add_scene_exits(scene_start, header_offset)
+                        header_list += 4
+                if command == 0x13: # Exit List
+                    exit_list_start_off = rom.read_int32(current + 4) & 0x00FFFFFF
+                if command == 0x0F: # Lighting list, follows exit list
+                    exit_list_end_off = rom.read_int32(current + 4) & 0x00FFFFFF
+                current += 8
+            
+            if exit_list_start_off == 0 or exit_list_end_off == 0:
+                return
+
+            # calculate the exit list length
+            list_length = (exit_list_end_off - exit_list_start_off) // 2
+            last_id = rom.read_int16(scene_start + exit_list_end_off - 2)
+            if last_id == 0:
+                list_length -= 1
+
+            # update 
+            addr = scene_start + exit_list_start_off
+            for _ in range(0, list_length):
+                index = rom.read_int16(addr)
+                if index not in exit_table:
+                    exit_table[index] = []
+                exit_table[index].append(addr)
+                addr += 2
+
         scene_table = 0x00B71440
         for scene in range(0x00, 0x65):
-            #really hacky
-            if data_index == 0 and scene != 0x55:
-                continue
             scene_start = rom.read_int32(scene_table + (scene * 0x14));
-            write_scene_exit(target_index, data_index, scene_start, scene_start)
-
+            add_scene_exits(scene_start)
+            
         #Special case: Jabu with the fish is entered from a cutscene hardcode
-        if data_index == 0x0028:
-            entrance_updates.append((0xAC95C2, target_index))
+        exit_table[0x0028].append(0xAC95C2)
+
+        return exit_table
+
 
     def set_entrance_updates(entrances):
         for entrance in entrances:
             new_entrance = entrance.data
             replaced_entrance = entrance.replaces.data
-            write_scenes_exits(replaced_entrance['index'], new_entrance['index'])
+            exit_updates.append(new_entrance['index'], replaced_entrance['index'])
 
             if "dynamic_address" in new_entrance:
                 # Dynamic exits are special and have to be set on a specific address
@@ -746,15 +758,12 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         main_entrance = 0x01F9 # Hyrule Field entrance from Lon Lon Ranch (main land entrance)
         ranch_leap_entrances = [0x028A, 0x028E, 0x0292, 0x0476] # Southern, Western, Eastern, Front Gate
         for entrance_idx in ranch_leap_entrances:
-            write_scenes_exits(main_entrance, entrance_idx)
+            exit_updates.append(entrance_idx, main_entrance)
 
         # Patch the water exits between Hyrule Field and Zora River to lead to the land entrance instead of the water entrance
-        write_scenes_exits(0x00EA, 0x01D9) # Hyrule Field -> Zora River
-        write_scenes_exits(0x0181, 0x0311) # Zora River -> Hyrule Field
-
-        for entrance, target in entrance_updates:
-            rom.write_int16(entrance, target)
-        entrance_updates = []
+        exit_updates.append(0x01D9, 0x00EA) # Hyrule Field -> Zora River
+        exit_updates.append(0x0311, 0x0181) # Zora River -> Hyrule Field
+        ## writeback entrance updates
 
         # Change Impa escort to bring link at the hyrule castle grounds entrance from market, instead of hyrule field
         write_entrance(0x0138, 0x0594) # After Impa escort (overridden to Hyrule Castle entrance from Market)
@@ -809,8 +818,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.shuffle_special_interior_entrances:
         set_entrance_updates(world.get_shuffled_entrances(type='SpecialInterior'))
 
-    for entrance, target in entrance_updates:
-        rom.write_int16(entrance, target)
+    exit_table = generate_exit_lookup_table()
+
+    for k, v in [(k,v) for k, v in exit_updates if k in exit_table]:
+        for addr in exit_table[k]:
+            rom.write_int16(addr, v)
 
     # Fix text for Pocket Cucco.
     rom.write_byte(0xBEEF45, 0x0B)


### PR DESCRIPTION
Rewrote how scene exits are updated. It now builds a lookup table containing the address of all indexes within the exit lists across all playable scene setups, instead of iterating over the scene setups for every modified index.

Renamed write_entrance -> copy_entrance_record

Fixed a bug where hopping over the gate blocked by Ingo would take you to the vanilla location