### PR TITLE
python3.8 compatibility: Str vs Constant

### DIFF
--- a/RuleParser.py
+++ b/RuleParser.py
@@ -73,6 +73,10 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             args=[ast.Str(node.s)],
             keywords=[])
 
+    # python 3.8 compatibility: ast walking now uses visit_Constant for Constant subclasses
+    # this includes Num, Str, NameConstant, Bytes, and Ellipsis. We only use Str, so...
+    visit_Constant = visit_Str
+
     def visit_Tuple(self, node):
         if len(node.elts) != 2:
             raise Exception('Parse Error: Tuple must have 2 values', self.current_spot.name, ast.parse(node, False))

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -74,8 +74,12 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             keywords=[])
 
     # python 3.8 compatibility: ast walking now uses visit_Constant for Constant subclasses
-    # this includes Num, Str, NameConstant, Bytes, and Ellipsis. We only use Str, so...
-    visit_Constant = visit_Str
+    # this includes Num, Str, NameConstant, Bytes, and Ellipsis. We only handle Str.
+    def visit_Constant(self, node):
+        if isinstance(node, ast.Str):
+            return self.visit_Str(node)
+        return node
+
 
     def visit_Tuple(self, node):
         if len(node.elts) != 2:

--- a/State.py
+++ b/State.py
@@ -142,7 +142,7 @@ class State(object):
 
     def as_age(self, spot, tod=None, adult=True):
         if (self.can_become_adult() if adult else self.can_become_child()):
-            return self.with_age(lambda state: state.can_reach(spot, tod=tod))
+            return self.with_age(lambda state: state.can_reach(spot, tod=tod), adult=adult)
         return False
 
 


### PR DESCRIPTION
py3.8 is broken due to an AST change where Str is treated as Constant, meaning the visit_Str is not called appropriately.