### PR TITLE
Minor speed improvements to playthrough algorithm

### DIFF
--- a/Entrance.py
+++ b/Entrance.py
@@ -33,8 +33,8 @@ class Entrance(object):
         return new_entrance
 
 
-    def can_reach(self, state, noparent=False):
-        return state.with_spot(self.access_rule, spot=self) and (noparent or state.can_reach(self.parent_region, keep_tod=True))
+    def can_reach(self, state):
+        return state.with_spot(self.access_rule, spot=self) and state.can_reach(self.parent_region, keep_tod=True)
 
 
     def can_reach_simple(self, state):

--- a/Entrance.py
+++ b/Entrance.py
@@ -37,6 +37,11 @@ class Entrance(object):
         return state.with_spot(self.access_rule, spot=self) and (noparent or state.can_reach(self.parent_region, keep_tod=True))
 
 
+    def can_reach_simple(self, state):
+        # todo: raw evaluation of access_rule? requires nonrecursive tod checks in state
+        return state.with_spot(self.access_rule, spot=self)
+
+
     def connect(self, region):
         self.connected_region = region
         region.entrances.append(self)

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -460,7 +460,7 @@ def split_entrances_by_requirements(worlds, entrances_to_split, assumed_entrance
 
     for entrance in entrances_to_split:
         # Here, we find entrances that may be unreachable under certain conditions
-        if not max_playthrough.state_list[entrance.world.id].can_reach_as_both(entrance, tod='all'):
+        if not max_playthrough.state_list[entrance.world.id].as_both(entrance, tod='all'):
             restrictive_entrances.append(entrance)
             continue
         # If an entrance is reachable as both ages and all times of day with all the other entrances disconnected,
@@ -540,12 +540,12 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
         for world in worlds:
             # Links House entrance should be reachable as child at some point in the seed
             links_house_entrance = get_entrance_replacing(world.get_region('Links House'), 'Kokiri Forest -> Links House')
-            if not max_playthrough.state_list[world.id].can_reach_as_both(links_house_entrance):
+            if not max_playthrough.state_list[world.id].as_age(links_house_entrance, adult=False):
                 raise EntranceShuffleError('Links House Entrance is never reachable as child')
 
             # Temple of Time entrance should be reachable as both ages at some point in the seed
             temple_of_time_entrance = get_entrance_replacing(world.get_region('Temple of Time'), 'Temple of Time Exterior -> Temple of Time')
-            if not max_playthrough.state_list[world.id].can_reach_as_both(temple_of_time_entrance):
+            if not max_playthrough.state_list[world.id].as_both(temple_of_time_entrance):
                 raise EntranceShuffleError('Temple of Time Entrance is never reachable as both ages')
 
             # Temple of Time shouldn't be placed inside the Fishing Pond to prevent potential issues with the lake hylia water control
@@ -554,7 +554,7 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
 
             # Windmill door entrance should be reachable as both ages at some point in the seed
             windmill_door_entrance = get_entrance_replacing(world.get_region('Windmill'), 'Kakariko Village -> Windmill')
-            if not max_playthrough.state_list[world.id].can_reach_as_both(windmill_door_entrance):
+            if not max_playthrough.state_list[world.id].as_both(windmill_door_entrance):
                 raise EntranceShuffleError('Windmill Door Entrance is never reachable as both ages')
 
         # At least one valid starting region with all basic refills should be reachable without using any items at the beginning of the seed

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -460,7 +460,7 @@ def split_entrances_by_requirements(worlds, entrances_to_split, assumed_entrance
 
     for entrance in entrances_to_split:
         # Here, we find entrances that may be unreachable under certain conditions
-        if not max_playthrough.state_list[entrance.world.id].can_reach(entrance, age='both', tod='all'):
+        if not max_playthrough.state_list[entrance.world.id].can_reach_as_both(entrance, tod='all'):
             restrictive_entrances.append(entrance)
             continue
         # If an entrance is reachable as both ages and all times of day with all the other entrances disconnected,
@@ -540,12 +540,12 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
         for world in worlds:
             # Links House entrance should be reachable as child at some point in the seed
             links_house_entrance = get_entrance_replacing(world.get_region('Links House'), 'Kokiri Forest -> Links House')
-            if not max_playthrough.state_list[world.id].can_reach(links_house_entrance, age='child'):
+            if not max_playthrough.state_list[world.id].can_reach_as_both(links_house_entrance):
                 raise EntranceShuffleError('Links House Entrance is never reachable as child')
 
             # Temple of Time entrance should be reachable as both ages at some point in the seed
             temple_of_time_entrance = get_entrance_replacing(world.get_region('Temple of Time'), 'Temple of Time Exterior -> Temple of Time')
-            if not max_playthrough.state_list[world.id].can_reach(temple_of_time_entrance, age='both'):
+            if not max_playthrough.state_list[world.id].can_reach_as_both(temple_of_time_entrance):
                 raise EntranceShuffleError('Temple of Time Entrance is never reachable as both ages')
 
             # Temple of Time shouldn't be placed inside the Fishing Pond to prevent potential issues with the lake hylia water control
@@ -554,7 +554,7 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
 
             # Windmill door entrance should be reachable as both ages at some point in the seed
             windmill_door_entrance = get_entrance_replacing(world.get_region('Windmill'), 'Kakariko Village -> Windmill')
-            if not max_playthrough.state_list[world.id].can_reach(windmill_door_entrance, age='both'):
+            if not max_playthrough.state_list[world.id].can_reach_as_both(windmill_door_entrance):
                 raise EntranceShuffleError('Windmill Door Entrance is never reachable as both ages')
 
         # At least one valid starting region with all basic refills should be reachable without using any items at the beginning of the seed

--- a/Location.py
+++ b/Location.py
@@ -58,11 +58,11 @@ class Location(object):
         return (self.parent_region.can_fill(item, manual) and self.item_rule(self, item))
 
 
-    def can_reach(self, state, noparent=False):
+    def can_reach(self, state):
         if self.is_disabled():
             return False
 
-        return state.with_spot(self.access_rule, spot=self) and (noparent or state.can_reach(self.parent_region, keep_tod=True))
+        return state.with_spot(self.access_rule, spot=self) and state.can_reach(self.parent_region, keep_tod=True)
 
 
     def can_reach_simple(self, state):

--- a/Location.py
+++ b/Location.py
@@ -65,6 +65,12 @@ class Location(object):
         return state.with_spot(self.access_rule, spot=self) and (noparent or state.can_reach(self.parent_region, keep_tod=True))
 
 
+    def can_reach_simple(self, state):
+        # todo: raw evaluation of access_rule? requires nonrecursive tod checks in state
+        # and GS Token and Gossip Stone Fairy have special checks as well
+        return state.with_spot(self.access_rule, spot=self)
+
+
     def is_disabled(self):
         return (self.disabled == DisableType.DISABLED) or \
                (self.disabled == DisableType.PENDING and self.locked)

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -1,5 +1,5 @@
 import copy
-from collections import deque, defaultdict
+from collections import defaultdict
 import itertools
 
 
@@ -18,13 +18,13 @@ class Playthrough(object):
         # Mapping from item to sphere index, if this is tracking items. 0-based.
         self.item_in_sphere = defaultdict(int)
 
-        # Prefill sphere 0 if not already filled.
-        if not self.cached_spheres:
-            self.next_sphere()
-
         # Let the states reference this playthrough.
         for state in self.state_list:
             state.playthrough = self
+
+        # Prefill sphere 0 if not already filled.
+        if not self.cached_spheres:
+            self.next_sphere()
 
 
     def copy(self):
@@ -98,15 +98,15 @@ class Playthrough(object):
         self.item_in_sphere.clear()
 
 
-    # simplified exit.can_reach(state), with_age bypasses can_become_age
+    # simplified exit.can_reach(state), bypasses can_become_age
     # which we've already accounted for
     def validate_child(self, exit):
-        return self.state_list[exit.parent_region.world.id].with_age(
-                lambda state: exit.can_reach(state, noparent=True), 'child')
+        return self.state_list[exit.parent_region.world.id].as_child(
+                exit.can_reach_simple)
 
     def validate_adult(self, exit):
-        return self.state_list[exit.parent_region.world.id].with_age(
-                lambda state: exit.can_reach(state, noparent=True), 'adult')
+        return self.state_list[exit.parent_region.world.id].as_adult(
+                exit.can_reach_simple)
 
 
     # Internal to the iteration. Modifies the exit_queue, region_set. 
@@ -114,14 +114,13 @@ class Playthrough(object):
     # as a cache for the exits to try on the next iteration.
     @staticmethod
     def _expand_regions(exit_queue, region_set, validate):
-        new_exit = lambda exit: exit.connected_region != None and exit.connected_region not in region_set
+        new_exit = lambda exit: exit.connected_region and exit.connected_region not in region_set
         failed = []
-        while exit_queue:
-            exit = exit_queue.popleft()
+        for exit in exit_queue:
             if new_exit(exit):
                 if validate(exit):
                     region_set.add(exit.connected_region)
-                    exit_queue.extend(filter(new_exit, exit.connected_region.exits))
+                    exit_queue.extend(exit.connected_region.exits)
                 else:
                     failed.append(exit)
         return failed
@@ -144,8 +143,8 @@ class Playthrough(object):
             visited_locations = copy.copy(self.cached_spheres[-1]['visited_locations'])
         else:
             root_regions = [state.world.get_region('Root') for state in self.state_list]
-            child_queue = deque(exit for region in root_regions for exit in region.exits)
-            adult_queue = deque(exit for region in root_regions for exit in region.exits)
+            child_queue = list(exit for region in root_regions for exit in region.exits)
+            adult_queue = list(exit for region in root_regions for exit in region.exits)
             child_regions = set(root_regions)
             adult_regions = set(root_regions)
             visited_locations = set()
@@ -156,18 +155,15 @@ class Playthrough(object):
         child_failed = Playthrough._expand_regions(child_queue, child_regions, self.validate_child)
 
         # Save the current data into the cache.
-        new_child_exit = lambda exit: exit.connected_region not in child_regions
-        new_adult_exit = lambda exit: exit.connected_region not in adult_regions
-
         self.cached_spheres.append({
             'child_regions': child_regions,
             'adult_regions': adult_regions,
             # Didn't change here, but this will be the editable layer of the cache.
             'visited_locations': visited_locations,
-            # Exits that didn't pass validation (and still point to new places)
+            # Exits that didn't pass validation
             # are the only exits we'll be interested in
-            'child_queue': deque(filter(new_child_exit, child_failed)),
-            'adult_queue': deque(filter(new_adult_exit, adult_failed)),
+            'child_queue': child_failed,
+            'adult_queue': adult_failed,
         })
         return child_regions, adult_regions, visited_locations
 
@@ -186,9 +182,9 @@ class Playthrough(object):
                     and not loc.is_disabled()
                     # Check adult first; it's the most likely.
                     and (loc.parent_region in adult_regions
-                         and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'adult')
+                         and self.state_list[loc.world.id].as_adult(loc.can_reach_simple)
                      or (loc.parent_region in child_regions
-                         and self.state_list[loc.world.id].with_age(lambda state: loc.can_reach(state, noparent=True), 'child'))))
+                         and self.state_list[loc.world.id].as_child(loc.can_reach_simple))))
 
 
         had_reachable_locations = True
@@ -257,6 +253,7 @@ class Playthrough(object):
 
     # Use the cache in the playthrough to determine region reachability.
     def can_reach(self, region, age=None):
+        if not self.cached_spheres: return False
         if age == 'adult':
             return region in self.cached_spheres[-1]['adult_regions']
         elif age == 'child':

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -101,12 +101,12 @@ class Playthrough(object):
     # simplified exit.can_reach(state), bypasses can_become_age
     # which we've already accounted for
     def validate_child(self, exit):
-        return self.state_list[exit.parent_region.world.id].as_child(
-                exit.can_reach_simple)
+        return self.state_list[exit.parent_region.world.id].with_age(
+                exit.can_reach_simple, adult=False)
 
     def validate_adult(self, exit):
-        return self.state_list[exit.parent_region.world.id].as_adult(
-                exit.can_reach_simple)
+        return self.state_list[exit.parent_region.world.id].with_age(
+                exit.can_reach_simple, adult=True)
 
 
     # Internal to the iteration. Modifies the exit_queue, region_set. 
@@ -182,9 +182,9 @@ class Playthrough(object):
                     and not loc.is_disabled()
                     # Check adult first; it's the most likely.
                     and (loc.parent_region in adult_regions
-                         and self.state_list[loc.world.id].as_adult(loc.can_reach_simple)
+                         and self.state_list[loc.world.id].with_age(loc.can_reach_simple, adult=True)
                      or (loc.parent_region in child_regions
-                         and self.state_list[loc.world.id].as_child(loc.can_reach_simple))))
+                         and self.state_list[loc.world.id].with_age(loc.can_reach_simple, adult=False))))
 
 
         had_reachable_locations = True

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -208,6 +208,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             newrule = ast.fix_missing_locations(
                 ast.Expression(ast.Lambda(
                     args=ast.arguments(
+                        posonlyargs=[],
                         args=[ast.arg(arg='state')],
                         defaults=[],
                         kwonlyargs=[],

--- a/State.py
+++ b/State.py
@@ -171,22 +171,6 @@ class State(object):
         return lambda_rule_result
 
 
-    def as_either_here(self, lambda_rule=lambda state: True):
-        return self.as_either(self.add_reachability(lambda_rule))
-
-
-    def as_both_here(self, lambda_rule=lambda state: True):
-        return self.as_both(self.add_reachability(lambda_rule))
-
-
-    def as_adult_here(self, lambda_rule=lambda state: True):
-        return self.as_adult(self.add_reachability(lambda_rule))
-
-
-    def as_child_here(self, lambda_rule=lambda state: True):
-        return self.as_child(self.add_reachability(lambda_rule))
-
-
     def add_reachability(self, lambda_rule):
         return lambda state: state.can_reach() and lambda_rule(state)
 

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -19,18 +19,18 @@
                     ( (has_nuts or can_use(Boomerang)) and 
                         (can_use(Kokiri_Sword) or has_slingshot) ) ))",
             "Spirit Temple Child Right Chest": "(is_adult and has_fire_source) or 
-                (has_fire_source_with_torch and (as_adult_here or
+                (has_fire_source_with_torch and (here(is_adult) or
                 (
                 (can_use(Boomerang) or has_slingshot or has_bombchus or can_mega) and 
                 (has_sticks or has_explosives or 
                     ( (has_nuts or can_use(Boomerang)) and 
                         (can_use(Kokiri_Sword) or has_slingshot) ) ))))",
             "GS Spirit Temple Metal Fence": "is_adult or
-            (
-            (can_use(Boomerang) or has_slingshot or has_bombchus or can_mega) and 
-            (has_sticks or has_explosives or 
-                ( (has_nuts or can_use(Boomerang)) and 
-                    (can_use(Kokiri_Sword) or has_slingshot) ) ))",
+                (
+                (can_use(Boomerang) or has_slingshot or has_bombchus or can_mega) and 
+                (has_sticks or has_explosives or 
+                    ( (has_nuts or can_use(Boomerang)) and 
+                        (can_use(Kokiri_Sword) or has_slingshot) ) ))",
             "Nut Crate": "True"
         },
         "exits": {

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -17,7 +17,7 @@
                     here(can_use(Slingshot) or can_use(Bow)) and
                     here(can_blast_or_smash) and
                     here(can_use(Hookshot) or can_use(Boomerang))) or
-                ((logic_deku_b1_skip or as_adult_here) and is_child and
+                ((logic_deku_b1_skip or here(is_adult)) and is_child and
                     has_explosives and can_use(Boomerang) and
                     (has_sticks or can_use(Dins_Fire)))",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",


### PR DESCRIPTION
Big (ish) changes:
- There aren't any more recursive calls that involve changing age and testing can_reach again, so we can mostly remove the age parameter from `State.can_reach` and `State.with_age` can be split in two to be more efficient.
- There are a few cases where `current_spot` is still needed, so we can't quite remove `with_spot` yet, but we can remove a few extra lambda declarations by having a separate `can_reach_simple`.
- We don't actually need to pop things out of the entrance queue!