### PR TITLE
Upgraded fast chickens option

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -942,13 +942,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.chicken_count_random:
         world.chicken_count = random.randint(0, 7)
     rom.write_byte(0x00E1E523, world.chicken_count)
-        # save_context.write_bits(0x0F2A, 0x08) # "Caught Cucco Near Cucco Pen"
-        # save_context.write_bits(0x0F2A, 0x02) # "Caught Cucco Near Hyrule Field Entrance"
-        # save_context.write_bits(0x0F2A, 0x04) # "Caught Cucco Near Bazaar"
-        # save_context.write_bits(0x0F2A, 0x10) # "Caught Cucco Behind Windmill"
-        # save_context.write_bits(0x0F2A, 0x20) # "Caught Cucco In Crate"
-        # save_context.write_bits(0x0F2A, 0x40) # "Caught Cucco Near Skulltula House"
-        # save_context.write_bits(0x0F2A, 0x80) # "Caught Cucco Behind Potion Shop"
 
     # Make the Kakariko Gate not open with the MS
     rom.write_int32(0xDD3538, 0x34190000) # li t9, 0
@@ -1176,7 +1169,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         update_message_by_id(messages, 0x70f7, new_message)
         new_message = "\x1AWait a minute! WOW!\x04\x1AYou have earned \x05\x41%d points\x05\x40!\x04\x1AYoung man, you are a genuine\x01\x05\x41Ghost Hunter\x05\x40!\x04\x1AIs that what you expected me to\x01say? Heh heh heh!\x04\x1ABecause of you, I have extra\x01inventory of \x05\x41Big Poes\x05\x40, so this will\x01be the last time I can buy a \x01ghost.\x04\x1AYou're thinking about what I \x01promised would happen when you\x01earned %d points. Heh heh.\x04\x1ADon't worry, I didn't forget.\x01Just take this." % (poe_points, poe_points)
         update_message_by_id(messages, 0x70f8, new_message)
-
+    new_message = "\x08What should I do!?\x01My \x05\x41Cuccos\x05\x40 have all flown away!\x04You, little boy, please!\x01Please gather at least \x05\x41%d Cuccos\x05\x40\x01for me.\x02" % world.chicken_count
+    update_message_by_id(messages, 0x5036, new_message)
 
     # use faster jabu elevator
     if not world.dungeon_mq['Jabu Jabus Belly'] and world.shuffle_scrubs == 'off':

--- a/Patches.py
+++ b/Patches.py
@@ -1180,6 +1180,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         update_message_by_id(messages, 0x70f7, new_message)
         new_message = "\x1AWait a minute! WOW!\x04\x1AYou have earned \x05\x41%d points\x05\x40!\x04\x1AYoung man, you are a genuine\x01\x05\x41Ghost Hunter\x05\x40!\x04\x1AIs that what you expected me to\x01say? Heh heh heh!\x04\x1ABecause of you, I have extra\x01inventory of \x05\x41Big Poes\x05\x40, so this will\x01be the last time I can buy a \x01ghost.\x04\x1AYou're thinking about what I \x01promised would happen when you\x01earned %d points. Heh heh.\x04\x1ADon't worry, I didn't forget.\x01Just take this." % (poe_points, poe_points)
         update_message_by_id(messages, 0x70f8, new_message)
+
+    # Update Child Anju's dialogue
     new_message = "\x08What should I do!?\x01My \x05\x41Cuccos\x05\x40 have all flown away!\x04You, little boy, please!\x01Please gather at least \x05\x41%d Cuccos\x05\x40\x01for me.\x02" % world.chicken_count
     update_message_by_id(messages, 0x5036, new_message)
 

--- a/Patches.py
+++ b/Patches.py
@@ -939,9 +939,20 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     save_context.write_bits(0x0EEB, 0x01) # "Entered Dodongo's Cavern"
     save_context.write_bits(0x0F08, 0x08) # "Entered Hyrule Castle"
 
+    # Set the number of chickens to collect
+    # Generate random number if needed
     if world.chicken_count_random:
         world.chicken_count = random.randint(0, 7)
     rom.write_byte(0x00E1E523, world.chicken_count)
+    
+    # Change Anju to always say how many chickens are needed
+    # Does not affect text for collecting item or afterwards
+    rom.write_int16(0x00E1F3C2, 0x5036)
+    rom.write_int16(0x00E1F3C4, 0x5036)
+    rom.write_int16(0x00E1F3C6, 0x5036)
+    rom.write_int16(0x00E1F3C8, 0x5036)
+    rom.write_int16(0x00E1F3CA, 0x5036)
+    rom.write_int16(0x00E1F3CC, 0x5036)
 
     # Make the Kakariko Gate not open with the MS
     rom.write_int32(0xDD3538, 0x34190000) # li t9, 0

--- a/Patches.py
+++ b/Patches.py
@@ -939,14 +939,16 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     save_context.write_bits(0x0EEB, 0x01) # "Entered Dodongo's Cavern"
     save_context.write_bits(0x0F08, 0x08) # "Entered Hyrule Castle"
 
-    if world.fast_chickens:
+    if world.chicken_count_random:
+        world.chicken_count = random.randint(0, 7)
+    rom.write_byte(0x00E1E523, world.chicken_count)
         # save_context.write_bits(0x0F2A, 0x08) # "Caught Cucco Near Cucco Pen"
-        save_context.write_bits(0x0F2A, 0x02) # "Caught Cucco Near Hyrule Field Entrance"
-        save_context.write_bits(0x0F2A, 0x04) # "Caught Cucco Near Bazaar"
-        save_context.write_bits(0x0F2A, 0x10) # "Caught Cucco Behind Windmill"
-        save_context.write_bits(0x0F2A, 0x20) # "Caught Cucco In Crate"
-        save_context.write_bits(0x0F2A, 0x40) # "Caught Cucco Near Skulltula House"
-        save_context.write_bits(0x0F2A, 0x80) # "Caught Cucco Behind Potion Shop"
+        # save_context.write_bits(0x0F2A, 0x02) # "Caught Cucco Near Hyrule Field Entrance"
+        # save_context.write_bits(0x0F2A, 0x04) # "Caught Cucco Near Bazaar"
+        # save_context.write_bits(0x0F2A, 0x10) # "Caught Cucco Behind Windmill"
+        # save_context.write_bits(0x0F2A, 0x20) # "Caught Cucco In Crate"
+        # save_context.write_bits(0x0F2A, 0x40) # "Caught Cucco Near Skulltula House"
+        # save_context.write_bits(0x0F2A, 0x80) # "Caught Cucco Behind Potion Shop"
 
     # Make the Kakariko Gate not open with the MS
     rom.write_int32(0xDD3538, 0x34190000) # li t9, 0

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1028,13 +1028,27 @@ setting_infos = [
         ''',
         shared         = True,
     ),
-	Checkbutton(
-		name           = 'fast_chickens',
-        gui_text       = 'Fast Chickens',
+    Checkbutton(
+        name           = 'chicken_count_random',
+        gui_text       = 'Random Cucco Count',
         gui_group      = 'convenience',
         gui_tooltip    = '''\
-            Moves all except the Chicken near the pen into the pen.
+            Anju will give a reward for collecting a random
+            number of Cuccos.
         ''',
+        shared         = True,
+    ),
+    Scale(
+        name           = 'chicken_count',
+        default        = 7,
+        min            = 0,
+        max            = 7,
+        gui_group      = 'convenience',
+        gui_tooltip    = '''\
+            Anju will give a reward for turning
+            in the chosen number of Cuccos.
+        ''',
+        dependency     = lambda settings: 1 if settings.chicken_count_random else None,
         shared         = True,
     ),
     Checkbutton(


### PR DESCRIPTION
Changes the fast chickens option to behave more like the big poe option:

- All chickens start in their normal positions instead of some of them being inside the pen
- Anju only wants the number of chickens specified by the slider (or a random number)
- Setting the slider to 0 will make Anju automatically give the player her item
- Edited Anju's text to tell the player how many chickens she wants