### PR TITLE
Fix spirit temp flags ER bug

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -820,6 +820,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_int32(0x0C72C64, 0x240E0000)
         rom.write_int32(0x0C72C74, 0x240F0001)
 
+        #Purge temp flags on entrance to spirit from colossus through the front
+        #door.
+        rom.write_byte(0x021862E3, 0xC2)
+
         set_entrance_updates(world.get_shuffled_entrances(type='Dungeon'))
 
     if world.shuffle_interior_entrances:


### PR DESCRIPTION
In vanilla, when you zone out of spirit onto the hands of the colossus
then jump down and re-enter spirit from the front door, the temporary
switch flags are preserved. This is bad for ER, as it means flicking
switches in spirit, will cause switches to also flick in the dungeon
on-spirit if you jump off the hands.

Fix it by always clearing the temp flags zoning into spirit from the
front door when dungeon ER is enabled. Zoning out to a hand then back
in will still preserve the flags as per vanilla, only the front door
is changed.

This works by clearing the temp preservation flag on the sprit entry
polygon data.