### PR TITLE
Apply distribution to all worlds (fixes #716).

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -71,7 +71,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
 
     cloakable_locations = shop_locations + song_locations + fill_locations
     all_models = shopitempool + dungeon_items + songitempool + itempool
-    worlds[0].distribution.fill(window, worlds, [shop_locations, song_locations, fill_locations], [shopitempool, dungeon_items, songitempool, progitempool, prioitempool, restitempool])
+    worlds[0].settings.distribution.fill(window, worlds, [shop_locations, song_locations, fill_locations], [shopitempool, dungeon_items, songitempool, progitempool, prioitempool, restitempool])
     itempool = progitempool + prioitempool + restitempool
 
     # Start a playthrough cache here.

--- a/Main.py
+++ b/Main.py
@@ -88,7 +88,7 @@ def main(settings, window=dummy_window()):
             spoiler = generate(settings, window)
             break
         except FillError as fe:
-            logger.warn('Failed attempt %d of %d: %s', attempt, max_attempts, fe)
+            logger.warning('Failed attempt %d of %d: %s', attempt, max_attempts, fe)
             if attempt >= max_attempts:
                 raise
             else:

--- a/tests/ac-mq.sav
+++ b/tests/ac-mq.sav
@@ -7,7 +7,7 @@
 "create_cosmetics_log": false,
 "compress_rom": "None",
 "randomize_settings": false,
-"open_forest": true,
+"open_forest": "open",
 "open_door_of_time": true,
 "open_fountain": false,
 "gerudo_fortress": "fast",

--- a/tests/multiworld.sav
+++ b/tests/multiworld.sav
@@ -41,7 +41,14 @@
 "unlocked_ganondorf": true,
 "mq_dungeons_random": false,
 "mq_dungeons": 0,
-"disabled_locations": ["Deku Theater Mask of Truth"],
+"disabled_locations": [
+"10 Big Poes",
+"Frog Ocarina Game",
+"Horseback Archery 1500 Points",
+"Deku Theater Mask of Truth",
+"Haunted Wasteland Structure Chest",
+"DMC Deku Scrub Bombs"
+],
 "allowed_tricks": ["logic_fewer_tunic_requirements"],
 "logic_earliest_adult_trade": "prescription",
 "logic_latest_adult_trade": "claim_check",

--- a/tests/plentiful.sav
+++ b/tests/plentiful.sav
@@ -8,7 +8,7 @@
 "create_cosmetics_log": false,
 "compress_rom": "None",
 "randomize_settings": false,
-"open_forest": true,
+"open_forest": "open",
 "open_door_of_time": true,
 "open_fountain": false,
 "gerudo_fortress": "fast",


### PR DESCRIPTION
Fix a warning on logging.warn.

Unittest changes:
- Add unittests for disabled locations.
- Fix a bug in multiworld woth tests where all players were P1.
- Remove nut, stick, and shield refills from "max-once" consideration.
- Given that, canonicalizing "max-once" items isn't necessary.
- Changes to unittest settings files.