### PR TITLE
Prevent trade items from reverting on save load in certain ER settings

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -773,14 +773,16 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         
     exit_table = generate_exit_lookup_table()
 
+    if world.shuffle_interior_entrances or world.shuffle_overworld_entrances:
+        # Disable trade quest timers and prevent trade items from reverting on save load
+        rom.write_byte(rom.sym('DISABLE_TIMERS'), 0x01)
+        rom.write_int32(0xB064CC, 0x10000010) # b 0xB06510 (skip trade item revert)
+
     if world.shuffle_overworld_entrances:
         rom.write_byte(rom.sym('OVERWORLD_SHUFFLED'), 1)
 
         # Prevent the ocarina cutscene from leading straight to hyrule field
         rom.write_byte(rom.sym('OCARINAS_SHUFFLED'), 1)
-
-        # Disable trade quest timers
-        rom.write_byte(rom.sym('DISABLE_TIMERS'), 0x01)
 
         # Disable the fog state entirely to avoid fog glitches
         rom.write_byte(rom.sym('NO_FOG_STATE'), 1)
@@ -845,9 +847,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         set_entrance_updates(world.get_shuffled_entrances(type='Dungeon'))
 
     if world.shuffle_interior_entrances:
-        # Disable trade quest timers
-        rom.write_byte(rom.sym('DISABLE_TIMERS'), 0x01)
-
         # Change the Happy Mask Shop "throw out" entrance index to the new one (hardcode located in the shop actor)
         rom.write_int16(0xC6DA5E, world.get_entrance('Castle Town Mask Shop -> Castle Town').replaces.data['index'])
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1649,6 +1649,9 @@ setting_infos = [
             'All Indoors & Overworld':
             Same as 'All Indoors' but with Overworld loading zones shuffled
             in a new separate pool. Owl drop positions are also randomized.
+
+            Note: If Interior or Overworld entrances are shuffled, trade timers 
+            are disabled and trade items don't revert when loading a save.
         ''',
         shared         = True,
         gui_params     = {

--- a/State.py
+++ b/State.py
@@ -463,31 +463,22 @@ class State(object):
 
 
     def guarantee_trade_path(self):
-        # Require certain warp songs based on ER settings to ensure the player doesn't have to savewarp in order to complete the trade quest
-        # This is meant to avoid possible logical softlocks until either the trade quest is reworked or a better solution is found
-        if self.world.shuffle_special_indoor_entrances:
-            return self.can_play('Prelude of Light')
-        elif self.world.shuffle_interior_entrances:
-            colossus_fairy_entrance = self.world.get_entrance('Desert Colossus -> Colossus Fairy')
-            if colossus_fairy_entrance.connected_region and colossus_fairy_entrance.connected_region.name == 'Lake Hylia Lab':
-                return (self.has_ocarina() and \
-                           self.has_any_of(('Prelude of Light', 'Minuet of Forest', 'Serenade of Water', 'Nocturne of Shadow'))) or \
-                       (self.can_play('Bolero of Fire') and (self.has_any_of(('Progressive Hookshot', 'Hover Boots')) or \
-                           (self.can_become_child() and self.has_any_of(('Magic Bean', 'Magic Bean Pack'))))) or \
-                       (self.world.logic_reverse_wasteland and \
-                           (self.world.logic_wasteland_crossing or self.has('Hover Boots') or self.has('Progressive Hookshot', 2)))
-
-            # timer is disabled with shuffle_interior_entrances
+        if self.world.shuffle_interior_entrances or self.world.shuffle_overworld_entrances:
+            # Timers are disabled and items don't revert on save warp in those ER settings
             return True
         else:
             return (
-                # check necessary items for the paths that fit in the timer
+                # Check necessary items for the paths to Biggoron that fit the timer
                 self.world.logic_biggoron_bolero
                 # Getting to Biggoron without ER or the trick above involves either
                 # Darunia's Chamber access or clearing the boulders to get up DMT
                 or self.can_blast_or_smash()
                 or self.has('Stop Link the Goron')
             )
+
+
+    def disabled_trade_revert(self):
+        return self.world.shuffle_interior_entrances or self.world.shuffle_overworld_entrances
 
 
     def has_bottle(self):

--- a/State.py
+++ b/State.py
@@ -477,10 +477,6 @@ class State(object):
             )
 
 
-    def disabled_trade_revert(self):
-        return self.world.shuffle_interior_entrances or self.world.shuffle_overworld_entrances
-
-
     def has_bottle(self):
         # Extra Ruto's Letter are automatically emptied
         return self.has_any_of(ItemInfo.bottles) or self.has('Bottle with Letter', 2)

--- a/World.py
+++ b/World.py
@@ -49,11 +49,14 @@ class World(object):
         # rename a few attributes...
         self.keysanity = self.shuffle_smallkeys in ['keysanity', 'remove']
         self.check_beatable_only = not self.all_reachable
+    
         self.shuffle_dungeon_entrances = self.entrance_shuffle != 'off'
         self.shuffle_grotto_entrances = self.entrance_shuffle in ['simple-indoors', 'all-indoors', 'all']
         self.shuffle_interior_entrances = self.entrance_shuffle in ['simple-indoors', 'all-indoors', 'all']
         self.shuffle_special_indoor_entrances = self.entrance_shuffle in ['all-indoors', 'all']
         self.shuffle_overworld_entrances = self.entrance_shuffle == 'all'
+
+        self.disabled_trade_revert = self.shuffle_interior_entrances or self.shuffle_overworld_entrances
 
         # Determine LACS Condition
         if self.shuffle_ganon_bosskey == 'lacs_medallions':

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -141,6 +141,10 @@
         "region_name": "Lost Woods",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
+        "events": {
+            "Odd Mushroom Access": "is_adult and ('Cojiro Access' or Cojiro)",
+            "Poachers Saw Access": "is_adult and 'Odd Potion Access'"
+        },
         "locations": {
             "Skull Kid": "is_child and can_play(Sarias_Song)",
             "Ocarina Memory Game": "is_child and has_ocarina",
@@ -326,6 +330,11 @@
     },
     {
         "region_name": "Lake Hylia Lab",
+        "events": {
+            "Eyedrops Access": "
+                is_adult and 
+                ('Eyeball Frog Access' or (Eyeball_Frog and disabled_trade_revert))"
+        },
         "locations": {
             "Diving in the Lab": "
                 (Progressive_Scale, 2) or
@@ -387,6 +396,9 @@
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
+        "events": {
+            "Broken Sword Access": "is_adult and ('Poachers Saw Access' or Poachers_Saw)"
+        },
         "locations": {
             "Gerudo Valley Hammer Rocks Chest": "can_use(Hammer)",
             "GS Gerudo Valley Behind Tent": "can_use(Hookshot) and at_night",
@@ -816,6 +828,7 @@
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "events": {
+            "Cojiro Access": "is_adult and 'Wake Up Adult Talon'",
             "Kakariko Village Gate Open": "is_child and Zeldas_Letter"
         },
         "locations": {
@@ -862,6 +875,9 @@
     },
     {
         "region_name": "Carpenter Boss House",
+        "events": {
+            "Wake Up Adult Talon": "is_adult and (Pocket_Egg or Pocket_Cucco)"
+        },
         "exits": {
             "Kakariko Village": "True"
         }
@@ -959,6 +975,11 @@
     },
     {
         "region_name": "Odd Medicine Building",
+        "events": {
+            "Odd Potion Access": "
+                is_adult and
+                ('Odd Mushroom Access' or (Odd_Mushroom and disabled_trade_revert))"
+        },
         "exits": {
             "Kakariko Village": "True"
         }
@@ -1101,18 +1122,15 @@
         "scene": "Death Mountain",
         "hint": "Death Mountain Trail",
         "time_passes": true,
+        "events": {
+            "Prescription Access": "is_adult and ('Broken Sword Access' or Broken_Sword)"
+        },
         "locations": {
-            "Biggoron": "is_adult and guarantee_hint and (
-                Claim_Check or (
-                    guarantee_trade_path and 'Zora Thawed' and
-                    at('Lake Hylia Lab', is_adult) and (
-                        Eyedrops or Eyeball_Frog or Prescription or Broken_Sword or (
-                            at('Gerudo Valley Far Side', is_adult) and (
-                                Poachers_Saw or (
-                                    at('Lost Woods', is_adult) and
-                                    at('Odd Medicine Building', is_adult) and (
-                                        Odd_Mushroom or Cojiro or (
-                                            at('Carpenter Boss House', is_adult and (Pocket_Egg or Pocket_Cucco))))))))))",
+            "Biggoron": "
+                is_adult and guarantee_hint and 
+                (Claim_Check or 
+                    (guarantee_trade_path and 
+                    ('Eyedrops Access' or (Eyedrops and disabled_trade_revert))))",
             "GS Mountain Trail Path to Crater": "
                 (can_use(Hammer) or logic_trail_gs_upper) and at_night",
             "Death Mountain Trail Gossip Stone": "True",
@@ -1435,7 +1453,10 @@
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "events": {
-            "Zora Thawed": "is_adult and has_blue_fire"
+            "Zora Thawed": "is_adult and has_blue_fire",
+            "Eyeball Frog Access": "
+                is_adult and 'Zora Thawed' and 
+                (Eyedrops or Eyeball_Frog or Prescription or 'Prescription Access')"
         },
         "locations": {
             "Diving Minigame": "is_child",


### PR DESCRIPTION
Along with trade timers being disabled, items will now never revert in ER when interior or overworld entrances are shuffled ("Simple Indoors" and higher settings). This is done to avoid inconsistencies with logic not being able to account for the fact that save warping can't be used to deliver items.
Previously, logic would arbitrarily require certain songs to ensure you can reach adult's save warp which is the starting point for logic. But this wasn't ideal, especially when ToT or overworld entrances were shuffled, in which case Prelude was hard required to complete the trade sequence logically, even when it wasn't needed at all gameplay-wise.

With items not reverting under those circumstances, I had to rewrite the glitchless trade quest logic. 
I decided to split the different trade steps to make it a bit clearer as it was kind of a mess before.
@Zannick What do you think about this implementation? I know you said you would like it being written with locations that give the actual items but I don't think that would be compatible with items sometimes reverting and sometimes not, and the pattern I used seems like a good compromise to me.

I also added a small mention about trade related changes in the ER tooltip, to make it clear that timers are completely disabled and items don't revert.