### PR TITLE
More Tricks Again

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -262,16 +262,13 @@ logic_tricks = {
                     flower. You must backwalk with the flower and then
                     quickly throw it toward the wall.
                     '''},
-    'Water Temple Boss Key Chest with No Additional Items': {
+    'Water Temple Boss Key Chest with Iron Boots': {
         'name'    : 'logic_water_bk_chest',
         'tooltip' : '''\
-                    After reaching the Boss Key chest's area with Iron Boots
-                    and Longshot, the chest can be reached with no additional
-                    items aside from Small Keys. Stand on the blue switch
-                    with the Iron Boots, wait for the water to rise all the
-                    way up, and then swim straight to the exit. You should
-                    grab the ledge as you surface. It works best if you don't
-                    mash B.
+                    Stand on the blue switch in the Stinger room with the
+                    Iron Boots, wait for the water to rise all the way up,
+                    and then swim straight to the exit. You should grab the
+                    ledge as you surface. It works best if you don't mash B.
                     '''},
     'Adult Kokiri Forest GS with Hover Boots': {
         'name'    : 'logic_adult_kokiri_gs',
@@ -327,6 +324,17 @@ logic_tricks = {
                     If you move quickly you can sneak past the edge of
                     a flame wall before it can rise up to block you.
                     To do it without taking damage is more precise.
+                    Allows you to progress without needing either a
+                    Small Key or Hover Boots.
+                    '''},
+    'Fire Temple MQ Flame Wall Maze Skip': {
+        'name'    : 'logic_fire_mq_flame_maze',
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of
+                    a flame wall before it can rise up to block you.
+                    To do it without taking damage is more precise.
+                    Allows you to reach a GS without needing either
+                    Song of Time or Hover Boots.
                     '''},
     'Fire Temple MQ Chest Near Boss without Breaking Crate': {
         'name'    : 'logic_fire_mq_near_boss',
@@ -463,15 +471,93 @@ logic_tricks = {
                     on the torches is quite short so you must move
                     quickly in order to light all three.
                     '''},
-
-
-
+    'Forest Temple NE Outdoors Ledge with Hover Boots': {
+        'name'    : 'logic_forest_outdoors_ledge',
+        'tooltip' : '''\
+                    With precise Hover Boots movement you can fall down
+                    to this ledge from upper balconies. If done precisely
+                    enough, it is not necessary to take fall damage.
+                    In MQ, this skips a Longshot requirement.
+                    In Vanilla, this can skip a Hookshot requirement in
+                    entrance randomizer.
+                    '''},
+    'Water Temple Boss Key Region with Hover Boots': {
+        'name'    : 'logic_water_boss_key_region',
+        'tooltip' : '''\
+                    With precise Hover Boots movement it is possible
+                    to reach the boss key chest's region without
+                    needing the Longshot. It is not necessary to take
+                    damage from the spikes. The Gold Skulltula Token
+                    in the following room can also be obtained with
+                    just the Hover Boots.
+                    '''},
+    'Water Temple Falling Platform Room GS with Hookshot': {
+        'name'    : 'logic_water_falling_platform_gs',
+        'tooltip' : '''\
+                    If you stand on the very edge of the platform, this
+                    Gold Skulltula can be obtained with only the Hookshot.
+                    '''},
+    'Death Mountain Crater Upper to Lower with Hammer': {
+        'name'    : 'logic_crater_upper_to_lower',
+        'tooltip' : '''\
+                    With the Hammer, you can jumpslash the rock twice
+                    in the same jump in order to destroy it before you
+                    fall into the lava.
+                    '''},
     'Zora\'s Domain Entry with Hover Boots': {
         'name'    : 'logic_zora_with_hovers',
         'tooltip' : '''\
                     Can hover behind the waterfall as adult.
-                    This is very difficult.
                     '''},
+    'Shadow Temple River Statue with Bombchu': {
+        'name'    : 'logic_shadow_statue',
+        'tooltip' : '''\
+                    By sending a Bombchu around the edge of the
+                    gorge, you can knock down the statue without
+                    needing a Bow.
+                    Applies in both vanilla and MQ Shadow.
+                    '''},
+    'Stop Link the Goron with Din\'s Fire': {
+        'name'    : 'logic_link_goron_dins',
+        'tooltip' : '''\
+                    The timing is quite awkward.
+                    '''},
+    'Fire Temple Song of Time Room GS without Song of Time': {
+        'name'    : 'logic_fire_song_of_time',
+        'tooltip' : '''\
+                    A precise jump can be used to reach this room.
+                    '''},
+    'Climb Fire Temple without Strength': {
+        'name'    : 'logic_fire_strength',
+        'tooltip' : '''\
+                    A precise jump can be used to skip
+                    pushing the block.
+                    '''},
+    'Fire Temple MQ Big Lava Room Bombable Chest without Hookshot': {
+        'name'    : 'logic_fire_mq_bombable_chest',
+        'tooltip' : '''\
+                    A precisely-angled jump can get over the wall
+                    of fire in this room. It's expected that you
+                    will take damage as you do this. As it may
+                    take multiple attempts, you won't be expected
+                    to use a fairy to survive.
+                    '''},
+    'Light Trial MQ without Hookshot': {
+        'name'    : 'logic_light_trial_mq',
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of
+                    a flame wall before it can rise up to block you.
+                    In this case it doesn't seem possible to do it
+                    without taking damage.
+                    '''},
+    'Ice Cavern MQ Scarecrow GS with No Additional Items': {
+        'name'    : 'logic_ice_mq_scarecrow',
+        'tooltip' : '''\
+                    A precise jump can be used to reach this alcove.
+                    '''},
+
+
+
 }
 
 

--- a/State.py
+++ b/State.py
@@ -520,7 +520,8 @@ class State(object):
                             # Darunia's Chamber access or clearing the boulders to get up DMT
                             or self.has('Progressive Strength Upgrade')
                             or self.can_blast_or_smash()
-                            or self.has_bow())))
+                            or self.has_bow()
+                            or (self.world.logic_link_goron_dins and self.can_use('Dins Fire')))))
 
 
     def has_skull_mask(self):

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -38,7 +38,9 @@
                 has_fire_source and (has_bow or logic_fire_mq_bk_chest) and 
                 Progressive_Hookshot",
             "Fire Temple MQ Big Lava Room Bombable Chest": "
-                has_fire_source and Progressive_Hookshot and has_explosives",
+                has_fire_source and has_explosives and
+                (Progressive_Hookshot or
+                    (logic_fire_mq_bombable_chest and (damage_multiplier != 'ohko' or can_use(Nayrus_Love))))",
             "GS Fire Temple MQ Big Lava Room": "True"
         },
         "exits": {
@@ -79,7 +81,7 @@
             "Fire Temple MQ Freestanding Key": "True",
             "Fire Temple MQ West Tower Top Chest": "(Small_Key_Fire_Temple, 4)",
             "GS Fire Temple MQ Fire Wall Maze Side Room": "
-                can_play(Song_of_Time) or Hover_Boots",
+                can_play(Song_of_Time) or Hover_Boots or logic_fire_mq_flame_maze",
             "GS Fire Temple MQ Fire Wall Maze Center": "has_explosives",
             "GS Fire Temple MQ Above Fire Wall Maze": "(Small_Key_Fire_Temple, 5)"
         }

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -36,13 +36,15 @@
         "locations": {
             "Fire Temple Big Lava Room Open Chest": "True",
             "Fire Temple Big Lava Room Bombable Chest": "is_adult and has_explosives",
-            "GS Fire Temple Song of Time Room": "is_adult and can_play(Song_of_Time)"
+            "GS Fire Temple Song of Time Room": "
+                is_adult and (can_play(Song_of_Time) or logic_fire_song_of_time)"
         },
         "exits": {
             "Fire Temple Lower":  "True",
             "Fire Temple Middle": "
-                can_use(Goron_Tunic) and (Small_Key_Fire_Temple, 4) and Progressive_Strength_Upgrade and 
-                (has_explosives or ((has_bow or Progressive_Hookshot) and is_adult))"
+                can_use(Goron_Tunic) and (Small_Key_Fire_Temple, 4) and
+                (Progressive_Strength_Upgrade or logic_fire_strength) and 
+                (has_explosives or has_bow or Progressive_Hookshot)"
         }
     },
     {

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -90,7 +90,8 @@
             "Forest Temple MQ NE Outdoors Upper Chest": "True"
         },
         "exits": {
-            "Forest Temple NE Outdoors": "True"
+            "Forest Temple NE Outdoors": "True",
+            "Forest Temple NE Outdoors Ledge": "logic_forest_outdoors_ledge and can_use(Hover_Boots)"
         }
     },
     {

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -43,7 +43,8 @@
         "locations": {
             "Forest Temple Outside Hookshot Chest": "
                 can_use(Hookshot) or
-                can_reach(Forest_Temple_Falling_Room)",
+                can_reach(Forest_Temple_Falling_Room) or
+                (logic_forest_outdoors_ledge and can_use(Hover_Boots) and can_reach(Forest_Temple_Outdoors_High_Balconies))",
             "GS Forest Temple Outdoor East": "
                 can_use(Hookshot) or 
                 (can_reach(Forest_Temple_Falling_Room) and 
@@ -132,7 +133,7 @@
         },
         "exits": {
             "Forest Temple Falling Room": "
-            (Small_Key_Forest_Temple, 5) and (Bow or can_use(Dins_Fire))"
+            (Small_Key_Forest_Temple, 5) and (has_bow or can_use(Dins_Fire))"
         }
     },
     {

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -108,8 +108,9 @@
         "locations": {
             "Ganons Castle MQ Light Trial Lullaby Chest": "can_play(Zeldas_Lullaby)",
             "Ganons Castle Light Trial Clear": "
-                can_use(Light_Arrows) and Progressive_Hookshot and 
-                (Small_Key_Ganons_Castle, 3)"
+                can_use(Light_Arrows) and (Small_Key_Ganons_Castle, 3) and can_see_with_lens and
+                (Progressive_Hookshot or
+                    (logic_light_trial_mq and (damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love))))"
         }
     }
 ]

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -103,7 +103,7 @@
                 can_play(Zeldas_Lullaby) and (Small_Key_Ganons_Castle, 1)",
             "Ganons Castle Light Trial Clear": "
                 can_use(Light_Arrows) and Progressive_Hookshot and 
-                (Small_Key_Ganons_Castle, 2)"
+                (Small_Key_Ganons_Castle, 2) and can_see_with_lens"
         }
     }
 ]

--- a/data/World/Ice Cavern MQ.json
+++ b/data/World/Ice Cavern MQ.json
@@ -29,7 +29,8 @@
             "GS Ice Cavern MQ Red Ice": "can_play(Song_of_Time)",
             "GS Ice Cavern MQ Ice Block": "True",
             "GS Ice Cavern MQ Scarecrow": "
-                can_use(Scarecrow) or (Hover_Boots and can_use(Longshot))"
+                can_use(Scarecrow) or (Hover_Boots and can_use(Longshot)) or
+                logic_ice_mq_scarecrow"
         }
     }
 ]

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1102,7 +1102,8 @@
                 (has_explosives or (Progressive_Strength_Upgrade and logic_child_rolling_with_strength))",
             "Link the Goron": "
                 is_adult and 
-                (Progressive_Strength_Upgrade or has_explosives or has_bow)",
+                    (Progressive_Strength_Upgrade or has_explosives or has_bow or
+                    (logic_link_goron_dins and can_use(Dins_Fire)))",
             "GS Goron City Boulder Maze": "is_child and has_explosives",
             "GS Goron City Center Platform": "is_adult",
             "Goron City Maze Gossip Stone": "
@@ -1125,7 +1126,9 @@
                 (is_child and (can_use(Dins_Fire) or (can_reach(Darunias_Chamber) and has_sticks)))",
             "Darunias Chamber": "
                 (is_child and can_play(Zeldas_Lullaby)) or 
-                (is_adult and (Progressive_Strength_Upgrade or has_explosives or has_bow))",
+                (is_adult and
+                    (Progressive_Strength_Upgrade or has_explosives or has_bow or
+                    (logic_link_goron_dins and can_use(Dins_Fire))))",
             "Goron City Grotto": "
                 is_adult and 
                 ((can_play(Song_of_Time) and 
@@ -1189,7 +1192,9 @@
         },
         "exits": {
             "Death Mountain Summit": "True",
-            "Death Mountain Crater Lower": "can_use(Hover_Boots)",
+            "Death Mountain Crater Lower": "
+                can_use(Hover_Boots) or
+                (logic_crater_upper_to_lower and can_use(Hammer))",
             "Death Mountain Crater Central": "
                 can_use(Goron_Tunic) and can_use(Distant_Scarecrow) and 
                 ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -77,10 +77,14 @@
         "region_name": "Shadow Temple Beyond Boat",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Bongo Bongo Heart": "has_bow and Boss_Key_Shadow_Temple",
-            "Bongo Bongo": "has_bow and Boss_Key_Shadow_Temple",
+            "Bongo Bongo Heart": "
+                (has_bow or (logic_shadow_statue and has_bombchus)) and
+                Boss_Key_Shadow_Temple",
+            "Bongo Bongo": "
+                (has_bow or (logic_shadow_statue and has_bombchus)) and
+                Boss_Key_Shadow_Temple",
             "GS Shadow Temple MQ After Ship": "True",
-            "GS Shadow Temple MQ Near Boss": "has_bow"
+            "GS Shadow Temple MQ Near Boss": "has_bow or (logic_shadow_statue and has_bombchus)"
         },
         "exits": {
             "Shadow Temple Invisible Maze": "

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -76,11 +76,11 @@
             "Shadow Temple Boss Key Chest": "can_use(Dins_Fire)",
             "Shadow Temple Hidden Floormaster Chest": "True",
             "Bongo Bongo Heart": "
-                (Small_Key_Shadow_Temple, 5) and 
-                (Bow or can_use(Distant_Scarecrow)) and Boss_Key_Shadow_Temple",
+                (Small_Key_Shadow_Temple, 5) and Boss_Key_Shadow_Temple and
+                (has_bow or can_use(Distant_Scarecrow) or (logic_shadow_statue and has_bombchus))",
             "Bongo Bongo": "
-                (Small_Key_Shadow_Temple, 5) and 
-                (Bow or can_use(Distant_Scarecrow)) and Boss_Key_Shadow_Temple",
+                (Small_Key_Shadow_Temple, 5) and Boss_Key_Shadow_Temple and
+                (has_bow or can_use(Distant_Scarecrow) or (logic_shadow_statue and has_bombchus))",
             "GS Shadow Temple Triple Giant Pot": "True"
         }
     }

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -57,15 +57,15 @@
             "Water Temple Boss Key Chest": "
                 (Small_Key_Water_Temple, 6) and 
                 (can_play(Zeldas_Lullaby) or keysanity) and 
-                ((logic_water_bk_chest and Iron_Boots) or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots) and 
-                can_use(Longshot)",
+                (can_use(Longshot) or (logic_water_boss_key_region and can_use(Hover_Boots))) and
+                ((logic_water_bk_chest and Iron_Boots) or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
             "GS Water Temple South Basement": "
                 (can_use(Hookshot) or can_use(Hover_Boots)) and 
                 has_explosives and can_play(Zeldas_Lullaby)",
             "GS Water Temple Near Boss Key Chest": "
-                can_use(Longshot) and 
-                (can_play(Zeldas_Lullaby) or keysanity) and 
-                (Small_Key_Water_Temple, 5)" 
+                (Small_Key_Water_Temple, 5) and
+                (can_play(Zeldas_Lullaby) or keysanity) and
+                (can_use(Longshot) or (logic_water_boss_key_region and can_use(Hover_Boots)))"
                 # Longshot just reaches without the need to actually go near
         },
         "exits": {
@@ -102,7 +102,9 @@
                 has_bow and (can_play(Zeldas_Lullaby) or keysanity)",
             "GS Water Temple Serpent River": "
                 can_play(Song_of_Time) and (Small_Key_Water_Temple, 6) and Iron_Boots",
-            "GS Water Temple Falling Platform Room": "can_use(Longshot)"
+            "GS Water Temple Falling Platform Room": "
+                can_use(Longshot) or
+                (logic_water_falling_platform_gs and can_use(Hookshot))"
         }
     }
 ]


### PR DESCRIPTION
- I reworded the description on the Water Temple Boss Key Chest trick to just say it requires Iron Boots rather than "No Additional Items".
- I removed "this is very difficult" from the hover boots waterfall trick. Since we're passing that trick in difficulty now it seemed weird to call that one out.
- Added a short bit to the tooltip about what the Fire Temple Flame Wall Maze Skip allows you to skip.

- Corrected three wholly unimportant instances of "Bow" to "has_bow".
- Backspaced an unnecessary is_adult check in the Fire Temple Middle logic.
- Added lens requirements to both vanilla and mq light trials.

Added Tricks:
1. Forest Temple NE Outdoors Ledge with Hover Boots
- You can get from the balconies up top down to the ledge where you normally have to hookshot up to a chest or fall down from the door above.
- This one is mostly relevant in MQ, but also in vanilla with ER.
2. Water Temple Boss Key Region with Hover Boots
- This is the trick where you backwalk with the Hover Boots and then backflip over the spikes.
- It's only relevant in vanilla because you need the Longshot to even get to this room in MQ.
- In ER it's possible you might not even have the hookshot, so I had to modify the logic on the GS as well as the BK chest, since you can use the Hover Boots to kill and obtain the GS as well.
3. Water Temple Falling Platform Room GS with Hookshot
- Normally in logic with the Longshot, precise positioning can obtain the GS with only Hookshot.
4. Death Mountain Crater Upper to Lower with Hammer
- This is the move where you jumpslash the rock twice in the same jump in order to destroy it from the upper crater side.
- Relevant if you do not have the means to stop the Link the Goron and in ER.
5. Shadow Temple River Statue with Bombchu
6. Stop Link the Goron with Din's Fire
- Link the Goron, adult Goron City->Darunia's Chamber, and can_finish_adult_trades were affected by this.
7. Fire Temple Song of Time GS without Song of Time
- Precise jump.
8. Climb Fire Temple without Strength
- Precise jump.
9. Fire Temple MQ Flame Wall Maze Skip
10. Fire Temple MQ Big Lava Room Bombable Chest without Hookshot
- Precise jump.
11. Light Trial MQ without Hookshot
- This one is another flame wall skip.
12. Ice Cavern MQ Scarecrow GS with No Additional Items
- Precise jump.