### PR TITLE
Add Navi inner/outer separate cosmetics options back

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.html
+++ b/GUI/src/app/pages/generator/generator.component.html
@@ -32,22 +32,22 @@
                         </ng-container>
                         <!--Combo-->
                         <ng-container *ngSwitchCase="'Combobox'">
-                          <span *ngIf="section.is_colors && global.generator_settingsMap[setting.name] === 'Custom Color' && global.generator_customColorMap[setting.name].length > 0" class="comboBoxLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name]}">{{setting.text}} ({{global.generator_customColorMap[setting.name]}})</span>
-                          <span *ngIf="!section.is_colors || global.generator_settingsMap[setting.name] != 'Custom Color' || global.generator_customColorMap[setting.name].length == 0" class="comboBoxLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name]}">{{setting.text}}</span>
+                          <span *ngIf="section.is_colors && global.generator_settingsMap[setting.name] === 'Custom Color' && global.generator_customColorMap[setting.name].length > 0" class="comboBoxLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name], 'oneLineComboBox': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)), 'oLCBLabelFirst': getColumnCount(refEl) > 2 && setting.no_line_break, 'oLCBLabelSecond': getColumnCount(refEl) > 2 && itemIndex > 0 && section.settings[itemIndex-1].no_line_break}">{{setting.text}} ({{global.generator_customColorMap[setting.name]}})</span>
+                          <span *ngIf="!section.is_colors || global.generator_settingsMap[setting.name] != 'Custom Color' || global.generator_customColorMap[setting.name].length == 0" class="comboBoxLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name], 'oneLineComboBox': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)), 'oLCBLabelFirst': getColumnCount(refEl) > 2 && setting.no_line_break, 'oLCBLabelSecond': getColumnCount(refEl) > 2 && itemIndex > 0 && section.settings[itemIndex-1].no_line_break}">{{setting.text}}</span>
                           <!--Combobox with Custom Color Picker for Cosmetics-->
                           <ng-container *ngIf="section.is_colors">
-                            <div class="colorPickerContainer">
+                            <div class="colorPickerContainer" [ngClass]="{'oneLineComboBox oLCBPicker': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break))}">
                               <input #refColorPicker [(colorPicker)]="global.generator_customColorMap[setting.name]" [cpAlphaChannel]="disabled" [cpOutputFormat]="hex" [cpUseRootViewContainer]="true" [cpAddColorButton]="true" [cpPresetColors]="['#fff', '#000']" [cpMaxPresetColorsLength]="5"
                                      (colorPickerClose)="afterSettingChange(true)" />
                             </div>
-                            <nb-select class="selectXSmall" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [(selected)]="global.generator_settingsMap[setting.name]" (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event), refColorPicker)"
+                            <nb-select class="selectXSmall" [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)) }" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [(selected)]="global.generator_settingsMap[setting.name]" (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event), refColorPicker)"
                                        [nbPopover]="tooltipComponent" [nbPopoverContext]="{tooltip: setting.tooltip}" [nbPopoverTrigger]="setting.tooltip && setting.tooltip.length > 0 ? 'click' : 'noop'" nbPopoverPlacement="right" nbPopoverAdjustment="counterclockwise" size="xsmall">
                               <nb-option *ngFor="let option of setting.options; index as optionIndex" [value]="option.name">{{option.text}}</nb-option>
                             </nb-select>
                           </ng-container>
                           <!--Normal Combobox-->
                           <ng-container *ngIf="!section.is_colors">
-                            <nb-select class="selectXSmall" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [(selected)]="global.generator_settingsMap[setting.name]" (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event))"
+                            <nb-select class="selectXSmall" [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && setting.no_line_break}" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [(selected)]="global.generator_settingsMap[setting.name]" (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event))"
                                        [nbPopover]="tooltipComponent" [nbPopoverContext]="{tooltip: setting.tooltip}" [nbPopoverTrigger]="setting.tooltip && setting.tooltip.length > 0 ? 'click' : 'noop'" nbPopoverPlacement="right" nbPopoverAdjustment="counterclockwise" size="xsmall">
                               <nb-option *ngFor="let option of setting.options; index as optionIndex" [value]="option.name">{{option.text}}</nb-option>
                             </nb-select>

--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -146,6 +146,7 @@ nb-card-body {
 :host .oLCBLabelFirst {
   width: 248px;
   left: 0px;
+  text-align: center;
 
   @media (max-width: 1390px) {
     width: 223px;
@@ -167,6 +168,7 @@ nb-card-body {
 :host .oLCBLabelSecond {
   width: 112px;
   left: 0px;
+  text-align: center;
 
   @media (max-width: 1390px) {
     width: 108px;

--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -138,6 +138,78 @@ nb-card-body {
   margin-bottom: 0.8rem;
 }
 
+:host .oneLineComboBox {
+  display: inline-block !important;
+  margin-bottom: 10px;
+}
+
+:host .oLCBLabelFirst {
+  width: 248px;
+  left: 0px;
+
+  @media (max-width: 1390px) {
+    width: 223px;
+  }
+
+  @media (max-width: 1290px) {
+    width: 160px;
+  }
+
+  @media (max-width: 1075px) {
+    width: 140px;
+  }
+
+  @media (max-width: 1000px) {
+    width: 125px;
+  }
+}
+
+:host .oLCBLabelSecond {
+  width: 112px;
+  left: 0px;
+
+  @media (max-width: 1390px) {
+    width: 108px;
+  }
+
+  @media (max-width: 1290px) {
+    width: 100px;
+  }
+
+  @media (max-width: 1075px) {
+    width: 80px;
+  }
+
+  @media (max-width: 1000px) {
+    width: 62px;
+  }
+}
+
+:host .oLCBSelect {
+  width: 21%;
+  margin-right: 10px;
+
+  @media (max-width: 1290px) {
+    margin-right: 2px;
+    width: 23%;
+  }
+
+  @media (max-width: 1075px) {
+    margin-right: 2px;
+    width: 25%;
+  }
+
+  @media (max-width: 1000px) {
+    margin-right: 2px;
+    width: 27%;
+  }
+
+  @media (max-width: 915px) {
+    margin-right: 2px;
+    width: 23%;
+  }
+}
+
 .tileContainer {
   position: relative;
   width: 100%;
@@ -155,13 +227,11 @@ nb-card-body {
 
     /deep/ span {
 
+      white-space: pre-line;
+      line-height: 1.2;
+
       @media (max-width: 1350px) {
         font-size: 0.95rem;
-      }
-
-      @media (max-width: 1300px) {
-        white-space: pre-line;
-        line-height: 1.2;
       }
 
       @media (max-width: 1000px) {

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -572,9 +572,13 @@ export class GeneratorComponent implements OnInit {
     this.afterSettingChange(true);
   }
 
+  getColumnCount(tileRef: MatGridTile) {
+    return tileRef._gridList.cols;
+  }
+
   getColumnWidth(tileRef: MatGridTile, sections: any, index: number, length: number, colSpan: number = 0) {
 
-    let columnCount = tileRef._gridList.cols;
+    let columnCount = this.getColumnCount(tileRef);
 
     //col_span override
     if (colSpan > 0)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2302,9 +2302,27 @@ setting_infos = [
         '''
     ),
     Setting_Info(
-        name           = 'navi_color_default',
+        name           = 'navi_color_default_inner',
         type           = str,
-        gui_text       = "Navi Idle",
+        gui_text       = "Navi Idle Inner",
+        gui_type       = "Combobox",
+        gui_params     = {
+            'no_line_break' : True,
+        },
+        shared         = False,
+        choices        = get_navi_color_options(),
+        default        = 'White',
+        gui_tooltip    = '''\
+            'Random Choice': Choose a random
+            color from this list of colors.
+            'Completely Random': Choose a random
+            color from any color the N64 can draw.
+        '''
+    ),
+        Setting_Info(
+        name           = 'navi_color_default_outer',
+        type           = str,
+        gui_text       = "Outer",
         gui_type       = "Combobox",
         shared         = False,
         choices        = get_navi_color_options(),
@@ -2317,9 +2335,27 @@ setting_infos = [
         '''
     ),
     Setting_Info(
-        name           = 'navi_color_enemy',
+        name           = 'navi_color_enemy_inner',
         type           = str,
-        gui_text       = 'Navi Targeting Enemy',
+        gui_text       = 'Navi Targeting Enemy Inner',
+        gui_type       = "Combobox",
+        gui_params     = {
+            'no_line_break' : True,
+        },
+        shared         = False,
+        choices        = get_navi_color_options(),
+        default        = 'Yellow',
+        gui_tooltip    = '''\
+            'Random Choice': Choose a random
+            color from this list of colors.
+            'Completely Random': Choose a random
+            color from any color the N64 can draw.
+        '''
+    ),
+    Setting_Info(
+        name           = 'navi_color_enemy_outer',
+        type           = str,
+        gui_text       = 'Outer',
         gui_type       = "Combobox",
         shared         = False,
         choices        = get_navi_color_options(),
@@ -2332,9 +2368,27 @@ setting_infos = [
         '''
     ),
     Setting_Info(
-        name           = 'navi_color_npc',
+        name           = 'navi_color_npc_inner',
         type           = str,
-        gui_text       = 'Navi Targeting NPC',
+        gui_text       = 'Navi Targeting NPC Inner',
+        gui_type       = "Combobox",
+        gui_params     = {
+            'no_line_break' : True,
+        },
+        shared         = False,
+        choices        = get_navi_color_options(),
+        default        = 'Light Blue',
+        gui_tooltip    = '''\
+            'Random Choice': Choose a random
+            color from this list of colors.
+            'Completely Random': Choose a random
+            color from any color the N64 can draw.
+        '''
+    ),
+    Setting_Info(
+        name           = 'navi_color_npc_outer',
+        type           = str,
+        gui_text       = 'Outer',
         gui_type       = "Combobox",
         shared         = False,
         choices        = get_navi_color_options(),
@@ -2347,9 +2401,27 @@ setting_infos = [
         '''
     ),
     Setting_Info(
-        name           = 'navi_color_prop',
+        name           = 'navi_color_prop_inner',
         type           = str,
-        gui_text       = 'Navi Targeting Prop',
+        gui_text       = 'Navi Targeting Prop Inner',
+        gui_type       = "Combobox",
+        shared         = False,
+        gui_params     = {
+            'no_line_break' : True,
+        },
+        choices        = get_navi_color_options(),
+        default        = 'Green',
+        gui_tooltip    = '''\
+            'Random Choice': Choose a random
+            color from this list of colors.
+            'Completely Random': Choose a random
+            color from any color the N64 can draw.
+        '''
+    ),
+    Setting_Info(
+        name           = 'navi_color_prop_outer',
+        type           = str,
+        gui_text       = 'Outer',
         gui_type       = "Combobox",
         shared         = False,
         choices        = get_navi_color_options(),

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -330,10 +330,14 @@
           "is_colors": true,
           "row_span": 1,
           "settings": [
-            "navi_color_default",
-            "navi_color_enemy",
-            "navi_color_npc",
-            "navi_color_prop"
+            "navi_color_default_inner",
+            "navi_color_default_outer",
+            "navi_color_enemy_inner",
+            "navi_color_enemy_outer",
+            "navi_color_npc_inner",
+            "navi_color_npc_outer",
+            "navi_color_prop_inner",
+            "navi_color_prop_outer"
           ]
         },
         {


### PR DESCRIPTION
Adds separate inner/outer color options for Navi and place them on the same line if the GUI window size is big enough (4/12 column layout). With this Electron can now handle no_line_break for a ComboBox as well.

What's missing from this PR is the python source adjustment to properly handle the new separate color options on generation instead of looking for 2 hex colors in one setting.