### PR TITLE
Enable child serenade

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -814,6 +814,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         #Tell the well water we are always a child.
         rom.write_int32(0xDD5BF4, 0x00000000)
 
+        #Tell Sheik at Ice Cavern we are always an Adult
+        rom.write_int32(0xC7B9C0, 0x00000000)
+        rom.write_int32(0xC7BAEC, 0x00000000)
+        rom.write_int32(0xc7BCA4, 0x00000000)
+
         #Make the Adult well blocking stone dissappear if the well has been drained by
         #checking the well drain event flag instead of links age. This actor doesn't need a
         #code check for links age as the stone is absent for child via the scene alternate

--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -16,7 +16,7 @@
             "Ice Cavern Compass Chest": "has_blue_fire",
             "Ice Cavern Iron Boots Chest": "has_blue_fire",
             "Ice Cavern Freestanding PoH": "has_blue_fire",
-            "Sheik in Ice Cavern": "has_blue_fire and is_adult",
+            "Sheik in Ice Cavern": "has_blue_fire",
             "GS Ice Cavern Spinning Scythe Room": "can_use(Hookshot) or can_use(Boomerang)",
             "GS Ice Cavern Heart Piece Room": "
                 has_blue_fire and (can_use(Hookshot) or can_use(Boomerang))",


### PR DESCRIPTION
Enable child to learn Serenade from the Ice Cavern. This is consistent
with requiem and also bring another child learnable song into play
that is not weir egg locked (makes closed DoT much more interesting).

Hacked the en_xc (Sheik) actor to always consider Link an adult. en_xc
is removed from the actor table for child for most instances. (e.g.
Sheik is simply absent from Child crater by actor lists). Sheik at ToT
is unaffected (by testing) and all others are cutscenes except for
requiem where we want Sheik to work for child anyway. So make the
change unconditional on location.