### PR TITLE
Global retry and debugging changes

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -308,7 +308,11 @@ def fill_restrictive(window, worlds, base_playthrough, locations, itempool, coun
 
         # get an item and remove it from the itempool
         item_to_place = itempool.pop()
-        random.shuffle(locations)
+        if item_to_place.majoritem:
+            l2cations = [l for l in locations if not l.minor_only]
+        else:
+            l2cations = locations
+        random.shuffle(l2cations)
 
         # generate the max playthrough with every remaining item
         # this will allow us to place this item in a reachable location
@@ -330,7 +334,7 @@ def fill_restrictive(window, worlds, base_playthrough, locations, itempool, coun
         # find a location that the item can be placed. It must be a valid location
         # in the world we are placing it (possibly checking for reachability)
         spot_to_fill = None
-        for location in locations:
+        for location in l2cations:
             if location.can_fill(max_playthrough.state_list[location.world.id], item_to_place, perform_access_check):
                 # for multiworld, make it so that the location is also reachable
                 # in the world the item is for. This is to prevent early restrictions

--- a/Fill.py
+++ b/Fill.py
@@ -380,7 +380,7 @@ def fill_restrictive(window, worlds, base_playthrough, locations, itempool, coun
                 continue
             else:
                 # we expect all items to be placed
-                raise FillError('Game unbeatable: No more spots to place %s [World %d]' % (item_to_place, item_to_place.world.id))
+                raise FillError('Game unbeatable: No more spots to place %s [World %d] from %d locations (%d total); %d other items left to place, plus %d skipped' % (item_to_place, item_to_place.world.id, len(l2cations), len(locations), len(itempool), len(unplaced_items)))
 
         # Place the item in the world and continue
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)

--- a/Main.py
+++ b/Main.py
@@ -75,10 +75,12 @@ def main(settings, window=dummy_window()):
         else:
             settings.player_num = 1
 
-    logger.info('OoT Randomizer Version %s  -  Seed: %s\n\n', __version__, settings.seed)
+    logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)
     settings.remove_disabled()
+    logger.info('(Original) Settings string: %s\n', settings.settings_string)
     random.seed(settings.numeric_seed)
     settings.resolve_random_settings()
+    logger.debug(settings.get_settings_display())
 
     for i in range(0, settings.world_count):
         worlds.append(World(settings))

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -53,7 +53,7 @@ def start():
         cosmetic_patch(settings)
     elif settings.patch_file != '':
         from_patch_file(settings)
-    elif settings.count is not None:
+    elif settings.count > 1:
         orig_seed = settings.seed
         for i in range(settings.count):
             settings.update_seed(orig_seed + '-' + str(i))

--- a/Unittest.py
+++ b/Unittest.py
@@ -162,7 +162,7 @@ class TestValidSpoilers(unittest.TestCase):
             'output_file': os.path.join(output_dir, 'fuzz-%d' % i),
         }) for i in range(10)]
         out_keys = ['randomize_settings', 'compress_rom',
-                    'create_spoiler', 'output_file', 'seed', 'numeric_seed']
+                    'create_spoiler', 'output_file', 'seed']
         for settings in fuzz_settings:
             output_file = '%s_Spoiler.json' % settings.output_file
             settings_file = '%s_%s_Settings.json' % (settings.output_file, settings.seed)
@@ -175,8 +175,7 @@ class TestValidSpoilers(unittest.TestCase):
                 except Exception as e:
                     # output the settings file in case of any failure
                     with open(settings_file, 'w') as f:
-                        d = settings.to_json()
-                        d.update({k: settings.__dict__[k] for k in out_keys})
+                        d = {k: settings.__dict__[k] for k in out_keys}
                         json.dump(d, f, indent=0)
                     raise
 

--- a/Unittest.py
+++ b/Unittest.py
@@ -22,7 +22,7 @@ never_prefix = ['Bombs', 'Arrows', 'Rupee', 'Deku Seeds', 'Map', 'Compass']
 never_suffix = ['Mask', 'Capacity']
 never = {
     'Bunny Hood', 'Mask of Truth', 'Recovery Heart', 'Milk', 'Ice Arrows', 'Ice Trap',
-    'Double Defense', 'Serenade of Water', 'Prelude of Light', 'Biggoron Sword',
+    'Double Defense', 'Biggoron Sword',
 } | {item for item, (t, adv, _, special) in item_table.items() if adv is False
      or any(map(item.startswith, never_prefix)) or any(map(item.endswith, never_suffix))}
 
@@ -158,11 +158,10 @@ class TestValidSpoilers(unittest.TestCase):
         fuzz_settings = [Settings({
             'randomize_settings': True,
             'compress_rom': "None",
-            'count': 1,
             'create_spoiler': True,
             'output_file': os.path.join(output_dir, 'fuzz-%d' % i),
         }) for i in range(10)]
-        out_keys = ['randomize_settings', 'compress_rom', 'count',
+        out_keys = ['randomize_settings', 'compress_rom',
                     'create_spoiler', 'output_file', 'seed', 'numeric_seed']
         for settings in fuzz_settings:
             output_file = '%s_Spoiler.json' % settings.output_file
@@ -176,6 +175,8 @@ class TestValidSpoilers(unittest.TestCase):
                 except Exception as e:
                     # output the settings file in case of any failure
                     with open(settings_file, 'w') as f:
-                        json.dump(settings.to_json(), f, indent=0)
+                        d = settings.to_json()
+                        d.update({k: settings.__dict__[k] for k in out_keys})
+                        json.dump(d, f, indent=0)
                     raise
 


### PR DESCRIPTION
Adds a global retry to seed generation, fixes fuzzer settings output to be run reproducibly (the settings string is for the originally provided settings, NOT the randomly selected settings, and adds some better debug information to the log (like the full list of settings).

Also skips attempting to fill locations marked minor-only for major items, which helps diagnose placement issues from one_item_per_dungeon.