### PR TITLE
Add fanfare shuffle

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -185,11 +185,9 @@ def patch_dpad(rom, settings, log, symbols):
 
 def patch_music(rom, settings, log, symbols):
     # patch music
-    if settings.background_music == 'random':
+    if settings.background_music != 'normal' or settings.fanfares != 'normal':
         music.restore_music(rom)
         log.bgm = music.randomize_music(rom, settings)
-    elif settings.background_music == 'off':
-        music.disable_music(rom)
     else:
         music.restore_music(rom)
 

--- a/Music.py
+++ b/Music.py
@@ -1,4 +1,4 @@
-#Much of this is heavily inspired from and/or based on az64's MM randomizer
+#Much of this is heavily inspired from and/or based on az64's / Deathbasket's MM randomizer
 
 import random
 import os
@@ -6,55 +6,87 @@ import os
 
 # Format: (Title, Sequence ID)
 bgm_sequence_ids = [
-    ('Hyrule Field', 0x02),
-    ('Dodongos Cavern', 0x18),
-    ('Kakariko Adult', 0x19),
-    ('Battle', 0x1A),
-    ('Boss Battle', 0x1B),
-    ('Inside Deku Tree', 0x1C),
-    ('Market', 0x1D),
-    ('Title Theme', 0x1E),
-    ('House', 0x1F),
-    ('Jabu Jabu', 0x26),
-    ('Kakariko Child', 0x27),
-    ('Fairy Fountain', 0x28),
-    ('Zelda Theme', 0x29),
-    ('Fire Temple', 0x2A),
-    ('Forest Temple', 0x2C),
-    ('Castle Courtyard', 0x2D),
-    ('Ganondorf Theme', 0x2E),
-    ('Lon Lon Ranch', 0x2F),
-    ('Goron City', 0x30),
-    ('Miniboss Battle', 0x38),
-    ('Temple of Time', 0x3A),
-    ('Kokiri Forest', 0x3C),
-    ('Lost Woods', 0x3E),
-    ('Spirit Temple', 0x3F),
-    ('Horse Race', 0x40),
-    ('Ingo Theme', 0x42),
-    ('Fairy Flying', 0x4A),
-    ('Deku Tree', 0x4B),
-    ('Windmill Hut', 0x4C),
-    ('Shooting Gallery', 0x4E),
-    ('Sheik Theme', 0x4F),
-    ('Zoras Domain', 0x50),
-    ('Shop', 0x55),
-    ('Chamber of the Sages', 0x56),
-    ('Ice Cavern', 0x58),
-    ('Kaepora Gaebora', 0x5A),
-    ('Shadow Temple', 0x5B),
-    ('Water Temple', 0x5C),
-    ('Gerudo Valley', 0x5F),
-    ('Potion Shop', 0x60),
-    ('Kotake and Koume', 0x61),
-    ('Castle Escape', 0x62),
-    ('Castle Underground', 0x63),
-    ('Ganondorf Battle', 0x64),
-    ('Ganon Battle', 0x65),
-    ('Fire Boss', 0x6B),
-    ('Mini-game', 0x6C)
+    ("Hyrule Field", 0x02),
+    ("Dodongos Cavern", 0x18),
+    ("Kakariko Adult", 0x19),
+    ("Battle", 0x1A),
+    ("Boss Battle", 0x1B),
+    ("Inside Deku Tree", 0x1C),
+    ("Market", 0x1D),
+    ("Title Theme", 0x1E),
+    ("House", 0x1F),
+    ("Jabu Jabu", 0x26),
+    ("Kakariko Child", 0x27),
+    ("Fairy Fountain", 0x28),
+    ("Zelda Theme", 0x29),
+    ("Fire Temple", 0x2A),
+    ("Forest Temple", 0x2C),
+    ("Castle Courtyard", 0x2D),
+    ("Ganondorf Theme", 0x2E),
+    ("Lon Lon Ranch", 0x2F),
+    ("Goron City", 0x30),
+    ("Miniboss Battle", 0x38),
+    ("Temple of Time", 0x3A),
+    ("Kokiri Forest", 0x3C),
+    ("Lost Woods", 0x3E),
+    ("Spirit Temple", 0x3F),
+    ("Horse Race", 0x40),
+    ("Ingo Theme", 0x42),
+    ("Fairy Flying", 0x4A),
+    ("Deku Tree", 0x4B),
+    ("Windmill Hut", 0x4C),
+    ("Shooting Gallery", 0x4E),
+    ("Sheik Theme", 0x4F),
+    ("Zoras Domain", 0x50),
+    ("Shop", 0x55),
+    ("Chamber of the Sages", 0x56),
+    ("Ice Cavern", 0x58),
+    ("Kaepora Gaebora", 0x5A),
+    ("Shadow Temple", 0x5B),
+    ("Water Temple", 0x5C),
+    ("Gerudo Valley", 0x5F),
+    ("Potion Shop", 0x60),
+    ("Kotake and Koume", 0x61),
+    ("Castle Escape", 0x62),
+    ("Castle Underground", 0x63),
+    ("Ganondorf Battle", 0x64),
+    ("Ganon Battle", 0x65),
+    ("Fire Boss", 0x6B),
+    ("Mini-game", 0x6C)
 ]
 
+fanfare_sequence_ids = [
+    ("Game Over", 0x20),
+    ("Boss Defeated", 0x21),
+    ("Item Get", 0x22),
+    ("Ganondorf Appears", 0x23),
+    ("Heart Container Get", 0x24),
+    ("Treasure Chest", 0x2B),
+    ("Spirit Stone Get", 0x32),
+    ("Heart Piece Get", 0x39),
+    ("Escape from Ranch", 0x3B),
+    ("Learn Song", 0x3D),
+    ("Epona Race Goal", 0x41),
+    ("Medallion Get", 0x43),
+    ("Zelda Turns Around", 0x51),
+    ("Master Sword", 0x53),
+    ("Door of Time", 0x59)
+]
+
+ocarina_sequence_ids = [
+    ("Prelude of Light", 0x25),
+    ("Bolero of Fire", 0x33),
+    ("Minuet of Forest", 0x34),
+    ("Serenade of Water", 0x35),
+    ("Requiem of Spirit", 0x36),
+    ("Nocturne of Shadow", 0x37),
+    ("Saria's Song", 0x44),
+    ("Epona's Song", 0x45),
+    ("Zelda's Lullaby", 0x46),
+    ("Sun's Song", 0x47),
+    ("Song of Time", 0x48),
+    ("Song of Storms", 0x49)
+]
 
 # Represents the information associated with a sequence, aside from the sequence data itself
 class TableEntry(object):
@@ -75,9 +107,9 @@ class Sequence(object):
         self.data = []
 
 
-def process_sequences(rom, sequences, target_sequences):
+def process_sequences(rom, sequences, target_sequences, ids, seq_type = 'bgm'):
     # Process vanilla music data
-    for bgm in bgm_sequence_ids:
+    for bgm in ids:
         # Get sequence metadata
         name = bgm[0]
         cosmetic_name = name
@@ -96,7 +128,7 @@ def process_sequences(rom, sequences, target_sequences):
 
     # Process music data in data/Music/
     # Each sequence requires a valid .seq sequence file and a .meta metadata file
-    # Current .meta format: Cosmetic Name\nInstrument Set
+    # Current .meta format: Cosmetic Name\nInstrument Set\nPool
     for f in os.listdir('data/Music'):
         fname = os.fsdecode(f)
         # Find meta file and check if corresponding seq file exists
@@ -111,13 +143,14 @@ def process_sequences(rom, sequences, target_sequences):
             except FileNotFoundError as ex:
                 raise FileNotFoundError('No meta file for: "' + fname + '". This should never happen')
 
-            # Create new sequence
-            seq = TableEntry(fname.split('.')[0], lines[0], instrument_set = int(lines[1], 16))
+            # Create new sequence, checking third line for correct type
+            if (len(lines) > 2 and (lines[2].lower().rstrip() == seq_type.lower() or lines[2] == '')) or (len(lines) <= 2 and seq_type == 'bgm'):
+                seq = TableEntry(fname.split('.')[0], lines[0], instrument_set = int(lines[1], 16))
 
-            if seq.instrument_set < 0x00 or seq.instrument_set > 0x24:
-                raise Exception('Sequence instrument must be in range [0x00, 0x25]')
+                if seq.instrument_set < 0x00 or seq.instrument_set > 0x25:
+                    raise Exception('Sequence instrument must be in range [0x00, 0x25]')
 
-            sequences.append(seq)
+                sequences.append(seq)
 
     return sequences, target_sequences
 
@@ -257,10 +290,10 @@ def rebuild_sequences(rom, sequences, log):
     return log
 
 
-def shuffle_pointers_table(rom, log):
+def shuffle_pointers_table(rom, ids, log):
     # Read in all the Music data
     bgm_data = []
-    for bgm in bgm_sequence_ids:
+    for bgm in ids:
         bgm_sequence = rom.read_bytes(0xB89AE0 + (bgm[1] * 0x10), 0x10)
         bgm_instrument = rom.read_int16(0xB89910 + 0xDD + (bgm[1] * 2))
         bgm_data.append((bgm[0], bgm_sequence, bgm_instrument))
@@ -269,7 +302,7 @@ def shuffle_pointers_table(rom, log):
     random.shuffle(bgm_data)
 
     # Write Music data back in random ordering
-    for bgm in bgm_sequence_ids:
+    for bgm in ids:
         bgm_name, bgm_sequence, bgm_instrument = bgm_data.pop()
         rom.write_bytes(0xB89AE0 + (bgm[1] * 0x10), bgm_sequence)
         rom.write_int16(0xB89910 + 0xDD + (bgm[1] * 2), bgm_instrument)
@@ -282,31 +315,57 @@ def shuffle_pointers_table(rom, log):
 
 def randomize_music(rom, settings):
     log = {}
+    sequences = []
+    target_sequences = []
+    fanfare_sequences = []
+    fanfare_target_sequences = []
 
+    # Include ocarina songs in fanfare pool if checked
+    ff_ids = fanfare_sequence_ids
+    if settings.ocarina_fanfares:
+        ff_ids += ocarina_sequence_ids
+
+    # If not creating patch file, shuffle audio sequences. Otherwise, shuffle pointer table
     if settings.compress_rom != 'Patch':
-        # Create empty sequence metadata arrays
-        sequences = []
-        target_sequences = []
+        if settings.background_music == 'random':
+            sequences, target_sequences = process_sequences(rom, sequences, target_sequences, bgm_sequence_ids)
+            sequences, log = shuffle_music(sequences, target_sequences, log)
 
-        sequences, target_sequences = process_sequences(rom, sequences, target_sequences)
-        sequences, log = shuffle_music(sequences, target_sequences, log)
-        log = rebuild_sequences(rom, sequences, log)
+        if settings.fanfares == 'random':
+            fanfare_sequences, fanfare_target_sequences = process_sequences(rom, fanfare_sequences, fanfare_target_sequences, ff_ids, 'fanfare')
+            fanfare_sequences, log = shuffle_music(fanfare_sequences, fanfare_target_sequences, log)
+
+        log = rebuild_sequences(rom, sequences + fanfare_sequences, log)
+
+        if settings.background_music == 'off':
+            disable_music(rom, bgm_sequence_ids)
+        if settings.fanfares == 'off':
+            disable_music(rom, ff_ids)
+
     else:
-        log = shuffle_pointers_table(rom, log)
+        if settings.background_music == 'random':
+            log = shuffle_pointers_table(rom, bgm_sequence_ids, log)
+        elif settings.background_music == 'off':
+            disable_music(rom, bgm_sequence_ids)
+
+        if settings.fanfares == 'random':
+            log = shuffle_pointers_table(rom, ff_ids, log)
+        elif settings.fanfares == 'off':
+            disable_music(rom, ff_ids)
 
     return log
 
 
-def disable_music(rom):
+def disable_music(rom, ids):
     # First track is no music
     blank_track = rom.read_bytes(0xB89AE0 + (0 * 0x10), 0x10)
-    for bgm in bgm_sequence_ids:
+    for bgm in ids:
         rom.write_bytes(0xB89AE0 + (bgm[1] * 0x10), blank_track)
 
 
 def restore_music(rom):
     # Restore all music from original
-    for bgm in bgm_sequence_ids:
+    for bgm in bgm_sequence_ids + fanfare_sequence_ids + ocarina_sequence_ids:
         bgm_sequence = rom.original.read_bytes(0xB89AE0 + (bgm[1] * 0x10), 0x10)
         rom.write_bytes(0xB89AE0 + (bgm[1] * 0x10), bgm_sequence)
         bgm_instrument = rom.original.read_int16(0xB89910 + 0xDD + (bgm[1] * 2))

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2241,6 +2241,42 @@ setting_infos = [
             be loaded from data/Music/
         ''',
     ),
+    Combobox(
+        name           = 'fanfares',
+        gui_text       = 'Fanfares',
+        default        = 'normal',
+        choices        = {
+            'normal': 'Normal',
+            'off':    'No Fanfares',
+            'random': 'Random',
+        },
+        disable        = {
+            'normal' : {'settings' : ['ocarina_fanfares']},
+        },
+        gui_tooltip    = '''\
+            'No Fanfares': No fanfares 
+            (short non-looping tracks)
+            are played.
+
+            'Random': Fanfares are randomized.
+            Additional fanfares can be loaded
+            from data/Music/
+        ''',
+    ),
+    Checkbutton(
+        name           = 'ocarina_fanfares',
+        gui_text       = 'Ocarina Songs as Fanfares',
+        gui_tooltip    = '''\
+            Include the songs that play when an ocarina song
+            is played as part of the fanfare pool when
+            shuffling or disabling fanfares. Note that these
+            are a bit longer than most fanfares.
+        ''',
+        gui_params  = {
+            "hide_when_disabled": True,
+        },
+        default        = False,
+    ),
     Checkbutton(
         name           = 'display_dpad',
         gui_text       = 'Display D-Pad HUD',

--- a/data/Music/README.md
+++ b/data/Music/README.md
@@ -5,3 +5,63 @@ For example, if there is a sequence file `Foo.seq` then you need a meta file `Fo
 Awesome Name
 C
 ```
+
+Additionally, if the sequence is to be shuffled with the non-looping fanfares, a third line must exist containing the word 'fanfare'.
+
+Sequences are in the seq64 format. Other known games that use this format and may be compatible are (list from https://github.com/sauraen/seq64)
+```
+Super Mario 64
+Mario Kart 64
+Yoshi's Story
+Legend of Zelda: Majora's Mask
+1080 Snowboarding
+F-ZERO X
+Lylat Wars
+Pokemon Stadium
+Pokemon Stadium 2
+Wave Race 64
+```
+
+There are also tools available to help convert midi files to valid seq64 files.
+
+The instrument list is as follows (from https://sites.google.com/site/deathbasketslair/zelda/ocarina-of-time/instrument-sets-and-sequences and https://github.com/sauraen/seq64):
+```
+0x00 - Ocarina Songs?
+0x01 - Actor Sounds
+0x02 - Nature Sounds
+0x03 - Hyrule Field (often the best choice, main orchestra with percussion)
+0x04 - Deku Tree
+0x05 - Castle Market
+0x06 - Title Screen
+0x07 - Jabu Jabu's Belly
+0x08 - Kakariko Village (Guitar)
+0x09 - Fairy Fountain (Harp, Strings)
+0x0A - Fire Temple
+0x0B - Dodongo's Cavern
+0x0C - Forest Temple
+0x0D - Lon Lon Ranch
+0x0E - Goron City
+0x0F - Kokiri Forest
+0x10 - Spirit Temple
+0x11 - Horse Race
+0x12 - Warp Songs
+0x13 - Goddess Cutscene
+0x14 - Shooting Gallery
+0x15 - Zora's Domain
+0x16 - Shop
+0x17 - Ice Cavern
+0x18 - Shadow Temple
+0x19 - Water Temple
+0x1A - Unused Piano
+0x1B - Gerudo Valley
+0x1C - Lakeside Laboratory
+0x1D - Kotake and Koume's Theme
+0x1E - Ganon's Castle (Organ)
+0x1F - Inside Ganon's Castle
+0x20 - Ganondorf Battle
+0x21 - Ending 1
+0x22 - Ending 2
+0x23 - Game Over / Fanfares
+0x24 - Owl
+0x25 - Unknown (probably should not use)
+```

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -363,6 +363,8 @@
           "row_span": 3,
           "settings": [
             "background_music",
+            "fanfares",
+            "ocarina_fanfares",
             "sfx_low_hp",
             "sfx_horse_neigh",
             "sfx_nightfall",


### PR DESCRIPTION
Adds an option similar to Background Music shuffle/disable, except for the short, non-looping fanfares. Includes the ability to load user sequences. Also adds a toggle (hidden unless fanfares are shuffled or disabled) for adding ocarina songs to the fanfare pool. Also expanded the music readme a bit.