### PR TITLE
Fix trade items still reverting on death in ER

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -785,9 +785,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     exit_table = generate_exit_lookup_table()
 
     if world.shuffle_interior_entrances or world.shuffle_overworld_entrances:
-        # Disable trade quest timers and prevent trade items from reverting on save load
+        # Disable trade quest timers and prevent trade items from ever reverting
         rom.write_byte(rom.sym('DISABLE_TIMERS'), 0x01)
-        rom.write_int32(0xB064CC, 0x10000010) # b 0xB06510 (skip trade item revert)
+        rom.write_int16s(0xB6D460, [0x0030, 0x0035, 0x0036]) # Change trade items revert table to prevent all reverts
 
     if world.shuffle_overworld_entrances:
         rom.write_byte(rom.sym('OVERWORLD_SHUFFLED'), 1)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1652,7 +1652,7 @@ setting_infos = [
             in a new separate pool. Owl drop positions are also randomized.
 
             Note: If Interior or Overworld entrances are shuffled, trade timers 
-            are disabled and trade items don't revert when loading a save.
+            are disabled and trade items never revert.
         ''',
         shared         = True,
         gui_params     = {


### PR DESCRIPTION
Changed the patch used to prevent trade reverts to override the "trade revert table" item IDs so all reverts no longer work, no matter which part of the game code triggers them.

This should ensure trade items never revert back to a previous item, which is now the expected behavior in ER settings where the adult trade quest is affected.