### PR TITLE
Copy state before generating WoTH. (Fixes #811)

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -590,7 +590,7 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
         # This also means that, in order to test for this, we have to temporarily remove that assumption about root access to time passing
         for world in worlds:
             world.get_region('Root').can_reach = lambda state: state.tod == None
-        no_time_passing_playthrough = Playthrough.with_items([world.state.copy() for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
+        no_time_passing_playthrough = Playthrough.with_items([world.state for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
         for world in worlds:
             world.get_region('Root').can_reach = lambda state: True
 

--- a/Fill.py
+++ b/Fill.py
@@ -79,7 +79,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     itempool = progitempool + prioitempool + restitempool
 
     # Start a playthrough cache here.
-    playthrough = Playthrough([world.state.copy() for world in worlds])
+    playthrough = Playthrough([world.state for world in worlds])
 
     # We place all the shop items first. Like songs, they have a more limited
     # set of locations that they can be placed in, so placing them first will

--- a/Rules.py
+++ b/Rules.py
@@ -134,7 +134,7 @@ def set_entrances_based_rules(worlds):
 
     # Use the states with all items available in the pools for this seed
     complete_itempool = [item for world in worlds for item in world.get_itempool_with_dungeon_items()]
-    playthrough = Playthrough([world.state.copy() for world in worlds])
+    playthrough = Playthrough([world.state for world in worlds])
     playthrough.collect_all(complete_itempool)
     playthrough.collect_locations()
 

--- a/State.py
+++ b/State.py
@@ -624,7 +624,7 @@ class State(object):
     @staticmethod
     def update_required_items(spoiler):
         worlds = spoiler.worlds
-        state_list = [world.state for world in worlds]
+        state_list = [world.state.copy() for world in worlds]
 
         # get list of all of the progressive items that can appear in hints
         # all_locations: all progressive items. have to collect from these

--- a/State.py
+++ b/State.py
@@ -617,14 +617,13 @@ class State(object):
 
 
     @staticmethod
-    def can_beat_game(state_list, scan_for_items=True):
-        return Playthrough(state_list).can_beat_game(scan_for_items)
+    def can_beat_game(state_list):
+        return Playthrough(state_list).can_beat_game()
 
 
     @staticmethod
     def update_required_items(spoiler):
         worlds = spoiler.worlds
-        state_list = [world.state.copy() for world in worlds]
 
         # get list of all of the progressive items that can appear in hints
         # all_locations: all progressive items. have to collect from these
@@ -644,7 +643,7 @@ class State(object):
 
         required_locations = []
 
-        playthrough = Playthrough(state_list)
+        playthrough = Playthrough([world.state for world in worlds])
         for location in playthrough.iter_reachable_locations(all_locations):
             # Try to remove items one at a time and see if the game is still beatable
             if location in item_locations:
@@ -655,7 +654,7 @@ class State(object):
                 if not playthrough.can_beat_game():
                     required_locations.append(location)
                 location.item = old_item
-            state_list[location.item.world.id].collect(location.item)
+            playthrough.state_list[location.item.world.id].collect(location.item)
 
         # Filter the required location to only include location in the world
         required_locations_dict = {}


### PR DESCRIPTION
Now fixes #811 by ensuring Playthrough always copies, but this had a strange interaction with how location hints modify the locations they're hinting at, possibly due to a couple latent bugs, including testing for adult access to child-only stones which kills the logic. Fixed that by using `Playthrough.can_reach` as child only, instead of `State.can_reach` at whatever age being tested.