### PR TITLE
Logic fixes - set 1 (audit in progress - there will be more)

### DIFF
--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -12,6 +12,7 @@
         "region_name": "Dodongos Cavern Lobby",
         "dungeon": "Dodongos Cavern",
         "locations": {
+            "Deku Baba Sticks": "is_adult or Kokiri_Sword or can_use(Boomerang)",
             "Dodongos Cavern MQ Map Chest": "True",
             "Dodongos Cavern MQ Compass Chest": "is_adult or can_child_attack or has_nuts",
             "Dodongos Cavern MQ Larva Room Chest": "can_use(Sticks) or has_fire_source",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -316,8 +316,8 @@
                 is_child or can_use(Scarecrow) or
                 here(can_plant_bean) or 'Water Temple Clear'",
             "Water Temple Lobby": "
-                here(is_adult and (can_use(Hookshot) and Iron_Boots or can_use(Longshot))) and
-                ((Progressive_Scale, 2) or can_use(Iron_Boots)) and is_adult",
+                (can_use(Hookshot) and can_use(Iron_Boots)) or
+                (can_use(Longshot) and (Progressive_Scale, 2))",
             "Lake Hylia Grotto": "True"
         }
     },

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -67,13 +67,18 @@
         }
     },
     {
+        #In this region, child reachability really means age-unknown, but with the caveat
+        #that child has as least entered the dungeon. is_adult means is_adult as usual.
+        #All child specific logic must be anded with 7 keys to convert child-as-unknown-age
+        #back to child.
         "region_name": "Spirit Temple Shared",
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple MQ Child Climb North Chest": "(Small_Key_Spirit_Temple, 6)",
             "Spirit Temple MQ Compass Chest": "
-                (can_use(Slingshot) and (has_bow or (Small_Key_Spirit_Temple, 7))) or
-                can_use(Bow)",
+                (can_use(Slingshot) and (Small_Key_Spirit_Temple, 7)) or
+                can_use(Bow) or
+                (has_bow and has_slingshot)",
             "Spirit Temple MQ Sun Block Room Chest": " can_play(Song_of_Time) or is_adult",
             "GS Spirit Temple MQ Sun Block Room": "
                 (logic_spirit_mq_sun_block_gs and can_play(Song_of_Time) and Boomerang) or

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -72,23 +72,18 @@
         "locations": {
             "Spirit Temple MQ Child Climb North Chest": "(Small_Key_Spirit_Temple, 6)",
             "Spirit Temple MQ Compass Chest": "
-                ((Small_Key_Spirit_Temple, 7) and can_use(Slingshot)) or 
-                (can_use(Longshot) and can_use(Silver_Gauntlets) and has_bow) or 
-                (has_slingshot and has_bow)",
-            "Spirit Temple MQ Sun Block Room Chest": "
-                can_play(Song_of_Time) or 
-                (can_use(Longshot) and can_use(Silver_Gauntlets))",
+                (can_use(Slingshot) and (has_bow or (Small_Key_Spirit_Temple, 7))) or
+                can_use(Bow)",
+            "Spirit Temple MQ Sun Block Room Chest": " can_play(Song_of_Time) or is_adult",
             "GS Spirit Temple MQ Sun Block Room": "
                 (logic_spirit_mq_sun_block_gs and can_play(Song_of_Time) and Boomerang) or
-                (can_use(Longshot) and can_use(Silver_Gauntlets))"
+                is_adult"
         },
         "exits": {
             "Silver Gauntlets Hand": "
-                ((Small_Key_Spirit_Temple, 7) and 
-                    (can_play(Song_of_Time) or 
-                        (can_use(Longshot) and can_use(Silver_Gauntlets)))) or 
+                ((Small_Key_Spirit_Temple, 7) and (can_play(Song_of_Time) or is_adult)) or 
                 ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and 
-                    can_see_with_lens)"
+                 can_see_with_lens)"
         }
     },
     {

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -31,10 +31,10 @@
                 has_sticks or Kokiri_Sword or has_explosives",
             "Spirit Temple MQ Silver Block Hallway Chest": "
                 has_bombchus and (Small_Key_Spirit_Temple, 7) and has_slingshot and 
-                (can_use(Dins_Fire) or 
-                    here(is_adult and can_use(Longshot) and can_use(Silver_Gauntlets) and 
-                          (can_use(Fire_Arrows) or
-                              (logic_spirit_mq_frozen_eye and has_bow and can_play(Song_of_Time)))))"
+                (can_use(Dins_Fire) or
+                 at('Adult Spirit Temple', (can_use(Fire_Arrows) or
+                                           (logic_spirit_mq_frozen_eye and can_use(Bow) and
+                                            can_play(Song_of_Time)))))"
         },
         "exits": {
             "Spirit Temple Shared": "has_bombchus and (Small_Key_Spirit_Temple, 2)"

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -83,7 +83,11 @@
             "Silver Gauntlets Hand": "
                 ((Small_Key_Spirit_Temple, 7) and (can_play(Song_of_Time) or is_adult)) or 
                 ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and 
-                 can_see_with_lens)"
+                 can_see_with_lens)",
+            "Desert Colossus": "
+                ((Small_Key_Spirit_Temple, 7) and (can_play(Song_of_Time) or is_adult)) or
+                ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and
+                 can_see_with_lens and is_adult)"
         }
     },
     {


### PR DESCRIPTION
Fix the first batch of logic issues identified in detailed review of the logic by r0b.

commit d900e00e6c3019bd97f166f376d0fae0a8c9052b (HEAD -> settings, rattus/logic-audit-1)
Author: rattus128 <rattus128@gmail.com>
Date:   Tue Jul 30 14:42:24 2019 +1000

    Add collossus exit MQ Spirit
    
    Its almost the same as the silvers chest, however you must check for
    adult on the 4 key route and only let adult escape on that route to
    avoid an unknown age issue in the colossus.

commit 97361e544b2a3cf84bda5184e51e3df71e283358
Author: rattus128 <rattus128@gmail.com>
Date:   Tue Jul 30 14:35:11 2019 +1000

    Fix spirit MQ hallway logic
    
    This needs to be an at() rather than a here. The here(is_adult and ...)
    was self contradictory, as this region is only ever reachable as child,
    placing the fire arrows route completely out of logic.

commit f2e97839c01e9402f8c39eedd2368934cfc099e9
Author: rattus128 <rattus128@gmail.com>
Date:   Tue Jul 30 12:03:11 2019 +1000

    Add baba sticks to MQ DC
    
    Theres a sticks baba in MQ DC in the falling stairs room.

commit d03e641c925d772fb9672a81d17fad5b2688b0af
Author: rattus128 <rattus128@gmail.com>
Date:   Tue Jul 30 14:38:57 2019 +1000

    Simplify shared region of MQ spirit
    
    LS + Silvers is just a longhand of is_adult here. A step further,
    has_bow + is_adult is just can_use(Bow).
    
    This gets the logic in the new notation and prepares for adding the
    colossus hand exit which doesn't mix well with this style (would
    create inconsitencies in the schema use).

commit ff1a2bb92dfe1b97989cda646678c91a92248da6
Author: rattus128 <rattus128@gmail.com>
Date:   Tue Jul 30 11:50:30 2019 +1000

    Overworld: Simplify water temple entry logic
    
    This has a hangover from when child water temple entry was a thing.
    Avoid reader confusion.
