### PR TITLE
Gossip Stone Fairy fixes

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -644,6 +644,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # Allow owl to always carry the kid down Death Mountain
     rom.write_bytes(0xE304F0, [0x24, 0x0E, 0x00, 0x01])
 
+    # Fix Vanilla Dodongo's Cavern Gossip Stone to not use a permanent flag for the fairy
+    if not world.dungeon_mq['Dodongos Cavern']:
+        rom.write_byte(0x1F281FE, 0x38)
+
     # Forbid Sun's Song from a bunch of cutscenes
     Suns_scenes = [0x2016FC9, 0x2017219, 0x20173D9, 0x20174C9, 0x2017679, 0x20C1539, 0x20C15D9, 0x21A0719, 0x21A07F9, 0x2E90129, 0x2E901B9, 0x2E90249, 0x225E829, 0x225E939, 0x306D009]
     for address in Suns_scenes:

--- a/State.py
+++ b/State.py
@@ -430,8 +430,11 @@ class State(object):
 
 
     def can_summon_gossip_fairy(self):
-        return self.can_play('Zeldas Lullaby') or self.can_play('Eponas Song') or self.can_play('Song of Time') or \
-               (self.current_spot.parent_region.time_passes and self.can_play('Suns Song'))
+        return self.has_ocarina() and self.has_any_of(('Zeldas Lullaby', 'Eponas Song', 'Song of Time', 'Suns Song'))
+
+
+    def can_summon_gossip_fairy_without_suns(self):
+        return self.has_ocarina() and self.has_any_of(('Zeldas Lullaby', 'Eponas Song', 'Song of Time'))
 
 
     def can_plant_bugs(self):

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -37,7 +37,7 @@
                 is_adult and at_night and 
                 (can_use(Hookshot) or can_use(Hover_Boots) or can_isg)",
             "Kokiri Forest Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
         },
         "exits": {
             "Links House": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -38,7 +38,7 @@
                 is_adult and at_night and 
                 (can_use(Hookshot) or (logic_adult_kokiri_gs and can_use(Hover_Boots)))",
             "Kokiri Forest Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
             "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
         },
         "exits": {
@@ -148,7 +148,7 @@
             "LW Deku Scrub Deku Stick Upgrade": "is_child and can_stun_deku",
             "GS Lost Woods Bean Patch Near Bridge": "can_plant_bugs and can_child_attack",
             "Lost Woods Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
             "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Bug Shrub": "is_child and can_cut_shrubs and has_bottle"
         },
@@ -212,7 +212,7 @@
             "Sacred Forest Meadow Maze Gossip Stone (Lower)": "True",
             "Sacred Forest Meadow Maze Gossip Stone (Upper)": "True",
             "Sacred Forest Meadow Saria Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
         },
         "exits": {
             "Sacred Forest Meadow Entryway": "True",
@@ -559,7 +559,7 @@
             "Temple of Time Gossip Stone (Left-Center)": "True",
             "Temple of Time Gossip Stone (Right)": "True",
             "Temple of Time Gossip Stone (Right-Center)": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
         },
         "exits": {
             "Castle Town": "True",
@@ -1031,7 +1031,7 @@
         "hint": "the Graveyard",
         "locations": {
             "Graveyard Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
         },
         "exits": {
             "Graveyard": "True",
@@ -1161,7 +1161,7 @@
             "Goron City Medigoron Gossip Stone": "
                 can_blast_or_smash or Progressive_Strength_Upgrade",
             "Gossip Stone Fairy": "
-                can_summon_gossip_fairy and has_bottle and
+                can_summon_gossip_fairy_without_suns and has_bottle and
                 (can_blast_or_smash or can_use(Silver_Gauntlets) or Progressive_Strength_Upgrade)",
             "Bug Rock": "(can_blast_or_smash or can_use(Silver_Gauntlets)) and has_bottle",
             "Stick Pot": "is_child"
@@ -1235,7 +1235,8 @@
             "GS Death Mountain Crater Crate": "is_child and can_child_attack",
             "DMC Deku Scrub Bombs": "is_child and can_stun_deku",
             "Death Mountain Crater Gossip Stone": "has_explosives",
-            "Gossip Stone Fairy": "has_explosives and can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "
+                has_explosives and can_summon_gossip_fairy_without_suns and has_bottle"
         },
         "exits": {
             "Death Mountain Summit": "True",
@@ -1377,7 +1378,7 @@
             "GS Zora's Domain Frozen Waterfall": "
                 is_adult and at_night and (Progressive_Hookshot or has_bow or Magic_Meter)",
             "Zoras Domain Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
             "Fish Group": "is_child and has_bottle",
             "Stick Pot": "is_child",
             "Nut Pot": "True"
@@ -1413,7 +1414,7 @@
                 can_use(Hookshot) and at_night",
             "Zoras Fountain Fairy Gossip Stone": "True",
             "Zoras Fountain Jabu Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
             "Butterfly Fairy": "can_use(Sticks) and at_day and has_bottle"
         },
         "exits": {


### PR DESCRIPTION
Changed gossip fairy logic to use another state method that checks if you can summon a gossip fairy without Sun's Song for places where playing Sun's Song reloads the room. 
The previous implementation checked for time passing instead, but some places like grottos and dungeons don't reload with Sun's Song even though they don't have time passing so it didn't work for all cases. 
This essentially fixes grotto and DC gossip stone fairies not being in logic with Sun's Song when they should have been.

Also fixed the gossip stone in vanilla DC to use a local flag instead of a permanent flag for the fairy spawn so it can be a reliable fairy source. All other gossip stones, including the one in MQ DC, use local flags, so only that one seems to have been a mistake in the original game.