### PR TITLE
Patching time of day fix

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1056,11 +1056,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.starting_tod != 'default':
         tod = {
              'sunrise':       0x4555,
--            'morning':       0x6000,
--            'noon':          0x8001,
--            'afternoon':     0xA000,
--            'sunset':        0xC001,
--            'evening':       0xE000,
+             'morning':       0x6000,
+             'noon':          0x8001,
+             'afternoon':     0xA000,
+             'sunset':        0xC001,
+             'evening':       0xE000,
              'midnight':      0x0000,
              'witching-hour': 0x2000,
 


### PR DESCRIPTION
For some reason '-' operators were put at the beginning of a couple of lines defining the 'tod' dictionary, breaking the patching process when changing the time of day in the randomizer.

This just removes those '-' and fixes the problem.