### PR TITLE
Allow Warp Songs and Farore's Wind in additional places

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -662,6 +662,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # Forbid Sun's Song in Treasure Chest Minigame
     rom.write_byte(0xB6D34B, 0xD5)
 
+    # Allow Farore's Wind in dungeons where it's normally forbidden
+    rom.write_byte(0xB6D3D3, 0x00) # Gerudo Training Grounds
+    rom.write_byte(0xB6D42B, 0x00) # Inside Ganon's Castle
+
     # Remove disruptive text from Gerudo Training Grounds and early Shadow Temple (vanilla)
     Wonder_text = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, 0x27CE080,
                    0x27CE090, 0x2887070, 0x2887080, 0x2887090, 0x2897070, 0x28C7134, 0x28D91BC, 0x28A60F4, 0x28AE084,

--- a/Patches.py
+++ b/Patches.py
@@ -653,6 +653,15 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     for address in Suns_scenes:
         rom.write_byte(address,0x01)
 
+    # Allow Warp Songs in additional places
+    rom.write_byte(0xB6D3D2, 0x00) # Gerudo Training Grounds
+    rom.write_byte(0xB6D42A, 0x00) # Inside Ganon's Castle
+    rom.write_byte(0xB6D426, 0x00) # Dampe's Grave / Windmill
+    rom.write_byte(0xB6D34A, 0x10) # Treasure Chest Minigame
+
+    # Forbid Sun's Song in Treasure Chest Minigame
+    rom.write_byte(0xB6D34B, 0xD5)
+
     # Remove disruptive text from Gerudo Training Grounds and early Shadow Temple (vanilla)
     Wonder_text = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, 0x27CE080,
                    0x27CE090, 0x2887070, 0x2887080, 0x2887090, 0x2897070, 0x28C7134, 0x28D91BC, 0x28A60F4, 0x28AE084,


### PR DESCRIPTION
Removed the scene restriction on warp songs in some relevant places:
- Gerudo Training Grounds
- Inside Ganon's Castle (Trials)
- Dampe's Grave / Windmill
- Treasure Chest Minigame

Also removed the restriction on Farore's Wind in dungeons where it was originally forbidden:
- Gerudo Training Grounds
- Inside Ganon's Castle (Trials)

Note: The Treasure Chest Minigame case is a bit special because allowing warp songs requires allowing Ocarina usage, which can be a problem due to Sun's Song being usable to cheat your way through the minigame. To avoid this abuse, Sun's Song is now explicitly forbidden in the Chest Minigame scene.