### PR TITLE
Redo starting ToD stuff

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1049,14 +1049,14 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # Set starting time of day
     if world.starting_tod != 'default':
         tod = {
+            'sunrise':       0x4555,
+            'morning':       0x6000,
+            'noon':          0x8001,
+            'afternoon':     0xA000,
+            'sunset':        0xC001,
+            'evening':       0xE000,
             'midnight':      0x0000,
             'witching-hour': 0x2000,
-            'early-morning': 0x4000,
-            'morning':       0x6000,
-            'noon':          0x8000,
-            'afternoon':     0xA000,
-            'evening':       0xC000,
-            'dusk':          0xE000,
         }
         save_context.addresses['time_of_day'].value = tod[world.starting_tod]
 

--- a/Patches.py
+++ b/Patches.py
@@ -1049,14 +1049,15 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # Set starting time of day
     if world.starting_tod != 'default':
         tod = {
-            'sunrise':       0x4555,
-            'morning':       0x6000,
-            'noon':          0x8001,
-            'afternoon':     0xA000,
-            'sunset':        0xC001,
-            'evening':       0xE000,
-            'midnight':      0x0000,
-            'witching-hour': 0x2000,
+             'sunrise':       0x4555,
+-            'morning':       0x6000,
+-            'noon':          0x8001,
+-            'afternoon':     0xA000,
+-            'sunset':        0xC001,
+-            'evening':       0xE000,
+             'midnight':      0x0000,
+             'witching-hour': 0x2000,
+
         }
         save_context.addresses['time_of_day'].value = tod[world.starting_tod]
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1822,12 +1822,12 @@ setting_infos = [
         choices        = {
             'default':       'Default',
             'random':        'Random Choice',
-            'early-morning': 'Early Morning',
+            'sunrise':       'Sunrise',
             'morning':       'Morning',
             'noon':          'Noon',
             'afternoon':     'Afternoon',
+            'sunset':        'Sunset',
             'evening':       'Evening',
-            'dusk':          'Dusk',
             'midnight':      'Midnight',
             'witching-hour': 'Witching Hour',
         },
@@ -1840,7 +1840,6 @@ setting_infos = [
             nighttime at 18:00 (6:00 PM).
 
             Default is 10:00 in the morning.
-            The alternatives are multiples of 3 hours.
         ''',
         shared         = True,
     ),

--- a/State.py
+++ b/State.py
@@ -578,9 +578,9 @@ class State(object):
 
     def had_night_start(self):
         stod = self.world.starting_tod
-        # These are all between 6:30 and 18:00
+        # These are all not between 6:30 and 18:00
         if (stod == 'sunset' or         # 18
-            stod == 'eevning' or        # 21
+            stod == 'evening' or        # 21
             stod == 'midnight' or       # 00
             stod == 'witching-hour'):   # 03
             return True

--- a/State.py
+++ b/State.py
@@ -579,11 +579,10 @@ class State(object):
     def had_night_start(self):
         stod = self.world.starting_tod
         # These are all between 6:30 and 18:00
-        if (stod == 'evening' or        # 18
-            stod == 'dusk' or           # 21
+        if (stod == 'sunset' or         # 18
+            stod == 'eevning' or        # 21
             stod == 'midnight' or       # 00
-            stod == 'witching-hour' or  # 03
-            stod == 'early-morning'):   # 06
+            stod == 'witching-hour'):   # 03
             return True
         else:
             return False


### PR DESCRIPTION
Renamed the starting times of day to be more universal and updated the times they set based on in-game times and intention of the times of day, i.e. sunrise is the frame after skulltulas despawn and sunset is the frame skulltulas spawn.