### PR TITLE
Don't fail on disabling locked locations.

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -494,6 +494,8 @@ class WorldDistribution(object):
                     raise RuntimeError('Unknown location in world %d: %s' % (world.id + 1, name))
                 if location.type == 'Boss':
                     continue
+                elif location.name in world.disabled_locations:
+                    continue
                 else:
                     raise RuntimeError('Location already filled in world %d: %s' % (self.id + 1, location_name))
 


### PR DESCRIPTION
Pushing junk to disabled locations causes an error when a disabled location is locked due to not being included in the seed (eg. a scrub when scrubsanity is off). This restores previous functionality ignoring the excess disabled locations.