### PR TITLE
Minor ER validation changes and fixes

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -553,10 +553,6 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
             if not max_playthrough.state_list[world.id].as_both(temple_of_time_entrance):
                 raise EntranceShuffleError('Temple of Time Entrance is never reachable as both ages')
 
-            # Temple of Time shouldn't be placed inside the Fishing Pond to prevent potential issues with the lake hylia water control
-            if temple_of_time_entrance.name == 'Lake Hylia -> Fishing Hole':
-                raise EntranceShuffleError('Temple of Time is placed behind the Fishing Pond')
-
             # Windmill door entrance should be reachable as both ages at some point in the seed
             windmill_door_entrance = get_entrance_replacing(world.get_region('Windmill'), 'Kakariko Village -> Windmill')
             if not max_playthrough.state_list[world.id].as_both(windmill_door_entrance):

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -610,7 +610,8 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
                     raise EntranceShuffleError('Links House to Temple of Time path as child is not guaranteed')
 
     if entrance_placed == None or (entrance_placed != None and entrance_placed.type in ['Interior', 'SpecialInterior', 'Overworld']):
-        # The Big Poe Shop should always be accessible as adult without the need to use any bottles (eg. without any items)
+        # The Big Poe Shop should always be accessible as adult without the need to use any bottles
+        # Since we can't guarantee that items in the pool won't be placed behind bottles, we guarantee the access without using any items
         # This is important to ensure that players can never lock their only bottles by filling them with Big Poes they can't sell
         no_items_time_travel_playthrough = Playthrough.with_items([State(world) for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
 

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -604,6 +604,16 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
             for world in worlds:
                 if world.starting_age == 'adult' and not time_travel_playthrough.can_reach(world.get_region('Temple of Time'), age='child'):
                     raise EntranceShuffleError('Links House to Temple of Time path as child is not guaranteed')
+
+    if entrance_placed == None or (entrance_placed != None and entrance_placed.type in ['Interior', 'SpecialInterior', 'Overworld']):
+        # The Big Poe Shop should always be accessible as adult without the need to use any bottles (eg. without any items)
+        # This is important to ensure that players can never lock their only bottles by filling them with Big Poes they can't sell
+        no_items_time_travel_playthrough = Playthrough.with_items([State(world) for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
+
+        for world in worlds:
+            if not no_items_time_travel_playthrough.can_reach(world.get_region('Castle Town Rupee Room'), age='adult'):
+                raise EntranceShuffleError('Big Poe Shop access is not guaranteed as adult')
+
     return
 
 

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -590,7 +590,7 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
         # This also means that, in order to test for this, we have to temporarily remove that assumption about root access to time passing
         for world in worlds:
             world.get_region('Root').can_reach = lambda state: state.tod == None
-        no_time_passing_playthrough = Playthrough.with_items([world.state.copy() for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
+        no_time_passing_playthrough = Playthrough.with_items([world.state for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
         for world in worlds:
             world.get_region('Root').can_reach = lambda state: True
 

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -431,6 +431,10 @@ def shuffle_entrance_pool(worlds, entrance_pool, target_entrances, locations_to_
             # Shuffle the rest of the entrances, we don't have to check for beatability or reachability of locations when placing those
             shuffle_entrances(worlds, soft_entrances, target_entrances, rollbacks)
 
+            # Fully validate the resulting worlds to ensure everything is still fine after shuffling this pool
+            complete_itempool = [item for world in worlds for item in world.get_itempool_with_dungeon_items()]
+            validate_worlds(worlds, None, locations_to_ensure_reachable, complete_itempool)
+
             # If all entrances could be connected without issues, log connections and continue
             for entrance, target in rollbacks:
                 confirm_replacement(entrance, target)


### PR DESCRIPTION
Some changes and fixes to the special checks run while shuffling entrances:
- Removed the hard restriction for Temple of Time not being at the Fishing Pond entrance since that was intended to prevent potential issues with child lake control which is no longer a thing.
- Added a check to guarantee access to the Big Poe Shop as adult so players can never be locked by filling their bottles with Big Poes when they don't have access to the place where they can get rid of them. I had intended to handle that a long time ago but had forgotten about it until recently..
- Made it so all validation checks are run once before confirming the placement of every entrance pool. This is meant to catch problems earlier so the local retry can be used if something went wrong when shuffling a specific entrance pool, instead of having it fall later in the global retry.
- Removed a redundant state copy when generating the playthrough to guarantee time passing access. `Playthrough.with_items` already copies states just like `Playthrough.max_explore` does so this was completely unnecessary.