### PR TITLE
Add relevant fairy locations for growing a planted bean

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -504,6 +504,7 @@ droplocations = {
     'Free Fairies': 'Fairy',
     'Butterfly Fairy': 'Fairy',
     'Gossip Stone Fairy': 'Fairy',
+    'Bean Plant Fairy': 'Fairy',
     'Fairy Pond': 'Fairy',
     'Big Poe Kill': 'Big Poe',
 }

--- a/LocationList.py
+++ b/LocationList.py
@@ -141,6 +141,7 @@ location_table = {
     "Free Fairies":                                    ("Drop",        None,  None, None,                     None),
     "Butterfly Fairy":                                 ("Drop",        None,  None, None,                     None),
     "Gossip Stone Fairy":                              ("Drop",        None,  None, None,                     None),
+    "Bean Plant Fairy":                                ("Drop",        None,  None, None,                     None),
     "Fairy Pond":                                      ("Drop",        None,  None, None,                     None),
     "Big Poe Kill":                                    ("Drop",        None,  None, None,                     None),
 

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -38,7 +38,8 @@
                 is_adult and at_night and 
                 (can_use(Hookshot) or (logic_adult_kokiri_gs and can_use(Hover_Boots)))",
             "Kokiri Forest Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
         },
         "exits": {
             "Links House": "True",
@@ -148,6 +149,7 @@
             "GS Lost Woods Bean Patch Near Bridge": "can_plant_bugs and can_child_attack",
             "Lost Woods Gossip Stone": "True",
             "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Bug Shrub": "is_child and can_cut_shrubs and has_bottle"
         },
         "exits": {
@@ -294,6 +296,7 @@
             "Lake Hylia Gossip Stone (Southeast)": "True",
             "Lake Hylia Gossip Stone (Southwest)": "True",
             "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Butterfly Fairy": "can_use(Sticks) and has_bottle",
             "Bug Shrub": "is_child and can_cut_shrubs and has_bottle"
         },
@@ -369,7 +372,8 @@
             "GS Gerudo Valley Bean Patch": "can_plant_bugs and can_child_attack",
             "Gerudo Valley Cow": "is_child and can_play(Eponas_Song)",
             "Gerudo Valley Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
         },
         "exits": {
             "Lake Hylia": "True"
@@ -942,6 +946,7 @@
             "GS Graveyard Wall": "can_use(Boomerang) and at_night",
             "GS Graveyard Bean Patch": "can_plant_bugs and can_child_attack",
             "Butterfly Fairy": "can_use(Sticks) and at_day and has_bottle",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -1043,7 +1048,10 @@
                 can_plant_bugs and (has_explosives or Progressive_Strength_Upgrade)",
             "GS Mountain Trail Bomb Alcove": "can_blast_or_smash",
             "GS Mountain Trail Path to Crater": "can_use(Hammer) and at_night",
-            "GS Mountain Trail Above Dodongo's Cavern": "can_use(Hammer) and at_night"
+            "GS Mountain Trail Above Dodongo's Cavern": "can_use(Hammer) and at_night",
+            "Bean Plant Fairy": "
+                can_plant_bean and can_play(Song_of_Storms) and has_bottle and
+                (has_explosives or Progressive_Strength_Upgrade)"
         },
         "exits": {
             "Kakariko Village Behind Gate": "True",
@@ -1237,7 +1245,8 @@
                 (here(can_plant_bean) or 
                     (logic_crater_bean_poh_with_hovers and can_use(Hover_Boots)))",
             "Sheik in Crater": "is_adult",
-            "GS Mountain Crater Bean Patch": "can_plant_bugs and can_child_attack"
+            "GS Mountain Crater Bean Patch": "can_plant_bugs and can_child_attack",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
         },
         "exits": {
             "Death Mountain Crater Lower": "
@@ -1302,6 +1311,7 @@
             "Zoras River Plateau Gossip Stone": "True",
             "Zoras River Waterfall Gossip Stone": "True",
             "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Butterfly Fairy": "can_use(Sticks) and has_bottle",
             "Bug Shrub": "can_cut_shrubs and has_bottle"
         },


### PR DESCRIPTION
Playing the song of storms near a planted bean spawns 3 fairies that can be stored in a bottle, and this can be relevant in some ER scenarios.

Note: I plan on adding a part about the many ways to get fairies in the ER logic quirks on the wiki. This will be included as well since it's not necessarily common knowledge.