### PR TITLE
Fix Altar Text

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -619,7 +619,7 @@ def buildBossString(reward, color, world):
         if location.item.name == reward:
             item_icon = chr(location.item.special['item_id'])
             location_text = getHint(location.name, world.clearer_hints).text
-            return str(GossipText("\x08\x13%s%s" % (item_icon, location_text), [color], prefix=''))
+            return str(GossipText("\x08\x13%s%s" % (item_icon, location_text), [color], prefix='')) + '\x04'
     return ''
 
 


### PR DESCRIPTION
Fixes #761.

My rewrite of the line wrapping function seems to have caused the altar text to lose a bunch of box breaks. This adds them back in.