### PR TITLE
Match GUI closer to the existing Entrance Shuffle options

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -300,7 +300,7 @@ def set_entrances(worlds):
     for world in worlds:
         world.initialize_entrances()
 
-    if worlds[0].entrance_shuffle != 'off':
+    if worlds[0].are_entrances_shuffled():
         shuffle_random_entrances(worlds)
 
     set_entrances_based_rules(worlds)

--- a/Hints.py
+++ b/Hints.py
@@ -340,7 +340,7 @@ def get_dungeon_hint(spoiler, world, checked):
 
 
 def get_entrance_hint(spoiler, world, checked):
-    if world.entrance_shuffle == 'off':
+    if world.are_entrances_shuffled():
         return None
 
     entrance_hints = getHintGroup('entrance', world)

--- a/Main.py
+++ b/Main.py
@@ -593,5 +593,5 @@ def create_playthrough(spoiler):
     # Then we can finally output our playthrough
     spoiler.playthrough = OrderedDict((str(i + 1), {location: location.item for location in sphere}) for i, sphere in enumerate(collection_spheres))
 
-    if worlds[0].entrance_shuffle != 'off':
+    if worlds[0].are_entrances_shuffled():
         spoiler.entrance_playthrough = OrderedDict((str(i + 1), list(sphere)) for i, sphere in enumerate(entrance_spheres))

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1247,7 +1247,7 @@ setting_infos = [
             be beatable.
             ''',
         disable        = {
-            'glitched'  : {'settings' : ['entrance_shuffle', 'mq_dungeons_random', 'mq_dungeons']},
+            'glitched'  : {'settings' : ["dungeon_shuffle", "grotto_shuffle", "special_entrance_shuffle", "indoor_entrance_shuffle", "overworld_entrance_shuffle", 'mq_dungeons_random', 'mq_dungeons']},
             'none'      : {'tabs'     : ['detailed_tab']},
         },
         shared         = True,
@@ -1617,53 +1617,75 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
     ),
-    Combobox(
-        name           = 'entrance_shuffle',
-        gui_text       = 'Entrance Shuffle',
-        default        = 'off',
-        choices        = {
-            'off':              'Off',
-            'dungeons':         'Dungeons Only',
-            'simple-indoors':   'Simple Indoors',
-            'all-indoors':      'All Indoors',
-            'all':              'All Indoors & Overworld',
-        },
-        gui_tooltip    = '''\
-            Shuffle entrances bidirectionally within different pools.
-
-            'Dungeons Only':
+    Checkbutton(
+        name='dungeon_shuffle',
+        gui_text='Shuffle Dungeon Entrances',
+        gui_tooltip='''\
             Shuffle dungeon entrances with each other, including Bottom 
             of the Well, Ice Cavern, and Gerudo Training Grounds. 
             However, Ganon's Castle is not shuffled.
             Additionally, the entrances of Deku Tree, Fire Temple and 
             Bottom of the Well are opened for both adult and child.
-
-            'Simple Indoors':
-            Shuffle dungeon entrances along with simple Grotto and
-            Interior entrances (i.e. most Houses and Great Fairies).
-
-            'All Indoors':
-            Extended version of 'Simple Indoors' with some extra entrances:
-            Adult Potion Shop, Windmill, Link's House, Temple of Time and
-            Dampe's Grave.
- 
-            'All Indoors & Overworld':
-            Same as 'All Indoors' but with Overworld loading zones shuffled
-            in a new separate pool. Owl drop positions are also randomized.
-
-            Note: If Interior or Overworld entrances are shuffled, trade timers 
-            are disabled and trade items don't revert when loading a save.
         ''',
+        default=False,
+        shared=True,
+        gui_params={
+            'randomize_key': 'randomize_settings',
+        },
+    ),
+    Checkbutton(
+        name           = 'grotto_shuffle',
+        gui_text       = 'Shuffle Grotto Entrances',
+        gui_tooltip    = '''\
+            Shuffle all grottos, including fairy fountains and the octorok grotto.
+        ''',
+        default        = False,
         shared         = True,
         gui_params     = {
             'randomize_key': 'randomize_settings',
-            'distribution':  [
-                ('off', 4),
-                ('dungeons', 1),
-                ('simple-indoors', 1),
-                ('all-indoors', 1),
-                ('all', 1),
-            ],
+        },
+    ),
+    Checkbutton(
+        name           = 'indoor_entrance_shuffle',
+        gui_text       = 'Shuffle Indoor Entrances',
+        gui_tooltip    = '''\
+            Shuffle simple Interior entrances (i.e. most Houses and Great Fairies).
+        ''',
+        default        = False,
+        disable        = {
+            False:          {'settings': ['special_entrance_shuffle']}
+        },
+        shared         = True,
+        gui_params     = {
+            'randomize_key': 'randomize_settings',
+        },
+    ),
+    Checkbutton(
+        name           = 'special_entrance_shuffle',
+        gui_text       = 'Shuffle Special Entrances',
+        gui_tooltip    = '''\
+            Shuffle Adult Potion Shop, Windmill, Link's House, 
+            Temple of Time and Dampe's Grave.
+        ''',
+        default        = False,
+        shared         = True,
+        gui_params     = {
+            'randomize_key': 'randomize_settings',
+        },
+    ),
+    Checkbutton(
+        name           = 'overworld_entrance_shuffle',
+        gui_text       = 'Shuffle Overworld Entrances',
+        gui_tooltip    = '''\
+            Overworld loading zones shuffled in a new separate pool. 
+            Owl drop positions are also randomized.
+            Note: Trade timers are disabled and 
+            trade items don't revert when loading a save.
+        ''',
+        default        = False,
+        shared         = True,
+        gui_params     = {
+            'randomize_key': 'randomize_settings',
         },
     ),
     Combobox(

--- a/World.py
+++ b/World.py
@@ -43,18 +43,18 @@ class World(object):
         self.__dict__.update(settings.__dict__)
         self.distribution = settings.distribution.world_dists[id]
 
-        if self.open_forest == 'closed' and self.entrance_shuffle in ['all-indoors', 'all']:
+        if self.open_forest == 'closed' and self.special_indoor_entrance_shuffle:
             self.open_forest = 'closed_deku'
 
         # rename a few attributes...
         self.keysanity = self.shuffle_smallkeys in ['keysanity', 'remove']
         self.check_beatable_only = not self.all_reachable
     
-        self.shuffle_dungeon_entrances = self.entrance_shuffle != 'off'
-        self.shuffle_grotto_entrances = self.entrance_shuffle in ['simple-indoors', 'all-indoors', 'all']
-        self.shuffle_interior_entrances = self.entrance_shuffle in ['simple-indoors', 'all-indoors', 'all']
-        self.shuffle_special_indoor_entrances = self.entrance_shuffle in ['all-indoors', 'all']
-        self.shuffle_overworld_entrances = self.entrance_shuffle == 'all'
+        self.shuffle_dungeon_entrances = self.dungeon_shuffle
+        self.shuffle_grotto_entrances = self.grotto_shuffle
+        self.shuffle_interior_entrances = self.indoor_entrance_shuffle
+        self.shuffle_special_indoor_entrances = self.special_entrance_shuffle
+        self.shuffle_overworld_entrances = self.overworld_entrance_shuffle
 
         self.disable_trade_revert = self.shuffle_interior_entrances or self.shuffle_overworld_entrances
 
@@ -346,6 +346,9 @@ class World(object):
             loc = prize_locs.pop()
             self.push_item(loc, item)
 
+
+    def are_entrances_shuffled(self):
+        return self.dungeon_shuffle or self.grotto_shuffle or self.indoor_entrance_shuffle or self.special_entrance_shuffle or self.overworld_entrance_shuffle
 
     def get_region(self, regionname):
         if isinstance(regionname, Region):

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -275,6 +275,18 @@
             "logic_earliest_adult_trade",
             "logic_latest_adult_trade"
           ]
+        },
+        {
+          "name": "entrance_shuffle_section",
+          "text": "Entrance Shuffle",
+          "row_span": 1,
+          "settings": [
+            "dungeon_shuffle",
+            "grotto_shuffle",
+            "indoor_entrance_shuffle",
+            "special_entrance_shuffle",
+            "overworld_entrance_shuffle"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Moved entrance shuffle to it's own sub tab in Other with the option to toggle each category of entrances separately:

- Dungeons
- Grottos
- Overworld
- Interiors
- Special Interiors (disabled if interiors not selected)

This was moved to the other tab because adding an extra four checkboxes to the World tab bloated it up, this was the best immediate compromise I saw at the time, and I'm open to counter suggestions.

Also added a are_entrances_shuffled helper method to World since the conditional is a little more convoluted now.