### PR TITLE
Fix entrance shuffle fails not being caught by the global retry

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -1,5 +1,6 @@
 import random
 import logging
+from Fill import ShuffleError
 from collections import OrderedDict
 from Playthrough import Playthrough
 from Rules import set_entrances_based_rules
@@ -286,7 +287,7 @@ entrance_shuffle_table = [
 ]
 
 
-class EntranceShuffleError(RuntimeError):
+class EntranceShuffleError(ShuffleError):
     pass
 
 

--- a/Fill.py
+++ b/Fill.py
@@ -12,7 +12,11 @@ from Playthrough import Playthrough
 from functools import reduce
 
 
-class FillError(RuntimeError):
+class ShuffleError(RuntimeError):
+    pass
+
+
+class FillError(ShuffleError):
     pass
 
 

--- a/Main.py
+++ b/Main.py
@@ -19,7 +19,7 @@ from Rom import Rom
 from Patches import patch_rom
 from Cosmetics import patch_cosmetics
 from DungeonList import create_dungeons
-from Fill import distribute_items_restrictive, FillError
+from Fill import distribute_items_restrictive, ShuffleError
 from Item import Item
 from ItemList import item_table
 from ItemPool import generate_itempool
@@ -88,8 +88,8 @@ def main(settings, window=dummy_window()):
         try:
             spoiler = generate(settings, window)
             break
-        except FillError as fe:
-            logger.warning('Failed attempt %d of %d: %s', attempt, max_attempts, fe)
+        except ShuffleError as e:
+            logger.warning('Failed attempt %d of %d: %s', attempt, max_attempts, e)
             if attempt >= max_attempts:
                 raise
             else:


### PR DESCRIPTION
I added a common type of exception called `ShuffleError`, currently only extended by `FillError` and `EntranceShuffleError`, corresponding to errors likely due to randomisation fails on which the global retry should trigger.

Previously only `FillError` exceptions were caught by the global retry which didn't handle the ER algorithm fails since it uses `EntranceShuffleError`.