### PR TITLE
[RFC] Bugfix for spirit non-repeatable-access in special interior ER

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -121,17 +121,20 @@ def set_shop_rules(world):
                                       'Buy Poe',
                                       'Buy Red Potion [30]',
                                       'Buy Red Potion [40]',
-                                      'Buy Red Potion [50]',
-                                      'Buy Fairy\'s Spirit']:
+                                      'Buy Red Potion [50]']:
                 add_rule(location, lambda state: state.has_bottle())
 
             #cleanup the playthrough to not show chu refill before chus if not doing high
             #level ER. In special interiors ER or higher, the chu refill can have logical
-            #impact without the bombchu item.
-            if  not world.shuffle_special_indoor_entrances and \
-                location.item.name in ['Bombchu Bowling Bombchus', 'Buy Bombchu (10)', \
-                                       'Buy Bombchu (20)', 'Buy Bombchu (5)']:
-                add_rule(location, lambda state: state.has_bombchus_item())
+            #impact without the bombchu item. Same for Fairies
+            if  not world.shuffle_special_indoor_entrances:
+                if  location.item.name in ['Bombchu Bowling Bombchus', 'Buy Bombchu (10)', \
+                                           'Buy Bombchu (20)', 'Buy Bombchu (5)']:
+                    add_rule(location, lambda state: state.has_bombchus_item())
+                if  location.item.name in ['Buy Fairy\'s Spirit', 'Gossip Stone Fairy', \
+                                           'Fairy Pot', 'Butterfly Fairy', 'Free Fairies' \
+                                           'Bean Plant Fairy']:
+                    add_rule(location, lambda state: state.has_bottle())
 
 
 # This function should be ran once after setting up entrances and before placing items

--- a/Rules.py
+++ b/Rules.py
@@ -124,7 +124,13 @@ def set_shop_rules(world):
                                       'Buy Red Potion [50]',
                                       'Buy Fairy\'s Spirit']:
                 add_rule(location, lambda state: state.has_bottle())
-            if location.item.name in ['Buy Bombchu (10)', 'Buy Bombchu (20)', 'Buy Bombchu (5)']:
+
+            #cleanup the playthrough to not show chu refill before chus if not doing high
+            #level ER. In special interiors ER or higher, the chu refill can have logical
+            #impact without the bombchu item.
+            if  not world.shuffle_special_indoor_entrances and \
+                location.item.name in ['Bombchu Bowling Bombchus', 'Buy Bombchu (10)', \
+                                       'Buy Bombchu (20)', 'Buy Bombchu (5)']:
                 add_rule(location, lambda state: state.has_bombchus_item())
 
 

--- a/State.py
+++ b/State.py
@@ -431,7 +431,7 @@ class State(object):
 
 
     def has_fairy(self):
-        return self.has_any_of(('Fairy', 'Buy Fairy\'s Spirit'))
+        return self.has_any_of(('Fairy', 'Buy Fairy\'s Spirit')) and self.has_bottle()
 
 
     def has_big_poe_drop(self):

--- a/State.py
+++ b/State.py
@@ -585,6 +585,11 @@ class State(object):
             return True
 
 
+    def all_ammo_replenishable(self):
+        return (self.has_any_of(('Fairy', 'Buy Fairy\'s Spirit')) or self.can_live_dmg(1)) and \
+                self.has_sticks() and self.can_buy_bombchus()
+
+
     # Be careful using this function. It will not collect any
     # items that may be locked behind the item, only the item itself.
     def collect(self, item):

--- a/State.py
+++ b/State.py
@@ -374,7 +374,7 @@ class State(object):
 
 
     def has_bombchus(self):
-        return self.can_buy_bombchus() and (self.world.bombchus_in_logic or self.has('Bomb Bag'))
+        return self.can_buy_bombchus() and self.has_bombchu_item()
 
 
     def has_bombchus_item(self):

--- a/State.py
+++ b/State.py
@@ -374,7 +374,7 @@ class State(object):
 
 
     def has_bombchus(self):
-        return self.can_buy_bombchus() and self.has_bombchu_item()
+        return self.can_buy_bombchus() and self.has_bombchus_item()
 
 
     def has_bombchus_item(self):
@@ -432,7 +432,6 @@ class State(object):
 
     def has_fairy(self):
         return self.has_any_of(('Fairy', 'Buy Fairy\'s Spirit')) and self.has_bottle()
-
 
     def has_big_poe_drop(self):
         return self.has('Big Poe')

--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -26,7 +26,7 @@
             "DC MQ Deku Scrub Deku Seeds": "can_stun_deku",
             "DC MQ Deku Scrub Deku Shield": "can_stun_deku",
             "Dodongos Cavern Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy"
         },
         "exits": {
             "Dodongos Cavern Lower Right Side": "

--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -27,7 +27,7 @@
                 has_explosives or Kokiri_Sword",
             "DC Deku Scrub Deku Shield": "True",
             "Dodongos Cavern Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy"
         },
         "exits": {
             "Dodongos Cavern Beginning": "True",
@@ -82,7 +82,7 @@
                 (has_bombs or Progressive_Strength_Upgrade) and 
                 (is_adult or has_sticks or Kokiri_Sword)",
             "GS Dodongo's Cavern Back Room": "True",
-            "Fairy Pot": "has_bottle"
+            "Fairy Pot": "True"
         },
         "exits": {
             "Dodongos Cavern Lobby": "True"

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -20,7 +20,7 @@
             "GS Fire Temple Basement": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Hammer)",
             "Fairy Pot": "
-                has_bottle and (can_use(Hover_Boots) or can_use(Hookshot)) and
+                (can_use(Hover_Boots) or can_use(Hookshot)) and
                 (logic_fewer_tunic_requirements or can_use(Goron_Tunic))"
         },
         "exits": {

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -7,7 +7,7 @@
             "Forest Temple Chest Behind Lobby": "is_adult or Kokiri_Sword",
             "GS Forest Temple First Room": "can_use(Dins_Fire) or can_use_projectile",
             "GS Forest Temple Lobby": "can_use(Hookshot) or can_use(Boomerang)",
-            "Fairy Pot": "has_bottle and (is_adult or can_child_attack or has_nuts)"
+            "Fairy Pot": "is_adult or can_child_attack or has_nuts"
         },
         "exits": {
             "Sacred Forest Meadow": "True",

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -59,7 +59,7 @@
         "locations": {
             "Ganons Castle Water Trial Left Chest": "True",
             "Ganons Castle Water Trial Right Chest": "True",
-            "Fairy Pot": "has_blue_fire and has_bottle",
+            "Fairy Pot": "has_blue_fire",
             "Blue Fire": "has_bottle"
         }
     },

--- a/data/World/Jabu Jabus Belly.json
+++ b/data/World/Jabu Jabus Belly.json
@@ -17,7 +17,7 @@
             "GS Jabu Jabu Lobby Basement Upper": "can_use(Boomerang) or can_use(Hookshot)",
             "Jabu Deku Scrub Deku Nuts": "
                 can_dive or is_child or logic_jabu_scrub_jump_dive or can_use(Iron_Boots)",
-            "Fairy Pot": "has_bottle"
+            "Fairy Pot": "True"
         },
         "exits": {
             "Jabu Jabus Belly Beginning": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -764,7 +764,7 @@
         "locations": {
             "Bombchu Bowling Bomb Bag": "has_bombchus_item",
             "Bombchu Bowling Piece of Heart": "has_bombchus_item",
-            "Bombchu Bowling Bombchus": "has_bombchus_item"
+            "Bombchu Bowling Bombchus": "True"
         },
         "exits": {
             "Castle Town": "True"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -38,8 +38,8 @@
                 is_adult and at_night and 
                 (can_use(Hookshot) or (logic_adult_kokiri_gs and can_use(Hover_Boots)))",
             "Kokiri Forest Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)"
         },
         "exits": {
             "Links House": "True",
@@ -152,8 +152,8 @@
             "LW Deku Scrub Deku Stick Upgrade": "is_child and can_stun_deku",
             "GS Lost Woods Bean Patch Near Bridge": "can_plant_bugs and can_child_attack",
             "Lost Woods Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)",
             "Bug Shrub": "is_child and can_cut_shrubs and has_bottle"
         },
         "exits": {
@@ -183,7 +183,7 @@
             "GS Lost Woods Bean Patch Near Stage": "
                 can_plant_bugs and 
                 (can_child_attack or (shuffle_scrubs == 'off' and Buy_Deku_Shield))",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle"
+            "Butterfly Fairy": "can_use(Sticks)"
         },
         "exits": {
             "Lost Woods Forest Exit": "True",
@@ -216,7 +216,7 @@
             "Sacred Forest Meadow Maze Gossip Stone (Lower)": "True",
             "Sacred Forest Meadow Maze Gossip Stone (Upper)": "True",
             "Sacred Forest Meadow Saria Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns"
         },
         "exits": {
             "Sacred Forest Meadow Entryway": "True",
@@ -302,9 +302,9 @@
             "Lake Hylia Lab Gossip Stone": "True",
             "Lake Hylia Gossip Stone (Southeast)": "True",
             "Lake Hylia Gossip Stone (Southwest)": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "is_child and can_cut_shrubs and has_bottle"
         },
         "exits": {
@@ -384,8 +384,8 @@
             "GS Gerudo Valley Bean Patch": "can_plant_bugs and can_child_attack",
             "Gerudo Valley Cow": "is_child and can_play(Eponas_Song)",
             "Gerudo Valley Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)"
         },
         "exits": {
             "Lake Hylia": "True"
@@ -489,7 +489,7 @@
                 Progressive_Wallet and 
                 (is_adult or has_sticks or Kokiri_Sword)",
             "GS Wasteland Ruins": "can_use(Hookshot) or can_use(Boomerang)",
-            "Fairy Pot": "has_bottle",
+            "Fairy Pot": "True",
             "Nut Pot": "True"
         },
         "exits": {
@@ -521,8 +521,8 @@
                     (here(can_plant_bean) or can_use(Longshot) or
                         (logic_colossus_gs and can_use(Hookshot)))",
             "Desert Colossus Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Fairy Pond": "can_play(Song_of_Storms) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Fairy Pond": "can_play(Song_of_Storms)",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -579,7 +579,7 @@
             "Temple of Time Gossip Stone (Left-Center)": "True",
             "Temple of Time Gossip Stone (Right)": "True",
             "Temple of Time Gossip Stone (Right-Center)": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns"
         },
         "exits": {
             "Castle Town": "True",
@@ -637,8 +637,8 @@
             "GS Hyrule Castle Tree": "can_child_attack",
             "Hyrule Castle Malon Gossip Stone": "True",
             "Hyrule Castle Rock Wall Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -1025,8 +1025,8 @@
             "Gravedigging Tour": "is_child and at_dampe_time",
             "GS Graveyard Wall": "can_use(Boomerang) and at_night",
             "GS Graveyard Bean Patch": "can_plant_bugs and can_child_attack",
-            "Butterfly Fairy": "can_use(Sticks) and at_day and has_bottle",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
+            "Butterfly Fairy": "can_use(Sticks) and at_day",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -1051,7 +1051,7 @@
         "region_name": "Heart Piece Grave",
         "locations": {
             "Heart Piece Grave Chest": "can_play(Suns_Song)",
-            "Free Fairies": "can_blast_or_smash and has_bottle"
+            "Free Fairies": "can_blast_or_smash"
         },
         "exits": {
             "Graveyard": "True"
@@ -1097,7 +1097,7 @@
         "hint": "the Graveyard",
         "locations": {
             "Graveyard Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns"
         },
         "exits": {
             "Graveyard": "True",
@@ -1135,7 +1135,7 @@
             "GS Mountain Trail Above Dodongo's Cavern": "
                 (can_use(Hammer) or (logic_trail_gs_lower and can_use(Hookshot))) and at_night",
             "Bean Plant Fairy": "
-                can_plant_bean and can_play(Song_of_Storms) and has_bottle and
+                can_plant_bean and can_play(Song_of_Storms) and
                 (has_explosives or Progressive_Strength_Upgrade)"
         },
         "exits": {
@@ -1164,7 +1164,7 @@
             "GS Mountain Trail Path to Crater": "
                 (can_use(Hammer) or logic_trail_gs_upper) and at_night",
             "Death Mountain Trail Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
             "Bug Rock": "is_child and has_bottle"
         },
         "exits": {
@@ -1226,7 +1226,7 @@
             "Goron City Medigoron Gossip Stone": "
                 can_blast_or_smash or Progressive_Strength_Upgrade",
             "Gossip Stone Fairy": "
-                can_summon_gossip_fairy_without_suns and has_bottle and
+                can_summon_gossip_fairy_without_suns and
                 (can_blast_or_smash or can_use(Silver_Gauntlets) or Progressive_Strength_Upgrade)",
             "Bug Rock": "(can_blast_or_smash or can_use(Silver_Gauntlets)) and has_bottle",
             "Stick Pot": "is_child"
@@ -1310,7 +1310,7 @@
             "GS Death Mountain Crater Crate": "is_child and can_child_attack",
             "Death Mountain Crater Gossip Stone": "has_explosives",
             "Gossip Stone Fairy": "
-                has_explosives and can_summon_gossip_fairy_without_suns and has_bottle"
+                has_explosives and can_summon_gossip_fairy_without_suns"
         },
         "exits": {
             "Death Mountain Crater Upper Nearby": "True",
@@ -1380,7 +1380,7 @@
         "hint": "Death Mountain Crater",
         "locations": {
             "GS Mountain Crater Bean Patch": "can_plant_bugs and can_child_attack",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle"
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)"
         },
         "exits": {
             "Death Mountain Crater Central Nearby": "True",
@@ -1453,9 +1453,9 @@
             "GS Zora River Above Bridge": "can_use(Hookshot) and at_night",
             "Zoras River Plateau Gossip Stone": "True",
             "Zoras River Waterfall Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms)",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle"
         },
         "exits": {
@@ -1496,7 +1496,7 @@
             "GS Zora's Domain Frozen Waterfall": "
                 is_adult and at_night and (Progressive_Hookshot or has_bow or Magic_Meter)",
             "Zoras Domain Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns",
             "Fish Group": "is_child and has_bottle",
             "Stick Pot": "is_child",
             "Nut Pot": "True"
@@ -1532,8 +1532,8 @@
                 can_use(Hookshot) and at_night",
             "Zoras Fountain Fairy Gossip Stone": "True",
             "Zoras Fountain Jabu Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and at_day and has_bottle"
+            "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns",
+            "Butterfly Fairy": "can_use(Sticks) and at_day"
         },
         "exits": {
             "Zoras Domain Behind King Zora": "True",
@@ -1631,7 +1631,7 @@
     {
         "region_name": "Gerudo Fortress Storms Grotto",
         "locations": {
-            "Free Fairies": "has_bottle"
+            "Free Fairies": "True"
         },
         "exits": {
             "Gerudo Fortress": "True"
@@ -1640,7 +1640,7 @@
     {
         "region_name": "Zoras Domain Storms Grotto",
         "locations": {
-            "Free Fairies": "has_bottle"
+            "Free Fairies": "True"
         },
         "exits": {
             "Zoras Domain": "True"
@@ -1651,8 +1651,8 @@
         "locations": {
             "Kokiri Forest Storms Grotto Chest": "True",
             "Kokiri Forest Storms Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1665,8 +1665,8 @@
         "locations": {
             "Lost Woods Generic Grotto Chest": "True",
             "Lost Woods Generic Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1697,7 +1697,7 @@
     {
         "region_name": "Meadow Fairy Grotto",
         "locations": {
-            "Free Fairies": "has_bottle"
+            "Free Fairies": "True"
         },
         "exits": {
             "Sacred Forest Meadow": "True"
@@ -1740,8 +1740,8 @@
         "locations": {
             "Remote Southern Grotto Chest": "True",
             "Remote Southern Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1754,8 +1754,8 @@
         "locations": {
             "Field Near Lake Outside Fence Grotto Chest": "True",
             "Field Near Lake Outside Fence Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1779,7 +1779,7 @@
                 has_fire_source and (can_use(Hookshot) or can_use(Boomerang))",
             "HF Grotto Cow": "has_fire_source and can_play(Eponas_Song)",
             "Field Valley Grotto Gossip Stone": "has_fire_source",
-            "Gossip Stone Fairy": "has_fire_source and can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "has_fire_source and can_summon_gossip_fairy",
             "Bug Shrub": "has_fire_source and can_cut_shrubs and has_bottle",
             "Nut Pot": "has_fire_source"
         },
@@ -1792,8 +1792,8 @@
         "locations": {
             "Field West Castle Town Grotto Chest": "True",
             "Field West Castle Town Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1804,7 +1804,7 @@
     {
         "region_name": "Field Far West Castle Town Grotto",
         "locations": {
-            "Free Fairies": "has_bottle"
+            "Free Fairies": "True"
         },
         "exits": {
             "Hyrule Field": "True"
@@ -1834,7 +1834,7 @@
         "locations": {
             "GS Hyrule Castle Grotto": "can_blast_or_smash and (can_use(Boomerang) or can_use(Hookshot))",
             "Castle Storms Grotto Gossip Stone": "can_blast_or_smash",
-            "Gossip Stone Fairy": "can_blast_or_smash and can_summon_gossip_fairy and has_bottle",
+            "Gossip Stone Fairy": "can_blast_or_smash and can_summon_gossip_fairy",
             "Wandering Bugs": "can_blast_or_smash and has_bottle",
             "Nut Pot": "can_blast_or_smash"
         },
@@ -1858,8 +1858,8 @@
         "locations": {
             "Kakariko Back Grotto Chest": "True",
             "Kakariko Back Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1881,8 +1881,8 @@
         "locations": {
             "Mountain Storms Grotto Chest": "True",
             "Mountain Storms Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1906,8 +1906,8 @@
         "locations": {
             "Top of Crater Grotto Chest": "True",
             "Top of Crater Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1931,8 +1931,8 @@
         "locations": {
             "Zora River Plateau Open Grotto Chest": "True",
             "Zora River Plateau Open Grotto Gossip Stone": "True",
-            "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
-            "Butterfly Fairy": "can_use(Sticks) and has_bottle",
+            "Gossip Stone Fairy": "can_summon_gossip_fairy",
+            "Butterfly Fairy": "can_use(Sticks)",
             "Bug Shrub": "can_cut_shrubs and has_bottle",
             "Lone Fish": "has_bottle"
         },
@@ -1943,7 +1943,7 @@
     {
         "region_name": "Zora River Plateau Bombable Grotto",
         "locations": {
-            "Free Fairies": "has_bottle"
+            "Free Fairies": "True"
         },
         "exits": {
             "Zora River": "True"

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -2,6 +2,18 @@
     {
         "region_name": "Spirit Temple Lobby",
         "dungeon": "Spirit Temple",
+        "events": {
+            #Spirit temple has unknown age logic, where the player can pop one of
+            #two different locked doors as adult or child respectively. That age can
+            #then can be expected to clear checks accessible via both doors as that
+            #particular age before getting more keys. This breaks down if spirit temple
+            #is accessible on a non-repeatable access. This can only happen in
+            #special indoors ER, and can only happen in the player has access to some
+            #form of depletable ammo (usually bombchus).
+            "Spirit Temple Unknown Age" : "
+                (not shuffle_special_indoor_entrances) or all_ammo_replenishable or 
+                (here(is_child) and here(is_adult))"
+        },
         "exits": {
             "Desert Colossus": "True",
             "Child Spirit Temple": "is_child",
@@ -35,32 +47,40 @@
     {
         "region_name": "Child Spirit Temple Climb",
         "dungeon": "Spirit Temple",
+        "events": {
+            #When bombcus are in logic, and child has sphere 0 access to chu refills (usually
+            #bowling), it's impossible for child to get into the central chamber and waste a
+            #second key without having in-logic usable bombchus. This allows adult to have
+            #have logic on some of these shared spirit checks with only 2 keys. Interior ER
+            #removes access to child sphere 0 chu refills.
+            #
+            #These situations are unknown age situtations in their own right, however, we do
+            #not yet condition them as such as the unknown-age logic is safe for any ER level
+            #below interior anyway.
+            "Spirit Temple Child Climb Chests": "
+                ('Spirit Temple Unknown Age' and has_projectile(both)) or 
+                (((Small_Key_Spirit_Temple, 3) or 
+                  ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_interior_entrances)) and 
+                is_adult and has_projectile(adult)) or 
+                ((Small_Key_Spirit_Temple, 5) and is_child and has_projectile(child))"
+        },
         "locations": {
-            "Spirit Temple Child Climb East Chest": "
-                has_projectile(both) or 
-                (((Small_Key_Spirit_Temple, 3) or 
-                    ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                can_use(Silver_Gauntlets) and has_projectile(adult)) or 
-                ((Small_Key_Spirit_Temple, 5) and is_child and 
-                    has_projectile(child))",
-            "Spirit Temple Child Climb North Chest": "
-                has_projectile(both) or 
-                (((Small_Key_Spirit_Temple, 3) or 
-                    ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                can_use(Silver_Gauntlets) and has_projectile(adult)) or 
-                ((Small_Key_Spirit_Temple, 5) and is_child and 
-                    has_projectile(child))",
+            "Spirit Temple Child Climb East Chest": "'Spirit Temple Child Climb Chests'",
+            "Spirit Temple Child Climb North Chest": "'Spirit Temple Child Climb Chests'",
             "GS Spirit Temple Bomb for Light Room": "
-                has_projectile(both) or can_use(Dins_Fire) or 
-                ((damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love)) and 
-                    (has_sticks or Kokiri_Sword or has_projectile(child))) or 
-                (is_child and 
-                    (Small_Key_Spirit_Temple, 5) and has_projectile(child)) or 
+                ('Spirit Temple Unknown Age' and
+                 (has_projectile(both) or can_use(Dins_Fire) or 
+                  ((damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love)) and 
+                   (has_sticks or Kokiri_Sword or has_projectile(child))))) or 
+                ((Small_Key_Spirit_Temple, 5) and is_child and
+                 (has_projectile(child) or can_use(Dins_Fire) or
+                  ((has_sticks or Kokiri_Sword) and
+                   (damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love))))) or
                 (((Small_Key_Spirit_Temple, 3) or 
-                    ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                can_use(Silver_Gauntlets) and
-                (has_projectile(adult) or damage_multiplier != 'ohko' or 
-                    has_fairy or can_use(Nayrus_Love)))"
+                  ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_interior_entrances)) and 
+                is_adult and
+                (has_projectile(adult) or can_use(Dins_Fire) or
+                 damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love)))"
         },
         "exits": {
             "Spirit Temple Central Chamber": "has_explosives"
@@ -90,45 +110,49 @@
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Map Chest": "
-                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                    (can_use(Dins_Fire) or
-                        (((Magic_Meter and Fire_Arrows) or logic_spirit_map_chest) and has_bow and has_sticks))) or 
-                ((Small_Key_Spirit_Temple, 5) and has_explosives and 
-                    can_use(Sticks)) or 
-                ((Small_Key_Spirit_Temple, 3) and
-                    (can_use(Fire_Arrows) or (logic_spirit_map_chest and has_bow)) and 
-                    can_use(Silver_Gauntlets))",
+                ('Spirit Temple Unknown Age' and
+                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or
+                  ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_interior_entrances)) and 
+                 (can_use(Dins_Fire) or
+                  (((Magic_Meter and Fire_Arrows) or logic_spirit_map_chest) and has_bow and has_sticks)))) or 
+                ((Small_Key_Spirit_Temple, 5) and is_child and 
+                 (can_use(Dins_Fire) or can_use(Sticks))) or 
+                ((Small_Key_Spirit_Temple, 3) and is_adult and
+                 (has_fire_source or (logic_spirit_map_chest and has_bow)))",
             "Spirit Temple Sun Block Room Chest": "
-                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                    (can_use(Dins_Fire) or
-                        (((Magic_Meter and Fire_Arrows) or logic_spirit_sun_chest) and has_bow and has_sticks))) or 
-                ((Small_Key_Spirit_Temple, 5) and has_explosives and
-                    can_use(Sticks)) or 
-                ((Small_Key_Spirit_Temple, 3) and
-                    (can_use(Fire_Arrows) or (logic_spirit_sun_chest and has_bow)) and 
-                    can_use(Silver_Gauntlets))",
+                ('Spirit Temple Unknown Age' and
+                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or
+                  ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_interior_entrances)) and 
+                 (can_use(Dins_Fire) or
+                  (((Magic_Meter and Fire_Arrows) or logic_spirit_sun_chest) and has_bow and has_sticks)))) or 
+                ((Small_Key_Spirit_Temple, 5) and is_child and 
+                 (can_use(Dins_Fire) or can_use(Sticks))) or 
+                ((Small_Key_Spirit_Temple, 3) and is_adult and
+                 (has_fire_source or (logic_spirit_sun_chest and has_bow)))",
             "Spirit Temple Statue Hand Chest": "
-                (Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and 
-                can_play(Zeldas_Lullaby)",
+                (Small_Key_Spirit_Temple, 3) and is_adult and can_play(Zeldas_Lullaby)",
             "Spirit Temple NE Main Room Chest": "
-                (Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and can_play(Zeldas_Lullaby) and 
+                (Small_Key_Spirit_Temple, 3) and is_adult and can_play(Zeldas_Lullaby) and 
                 (Progressive_Hookshot or Hover_Boots)",
             "GS Spirit Temple Hall to West Iron Knuckle": "
-                (has_explosives and Boomerang and Progressive_Hookshot) or 
-                (can_use(Boomerang) and (Small_Key_Spirit_Temple, 5) and has_explosives) or 
-                (Progressive_Hookshot and can_use(Silver_Gauntlets) and 
-                    ((Small_Key_Spirit_Temple, 3) or 
-                        ((Small_Key_Spirit_Temple, 2) and Boomerang and bombchus_in_logic and not shuffle_dungeon_entrances)))",
+                ('Spirit Temple Unknown Age' and
+                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or
+                  ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_interior_entrances)) and 
+                 (Boomerang and Progressive_Hookshot))) or 
+                ((Small_Key_Spirit_Temple, 5) and is_child and Boomerang) or 
+                ((Small_Key_Spirit_Temple, 3) and is_adult and Progressive_Hookshot)",
             "GS Spirit Temple Lobby": "
-                ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                    logic_spirit_lobby_gs and Boomerang and (Progressive_Hookshot or Hover_Boots)) or
-                (logic_spirit_lobby_gs and (Small_Key_Spirit_Temple, 5) and has_explosives and can_use(Boomerang)) or
-                ((Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and (Progressive_Hookshot or Hover_Boots))"
+                ('Spirit Temple Unknown Age' and
+                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or
+                  ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_interior_entrances)) and 
+                 logic_spirit_lobby_gs and Boomerang and (Progressive_Hookshot or Hover_Boots))) or
+                ((Small_Key_Spirit_Temple, 5) and is_child and logic_spirit_lobby_gs and Boomerang) or
+                ((Small_Key_Spirit_Temple, 3) and is_adult and (Progressive_Hookshot or Hover_Boots))"
         },
         "exits": {
             "Spirit Temple Outdoor Hands": "True",
             "Spirit Temple Beyond Central Locked Door": "
-                (Small_Key_Spirit_Temple, 4) and can_use(Silver_Gauntlets)",
+                (Small_Key_Spirit_Temple, 4) and is_adult",
             "Child Spirit Temple Climb": "True"
         }
     },
@@ -137,16 +161,17 @@
         "dungeon": "Spirit Temple",
         "locations": {
             "Silver Gauntlets Chest": "
-                ((Small_Key_Spirit_Temple, 3) and (Progressive_Hookshot, 2) and has_explosives) or 
+                ('Spirit Temple Unknown Age' and (Small_Key_Spirit_Temple, 3) and
+                 (Progressive_Hookshot, 2) and has_explosives) or 
                 (Small_Key_Spirit_Temple, 5)",
             "Mirror Shield Chest": "
-                (Small_Key_Spirit_Temple, 4) and can_use(Silver_Gauntlets) and has_explosives"
+                (Small_Key_Spirit_Temple, 4) and is_adult and has_explosives"
         },
         "exits": {
             "Desert Colossus": "
                 (is_child and (Small_Key_Spirit_Temple, 5)) or
-                (can_use(Silver_Gauntlets) and
-                    (((Small_Key_Spirit_Temple, 3) and has_explosives) or (Small_Key_Spirit_Temple, 5)))"
+                (is_adult and
+                 (((Small_Key_Spirit_Temple, 3) and has_explosives) or (Small_Key_Spirit_Temple, 5)))"
         }
     },
     {


### PR DESCRIPTION
Pretty complex update for what is ultimately a bug, but after a ton of back and forth with r0b, this is the least impactful logic we could come up with.

Despite its significant complexity, we go to the effort of detecting ammo based non-repeatable-access (or its abscence by getting logic on the ammo refills) as in most seeds, ammo refills are usually available quickly.

The other solution is to require logical access to spirit as both ages, but that is problematic in no-ALR, as it will not be able to place all keys if child spirit is in-accessible. Leave this in as a logical alternative to the ammo option anyway.

Also carve out an exemption if ER (special interiors) is off.