### PR TITLE
Cosmetics page simplification and randomized cosmetics

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2355,6 +2355,12 @@ setting_infos = [
             randomized. Additional music can
             be loaded from data/Music/
         ''',
+        gui_params  = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random', 1),
+            ]
+        },
     ),
     Combobox(
         name           = 'fanfares',
@@ -2377,6 +2383,12 @@ setting_infos = [
             Additional fanfares can be loaded
             from data/Music/
         ''',
+        gui_params  = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random', 1),
+            ]
+        },
     ),
     Checkbutton(
         name           = 'ocarina_fanfares',
@@ -2389,6 +2401,10 @@ setting_infos = [
         ''',
         gui_params  = {
             "hide_when_disabled": True,
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                (True, 1),
+            ]
         },
         default        = False,
     ),
@@ -2401,7 +2417,19 @@ setting_infos = [
         ''',
         default        = True,
     ),
+    Checkbutton(
+        name           = 'randomize_all_cosmetics',
+        gui_text       = 'Randomize All Cosmetics',
+        gui_tooltip    = '''\
+            Randomize all cosmetics settings
+        ''',
+        default        = False,
+        disable    = {
+            True : {'sections' : [ "equipment_section", "ui_section", "navi_section" ]
+            }
+        }
 
+    ),
     Setting_Info(
         name           = 'kokiri_color',
         type           = str,
@@ -2415,7 +2443,13 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
     ),
     Setting_Info(
         name           = 'goron_color',
@@ -2430,7 +2464,14 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'zora_color',
@@ -2445,16 +2486,20 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_default_inner',
         type           = str,
         gui_text       = "Navi Idle Inner",
         gui_type       = "Combobox",
-        gui_params     = {
-            'no_line_break' : True,
-        },
         shared         = False,
         choices        = get_navi_color_options(),
         default        = 'White',
@@ -2463,7 +2508,14 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'no_line_break' : True,
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
     ),
         Setting_Info(
         name           = 'navi_color_default_outer',
@@ -2478,16 +2530,20 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_enemy_inner',
         type           = str,
         gui_text       = 'Navi Targeting Enemy Inner',
         gui_type       = "Combobox",
-        gui_params     = {
-            'no_line_break' : True,
-        },
         shared         = False,
         choices        = get_navi_color_options(),
         default        = 'Yellow',
@@ -2496,7 +2552,15 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'no_line_break' : True,
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_enemy_outer',
@@ -2511,16 +2575,20 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_npc_inner',
         type           = str,
         gui_text       = 'Navi Targeting NPC Inner',
         gui_type       = "Combobox",
-        gui_params     = {
-            'no_line_break' : True,
-        },
         shared         = False,
         choices        = get_navi_color_options(),
         default        = 'Light Blue',
@@ -2529,7 +2597,15 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'no_line_break' : True,
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_npc_outer',
@@ -2544,7 +2620,14 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_prop_inner',
@@ -2552,9 +2635,6 @@ setting_infos = [
         gui_text       = 'Navi Targeting Prop Inner',
         gui_type       = "Combobox",
         shared         = False,
-        gui_params     = {
-            'no_line_break' : True,
-        },
         choices        = get_navi_color_options(),
         default        = 'Green',
         gui_tooltip    = '''\
@@ -2562,7 +2642,15 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'no_line_break' : True,
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'navi_color_prop_outer',
@@ -2577,7 +2665,14 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Combobox(
         name           = 'sword_trail_duration',
@@ -2592,11 +2687,20 @@ setting_infos = [
         gui_tooltip    = '''\
             Select the duration for sword trails.
         ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                (4, 1),
+                (10, 1),
+                (15, 1),
+                (20, 1)
+            ]
+        }
     ),
     Setting_Info(
         name           = 'sword_trail_color_inner',
         type           = str,
-        gui_text       = 'Inner Color',
+        gui_text       = 'Sword Trail Inner Color',
         gui_type       = "Combobox",
         shared         = False,
         choices        = get_sword_color_options(),
@@ -2607,12 +2711,19 @@ setting_infos = [
             'Completely Random': Choose a random
             color from any color the N64 can draw.
             'Rainbow': Rainbow sword trails.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'sword_trail_color_outer',
         type           = str,
-        gui_text       = 'Outer Color',
+        gui_text       = 'Sword Trail Outer Color',
         gui_type       = "Combobox",
         shared         = False,
         choices        = get_sword_color_options(),
@@ -2623,7 +2734,14 @@ setting_infos = [
                   'Completely Random': Choose a random
                   color from any color the N64 can draw.
                   'Rainbow': Rainbow sword trails.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'silver_gauntlets_color',
@@ -2639,7 +2757,14 @@ setting_infos = [
             'Completely Random': Choose a random
             color from any color the N64 can draw.
             'Rainbow': Rainbow sword trails.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'golden_gauntlets_color',
@@ -2655,7 +2780,14 @@ setting_infos = [
             'Completely Random': Choose a random
             color from any color the N64 can draw.
             'Rainbow': Rainbow sword trails.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'heart_color',
@@ -2670,7 +2802,14 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
     ),
     Setting_Info(
         name           = 'magic_color',
@@ -2685,7 +2824,27 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-        '''
+        ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_cosmetics',
+            'distribution': [
+                ('Completely Random', 1),
+            ]
+        }
+
+    ),
+    Checkbutton(
+        name           = 'randomize_all_sfx',
+        gui_text       = 'Randomize All Sound Effects',
+        gui_tooltip    = '''\
+            Randomize all sound effects and music settings (ear safe)
+        ''',
+        default        = False,
+        disable    = {
+            True : {'sections' : [ "generalsfx_section", "menusfx_section", "npcsfx_section" ]
+            }
+        }
+
     ),
     Combobox(
         name           = 'sfx_low_hp',
@@ -2697,48 +2856,96 @@ setting_infos = [
             sound from this list.
             'Default': Beep. Beep. Beep.
         ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_navi_overworld',
         gui_text       = 'Navi Overworld',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.NAVI_OVERWORLD),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_navi_enemy',
         gui_text       = 'Navi Enemy',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.NAVI_ENEMY),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_menu_cursor',
         gui_text       = 'Menu Cursor',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.MENU_CURSOR),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_menu_select',
         gui_text       = 'Menu Select',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.MENU_SELECT),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_horse_neigh',
         gui_text       = 'Horse',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.HORSE_NEIGH),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_nightfall',
         gui_text       = 'Nightfall',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.NIGHTFALL),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_hover_boots',
         gui_text       = 'Hover Boots',
         choices        = sfx.get_setting_choices(sfx.SoundHooks.BOOTS_HOVER),
         default        = 'default',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-ear-safe', 1),
+            ]
+        }
     ),
     Combobox(
         name           = 'sfx_ocarina',
@@ -2756,6 +2963,12 @@ setting_infos = [
         gui_tooltip    = '''\
             Change the sound of the ocarina.
         ''',
+        gui_params     = {
+            'randomize_key': 'randomize_all_sfx',
+            'distribution': [
+                ('random-choice', 1),
+            ]
+        }
     ),
 ]
 

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -285,30 +285,26 @@
       "sections": [
         {
           "name": "generalcosmetics_section",
-          "text": "General",
-          "row_span": 1,
+          "col_span": 4,
+          "row_span": 2,
           "settings": [
             "default_targeting",
-            "display_dpad"
+            "display_dpad",
+            "randomize_all_cosmetics"
           ]
         },
         {
-          "name": "tunics_section",
-          "text": "Tunics",
+          "name": "equipment_section",
+          "text": "Equipment",
           "is_colors": true,
-          "row_span": 1,
+          "col_span": 1,
+          "row_span": 6,
           "settings": [
             "kokiri_color",
             "goron_color",
-            "zora_color"
-          ]
-        },
-        {
-          "name": "swordtrail_section",
-          "text": "Sword Trail Colors",
-          "is_colors": true,
-          "row_span": 1,
-          "settings": [
+            "zora_color",
+            "silver_gauntlets_color",
+            "golden_gauntlets_color",
             "sword_trail_duration",
             "sword_trail_color_inner",
             "sword_trail_color_outer"
@@ -318,7 +314,8 @@
           "name": "ui_section",
           "text": "UI Colors",
           "is_colors": true,
-          "row_span": 1,
+          "col_span": 1,
+          "row_span": 6,
           "settings": [
             "heart_color",
             "magic_color"
@@ -328,7 +325,8 @@
           "name": "navi_section",
           "text": "Navi Colors",
           "is_colors": true,
-          "row_span": 1,
+          "col_span": 2,
+          "row_span": 6,
           "settings": [
             "navi_color_default_inner",
             "navi_color_default_outer",
@@ -339,16 +337,6 @@
             "navi_color_prop_inner",
             "navi_color_prop_outer"
           ]
-        },
-        {
-          "name": "gauntlet_section",
-          "text": "Gauntlet Colors",
-          "is_colors": true,
-          "row_span": 1,
-          "settings": [
-            "silver_gauntlets_color",
-            "golden_gauntlets_color"
-          ]
         }
       ]
     },
@@ -358,10 +346,19 @@
       "is_cosmetics": true,
       "sections": [
         {
+          "name": "sfx_main_section",
+          "is_sfx": true,
+          "col_span": 4,
+          "row_span": 1,
+          "settings": [
+            "randomize_all_sfx"
+          ]
+        },
+        {
           "name": "generalsfx_section",
           "text": "General",
           "is_sfx": true,
-          "row_span": 3,
+          "row_span": 6,
           "settings": [
             "background_music",
             "fanfares",
@@ -377,7 +374,7 @@
           "name": "menusfx_section",
           "text": "Menu",
           "is_sfx": true,
-          "row_span": 3,
+          "row_span": 6,
           "settings": [
             "sfx_menu_cursor",
             "sfx_menu_select"
@@ -387,7 +384,7 @@
           "name": "npcsfx_section",
           "text": "NPC",
           "is_sfx": true,
-          "row_span": 3,
+          "row_span": 6,
           "settings": [
             "sfx_navi_overworld",
             "sfx_navi_enemy"


### PR DESCRIPTION
Simplify the cosmetics page to be a similar layout to the other pages.
This had too many micro-sections with only a few headings that have
little scope for future expansion.

Wrangle all sword, tunic and gauntlet settings under 'equipment'.

Move the 'general' pieces to the headline as these are more about
functionality and gameplay rather than cosmetic. For these reason,
they should be exempt from randomization so put them alongside the
new randomization setting in the headline.

Music and SFX has a headline with a randomize all toggle.