### PR TITLE
Another Batch of Tricks

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -154,6 +154,14 @@ logic_tricks = {
                     Silver Rupee Chest. May need to make multiple
                     trips.
                     '''},
+    'Pass Through Visible One-Way Collisions': {
+        'name'    : 'logic_visible_collisions',
+        'tooltip' : '''\
+                    Allows climbing through the platform to reach 
+                    Impa's House Back as adult with no items and 
+                    going through the Kakariko Village Gate as child
+                    when coming from the Mountain Trail side.
+                    '''},
     'Child Deadhand without Kokiri Sword': {
         'name'    : 'logic_child_deadhand',
         'tooltip' : '''\
@@ -555,16 +563,152 @@ logic_tricks = {
         'tooltip' : '''\
                     A precise jump can be used to reach this alcove.
                     '''},
-    'Pass Through Visible One-Way Collisions': {
-        'name'    : 'logic_visible_collisions',
+    'Zora\'s River Upper Freestanding PoH as Adult with Nothing': {
+        'name'    : 'logic_zora_river_upper',
         'tooltip' : '''\
-                    Allows climbing through the platform to reach 
-                    Impa's House Back as adult with no items and 
-                    going through the Kakariko Village Gate as child
-                    when coming from the Mountain Trail side.
+                    Adult can reach this PoH with a precise jump,
+                    no Hover Boots required.
                     '''},
-
-
+    'Shadow Temple MQ Truth Spinner Gap with Longshot': {
+        'name'    : 'logic_shadow_mq_gap',
+        'tooltip' : '''\
+                    You can Longshot a torch and jumpslash-recoil onto
+                    the tongue. It works best if you Longshot the right
+                    torch from the left side of the room.
+                    '''},
+    'Lost Woods Adult GS without Bean': {
+        'name'    : 'logic_lost_woods_gs_bean',
+        'tooltip' : '''\
+                    You can collect the token with a precise
+                    Hookshot use, as long as you can kill the
+                    Skulltula somehow first. It can be killed
+                    using Longshot, Bow, Bombchus or Din's Fire.
+                    '''},
+    'Graveyard Freestanding PoH with Boomerang': {
+        'name'    : 'logic_graveyard_poh',
+        'tooltip' : '''\
+                    Using a precise moving setup you can obtain
+                    the Piece of Heart by having the Boomerang
+                    interact with it along the return path.
+                    '''},
+    'Death Mountain Trail Soil GS without Destroying Boulder': {
+        'name'    : 'logic_dmt_soil_gs',
+        'tooltip' : '''\
+                    Bugs will go into the soft soil even while the boulder is
+                    still blocking the entrance.
+                    Then, using a precise moving setup you can kill the Gold
+                    Skulltula and obtain the token by having the Boomerang
+                    interact with it along the return path.
+                    '''},
+    'Gerudo Training Grounds Left Side Silver Rupees without Hookshot': {
+        'name'    : 'logic_gtg_without_hookshot',
+        'tooltip' : '''\
+                    After collecting the rest of the silver rupees in the room,
+                    you can reach the final silver rupee on the ceiling by being
+                    pulled up into it after getting grabbed by the Wallmaster.
+                    Then, you must also reach the exit of the room without the
+                    use of the Hookshot. If you move quickly you can sneak past
+                    the edge of a flame wall before it can rise up to block you.
+                    To do so without taking damage is more precise.
+                    '''},
+    'Gerudo Training Grounds MQ Left Side Silver Rupees without Hookshot': {
+        'name'    : 'logic_gtg_mq_without_hookshot',
+        'tooltip' : '''\
+                    After collecting the rest of the silver rupees in the room,
+                    you can reach the final silver rupee on the ceiling by being
+                    pulled up into it after getting grabbed by the Wallmaster.
+                    The Wallmaster will not track you to directly underneath the
+                    rupee. You should take the last step to be under the rupee
+                    after the Wallmaster has begun its attempt to grab you.
+                    Also included with this trick is that fact that the switch
+                    that unbars the door to the final chest of GTG can be hit
+                    without a projectile, using a precise jumpslash.
+                    This trick supersedes "Gerudo Training Grounds MQ Left Side
+                    Silver Rupees with Hookshot".
+                    '''},
+    'Reach Gerudo Training Grounds Fake Wall Ledge with Hover Boots': {
+        'name'    : 'logic_gtg_fake_wall',
+        'tooltip' : '''\
+                    A precise Hover Boots use from the top of the chest can allow
+                    you to grab the ledge without needing the usual requirements.
+                    In Master Quest, this always skips a Song of Time requirement.
+                    In Vanilla, this skips a Hookshot requirement, but is only
+                    relevant if "Gerudo Training Grounds Left Side Silver Rupees
+                    without Hookshot" is enabled.
+                    '''},
+    'Water Temple Cracked Wall with No Additional Items': {
+        'name'    : 'logic_water_cracked_wall_nothing',
+        'tooltip' : '''\
+                    A precise jumpslash (among other methods) will
+                    get you to the cracked wall without needing the
+                    Hover Boots or to raise the water to the middle
+                    level. This trick supersedes "Water Temple
+                    Cracked Wall with Hover Boots".
+                    '''},
+    'Water Temple North Basement Ledge with Precise Jump': {
+        'name'    : 'logic_water_north_basement',
+        'tooltip' : '''\
+                    In the northern basement there's a ledge from where, in
+                    vanilla Water Temple, boulders roll out into the room.
+                    Normally to jump directly to this ledge logically
+                    requires the Hover Boots, but with precise jump, it can
+                    be done without them. This trick supersedes "Water Temple
+                    Boss Key Chest with Iron Boots" and applies to both
+                    Vanilla and Master Quest.
+                    '''},
+    'Goron City Leftmost Maze Chest with Hover Boots': {
+        'name'    : 'logic_goron_city_leftmost',
+        'tooltip' : '''\
+                    A precise backwalk starting from on top of the
+                    crate and ending with a precisely-timed backflip
+                    can reach this chest without needing either
+                    the Hammer or Silver Gauntlets.
+                    '''},
+    'Deku Tree Basement without Slingshot': {
+        'name'    : 'logic_deku_b1_skip',
+        'tooltip' : '''\
+                    A precise jump can be used to skip
+                    needing to use the Slingshot to go
+                    around B1 of the Deku Tree. If used
+                    with the "Closed Forest" setting, a
+                    Slingshot will not be guaranteed to
+                    exist somewhere inside the Forest.
+                    This trick applies to both Vanilla
+                    and Master Quest.
+                    '''},
+    'Forest Temple Scarecrow Route': {
+        'name'    : 'logic_forest_scarecrow',
+        'tooltip' : '''\
+                    From on top of the door frame in the NE
+                    courtyard, you can summon Pierre. You
+                    can get there with a precise Hover Boots
+                    movement. You will take fall damage.
+                    This allows you to reach the falling
+                    ceiling room early.
+                    '''},
+    'Spirit Trial without Hookshot': {
+        'name'    : 'logic_spirit_trial_hookshot',
+        'tooltip' : '''\
+                    A precise jump off of an Armos can
+                    collect the highest rupee.
+                    '''},
+    'Shadow Temple Stone Umbrella Skip': {
+        'name'    : 'logic_shadow_umbrella',
+        'tooltip' : '''\
+                    A very precise Hover Boots movement
+                    from off of the lower chest can get you
+                    on top of the crushing spikes without
+                    needing to pull the block. Applies to
+                    both Vanilla and Master Quest.
+                    '''},
+    'Shadow Temple Entry with Fire Arrows': {
+        'name'    : 'logic_shadow_fire_arrow_entry',
+        'tooltip' : '''\
+                    It is possible to light all of the torches to
+                    open the Shadow Temple entrance with just Fire
+                    Arrows, but you must be very quick, precise,
+                    and strategic with how you take your shots.
+                    '''},
 }
 
 

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -20,7 +20,7 @@
                 here(has_fire_source_with_torch or can_use(Bow))",
             "Deku Tree Basement Water Room": "
                 here(can_use(Slingshot) or can_use(Bow)) and has_fire_source_with_torch",
-            "Deku Tree Basement Ledge": "here(is_adult)"
+            "Deku Tree Basement Ledge": "logic_deku_b1_skip or here(is_adult)"
         }
     },
     {

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -14,11 +14,12 @@
             "GS Deku Tree Basement Gate": "is_adult or can_child_attack",
             "GS Deku Tree Basement Back Room": "
                 (here(has_fire_source_with_torch) and
-                 here(can_use(Slingshot) or can_use(Bow)) and
-                 here(can_blast_or_smash) and
-                 here(can_use(Hookshot) or can_use(Boomerang))) or
-                (as_adult_here and is_child and has_explosives and
-                 can_use(Boomerang) and (has_sticks or can_use(Dins_Fire)))",
+                    here(can_use(Slingshot) or can_use(Bow)) and
+                    here(can_blast_or_smash) and
+                    here(can_use(Hookshot) or can_use(Boomerang))) or
+                ((logic_deku_b1_skip or as_adult_here) and is_child and
+                    has_explosives and can_use(Boomerang) and
+                    (has_sticks or can_use(Dins_Fire)))",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
             "Deku Baba Nuts": "
                 is_adult or has_slingshot or has_sticks or 
@@ -29,7 +30,7 @@
             "Deku Tree Slingshot Room": "here(has_shield)",
             "Deku Tree Boss Room": "
                 here(has_fire_source_with_torch) and
-                here(is_adult or can_use(Slingshot))"
+                (logic_deku_b1_skip or here(is_adult or can_use(Slingshot)))"
         }
     },
     {

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -58,8 +58,7 @@
                 can_use(Longshot) or (logic_forest_vines and can_use(Hookshot))",
                 #Longshot can grab some very high up vines to drain the well.
             "Forest Temple NW Outdoors": "can_use(Iron_Boots) or (Progressive_Scale, 2)",
-            "Forest Temple Lobby": "True",
-            "Forest Temple Falling Room": "False" #For some reason you can't actually activate this from below. Cool game.
+            "Forest Temple Lobby": "True"
         }
     },
     {
@@ -71,7 +70,9 @@
         },
         "exits": {
             "Forest Temple NW Outdoors": "True",
-            "Forest Temple NE Outdoors": "True"
+            "Forest Temple NE Outdoors": "True",
+            "Forest Temple Falling Room": "
+                logic_forest_scarecrow and can_use(Hover_Boots) and can_use(Scarecrow)"
         }
     },
     {

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -86,14 +86,18 @@
         "dungeon": "Ganons Castle",
         "events": {
             "Spirit Trial Clear": "
-                can_use(Light_Arrows) and Mirror_Shield and 
-                has_bombchus and Progressive_Hookshot"
+                can_use(Light_Arrows) and Mirror_Shield and has_bombchus and
+                (logic_spirit_trial_hookshot or Progressive_Hookshot)"
         },
         "locations": {
-            "Ganons Castle Spirit Trial First Chest": "Progressive_Hookshot",
+            "Ganons Castle Spirit Trial First Chest": "
+                (logic_spirit_trial_hookshot or Progressive_Hookshot)",
             "Ganons Castle Spirit Trial Second Chest": "
-                Progressive_Hookshot and has_bombchus and can_see_with_lens",
-            "Nut Pot": "Progressive_Hookshot and has_bombchus and Bow and Mirror_Shield"
+                (logic_spirit_trial_hookshot or Progressive_Hookshot) and
+                has_bombchus and can_see_with_lens",
+            "Nut Pot": "
+                (logic_spirit_trial_hookshot or Progressive_Hookshot) and
+                has_bombchus and Bow and Mirror_Shield"
         }
     },
     {

--- a/data/World/Gerudo Training Grounds MQ.json
+++ b/data/World/Gerudo Training Grounds MQ.json
@@ -13,8 +13,7 @@
         "exits": {
             "Gerudo Fortress": "True",
             "Gerudo Training Grounds Left Side": "here(has_fire_source)",
-            "Gerudo Training Grounds Right Side": "
-                here(can_use(Bow) or can_use(Slingshot))"
+            "Gerudo Training Grounds Right Side": "here(can_use(Bow) or can_use(Slingshot))"
         }
     },
     {
@@ -25,7 +24,8 @@
         },
         "exits": {
             # Still requires has_fire_source in the room
-            "Gerudo Training Grounds Underwater": "can_use(Hover_Boots)"
+            "Gerudo Training Grounds Underwater": "
+                (has_bow or can_use(Longshot)) and can_use(Hover_Boots)"
         }
     },
     {
@@ -33,7 +33,8 @@
         "dungeon": "Gerudo Training Grounds",
         "locations": {
             "Gerudo Training Grounds MQ Underwater Silver Rupee Chest": "
-                has_fire_source and can_use(Iron_Boots) and (logic_fewer_tunic_requirements or can_use(Zora_Tunic)) and 
+                has_fire_source and can_use(Iron_Boots) and
+                (logic_fewer_tunic_requirements or can_use(Zora_Tunic)) and 
                 (damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love))"
         }
     },
@@ -44,21 +45,24 @@
             "Gerudo Training Grounds MQ First Iron Knuckle Chest": "is_adult or Kokiri_Sword or has_explosives"
         },
         "exits": {
-            #Child cloud progress here after adult opens the door, but child logically
-            #inferior to adult so just keep child out for simplicity
-            "Gerudo Training Grounds Stalfos Room": "can_use(Longshot) or (logic_gtg_mq_with_hookshot and can_use(Hookshot))"
+            "Gerudo Training Grounds Stalfos Room": "
+                can_use(Longshot) or logic_gtg_mq_without_hookshot or
+                (logic_gtg_mq_with_hookshot and can_use(Hookshot))"
         }
     },
     {
         "region_name": "Gerudo Training Grounds Stalfos Room",
         "dungeon": "Gerudo Training Grounds",
         "locations": {
-            "Gerudo Training Grounds MQ Before Heavy Block Chest": "True",
+            # Very difficult to fight the Stalfos and Stulltulas under the time limit as child.
+            "Gerudo Training Grounds MQ Before Heavy Block Chest": "is_adult",
             "Gerudo Training Grounds MQ Heavy Block Chest": "can_use(Silver_Gauntlets)",
             "Blue Fire": "has_bottle"
         },
         "exits": {
-            "Gerudo Training Grounds Back Areas": "can_play(Song_of_Time) and can_see_with_lens and has_blue_fire"
+            "Gerudo Training Grounds Back Areas": "
+                is_adult and can_see_with_lens and has_blue_fire and
+                (can_play(Song_of_Time) or (logic_gtg_fake_wall and can_use(Hover_Boots)))"
         }
     },
     {
@@ -67,10 +71,9 @@
         "locations": {
             "Gerudo Training Grounds MQ Eye Statue Chest": "has_bow",
             "Gerudo Training Grounds MQ Second Iron Knuckle Chest": "True",
-            "Gerudo Training Grounds MQ Flame Circle Chest": "True"
+            "Gerudo Training Grounds MQ Flame Circle Chest": "can_use(Hookshot) or has_bow or has_explosives"
         },
         "exits": {
-            # Hookshot implicitly required to get here
             "Gerudo Training Grounds Central Maze Right": "Hammer",
             "Gerudo Training Grounds Right Side": "can_use(Longshot)"
         }
@@ -81,13 +84,15 @@
         "locations": {
             "Gerudo Training Grounds MQ Maze Right Central Chest": "True",
             "Gerudo Training Grounds MQ Maze Right Side Chest": "True",
+            # The switch that opens the door to the Ice Arrows chest can be hit with a precise jumpslash.
             "Gerudo Training Grounds MQ Ice Arrows Chest": "
                 (Small_Key_Gerudo_Training_Grounds, 3)"
         },
         "exits": {
             # guarantees fire with torch
-            "Gerudo Training Grounds Underwater": "can_use(Longshot) or has_bow",
-            "Gerudo Training Grounds Right Side": "True"
+            "Gerudo Training Grounds Underwater": "
+                can_use(Longshot) or (can_use(Hookshot) and has_bow)",
+            "Gerudo Training Grounds Right Side": "can_use(Hookshot)"
         }
     }
 ]

--- a/data/World/Gerudo Training Grounds.json
+++ b/data/World/Gerudo Training Grounds.json
@@ -10,7 +10,9 @@
         },
         "exits": {
             "Gerudo Fortress": "True",
-            "Gerudo Training Grounds Heavy Block Room": "can_use(Hookshot)",
+            "Gerudo Training Grounds Heavy Block Room": "
+                (is_adult or Kokiri_Sword) and
+                (can_use(Hookshot) or logic_gtg_without_hookshot)",
             "Gerudo Training Grounds Lava Room": "
                 here(has_explosives and (is_adult or Kokiri_Sword))",
             "Gerudo Training Grounds Central Maze": "True"
@@ -93,14 +95,26 @@
         "region_name": "Gerudo Training Grounds Heavy Block Room",
         "dungeon": "Gerudo Training Grounds",
         "locations": {
-            "Gerudo Training Grounds Before Heavy Block Chest": "True",
-            "Gerudo Training Grounds Heavy Block First Chest": "can_use(Silver_Gauntlets) and can_see_with_lens",
-            "Gerudo Training Grounds Heavy Block Second Chest": "can_use(Silver_Gauntlets) and can_see_with_lens",
-            "Gerudo Training Grounds Heavy Block Third Chest": "can_use(Silver_Gauntlets) and can_see_with_lens",
-            "Gerudo Training Grounds Heavy Block Fourth Chest": "can_use(Silver_Gauntlets) and can_see_with_lens"
+            "Gerudo Training Grounds Before Heavy Block Chest": "True"
         },
         "exits": {
-            "Gerudo Training Grounds Eye Statue Upper": "can_use(Hookshot) and can_see_with_lens"
+            "Gerudo Training Grounds Eye Statue Upper": "
+                can_see_with_lens and
+                (can_use(Hookshot) or (logic_gtg_fake_wall and can_use(Hover_Boots)))",
+            "Gerudo Training Grounds Like Like Room": "
+                can_use(Silver_Gauntlets) and can_see_with_lens and
+                (can_use(Hookshot) or (logic_gtg_fake_wall and can_use(Hover_Boots)))"
+        }
+    },
+    {
+        "region_name": "Gerudo Training Grounds Like Like Room",
+        "dungeon": "Gerudo Training Grounds",
+        "locations": {
+            "Gerudo Training Grounds Heavy Block First Chest": "True",
+            "Gerudo Training Grounds Heavy Block Second Chest": "True",
+            "Gerudo Training Grounds Heavy Block Third Chest": "True",
+            "Gerudo Training Grounds Heavy Block Fourth Chest": "True"
         }
     }
+
 ]

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -172,7 +172,10 @@
             "LW Deku Scrub Deku Nuts": "is_child and can_stun_deku",
             "LW Deku Scrub Deku Sticks": "is_child and can_stun_deku",
             "GS Lost Woods Above Stage": "
-                is_adult and here(can_plant_bean) and at_night",
+                is_adult and at_night and
+                (here(can_plant_bean) or
+                     (logic_lost_woods_gs_bean and can_use(Hookshot) and
+                     (can_use(Longshot) or can_use(Bow) or has_bombchus or can_use(Dins_Fire))))",
             "GS Lost Woods Bean Patch Near Stage": "
                 can_plant_bugs and 
                 (can_child_attack or (shuffle_scrubs == 'off' and Buy_Deku_Shield))",
@@ -944,7 +947,8 @@
         "hint": "the Graveyard",
         "locations": {
             "Graveyard Freestanding PoH": "
-                is_adult and (here(can_plant_bean) or can_use(Longshot))",
+                (is_adult and (here(can_plant_bean) or can_use(Longshot))) or
+                (logic_graveyard_poh and can_use(Boomerang))",
             "Gravedigging Tour": "is_child and at_dampe_time",
             "GS Graveyard Wall": "can_use(Boomerang) and at_night",
             "GS Graveyard Bean Patch": "can_plant_bugs and can_child_attack",
@@ -1024,7 +1028,9 @@
         },
         "exits": {
             "Graveyard": "True",
-            "Shadow Temple Entryway": "can_use(Dins_Fire)"
+            "Shadow Temple Entryway": "
+                can_use(Dins_Fire) or
+                (logic_shadow_fire_arrow_entry and can_use(Fire_Arrows))"
         }
     },
     {
@@ -1049,7 +1055,9 @@
                 is_child or (damage_multiplier != 'ohko') or 
                 can_use(Nayrus_Love) or has_fairy or Hover_Boots",
             "GS Mountain Trail Bean Patch": "
-                can_plant_bugs and (has_explosives or Progressive_Strength_Upgrade)",
+                can_plant_bugs and
+                    (has_explosives or Progressive_Strength_Upgrade or
+                    (logic_dmt_soil_gs and can_use(Boomerang)))",
             "GS Mountain Trail Bomb Alcove": "can_blast_or_smash",
             "GS Mountain Trail Path to Crater": "can_use(Hammer) and at_night",
             "GS Mountain Trail Above Dodongo's Cavern": "can_use(Hammer) and at_night",
@@ -1117,7 +1125,8 @@
         },
         "locations": {
             "Goron City Leftmost Maze Chest": "
-                can_use(Hammer) or can_use(Silver_Gauntlets)",
+                can_use(Hammer) or can_use(Silver_Gauntlets) or
+                (logic_goron_city_leftmost and has_explosives and can_use(Hover_Boots))",
             "Goron City Left Maze Chest": "
                 can_blast_or_smash or can_use(Silver_Gauntlets)",
             "Goron City Right Maze Chest": "
@@ -1306,7 +1315,7 @@
             "Zora River Lower Freestanding PoH": "
                 is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_lower)",
             "Zora River Upper Freestanding PoH": "
-                is_child or can_use(Hover_Boots)",
+                is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_upper)",
             "GS Zora River Ladder": "is_child and at_night and can_child_attack",
             "GS Zora River Near Raised Grottos": "can_use(Hookshot) and at_night",
             "GS Zora River Above Bridge": "can_use(Hookshot) and at_night",

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -14,7 +14,9 @@
         "dungeon": "Shadow Temple",
         "exits": {
             "Shadow Temple Entryway": "True",
-            "Shadow Temple First Beamos": "can_use(Fire_Arrows) or Hover_Boots",
+            "Shadow Temple First Beamos": "
+                can_use(Fire_Arrows) or Hover_Boots or
+                (logic_shadow_mq_gap and can_use(Longshot))",
             "Shadow Temple Dead Hand Area": "has_explosives and (Small_Key_Shadow_Temple, 6)"
         }
     },
@@ -55,8 +57,10 @@
         "locations": {
             "Shadow Temple MQ Beamos Silver Rupees Chest": "can_use(Longshot)",
             "Shadow Temple MQ Falling Spikes Lower Chest": "True",
-            "Shadow Temple MQ Falling Spikes Upper Chest": "Progressive_Strength_Upgrade",
-            "Shadow Temple MQ Falling Spikes Switch Chest": "Progressive_Strength_Upgrade",
+            "Shadow Temple MQ Falling Spikes Upper Chest": "
+                (logic_shadow_umbrella and Hover_Boots) or Progressive_Strength_Upgrade",
+            "Shadow Temple MQ Falling Spikes Switch Chest": "
+                (logic_shadow_umbrella and Hover_Boots) or Progressive_Strength_Upgrade",
             "Shadow Temple MQ Invisible Spikes Chest": "Hover_Boots and (Small_Key_Shadow_Temple, 3)",
             "Shadow Temple MQ Stalfos Room Chest": "
                 Hover_Boots and (Small_Key_Shadow_Temple, 3) and Progressive_Hookshot",

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -40,8 +40,8 @@
             "Shadow Temple Invisible Blades Visible Chest": "True",
             "Shadow Temple Invisible Blades Invisible Chest": "True",
             "Shadow Temple Falling Spikes Lower Chest": "True",
-            "Shadow Temple Falling Spikes Upper Chest": "Progressive_Strength_Upgrade",
-            "Shadow Temple Falling Spikes Switch Chest": "Progressive_Strength_Upgrade",
+            "Shadow Temple Falling Spikes Upper Chest": "logic_shadow_umbrella or Progressive_Strength_Upgrade",
+            "Shadow Temple Falling Spikes Switch Chest": "logic_shadow_umbrella or Progressive_Strength_Upgrade",
             "Shadow Temple Invisible Spikes Chest": "(Small_Key_Shadow_Temple, 2)",
             "Shadow Temple Freestanding Key": "
                 (Small_Key_Shadow_Temple, 2) and Progressive_Hookshot and 

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -51,16 +51,20 @@
         },
         "exits": {
             "Water Temple Basement Gated Areas": "
-                can_use(Dins_Fire) and (Hover_Boots or can_use(Scarecrow)) and can_use(Iron_Boots)"
+                can_use(Dins_Fire) and can_use(Iron_Boots)"
         }
     },
     {
         "region_name": "Water Temple Basement Gated Areas",
         "dungeon": "Water Temple",
         "locations": {
-            "Water Temple MQ Freestanding Key": "True",
-            "GS Water Temple MQ South Basement": "can_use(Fire_Arrows)",
-            "GS Water Temple MQ North Basement": "(Small_Key_Water_Temple, 2)"
+            "Water Temple MQ Freestanding Key": "
+                Hover_Boots or can_use(Scarecrow) or logic_water_north_basement",
+            "GS Water Temple MQ South Basement": "
+                can_use(Fire_Arrows) and (Hover_Boots or can_use(Scarecrow))",
+            "GS Water Temple MQ North Basement": "
+                (Small_Key_Water_Temple, 2) and
+                (Hover_Boots or can_use(Scarecrow) or logic_water_north_basement)"
         }
     }
 ]

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -57,7 +57,8 @@
                 (Small_Key_Water_Temple, 6) and 
                 (can_play(Zeldas_Lullaby) or keysanity) and 
                 (can_use(Longshot) or (logic_water_boss_key_region and can_use(Hover_Boots))) and
-                ((logic_water_bk_chest and Iron_Boots) or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
+                ((logic_water_bk_chest and Iron_Boots) or logic_water_north_basement or
+                    (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
             "GS Water Temple South Basement": "
                 (can_use(Hookshot) or can_use(Hover_Boots)) and 
                 has_explosives and can_play(Zeldas_Lullaby)",
@@ -69,8 +70,8 @@
         },
         "exits": {
             "Water Temple Cracked Wall": "
-                can_play(Zeldas_Lullaby) and logic_water_cracked_wall_hovers and
-                can_use(Hover_Boots)",
+                can_play(Zeldas_Lullaby) and
+                (logic_water_cracked_wall_nothing or (logic_water_cracked_wall_hovers and can_use(Hover_Boots)))",
             "Water Temple Middle Water Level": "
                 (has_bow or can_use(Dins_Fire) or
                  ((Small_Key_Water_Temple, 6) and can_use(Hookshot)) or


### PR DESCRIPTION
Changes:
- Moved Invisible Walls trick toward the top of the list, as that's a pretty basic trick.
- Fixed some bugs involving an assumed Bow when going from GTG MQ Right Side to the Underwater Rupee Room.

Added Tricks:
- Zora's River Upper Freestanding PoH as Adult with Nothing
- Shadow Temple MQ Truth Spinner Gap with Longshot
- Lost Woods Adult GS without Bean
- Graveyard Freestanding PoH with Boomerang
- Death Mountain Trail Soil GS without Destroying Boulder
- Gerudo Training Grounds Left Side Silver Rupees without Hookshot
- Gerudo Training Grounds MQ Left Side Silver Rupees without Hookshot
- Reach Gerudo Training Grounds Fake Wall Ledge with Hover Boots
- Water Temple Cracked Wall Chest with No Additional Items
- Water Temple North Basement with Precise Jump
- Goron City Leftmost Maze Chest with Hover Boots
- Deku Tree Basement without Slingshot
- Forest Temple Scarecrow Route
- Spirit Trial without Hookshot
- Shadow Temple Stone Umbrella Skip
- Shadow Temple Entry with Fire Arrows
