### PR TITLE
python3.8 beta compatibility: posonlyargs

### DIFF
--- a/RuleParser.py
+++ b/RuleParser.py
@@ -208,6 +208,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             newrule = ast.fix_missing_locations(
                 ast.Expression(ast.Lambda(
                     args=ast.arguments(
+                        posonlyargs=[],
                         args=[ast.arg(arg='state')],
                         defaults=[],
                         kwonlyargs=[],


### PR DESCRIPTION
This is a required argument in 3.8 but we can pass it in a keyword so it's ignored in < 3.8.