### PR TITLE
Make passing through visible one-way collisions a logic trick

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -555,7 +555,14 @@ logic_tricks = {
         'tooltip' : '''\
                     A precise jump can be used to reach this alcove.
                     '''},
-
+    'Pass Through Visible One-Way Collisions': {
+        'name'    : 'logic_visible_collisions',
+        'tooltip' : '''\
+                    Allows climbing through the platform to reach 
+                    Impa's House Back as adult with no items and 
+                    going through the Kakariko Village Gate as child
+                    when coming from the Mountain Trail side.
+                    '''},
 
 
 }

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -786,6 +786,9 @@
         "region_name": "Kakariko Village",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
+        "events": {
+            "Kakariko Village Gate Open": "is_child and Zeldas_Letter"
+        },
         "locations": {
             "Sheik in Kakariko": "
                 is_adult and Forest_Medallion and Fire_Medallion and Water_Medallion",
@@ -813,7 +816,7 @@
             "Carpenter Boss House": "True",
             "House of Skulltula": "True",
             "Impas House": "True",
-            "Impas House Back": "True",
+            "Impas House Back": "is_child or logic_visible_collisions or can_use(Hookshot)",
             "Windmill": "True",
             "Kakariko Bazaar": "is_adult and at_day",
             "Kakariko Shooting Gallery": "is_adult and at_day",
@@ -825,7 +828,7 @@
             "Kakariko Bombable Grotto": "can_blast_or_smash",
             "Kakariko Back Grotto": "True",
             "Graveyard": "True",
-            "Kakariko Village Behind Gate": "Zeldas_Letter or is_adult"
+            "Kakariko Village Behind Gate": "is_adult or 'Kakariko Village Gate Open'"
         }
     },
     {
@@ -1023,7 +1026,8 @@
         "region_name": "Kakariko Village Behind Gate",
         "scene": "Kakariko Village",
         "exits": {
-            "Kakariko Village": "True",
+            "Kakariko Village": "
+                is_adult or logic_visible_collisions or 'Kakariko Village Gate Open'",
             "Death Mountain": "True"
         }
     },


### PR DESCRIPTION
Adds a logic trick to remove the unintuitive ability to pass through some visually apparent one-way collisions from default logic. A casual player couldn't guess that those collisions don't actually exist when coming from one side so I think going through them belongs to a trick.

This is only relevant for starting as adult and for ER, but can be quite major in some situations. Especially passing through the Kakariko Gate as child can logically open up a lot of things in Overworld ER.

Note: I'm not 100% sure about the right wording on the trick itself, or where it belongs on the list.
@r0bd0g Let me know if this is fine or if anything should be changed.