### PR TITLE
Glitched Tweaks

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1549,6 +1549,16 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             if item['chest_type'] in (1, 3):
                 rom.write_int16(chest_address + 2, 0x0190) # X pos
                 rom.write_int16(chest_address + 6, 0xFABC) # Z pos
+        
+        # Move Silver Gauntlets chest if it is small so it is reachable from Spirit Hover Seam
+        chest_name = 'Silver Gauntlets Chest'
+        chest_address_0 = 0x21A02D0  # Address in setup 0
+        chest_address_2 = 0x21A06E4  # Address in setup 2
+        location = world.get_location(chest_name)
+        item = read_rom_item(rom, location.item.index)
+        if item['chest_type'] in (1, 3):
+            rom.write_int16(chest_address_0 + 6, 0x0172)  # Z pos
+            rom.write_int16(chest_address_2 + 6, 0x0172)  # Z pos
 
     # give dungeon items the correct messages
     add_item_messages(messages, shop_items, world)

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -164,12 +164,8 @@
         "region_name": "Spirit Temple Boss",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Twinrova Heart": "
-                Mirror_Shield and has_explosives and 
-                Progressive_Hookshot and Boss_Key_Spirit_Temple",
-            "Twinrova": "
-                Mirror_Shield and has_explosives and 
-                Progressive_Hookshot and Boss_Key_Spirit_Temple"
+            "Twinrova Heart": "True",
+            "Twinrova": "True"
         }
     }
 ]


### PR DESCRIPTION
Change the logic for Twinrova Heart and Medallion to be correct.
Moved the Silver Gauntlets Chest to the right a tad when it's small so that it's possible to do Spirit Hover still.