### PR TITLE
Fix Nayrus Love being incorrectly foolish in grotto ER

### DIFF
--- a/World.py
+++ b/World.py
@@ -428,7 +428,8 @@ class World(object):
             'Ice Arrows',
             'Biggoron Sword',
         ]
-        if self.damage_multiplier != 'ohko' and self.damage_multiplier != 'quadruple' and self.shuffle_scrubs == 'off':
+        if (self.damage_multiplier != 'ohko' and self.damage_multiplier != 'quadruple' and 
+            self.shuffle_scrubs == 'off' and not self.shuffle_grotto_entrances):
             # nayru's love may be required to prevent forced damage
             exclude_item_list.append('Nayrus Love')
         if self.hints != 'agony':


### PR DESCRIPTION
Nayru's Love may be required to reach the Goron City grotto which could contain a useful grotto in ER regardless of other settings, so it shouldn't be excluded from required items in that case. Fixes #668.