### PR TITLE
Reduce over-aggressive caching

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -521,6 +521,7 @@ def create_playthrough(spoiler):
     remaining_entrances = set(entrance for world in worlds for entrance in world.get_shuffled_entrances())
     
     while True:
+        playthrough.checkpoint()
         # Not collecting while the generator runs means we only get one sphere at a time
         # Otherwise, an item we collect could influence later item collection in the same sphere
         collected = list(playthrough.iter_reachable_locations(item_locations))

--- a/Main.py
+++ b/Main.py
@@ -30,7 +30,7 @@ from N64Patch import create_patch_file, apply_patch_file
 from SettingsList import setting_infos, logic_tricks
 from Rules import set_rules, set_shop_rules
 from Plandomizer import Distribution
-from Playthrough import Playthrough
+from Playthrough import Playthrough, ReversiblePlaythrough
 from EntranceShuffle import set_entrances
 from LocationList import set_drop_location_names
 
@@ -506,7 +506,7 @@ def create_playthrough(spoiler):
     if worlds[0].check_beatable_only and not State.can_beat_game([world.state for world in worlds]):
         raise RuntimeError('Cannot beat game. Something went terribly wrong here!')
 
-    playthrough = Playthrough([world.state for world in worlds])
+    playthrough = ReversiblePlaythrough([world.state for world in worlds])
     # Get all item locations in the worlds
     item_locations = [location for state in playthrough.state_list for location in state.world.get_filled_locations() if location.item.advancement]
     # Omit certain items from the playthrough

--- a/Main.py
+++ b/Main.py
@@ -30,7 +30,7 @@ from N64Patch import create_patch_file, apply_patch_file
 from SettingsList import setting_infos, logic_tricks
 from Rules import set_rules, set_shop_rules
 from Plandomizer import Distribution
-from Playthrough import Playthrough, ReversiblePlaythrough
+from Playthrough import Playthrough, RewindablePlaythrough
 from EntranceShuffle import set_entrances
 from LocationList import set_drop_location_names
 
@@ -506,7 +506,7 @@ def create_playthrough(spoiler):
     if worlds[0].check_beatable_only and not State.can_beat_game([world.state for world in worlds]):
         raise RuntimeError('Cannot beat game. Something went terribly wrong here!')
 
-    playthrough = ReversiblePlaythrough([world.state for world in worlds])
+    playthrough = RewindablePlaythrough([world.state for world in worlds])
     # Get all item locations in the worlds
     item_locations = [location for state in playthrough.state_list for location in state.world.get_filled_locations() if location.item.advancement]
     # Omit certain items from the playthrough

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -65,15 +65,8 @@ class Playthrough(object):
         raise Exception('Unimplemented for Playthrough. Perhaps you want ReversiblePlaythrough.')
 
 
-    # Drops the item from its respective state, and truncates the sphere cache
-    # based on which sphere an item was in.
-    # Does *not* uncollect any other items in or above that sphere!
-    # Doesn't forget which sphere items are in as an optimization, so be careful
-    # to only uncollect items in descending sphere order, or only track collected
-    # items in one sphere.
-    # Items not collected in this Playthrough are assumed to have been collected
-    # prior to sphere 0, so uncollecting them will discard the entire cache.
-    # Not safe to call during iteration.
+    # Drops the item from its respective state.
+    # Has no effect on cache!
     def uncollect(self, item):
         self.state_list[item.world.id].remove(item)
 
@@ -258,21 +251,8 @@ class ReversiblePlaythrough(Playthrough):
     def __init__(self, *args, **kwargs):
         # Mapping from location to sphere index. 0-based.
         self.location_in_sphere = defaultdict(int)
-        # Mapping from item to sphere index, if this is tracking items. 0-based.
-        self.item_in_sphere = defaultdict(int)
 
         super().__init__(*args, **kwargs)
-
-
-    def collect_all(self, itempool):
-        for item in itempool:
-            self.item_in_sphere[item] = len(self.cached_spheres)
-            self.state_list[item.world.id].collect(item)
-
-
-    def collect(self, item):
-        self.item_in_sphere[item] = len(self.cached_spheres)
-        self.state_list[item.world.id].collect(item)
 
 
     def unvisit(self, location):
@@ -281,16 +261,10 @@ class ReversiblePlaythrough(Playthrough):
             self.cached_spheres[-1]['visited_locations'].discard(location)
 
 
-    def uncollect(self, item):
-        self.state_list[item.world.id].remove(item)
-        self.cached_spheres[self.item_in_sphere[item]:] = []
-
-
     def reset(self):
         self.cached_spheres[1:] = []
         self.cached_spheres[0]['visited_locations'].clear()
         self.location_in_sphere.clear()
-        self.item_in_sphere.clear()
 
 
     def checkpoint(self):

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -73,7 +73,7 @@ class Playthrough(object):
     # in sphere 0, so unvisiting them will discard the entire cache.
     # Not safe to call during iteration.
     def unvisit(self, location):
-        raise Exception('Unimplemented for Playthrough. Perhaps you want ReversiblePlaythrough.')
+        raise Exception('Unimplemented for Playthrough. Perhaps you want RewindablePlaythrough.')
 
 
     # Drops the item from its respective state.
@@ -86,7 +86,7 @@ class Playthrough(object):
     # Does not uncollect any items!
     # Not safe to call during iteration.
     def reset(self):
-        raise Exception('Unimplemented for Playthrough. Perhaps you want ReversiblePlaythrough.')
+        raise Exception('Unimplemented for Playthrough. Perhaps you want RewindablePlaythrough.')
 
 
     # simplified exit.can_reach(state), bypasses can_become_age
@@ -241,7 +241,7 @@ class Playthrough(object):
             return self._cache['adult_regions'] + self._cache['child_regions']
 
 
-class ReversiblePlaythrough(Playthrough):
+class RewindablePlaythrough(Playthrough):
 
     def unvisit(self, location):
         # A location being unvisited is either:

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -35,7 +35,8 @@ class Playthrough(object):
     def copy(self):
         # we only need to copy the top sphere since that's what we're starting with and we don't go back
         new_cache = {k: copy.copy(v) for k,v in self._cache.items()}
-        return self.__class__(self.state_list, initial_cache=new_cache)
+        # copy always makes a nonreversible instance
+        return Playthrough(self.state_list, initial_cache=new_cache)
 
 
     def collect_all(self, itempool):


### PR DESCRIPTION
The Playthrough only needs to be rewindable for generating the seed playthrough, and not for seed generation nor even for determining beatability. This accounts for >90% of the memory previously used. We can also eliminate the sphere indexes, which aren't truly necessary.

Restructuring like this is also a minor speed improvement!

Some multiworld generation memory stats:
- 15: ~120 MB
- 25: ~280 MB
- 50: ~1 GB