### PR TITLE
Fix child lake control patching being always applied in ER

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -802,9 +802,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         set_entrance_updates(world.get_shuffled_entrances(type='Overworld'))
 
     if world.shuffle_dungeon_entrances:
-        symbol = rom.sym('CFG_CHILD_CONTROL_LAKE')
-        rom.write_int32(symbol, 1)
-
         # Connect lake hylia fill exit to revisit exit (Hylia blue will then be rewired below)
         rom.write_int16(0xAC995A, 0x060C)
 


### PR DESCRIPTION
This never affected logic but the lake state was always shared between child and adult in ER, even with the "child may drain lake hylia" option disabled. I think this was left from back when the child option wasn't a thing, and it was bound to dungeon ER instead.

It will now only be applied when the corresponding option is enabled.