### PR TITLE
Force Junk at Excluded Locations

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -187,17 +187,26 @@ class Settings:
     def update(self):
         self.settings_string = self.get_settings_string()
         self.numeric_seed = self.get_numeric_seed()
-    
+
     def load_distribution(self):
         if self.distribution_file is not None and self.distribution_file != '':
             try:
                 self.distribution = Distribution.from_file(self, self.distribution_file)
             except FileNotFoundError:
                 logging.getLogger('').warning("Distribution file not found at %s" % (self.distribution_file))
+        elif self.force_junk:
+            SongTable = ()
+            if not self.shuffle_song_items:
+                SongTable = (
+                'Sheik Forest Song', 'Sheik in Crater', 'Sheik in Ice Cavern', 'Sheik at Colossus', 'Sheik in Kakariko',
+                'Sheik at Temple', 'Impa at Castle', 'Song from Malon', 'Song from Saria', 'Song from Composer Grave',
+                'Song from Ocarina of Time', 'Song at Windmill')
+            self.distribution = Distribution(self, {
+                "locations": {location: "Rupees (5)" for location in self.disabled_locations if
+                              location not in SongTable}})
         else:
             self.distribution = Distribution(self)
         self.numeric_seed = self.get_numeric_seed()
-
 
     def check_dependency(self, setting_name, check_random=True):
         return self.get_dependency(setting_name, check_random) == None

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1438,6 +1438,17 @@ setting_infos = [
             '''
         }
     ),
+
+    Checkbutton(
+        name='force_junk',
+        gui_text='Force Junk',
+        gui_group='logic_tab',
+        default=False,
+        gui_tooltip    = '''\
+            Forces blue rupees at excluded locations on this list. Any songs will not have junk at them (unless song sanity is turned on), but will not contain important items. Distribution files supersedes this setting.
+        ''',
+    ),
+
     Setting_Info(
         name           = 'allowed_tricks',
         type           = list,


### PR DESCRIPTION
Added a "force junk" option to the Detailed Logic tab. Function will force blue rupees at the excluded locations, utilizing the Plandomizer routine. If songsanity is off, the function skips over song locations, allowing them to be handled by the fill algorithm. If a distribution file is loaded, that file takes precedent (as it's assumed the user will have defined which locations should be junk).