### PR TITLE
Gui options tweaks

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -990,7 +990,7 @@ setting_infos = [
         disable        = {
             True : {
                 'sections' : ['open_section', 'shuffle_section', 'shuffle_dungeon_section'],
-                'settings' : ['all_reachable','bombchus_in_logic','one_item_per_dungeon','mq_dungeons_random','mq_dungeons'],
+                'settings' : ['starting_age', 'bombchus_in_logic','one_item_per_dungeon','mq_dungeons_random','mq_dungeons'],
             }
         },
         shared         = True,
@@ -1159,10 +1159,7 @@ setting_infos = [
             to hold the keys needed to reach them.
         ''',
         default        = True,
-        shared         = True,
-        gui_params     = {
-            'randomize_key': 'randomize_settings',
-        },
+        shared         = True
     ),
     Checkbutton(
         name           = 'bombchus_in_logic',
@@ -1936,7 +1933,7 @@ setting_infos = [
     ),
     Combobox(
         name           = 'logic_earliest_adult_trade',
-        gui_text       = 'Earliest',
+        gui_text       = 'Adult Trade Sequence Earliest Item',
         default        = 'pocket_egg',
         choices        = {
             'pocket_egg':   'Pocket Egg',
@@ -1957,7 +1954,7 @@ setting_infos = [
     ),
     Combobox(
         name           = 'logic_latest_adult_trade',
-        gui_text       = 'Latest',
+        gui_text       = 'Adult Trade Sequence Latest Item',
         default        = 'claim_check',
         choices        = {
             'pocket_egg':   'Pocket Egg',
@@ -2213,6 +2210,12 @@ setting_infos = [
             Closed Forest.
         ''',
         shared         = True,
+        gui_params     = {
+            'randomize_key': 'randomize_settings',
+            'distribution': [
+                ('random', 1),
+            ],
+        }
     ),
     Combobox(
         name           = 'default_targeting',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -126,8 +126,9 @@
           "name": "main_section",
           "text": "",
           "col_span": 4,
-          "row_span": 1,
+          "row_span": 2,
           "settings": [
+            "logic_rules",
             "randomize_settings"
           ]
         },
@@ -150,12 +151,11 @@
           "text": "World",
           "row_span": 6,
           "settings": [
-            "logic_rules",
-            "all_reachable",
             "bombchus_in_logic",
             "one_item_per_dungeon",
             "mq_dungeons_random",
-            "mq_dungeons"
+            "mq_dungeons",
+            "starting_age"
           ]
         },
         {
@@ -196,6 +196,17 @@
       "app_type": "generator",
       "sections": [
         {
+          "name": "main_section",
+          "text": "",
+          "col_span": 4,
+          "row_span": 3,
+          "settings": [
+            "all_reachable",
+            "logic_no_night_tokens_without_suns_song",
+            "logic_lens"
+          ]
+        },
+        {
           "name": "disabled_locations_section",
           "text": "Exclude Locations",
           "col_span": 2,
@@ -212,25 +223,6 @@
           "settings": [
             "allowed_tricks"
           ]
-        },
-        {
-          "name": "ats",
-          "text": "Adult Trade Sequence",
-          "col_span": 2,
-          "row_span": 4,
-          "settings": [
-            "logic_earliest_adult_trade",
-            "logic_latest_adult_trade"
-          ]
-        },
-        {
-          "name": "lens",
-          "text": "Lens of Truth",
-          "col_span": 2,
-          "row_span": 4,
-          "settings": [
-            "logic_lens"
-          ]
         }
       ]
     },
@@ -242,6 +234,7 @@
         {
           "name": "speedup_section",
           "text": "Timesavers",
+          "col_span": 1,
           "row_span": 1,
           "settings": [
             "no_escape_sequence",
@@ -249,7 +242,6 @@
             "no_epona_race",
             "useful_cutscenes",
             "fast_chests",
-            "logic_no_night_tokens_without_suns_song",
             "free_scarecrow",
             "start_with_fast_travel",
             "start_with_rupees",
@@ -264,6 +256,7 @@
         {
           "name": "misc_section",
           "text": "Misc",
+          "col_span": 1,
           "row_span": 1,
           "settings": [
             "ocarina_songs",
@@ -272,11 +265,20 @@
             "hints",
             "hint_dist",
             "text_shuffle",
+            "damage_multiplier",
+            "starting_tod"
+          ]
+        },
+        {
+          "name": "item_pool_section",
+          "text": "Item Pool",
+          "col_span": 1,
+          "row_span": 1,
+          "settings": [
             "junk_ice_traps",
             "item_pool_value",
-            "damage_multiplier",
-            "starting_tod",
-            "starting_age"
+            "logic_earliest_adult_trade",
+            "logic_latest_adult_trade"
           ]
         }
       ]


### PR DESCRIPTION
The main focus of this is to get the detailed logic tab content
consistent, although there are a few other tweaks in here too.

Starting with detailed logic, im going for the following definition
of what belongs on the tab:

1: If it has any impact to no-logic gameplay it should not not be on
   this tab.
2: If it has no impact whatsoever to no-logic gameplay it should be
   on this tab.

The is because this tab greys out in entirety depending on whether
no-logic is selected or now.

This leads to the following changes:

The trade sequence clams should be booted off the tab as they do impact
no-logic gameplay. It makes sense to move to 'other' considing it is
a minor setting (affecting one check). The 'Misc' column is getting
long so buddy these two up with the Ice Traps and Item Pool to make a
consolidated column ('Item Pool') for what is in the item pool.

Night skull hunting should go to the detailed logic tab. On its face
its a "timesaver" but it does however have a massive impact to fill
and logic, with Suns appearing on WOTH due to this setting and fill
being restricted accordingly. No other timesaver does this. So pull
in to detailed logic.

ALR should be a detailed logic setting. This is the one I am a little
on the fence about, however support folks do talk about how ALR is
an un-intuitive setting that does trap up new players, so from that
perspective I can see pulling it into logic making sense. It does
also fit the definition above on detailed logic setting. The thing
I am uncertain about is it losing its randomization on random settings.

Layout wise, rather than having Lens have its own one-option setting,
just combine the 3 misc options for the detailed logic tab (ALR, Lens
and night skulls) on the headline section. ALR is the most major
setting so list it first.

I need help with how to space 3 columns evenly on the 'Other' tab.

Two other changes:

Starting age is promoted to main rules under world. When combined with
closed door, this is a major impacter to logic and a very different
early game.

The logic ruleset is promoted to main-rules headline section. This
makes the randomize main rules toggle consistent, as now all the
options under the sub-tabs are consistenly greyed out in entirety. This
is such a major setting, it is an appropriate headline (and also
dictates the grey out of the detailed logic tab). Settings
Randomization is just below it.