### PR TITLE
Make Temple of Time hints consistent with other interiors

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -240,6 +240,9 @@ def get_woth_hint(spoiler, world, checked):
     else:
         location_text = get_hint_area(location)
 
+    if world.shuffle_special_interior_entrances and location_text == 'Temple of Time':
+        location_text = 'the road to Temple of Time'
+
     return (GossipText('#%s# is on the way of the hero.' % location_text, ['Light Blue']), location)
 
 

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -542,7 +542,7 @@
     {
         "region_name": "Temple of Time Exterior",
         "scene": "Temple of Time Exterior",
-        "hint": "the Market",
+        "hint": "Temple of Time",
         "locations": {
             "Temple of Time Gossip Stone (Left)": "True",
             "Temple of Time Gossip Stone (Left-Center)": "True",
@@ -557,24 +557,13 @@
     },
     {
         "region_name": "Temple of Time",
-        "hint": "Temple of Time",
         "locations": {
-            "Zelda": "Shadow_Medallion and Spirit_Medallion and is_adult"
+            "Zelda": "Shadow_Medallion and Spirit_Medallion and is_adult",
+            "Master Sword Pedestal": "can_play(Song_of_Time) or open_door_of_time",
+            "Sheik at Temple": "(can_play(Song_of_Time) or open_door_of_time) and Forest_Medallion and is_adult"
         },
         "exits": {
-            "Temple of Time Exterior": "True",
-            "Beyond Door of Time": "can_play(Song_of_Time) or open_door_of_time"
-        }
-    },
-    {
-        "region_name": "Beyond Door of Time",
-        "hint": "Temple of Time",
-        "locations": {
-            "Master Sword Pedestal": "True",
-            "Sheik at Temple": "Forest_Medallion and is_adult"
-        },
-        "exits": {
-            "Temple of Time": "True"
+            "Temple of Time Exterior": "True"
         }
     },
     {


### PR DESCRIPTION
The primary motivation for this change is to remove an inconsistency when ToT is shuffled with other interiors. With this change, in non-ER hints are functionally identical and in ER ToT is in the hint region of its overworld location. This prevents such things as the overworld location where ToT is being barren, and if ToT is WotH then the overworld location will be WotH. To remain consistent with non-ER, the road to ToT is its own hint region used only by the interior located at the ToT entrance, though that can easily be changed.

-ToT changed to be a single region (needed for it to find the overworld region hint)
-ToT Exterior hint changed to Temple of Time instead of market
-ToT locations now use its overworld location hint like all other interiors. In non-ER, this is the ToT exterior and thus hints are unchanged
-In ER with ToT shuffled, the hint is renamed to "the road to Temple of Time" since the region refers to the interior where ToT normally is. ToT becomes part of whatever overworld region it is in, like any other interior