### PR TITLE
Fix wolfos child weapon checks in ER

### DIFF
--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -14,9 +14,15 @@
         "locations": {
             "Ice Cavern Map Chest": "has_blue_fire and is_adult",
             "Ice Cavern Compass Chest": "has_blue_fire",
-            "Ice Cavern Iron Boots Chest": "has_blue_fire",
+            "Ice Cavern Iron Boots Chest": "
+                has_blue_fire and 
+                (is_adult or has_slingshot or has_sticks or 
+                    Kokiri_Sword or can_use(Dins_Fire))",
+            "Sheik in Ice Cavern": "
+                has_blue_fire and 
+                (is_adult or has_slingshot or has_sticks or 
+                    Kokiri_Sword or can_use(Dins_Fire))",
             "Ice Cavern Freestanding PoH": "has_blue_fire",
-            "Sheik in Ice Cavern": "has_blue_fire",
             "GS Ice Cavern Spinning Scythe Room": "can_use(Hookshot) or can_use(Boomerang)",
             "GS Ice Cavern Heart Piece Room": "
                 has_blue_fire and (can_use(Hookshot) or can_use(Boomerang))",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -191,7 +191,7 @@
         "exits": {
             "Lost Woods Beyond Mido": "True",
             "Sacred Forest Meadow": "
-                is_adult or has_slingshot or has_sticks or has_explosives or 
+                is_adult or has_slingshot or has_sticks or 
                 Kokiri_Sword or can_use(Dins_Fire)",
             "Front of Meadow Grotto": "can_blast_or_smash"
         }
@@ -1558,7 +1558,9 @@
     {
         "region_name": "Front of Meadow Grotto",
         "locations": {
-            "Wolfos Grotto Chest": "is_adult or can_child_attack"
+            "Wolfos Grotto Chest": "
+                is_adult or has_slingshot or has_sticks or 
+                Kokiri_Sword or can_use(Dins_Fire)"
         },
         "exits": {
             "Sacred Forest Meadow Entryway": "True"


### PR DESCRIPTION
We generally agreed that using explosives to kill wolfos is too tough to be in default glitchless logic, so I updated the logic to not include them. This wasn't relevant before overworld ER because having explosives meant you could always get sticks from Goron City, so it never came up as an issue.

Also fixed a minor bug with the wolfos grotto chest where can_child_attack was used but that includes the Boomerang which doesn't actually damage them.