### PR TITLE
Fix Text Wrapping Issues

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -8,7 +8,7 @@ import random
 from HintList import getHint, getHintGroup, Hint, hintExclusions
 from Messages import update_message_by_id
 from Playthrough import Playthrough
-from TextBox import lineWrap
+from TextBox import line_wrap
 from Utils import random_choices
 
 
@@ -32,7 +32,7 @@ class GossipText():
 
 
     def __str__(self):
-        return get_raw_text(lineWrap(colorText(self)))
+        return get_raw_text(line_wrap(colorText(self)))
 
 
 gossipLocations = {

--- a/TextBox.py
+++ b/TextBox.py
@@ -30,10 +30,6 @@ def lineWrap(text):
         lines = [line.strip() for forcedLine in forcedLines for line in _wrapLines(forcedLine, line_width)]
 
         while lines:
-            if '\x10' in lines[0]:
-                boxesWithWrappedLines.append(lines.pop())
-                continue
-
             bow = LINE_BREAK[0].join(lines[:4])
             lines = lines[4:]
             boxesWithWrappedLines.append(bow)

--- a/TextBox.py
+++ b/TextBox.py
@@ -1,5 +1,4 @@
 import Messages
-import re
 
 # Least common multiple of all possible character widths. A line wrap must occur when the combined widths of all of the
 # characters on a line reach this value.
@@ -12,88 +11,155 @@ LINES_PER_BOX = 4
 # appear in lower areas of the text box. Eventually, the text box will become uncloseable.
 MAX_CHARACTERS_PER_BOX = 200
 
-LINE_BREAK = ['\x01', '&']
-BOX_BREAK  = ['\x04', '^']
+CONTROL_CHARS = {
+    'LINE_BREAK':   ['&', '\x01'],
+    'BOX_BREAK':    ['^', '\x04'],
+    'NAME':         ['@', '\x0F'],
+    'COLOR':        ['#', '\x05\x00'],
+}
 TEXT_END   = '\x02'
 
-def lineWrap(text):
-    boxes = text.split('|'.join(BOX_BREAK))
-    boxesWithWrappedLines = []
 
-    if '\x13' in text:
-        line_width = 1441440
-    else:
+def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, replace_control_chars=True):
+    # Replace stand-in characters with their actual control code.
+    if replace_control_chars:
+        for char in CONTROL_CHARS.values():
+            text = text.replace(char[0], char[1])
+
+    # Parse the text into a list of control codes.
+    text_codes = Messages.parse_control_codes(text)
+
+    # Existing line/box break codes to strip.
+    strip_codes = []
+    if strip_existing_boxes:
+        strip_codes.append(0x04)
+    if strip_existing_lines:
+        strip_codes.append(0x01)
+
+    # Replace stripped codes with a space.
+    if strip_codes:
+        index = 0
+        while index < len(text_codes):
+            text_code = text_codes[index]
+            if text_code.code in strip_codes:
+                # Check for existing whitespace near this control code.
+                # If one is found, simply remove this text code.
+                if index > 0 and text_codes[index-1].code == 0x20:
+                    text_codes.pop(index)
+                    continue
+                if index + 1 < len(text_codes) and text_codes[index+1].code == 0x20:
+                    text_codes.pop(index)
+                    continue
+                # Replace this text code with a space.
+                text_codes[index] = Messages.Text_Code(0x20, 0)
+            index += 1
+
+    # Split the text codes by current box breaks.
+    boxes = []
+    start_index = 0
+    end_index = 0
+    for text_code in text_codes:
+        end_index += 1
+        if text_code.code == 0x04:
+            boxes.append(text_codes[start_index:end_index])
+            start_index = end_index
+    boxes.append(text_codes[start_index:end_index])
+
+    # Split the boxes into lines and words.
+    processed_boxes = []
+    for box_codes in boxes:
         line_width = NORMAL_LINE_WIDTH
+        icon_code = None
+        words = []
 
-    for box in boxes:
-        forcedLines = re.split('|'.join(LINE_BREAK), box)
-        lines = [line.strip() for forcedLine in forcedLines for line in _wrapLines(forcedLine, line_width)]
+        # Group the text codes into words.
+        index = 0
+        while index < len(box_codes):
+            text_code = box_codes[index]
+            index += 1
 
-        while lines:
-            bow = LINE_BREAK[0].join(lines[:4])
-            lines = lines[4:]
-            boxesWithWrappedLines.append(bow)
+            # Check for an icon code and lower the width of this box if one is found.
+            if text_code.code == 0x13:
+                line_width = 1441440
+                icon_code = text_code
 
-    return BOX_BREAK[0].join(boxesWithWrappedLines)
+            # Find us a whole word.
+            if text_code.code in [0x01, 0x04, 0x20]:
+                if index > 1:
+                    words.append(box_codes[0:index-1])
+                if text_code.code in [0x01, 0x04]:
+                    # If we have ran into a line or box break, add it as a "word" as well.
+                    words.append([box_codes[index-1]])
+                box_codes = box_codes[index:]
+                index = 0
+            if index > 0 and index == len(box_codes):
+                words.append(box_codes)
+                box_codes = []
+
+        # Arrange our words into lines.
+        lines = []
+        start_index = 0
+        end_index = 0
+        box_count = 1
+        while end_index < len(words):
+            # Our current confirmed line.
+            end_index += 1
+            line = words[start_index:end_index]
+
+            # If this word is a line/box break, trim our line back a word and deal with it later.
+            break_char = False
+            if words[end_index-1][0].code in [0x01, 0x04]:
+                line = words[start_index:end_index-1]
+                break_char = True
+
+            # Check the width of the line after adding one more word.
+            if end_index == len(words) or break_char or calculate_width(words[start_index:end_index+1]) > line_width:
+                if line or lines:
+                    lines.append(line)
+                start_index = end_index
+
+            # If we've reached the end of the box, finalize it.
+            if end_index == len(words) or words[end_index-1][0].code == 0x04 or len(lines) == LINES_PER_BOX:
+                # Append the same icon to any wrapped boxes.
+                if icon_code and box_count > 1:
+                    lines[0][0] = [icon_code] + lines[0][0]
+                processed_boxes.append(lines)
+                lines = []
+                box_count += 1
+
+    # Construct our final string.
+    # This is a hideous level of list comprehension. Sorry.
+    return '\x04'.join(['\x01'.join([' '.join([''.join([code.get_string() for code in word]) for word in line]) for line in box]) for box in processed_boxes])
 
 
-def _wrapLines(text, line_width):
-    lines = []
-    currentLine = []
-    currentWidth = 0
-
-    for word in text.split(' '):
-        currentLinePlusWord = currentLine.copy()
-        currentLinePlusWord.append(word)
-        currentLinePlusWordWidth = _calculateWidth(currentLinePlusWord)
-
-        if (currentLinePlusWordWidth <= line_width):
-            currentLine = currentLinePlusWord
-            currentWidth = currentLinePlusWordWidth
-        else:
-            lines.append(' '.join(currentLine))
-            currentLine = [word]
-            currentWidth = _calculateWidth(currentLine)
-
-    lines.append(' '.join(currentLine))
-
-    return lines
-
-
-def _calculateWidth(words):
-    wordsWidth = 0
+def calculate_width(words):
+    words_width = 0
     for word in words:
         index = 0
         while index < len(word):
             character = word[index]
             index += 1
-            if ord(character) in Messages.CONTROL_CODES:
-                if character == '\x06':
-                    wordsWidth += ord(word[index])
-                index += Messages.CONTROL_CODES[ord(character)][1]
-            wordsWidth += _getCharacterWidth(character)
-    spacesWidth = _getCharacterWidth(' ') * (len(words) - 1)
+            if character.code in Messages.CONTROL_CODES:
+                if character.code == 0x06:
+                    words_width += character.data
+            words_width += get_character_width(chr(character.code))
+    spaces_width = get_character_width(' ') * (len(words) - 1)
 
-    return wordsWidth + spacesWidth
+    return words_width + spaces_width
 
 
-def _getCharacterWidth(character):
+def get_character_width(character):
     try:
-        return characterTable[character]
+        return character_table[character]
     except KeyError:
-        if character == '#':
-            character = '\x05'
-        if character == '@':
-            character = '\x0F'
-
         if ord(character) < 0x20:
             if character in control_code_width:
-                return sum([characterTable[c] for c in control_code_width[character]])
+                return sum([character_table[c] for c in control_code_width[character]])
             else:
                 return 0
-        else :
+        else:
             # A sane default with the most common character width
-            return characterTable[' ']
+            return character_table[' ']
 
 
 control_code_width = {
@@ -114,7 +180,7 @@ control_code_width = {
 # at worst. This ensures that we will never bleed text out of the text box while line wrapping.
 # Larger numbers in the denominator mean more of that character fits on a line; conversely, larger values in this table
 # mean the character is wider and can't fit as many on one line.
-characterTable = {
+character_table = {
     '\x0F': 655200,
     '\x16': 292215,
     '\x17': 292215,
@@ -201,23 +267,24 @@ characterTable = {
 }
 
 # To run tests, enter the following into a python3 REPL:
-# >>> from TextBox import test_lineWrapTests
-# >>> test_lineWrapTests()
-def test_lineWrapTests():
-    test_wrapSimpleLine()
-    test_honorForcedLineWraps()
-    test_honorBoxBreaks()
-    test_honorControlCharacters()
-    test_honorPlayerName()
-    test_maintainMultipleForcedBreaks()
-    test_trimWhitespace()
-    test_supportLongWords()
+# >>> import Messages
+# >>> from TextBox import line_wrap_tests
+# >>> line_wrap_tests()
+def line_wrap_tests():
+    test_wrap_simple_line()
+    test_honor_forced_line_wraps()
+    test_honor_box_breaks()
+    test_honor_control_characters()
+    test_honor_player_name()
+    test_maintain_multiple_forced_breaks()
+    test_trim_whitespace()
+    test_support_long_words()
 
 
-def test_wrapSimpleLine():
+def test_wrap_simple_line():
     words = 'Hello World! Hello World! Hello World!'
-    expected = 'Hello World! Hello World! Hello&World!'
-    result = lineWrap(words)
+    expected = 'Hello World! Hello World! Hello\x01World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Wrap Simple Line" test failed: Got ' + result + ', wanted ' + expected)
@@ -225,10 +292,10 @@ def test_wrapSimpleLine():
         print('"Wrap Simple Line" test passed!')
 
 
-def test_honorForcedLineWraps():
+def test_honor_forced_line_wraps():
     words = 'Hello World! Hello World!&Hello World! Hello World! Hello World!'
-    expected = 'Hello World! Hello World!&Hello World! Hello World! Hello&World!'
-    result = lineWrap(words)
+    expected = 'Hello World! Hello World!\x01Hello World! Hello World! Hello\x01World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Honor Forced Line Wraps" test failed: Got ' + result + ', wanted ' + expected)
@@ -236,10 +303,10 @@ def test_honorForcedLineWraps():
         print('"Honor Forced Line Wraps" test passed!')
 
 
-def test_honorBoxBreaks():
+def test_honor_box_breaks():
     words = 'Hello World! Hello World!^Hello World! Hello World! Hello World!'
-    expected = 'Hello World! Hello World!^Hello World! Hello World! Hello&World!'
-    result = lineWrap(words)
+    expected = 'Hello World! Hello World!\x04Hello World! Hello World! Hello\x01World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Honor Box Breaks" test failed: Got ' + result + ', wanted ' + expected)
@@ -247,10 +314,10 @@ def test_honorBoxBreaks():
         print('"Honor Box Breaks" test passed!')
 
 
-def test_honorControlCharacters():
+def test_honor_control_characters():
     words = 'Hello World! #Hello# World! Hello World!'
-    expected = 'Hello World! #Hello# World! Hello&World!'
-    result = lineWrap(words)
+    expected = 'Hello World! \x05\x00Hello\x05\x00 World! Hello\x01World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Honor Control Characters" test failed: Got ' + result + ', wanted ' + expected)
@@ -258,10 +325,10 @@ def test_honorControlCharacters():
         print('"Honor Control Characters" test passed!')
 
 
-def test_honorPlayerName():
+def test_honor_player_name():
     words = 'Hello @! Hello World! Hello World!'
-    expected = 'Hello @! Hello World!&Hello World!'
-    result = lineWrap(words)
+    expected = 'Hello \x0F! Hello World!\x01Hello World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Honor Player Name" test failed: Got ' + result + ', wanted ' + expected)
@@ -269,10 +336,10 @@ def test_honorPlayerName():
         print('"Honor Player Name" test passed!')
 
 
-def test_maintainMultipleForcedBreaks():
+def test_maintain_multiple_forced_breaks():
     words = 'Hello World!&&&Hello World!'
-    expected = 'Hello World!&&&Hello World!'
-    result = lineWrap(words)
+    expected = 'Hello World!\x01\x01\x01Hello World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Maintain Multiple Forced Breaks" test failed: Got ' + result + ', wanted ' + expected)
@@ -280,10 +347,10 @@ def test_maintainMultipleForcedBreaks():
         print('"Maintain Multiple Forced Breaks" test passed!')
 
 
-def test_trimWhitespace():
+def test_trim_whitespace():
     words = 'Hello World! & Hello World!'
-    expected = 'Hello World!&Hello World!'
-    result = lineWrap(words)
+    expected = 'Hello World!\x01Hello World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Trim Whitespace" test failed: Got ' + result + ', wanted ' + expected)
@@ -291,10 +358,10 @@ def test_trimWhitespace():
         print('"Trim Whitespace" test passed!')
 
 
-def test_supportLongWords():
+def test_support_long_words():
     words = 'Hello World! WWWWWWWWWWWWWWWWWWWW Hello World!'
-    expected = 'Hello World!&WWWWWWWWWWWWWWWWWWWW&Hello World!'
-    result = lineWrap(words)
+    expected = 'Hello World!\x01WWWWWWWWWWWWWWWWWWWW\x01Hello World!'
+    result = line_wrap(words)
 
     if result != expected:
         print('"Support Long Words" test failed: Got ' + result + ', wanted ' + expected)


### PR DESCRIPTION
Mostly fixes #749.

Splits out control code parsing into a static method so that it can be used to more intelligently replace line/box breaks with spaces when re-wrapping text for multiworld.

Removed a block of code from TextBox.py that seemed to serve no other purpose than to mangle the Magic Beans text.