### PR TITLE
Fix Dampe's Grave -> Windmill logic in ER

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -990,7 +990,7 @@
         },
         "exits": {
             "Graveyard": "True",
-            "Windmill": "can_play(Song_of_Time)"
+            "Windmill": "is_adult and can_play(Song_of_Time)"
         }
     },
     {


### PR DESCRIPTION
This was missing an adult check now that Dampe's Grave can sometimes be accessed by child in grotto ER (child isn't high enough to climb the ledge behind the time blocks).