### PR TITLE
Add Drop Locations

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -477,6 +477,7 @@ droplocations = {
     'Wandering Bugs': 'Bugs',
     'Fairy Pot': 'Fairy',
     'Free Fairies': 'Fairy',
+    'Wall Switch Fairy': 'Fairy',
     'Butterfly Fairy': 'Fairy',
     'Gossip Stone Fairy': 'Fairy',
     'Bean Plant Fairy': 'Fairy',

--- a/LocationList.py
+++ b/LocationList.py
@@ -139,6 +139,7 @@ location_table = {
     "Wandering Bugs":                                  ("Drop",        None,  None, None,                     None),
     "Fairy Pot":                                       ("Drop",        None,  None, None,                     None),
     "Free Fairies":                                    ("Drop",        None,  None, None,                     None),
+    "Wall Switch Fairy":                               ("Drop",        None,  None, None,                     None),
     "Butterfly Fairy":                                 ("Drop",        None,  None, None,                     None),
     "Gossip Stone Fairy":                              ("Drop",        None,  None, None,                     None),
     "Bean Plant Fairy":                                ("Drop",        None,  None, None,                     None),

--- a/data/World/Bottom of the Well MQ.json
+++ b/data/World/Bottom of the Well MQ.json
@@ -28,7 +28,8 @@
                 (can_play(Zeldas_Lullaby) or has_explosives) and can_see_with_lens",
             "GS Well MQ Coffin Room": "
                 can_child_attack and 
-                (Small_Key_Bottom_of_the_Well, 2)"
+                (Small_Key_Bottom_of_the_Well, 2)",
+            "Fairy Pot": "has_bottle and has_explosives and has_slingshot"
         },
         "exits": {
             "Bottom of the Well" : "True"

--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -80,7 +80,8 @@
             "King Dodongo": "
                 (has_bombs or Progressive_Strength_Upgrade) and 
                 (is_adult or has_sticks or Kokiri_Sword)",
-            "GS Dodongo's Cavern MQ Back Area": "True"
+            "GS Dodongo's Cavern MQ Back Area": "True",
+            "Fairy Pot": "has_bottle"
         }
     }
 ]

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -10,7 +10,8 @@
                 (can_use(Hookshot) and (can_use(Fire_Arrows) or 
                     (can_use(Dins_Fire) and 
                     ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or can_use(Goron_Tunic) or 
-                        can_use(Bow) or (Progressive_Hookshot, 2)))))"
+                        can_use(Bow) or (Progressive_Hookshot, 2)))))",
+            "Fairy Pot": "has_bottle and (Small_Key_Fire_Temple, 5)"
         },
         "exits": {
             "Fire Temple Entrance": "True",
@@ -42,7 +43,11 @@
                 has_fire_source and has_explosives and
                 (Progressive_Hookshot or
                     (logic_fire_mq_bombable_chest and (damage_multiplier != 'ohko' or can_use(Nayrus_Love))))",
-            "GS Fire Temple MQ Big Lava Room": "True"
+            "GS Fire Temple MQ Big Lava Room": "True",
+            "Fairy Pot": "
+                has_bottle and has_fire_source and (has_bow or logic_fire_mq_bk_chest) and
+                (Progressive_Hookshot or logic_fire_song_of_time)"
+
         },
         "exits": {
             "Fire Lower Maze": "
@@ -69,7 +74,9 @@
             "Fire Temple MQ Maze Upper Chest": "True",
             "Fire Temple MQ Compass Chest": "has_explosives",
             "GS Fire Temple MQ East Tower Top": "
-                can_play(Song_of_Time) or can_use(Longshot)"
+                can_play(Song_of_Time) or can_use(Longshot)",
+            "Wall Switch Fairy": "
+                has_bottle and (can_play(Song_of_Time) or can_use(Longshot))"
         },
         "exits": {
             "Fire Temple Upper": "(Small_Key_Fire_Temple, 3) and has_bow"
@@ -84,7 +91,8 @@
             "GS Fire Temple MQ Fire Wall Maze Side Room": "
                 can_play(Song_of_Time) or Hover_Boots or logic_fire_mq_flame_maze",
             "GS Fire Temple MQ Fire Wall Maze Center": "has_explosives",
-            "GS Fire Temple MQ Above Fire Wall Maze": "(Small_Key_Fire_Temple, 5)"
+            "GS Fire Temple MQ Above Fire Wall Maze": "(Small_Key_Fire_Temple, 5)",
+            "Fairy Pot": "has_bottle"
         }
     },
     {

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -22,7 +22,8 @@
                     (can_play(Song_of_Time) or is_child) and
                     (is_adult or can_use(Dins_Fire) or
                      can_use(Sticks) or can_use(Slingshot) or Kokiri_Sword)",
-            "GS Forest Temple MQ Block Push Room": "is_adult or Kokiri_Sword"
+            "GS Forest Temple MQ Block Push Room": "is_adult or Kokiri_Sword",
+            "Fairy Pot": "has_bottle and (can_play(Song_of_Time) or is_child)"
         },
         "exits": {
             "Forest Temple NW Outdoors": "can_use(Bow) or can_use(Slingshot)",

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -28,7 +28,8 @@
             "GC MQ Deku Scrub Arrows": "True",
             "GC MQ Deku Scrub Red Potion": "True",
             "GC MQ Deku Scrub Green Potion": "True",
-            "GC MQ Deku Scrub Deku Nuts": "True"
+            "GC MQ Deku Scrub Deku Nuts": "True",
+            "Free Fairies": "has_bottle"
         }
     },
     {
@@ -107,6 +108,9 @@
                 can_use(Fire_Arrows) and Mirror_Shield",
             "Ganons Castle MQ Spirit Trial Sun Back Right Chest": "
                 Hammer and has_bombchus and 
+                can_use(Fire_Arrows) and Mirror_Shield",
+            "Nut Pot": "
+                Hammer and has_bombchus and
                 can_use(Fire_Arrows) and Mirror_Shield"
         }
     },

--- a/data/World/Ice Cavern MQ.json
+++ b/data/World/Ice Cavern MQ.json
@@ -2,6 +2,9 @@
     {
         "region_name": "Ice Cavern Beginning",
         "dungeon": "Ice Cavern",
+        "locations": {
+            "Fairy Pot": "has_bottle"
+        },
         "exits": {
             "Zoras Fountain": "True",
             "Ice Cavern Map Room": "

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -55,7 +55,8 @@
             "Jabu Jabus Belly MQ Near Boss Chest": "True",
             "Barinade Heart": "True",
             "Barinade": "True",
-            "GS Jabu Jabu MQ Near Boss": "True"
+            "GS Jabu Jabu MQ Near Boss": "True",
+            "Fairy Pot": "has_bottle"
         },
         "exits": {
             "Jabu Jabus Belly Main": "True"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1044,7 +1044,8 @@
     {
         "region_name": "Shield Grave",
         "locations": {
-            "Shield Grave Chest": "True"
+            "Shield Grave Chest": "True",
+            "Free Fairies": "can_blast_or_smash and has_bottle"
         },
         "exits": {
             "Graveyard": "True"
@@ -1053,8 +1054,7 @@
     {
         "region_name": "Heart Piece Grave",
         "locations": {
-            "Heart Piece Grave Chest": "can_play(Suns_Song)",
-            "Free Fairies": "can_blast_or_smash and has_bottle"
+            "Heart Piece Grave Chest": "can_play(Suns_Song)"
         },
         "exits": {
             "Graveyard": "True"

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -79,7 +79,8 @@
             "Shadow Temple MQ After Wind Enemy Chest": "True",
             "Shadow Temple MQ After Wind Hidden Chest": "True",
             "GS Shadow Temple MQ Wind Hint Room": "True",
-            "GS Shadow Temple MQ After Wind": "True"
+            "GS Shadow Temple MQ After Wind": "True",
+            "Nut Pot": "True"
         },
         "exits": {
             "Shadow Temple Beyond Boat": "

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -34,7 +34,10 @@
                 (can_use(Dins_Fire) or
                  at('Adult Spirit Temple', (can_use(Fire_Arrows) or
                                            (logic_spirit_mq_frozen_eye and can_use(Bow) and
-                                            can_play(Song_of_Time)))))"
+                                            can_play(Song_of_Time)))))",
+            "Fairy Pot": "
+                has_bottle and (has_sticks or Kokiri_Sword) and
+                has_bombchus and has_slingshot"
         },
         "exits": {
             "Spirit Temple Shared": "has_bombchus and (Small_Key_Spirit_Temple, 2)"

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -47,7 +47,9 @@
         "dungeon": "Water Temple",
         "locations": {
             "Water Temple MQ Boss Key Chest": "can_use(Dins_Fire)",
-            "GS Water Temple MQ Serpent River": "True"
+            "GS Water Temple MQ Serpent River": "True",
+            "Fairy Pot": "has_bottle",
+            "Nut Pot": "True"
         },
         "exits": {
             "Water Temple Basement Gated Areas": "

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -21,7 +21,8 @@
         },
         "locations": {
             "Morpha": "Boss_Key_Water_Temple and can_use(Longshot)",
-            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot)"
+            "Morpha Heart": "Boss_Key_Water_Temple and can_use(Longshot)",
+            "Fairy Pot": "has_bottle and can_use(Longshot)"
         },
         "exits": {
             "Water Temple Dark Link Region": "(Small_Key_Water_Temple, 5) and can_use(Hookshot)",
@@ -83,9 +84,14 @@
                 (logic_water_bk_jump_dive or can_use(Iron_Boots)) and
                 ((logic_water_bk_chest and Iron_Boots) or logic_water_north_basement_ledge_jump or
                     (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
-            "GS Water Temple Near Boss Key Chest": "True"
+            "GS Water Temple Near Boss Key Chest": "True",
                 # Longshot just reaches without the need to actually go near,
                 # Otherwise you have hovers and just hover over and collect with a jump slash
+            "Fairy Pot": "
+                has_bottle and (Small_Key_Water_Temple, 6) and 
+                (logic_water_bk_jump_dive or can_use(Iron_Boots)) and
+                ((logic_water_bk_chest and Iron_Boots) or logic_water_north_basement_ledge_jump or
+                    (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)"
         }
     },
     {
@@ -123,7 +129,9 @@
                 can_play(Song_of_Time) and (Small_Key_Water_Temple, 6) and Iron_Boots",
             "GS Water Temple Falling Platform Room": "
                 can_use(Longshot) or
-                (logic_water_falling_platform_gs and can_use(Hookshot))"
+                (logic_water_falling_platform_gs and can_use(Hookshot))",
+            "Fairy Pot": 
+                "has_bottle and (Small_Key_Water_Temple, 6) and can_play(Song_of_Time)"
         }
     }
 ]


### PR DESCRIPTION
Fixing these drop locations seemed somewhat different from the rest of the logic changes I'm planning to make? So I made this a separate PR.

Added these drop locations:
- BotW MQ (Explosives + Slingshot - Fairy Pot)
- Ganon's MQ (Scrubs room - Free Fairies; Spirit Trial end - Nut Pot)
- Water MQ (Longhost + 1 key - Fairy Pot; Longshot + 1 key - Nut Pot)
- Forest MQ (Behind SoT block - Fairy Pot)
- Fire MQ (Behind lower right door - Fairy Pot; Boss Key Chest room - Fairy Pot; East Tower Climb - Wall Switch Fairy; Flame wall Maze - Fairy Pot; further fairies logically irrelevant)
- Shadow MQ (Room before boat - Nut Pot)
- Ice MQ (2nd Room - Fairy Pot)
- DC MQ (Boss Area - Fairy Pot)
- Spirit MQ (Child side, after Bombchu, sling, and sword/stick requirement - Fairy Pot)
- Jabu MQ (Pre boss room - Fairy Pot)
- Water Vanilla (Near Boss Door - Fairy Pot; Boss Key Chest room - Fairy Pot; In the River after SoT before Bow - Fairy Pot)
- Shield Grave fairies (removed Heart Piece Grave fairies)

Notes:
- The BotW MQ Fairy Pot can be broken using a Boomerang trick throw, but it wasn't worth including.
- The Fire MQ BK Chest Room Fairy Pot silently reuses the jump to get to this room that skips song of time in vanilla. Here, it skips a hookshot requirement to get up to the door. (You can also din's the torch by the bombable wall from a distance, without needing to hook up to it.) You can then use a magic charged spin to break the pot on the other side of the flame wall. It didn't seem worth mentioning that the fire song of time trick has this obscure secondary effect.
- The fairy pot in MQ Jabu could technically be claimed as adult, if child doesn't have access to sword or sticks, without needing to put adult big octo into logic, by using hovers (or hookshot). I might fix this another time?