### PR TITLE
fix scarecrow skull weapons check in ER

### DIFF
--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -20,7 +20,8 @@
                 has_explosives or is_adult or has_slingshot or 
                 Boomerang or has_sticks or Kokiri_Sword",
             "GS Dodongo's Cavern Scarecrow": "
-                can_use(Scarecrow) or can_use(Longshot) or logic_dc_scarecrow_gs",
+                can_use(Scarecrow) or can_use(Longshot) or 
+                (logic_dc_scarecrow_gs and (is_adult or can_child_attack))",
             "DC Deku Scrub Deku Sticks": "
                 is_adult or has_slingshot or has_sticks or 
                 has_explosives or Kokiri_Sword",


### PR DESCRIPTION
This was assuming either bombs (for the entry stone) or master sword.
With weaponless child entry now possible it needs weapons checks.