### PR TITLE
Nerf Bombchu Salesman. (Fixes #688)

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -493,7 +493,7 @@ eventlocations = {
     'Gerudo Fortress Carpenter Rescue': 'Carpenter Rescue',
     'Gerudo Fortress Open Gate': 'Gerudo Fortress Gate Open',
     'Bombchu Bowling Bombchus': 'Bombchu Drop',
-    'Haunted Wasteland Bombchu Salesman': 'Bombchu Drop',
+    'Haunted Wasteland Bombchu Salesman': 'Bombchus',
     'Windmill Drain Well': 'Drain Well',
     'Goron City Woods Warp from Woods': 'Goron City Woods Warp Open',
     'Goron City Woods Warp from City': 'Goron City Woods Warp Open',

--- a/State.py
+++ b/State.py
@@ -408,7 +408,7 @@ class State(object):
 
 
     def has_explosives(self):
-        return self.has_bombs() or self.has_bombchus()
+        return self.has_bombs() or (self.world.bombchus_in_logic and self.has_bombchus())
 
 
     def can_blast_or_smash(self):

--- a/State.py
+++ b/State.py
@@ -397,7 +397,7 @@ class State(object):
 
 
     def has_bombchus(self):
-        return self.can_buy_bombchus()
+        return self.can_buy_bombchus() and (self.world.bombchus_in_logic or self.has('Bomb Bag'))
 
 
     def has_bombchus_item(self):


### PR DESCRIPTION
Salesman now provides only Bombchus item, which with chus in logic
allows purchasing chus from shops and playing Bombchu Bowling, but
does not itself count as a renewable source. With chus not in logic,
Bombchus item has no effect.

Given that has_bombchus is thus impossible without a Bomb Bag
with chus not in logic, short-circuit the explosives check.