### PR TITLE
Fix Ocarina Songs as Fanfares on successive generations

### DIFF
--- a/Music.py
+++ b/Music.py
@@ -321,9 +321,10 @@ def randomize_music(rom, settings):
     fanfare_target_sequences = []
 
     # Include ocarina songs in fanfare pool if checked
-    ff_ids = fanfare_sequence_ids
+    ff_ids = []
+    ff_ids.extend(fanfare_sequence_ids)
     if settings.ocarina_fanfares:
-        ff_ids += ocarina_sequence_ids
+        ff_ids.extend(ocarina_sequence_ids)
 
     # If not creating patch file, shuffle audio sequences. Otherwise, shuffle pointer table
     if settings.compress_rom != 'Patch':


### PR DESCRIPTION
Ocarina Songs were added to the static list of fanfares causing duplicates to appear in the list and fail the assertion that there will only ever be one copy of a fanfare at any time in successive generations using the Generation Count feature.

A new list is now created and is extended to add both fanfares and ocarina songs to the new list and then operate on that new list instead of the static ones.