### PR TITLE
Ensure pending_junk_pool is emptied during generation.

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1235,7 +1235,8 @@ def get_pool_core(world):
         remove_junk_pool = list(remove_junk_pool) + ['Recovery Heart', 'Bombs (20)', 'Arrows (30)', 'Ice Trap']
 
         junk_candidates = [item for item in pool if item in remove_junk_pool]
-        for pending_item in pending_junk_pool:
+        while pending_junk_pool:
+            pending_item = pending_junk_pool.pop()
             if not junk_candidates:
                 raise RuntimeError("Not enough junk exists in item pool for %s to be added." % pending_item)
             junk_item = random.choice(junk_candidates)


### PR DESCRIPTION
If pending_junk_pool still contained items after all junk items were placed, the items in pending_junk_pool replace a random junk item. However, pending_junk_pool would retain those items for the next seed generation.