### PR TITLE
Simplify Goron City logic with event locations

### DIFF
--- a/State.py
+++ b/State.py
@@ -518,10 +518,8 @@ class State(object):
                             or self.world.logic_biggoron_bolero
                             # Getting to Biggoron without ER or the trick above involves either
                             # Darunia's Chamber access or clearing the boulders to get up DMT
-                            or self.has('Progressive Strength Upgrade')
                             or self.can_blast_or_smash()
-                            or self.has_bow()
-                            or (self.world.logic_link_goron_dins and self.can_use('Dins Fire')))))
+                            or self.has('Stop Link the Goron'))))
 
 
     def has_skull_mask(self):

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1094,9 +1094,10 @@
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
-            "Goron City Torches": "is_child and can_use(Dins_Fire)",
+            "Goron City Child Fire": "is_child and can_use(Dins_Fire)",
             "Goron City Woods Warp Open": "
-                can_blast_or_smash or can_use(Dins_Fire) or can_use(Bow) or Progressive_Strength_Upgrade"
+                can_blast_or_smash or can_use(Dins_Fire) or can_use(Bow) or 
+                Progressive_Strength_Upgrade or 'Goron City Child Fire'"
         },
         "locations": {
             "Goron City Leftmost Maze Chest": "
@@ -1106,7 +1107,7 @@
             "Goron City Right Maze Chest": "
                 can_blast_or_smash or can_use(Silver_Gauntlets)",
             "Goron City Pot Freestanding PoH": "
-                is_child and 'Goron City Torches' and
+                is_child and 'Goron City Child Fire' and
                 (has_bombs or Progressive_Strength_Upgrade)",
             "Rolling Goron as Child": "
                 is_child and 
@@ -1132,8 +1133,8 @@
             "Goron City Woods Warp": "'Goron City Woods Warp Open'",
             "Goron Shop": "
                 has_explosives or Progressive_Strength_Upgrade or can_use(Bow) or 
-                (can_use(Dins_Fire) and (is_child or logic_link_goron_dins)) or 
-                (is_child and at('Darunias Chamber', True) and has_sticks)",
+                (is_adult and logic_link_goron_dins and can_use(Dins_Fire)) or 
+                (is_child and 'Goron City Child Fire')",
             "Darunias Chamber": "
                 (is_child and can_play(Zeldas_Lullaby)) or 
                 (is_adult and
@@ -1164,8 +1165,7 @@
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
-            "Goron City Torches": "is_child and has_sticks",
-            "Goron City Woods Warp Open": "is_child and has_sticks"
+            "Goron City Child Fire": "can_use(Sticks)"
         },
         "locations": {
             "Darunias Joy": "is_child and can_play(Sarias_Song)"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1097,7 +1097,11 @@
             "Goron City Child Fire": "is_child and can_use(Dins_Fire)",
             "Goron City Woods Warp Open": "
                 can_blast_or_smash or can_use(Dins_Fire) or can_use(Bow) or 
-                Progressive_Strength_Upgrade or 'Goron City Child Fire'"
+                Progressive_Strength_Upgrade or 'Goron City Child Fire'",
+            "Stop Link the Goron": "
+                is_adult and 
+                (Progressive_Strength_Upgrade or has_explosives or has_bow or
+                    (logic_link_goron_dins and can_use(Dins_Fire)))"
         },
         "locations": {
             "Goron City Leftmost Maze Chest": "
@@ -1112,10 +1116,7 @@
             "Rolling Goron as Child": "
                 is_child and 
                 (has_explosives or (Progressive_Strength_Upgrade and logic_child_rolling_with_strength))",
-            "Link the Goron": "
-                is_adult and 
-                    (Progressive_Strength_Upgrade or has_explosives or has_bow or
-                    (logic_link_goron_dins and can_use(Dins_Fire)))",
+            "Link the Goron": "'Stop Link the Goron'",
             "GS Goron City Boulder Maze": "is_child and has_explosives",
             "GS Goron City Center Platform": "is_adult",
             "Goron City Maze Gossip Stone": "
@@ -1132,14 +1133,11 @@
             "Death Mountain": "True",
             "Goron City Woods Warp": "'Goron City Woods Warp Open'",
             "Goron Shop": "
-                has_explosives or Progressive_Strength_Upgrade or can_use(Bow) or 
-                (is_adult and logic_link_goron_dins and can_use(Dins_Fire)) or 
-                (is_child and 'Goron City Child Fire')",
+                (is_adult and 'Stop Link the Goron') or 
+                (is_child and (has_explosives or Progressive_Strength_Upgrade or 'Goron City Child Fire'))",
             "Darunias Chamber": "
-                (is_child and can_play(Zeldas_Lullaby)) or 
-                (is_adult and
-                    (Progressive_Strength_Upgrade or has_explosives or has_bow or
-                    (logic_link_goron_dins and can_use(Dins_Fire))))",
+                (is_adult and 'Stop Link the Goron') or
+                (is_child and can_play(Zeldas_Lullaby))",
             "Goron City Grotto": "
                 is_adult and 
                 ((can_play(Song_of_Time) and 


### PR DESCRIPTION
Made Goron City logic (for a child fire source and stopping Link the Goron) a bit simpler by using event locations more efficiently.