### PR TITLE
Messages.py clean-ups

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -771,7 +771,6 @@ def read_messages(rom):
 def repack_messages(rom, messages, permutation=None, speed_up_text=True):
 
     rom.update_dmadata_record(TEXT_START, TEXT_START, TEXT_START + ENG_TEXT_SIZE_LIMIT)
-    always_allow_skip=True
 
     if permutation is None:
         permutation = range(len(messages))
@@ -779,7 +778,6 @@ def repack_messages(rom, messages, permutation=None, speed_up_text=True):
     # repack messages
     offset = 0
     text_size_limit = ENG_TEXT_SIZE_LIMIT
-    text_bank = 0x07
 
     for old_index, new_index in enumerate(permutation):
         old_message = messages[old_index]

--- a/Patches.py
+++ b/Patches.py
@@ -1148,8 +1148,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     # Load Message and Shop Data
     messages = read_messages(rom)
-    shop_items = read_shop_items(rom, shop_item_file.start + 0x1DEC)
     remove_unused_messages(messages)
+    shop_items = read_shop_items(rom, shop_item_file.start + 0x1DEC)
 
     # Set Big Poe count to get reward from buyer
     poe_points = world.big_poe_count * 100
@@ -1561,14 +1561,17 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
        tycoon_message = make_player_message(tycoon_message)
     update_message_by_id(messages, 0x00F8, tycoon_message, 0x23)
 
-    repack_messages(rom, messages)
     write_shop_items(rom, shop_item_file.start + 0x1DEC, shop_items)
+
+    permutation = None
 
     # text shuffle
     if world.text_shuffle == 'except_hints':
-        shuffle_messages(rom, except_hints=True)
+        permutation = shuffle_messages(messages, except_hints=True)
     elif world.text_shuffle == 'complete':
-        shuffle_messages(rom, except_hints=False)
+        permutation = shuffle_messages(messages, except_hints=False)
+        
+    repack_messages(rom, messages, permutation)
 
     # output a text dump, for testing...
     #with open('keysanity_' + str(world.seed) + '_dump.txt', 'w', encoding='utf-16') as f:

--- a/Rom.py
+++ b/Rom.py
@@ -233,7 +233,8 @@ class Rom(BigStream):
                 '\n-------------------------------------\n'.join(overlapping_records))
 
 
-    # if key is not found, then add an entry
+    # update dmadata record with start vrom address "key"
+    # if key is not found, then attempt to add a new dmadata entry
     def update_dmadata_record(self, key, start, end, from_file=None):
         cur, dma_data_end = self.get_dma_table_range()
         dma_index = 0


### PR DESCRIPTION
* Expand nes_message_data_static to it's maximum size before overwriting the staff messages and removed the broken spillover to jpn_message_data_static. If the extra space is still not enough, let me know.
* Greatly simplified Message.size() and Message.write() by implementing Message.transform(), which modifies the message's text_code list before writing back. 
* Text shuffle now accepts the message list, instead of waiting for all dialogs to be written back and then read from rom again