### PR TITLE
Move the stable cows away from each other in cowsanity

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1467,8 +1467,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     if world.shuffle_cows:
         rom.write_byte(rom.sym('SHUFFLE_COWS'), 0x01)
-        #Moves the cow in LLR Tower, as the two cows are too close in vanilla
-        rom.write_bytes(0x33650CA, [0xFE, 0xD3, 0x00, 0x00, 0x00, 0x6E, 0x00, 0x00, 0x4A, 0x34])
+        # Move some cows because they are too close from each other in vanilla
+        rom.write_bytes(0x33650CA, [0xFE, 0xD3, 0x00, 0x00, 0x00, 0x6E, 0x00, 0x00, 0x4A, 0x34]) # LLR Tower right cow
+        rom.write_bytes(0x2C550AE, [0x00, 0x82]) # LLR Stable right cow
         set_cow_id_data(rom, world)
 
     if world.shuffle_beans:


### PR DESCRIPTION
In cowsanity, moves the right cow in the stable one block away so its trigger area no longer overlaps with the other cow. This makes getting the items much more reliable as you can no longer mistake which cow you got the item from, and you don't have to place yourself in a specific spot to get one of the cows.
Fixes #665.

Before the change:
![image](https://user-images.githubusercontent.com/32455037/60941229-655a4480-a2ac-11e9-9d4e-7173d18ea1b9.png)

After the change:
![image](https://user-images.githubusercontent.com/32455037/60941206-4eb3ed80-a2ac-11e9-9191-49a6544f744d.png)
