### PR TITLE
Consolidate sections on cosmetics page

### DIFF
--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -285,29 +285,31 @@
       "sections": [
         {
           "name": "generalcosmetics_section",
-          "text": "General",
-          "row_span": 1,
+          "col_span": 12,
+          "row_span": 2,
           "settings": [
             "default_targeting",
             "display_dpad"
           ]
         },
         {
-          "name": "tunics_section",
-          "text": "Tunics",
+          "name": "equipment_section",
+          "text": "Equipment",
           "is_colors": true,
-          "row_span": 1,
+          "row_span": 6,
           "settings": [
             "kokiri_color",
             "goron_color",
-            "zora_color"
+            "zora_color",
+            "silver_gauntlets_color",
+            "golden_gauntlets_color"
           ]
         },
         {
           "name": "swordtrail_section",
           "text": "Sword Trail Colors",
           "is_colors": true,
-          "row_span": 1,
+          "row_span": 6,
           "settings": [
             "sword_trail_duration",
             "sword_trail_color_inner",
@@ -318,32 +320,14 @@
           "name": "ui_section",
           "text": "UI Colors",
           "is_colors": true,
-          "row_span": 1,
+          "row_span": 6,
           "settings": [
             "heart_color",
-            "magic_color"
-          ]
-        },
-        {
-          "name": "navi_section",
-          "text": "Navi Colors",
-          "is_colors": true,
-          "row_span": 1,
-          "settings": [
+            "magic_color",
             "navi_color_default",
             "navi_color_enemy",
             "navi_color_npc",
             "navi_color_prop"
-          ]
-        },
-        {
-          "name": "gauntlet_section",
-          "text": "Gauntlet Colors",
-          "is_colors": true,
-          "row_span": 1,
-          "settings": [
-            "silver_gauntlets_color",
-            "golden_gauntlets_color"
           ]
         }
       ]


### PR DESCRIPTION
The cosmetics page is a little over-divided with 6 headings and as
few as two options under some.

Tunics and guantlets are combined under a single equipment heading
to reclaim one column. This is the "equipment" column.

The "General" tab content is moved to the headline. These two are
borderline non-cosmetic and are more 'personalization'. The reason
for headlining them, is when an all-random check is added, it
should not apply. So put these first, such the all random check
can be added below which will apply to everything in the sub columns
only, excluding the targeting and dpad stuff. This will behave
consistently with the randomize main rules option. It also buys
back a full column of width.

Navi is rolled into the 'UI' catgory. This is the one that I am
least confident about, as whether navi's aesthetic is UI is debatable.
The crosshair targetting colors are UI but the fairy sprite is not
I guess?

Layout the 3 remaining sections as columns. Needs DBs 3-column
spacing patch before it will look nice.