### PR TITLE
"Final" Final Logic & Trick Update

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -108,8 +108,8 @@ entrance_shuffle_table = [
                         ('House of Skulltula -> Kakariko Village',                          { 'index': 0x04EE })),
     ('Interior',        ('Kakariko Village -> Impas House',                                 { 'index': 0x039C }),
                         ('Impas House -> Kakariko Village',                                 { 'index': 0x0345 })),
-    ('Interior',        ('Kakariko Village -> Impas House Back',                            { 'index': 0x05C8 }),
-                        ('Impas House Back -> Kakariko Village',                            { 'index': 0x05DC })),
+    ('Interior',        ('Kakariko Impa Ledge -> Impas House Back',                         { 'index': 0x05C8 }),
+                        ('Impas House Back -> Kakariko Impa Ledge',                         { 'index': 0x05DC })),
     ('Interior',        ('Kakariko Village Backyard -> Odd Medicine Building',              { 'index': 0x0072 }),
                         ('Odd Medicine Building -> Kakariko Village Backyard',              { 'index': 0x034D })),
     ('Interior',        ('Graveyard -> Dampes House',                                       { 'index': 0x030D }),
@@ -287,7 +287,7 @@ entrance_shuffle_table = [
                         ('Zoras Fountain -> Zoras Domain Behind King Zora',                 { 'index': 0x01A1 })),
 
     ('OwlDrop',         ('Lake Hylia Owl Flight -> Hyrule Field',                           { 'index': 0x027E, 'code_address': 0xAC9F26 })),
-    ('OwlDrop',         ('Death Mountain Summit Owl Flight -> Kakariko Village',            { 'index': 0x0554, 'code_address': 0xAC9EF2 })),
+    ('OwlDrop',         ('Death Mountain Summit Owl Flight -> Kakariko Impa Ledge',         { 'index': 0x0554, 'code_address': 0xAC9EF2 })),
 ]
 
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -115,12 +115,6 @@ class Scale(Setting_Info):
 
 
 logic_tricks = {
-    'Rolling Goron (Hot Rodder Goron) as Child with Strength': {
-        'name'    : 'logic_child_rolling_with_strength',
-        'tooltip' : '''\
-                    Use the bombflower on the stairs or near Medigoron.
-                    Timing is tight, especially without backwalking
-                    '''},
     'Fewer Tunic Requirements': {
         'name'    : 'logic_fewer_tunic_requirements',
         'tooltip' : '''\
@@ -147,6 +141,13 @@ logic_tricks = {
         'name'    : 'logic_child_deadhand',
         'tooltip' : '''\
                     Requires 9 sticks or 5 jump slashes.
+                    '''},
+    'Second Dampe Race as Child': {
+        'name'    : 'logic_child_dampe_race_poh',
+        'tooltip' : '''\
+                    It is possible to complete the second dampe
+                    race as child in under a minute, but it is
+                    a strict time limit.
                     '''},
     'Man on Roof without Hookshot': {
         'name'    : 'logic_man_on_roof',
@@ -251,6 +252,12 @@ logic_tricks = {
                     drain switch is in the standard form can be barely
                     reached with just the Hookshot.
                     '''},
+    'Forest Temple East Courtyard GS with Boomerang': {
+        'name'    : 'logic_forest_outdoor_east_gs',
+        'tooltip' : '''\
+                    Precise Boomerang throws can allow child to
+                    kill the Skulltula and collect the token.
+                    '''},
     'Swim Through Forest Temple MQ Well with Hookshot': {
         'name'    : 'logic_forest_well_swim',
         'tooltip' : '''\
@@ -336,6 +343,9 @@ logic_tricks = {
         'tooltip' : '''\
                     After killing the Skulltula, the Like Like
                     can be used to boost you into the token.
+                    It is possible to do this in such a way
+                    that you collect the token prior to taking
+                    damage from the Like Like.
                     '''},
     'Bottom of the Well MQ Dead Hand Freestanding Key with Boomerang': {
         'name'    : 'logic_botw_mq_dead_hand_key',
@@ -360,6 +370,13 @@ logic_tricks = {
                     To do it without taking damage is more precise.
                     Allows you to reach a GS without needing either
                     Song of Time or Hover Boots.
+                    '''},
+    'Fire Temple MQ Climb without Fire Source': {
+        'name'    : 'logic_fire_mq_climb',
+        'tooltip' : '''\
+                    You can use the Hover Boots to hover around to
+                    the climbable wall, skipping the need to use a
+                    fire source and spawn a Hookshot target.
                     '''},
     'Fire Temple MQ Chest Near Boss without Breaking Crate': {
         'name'    : 'logic_fire_mq_near_boss',
@@ -403,8 +420,16 @@ logic_tricks = {
                     Release the Bombchu with good timing so that
                     it explodes near the bottom of the pot.
                     '''},
-    'Adult Meadow Access without Saria\'s or Minuet': {
-        'name'    : 'logic_adult_meadow_access',
+    'Shadow Temple MQ Lower Huge Pit without Fire Source': {
+        'name'    : 'logic_shadow_mq_huge_pit',
+        'tooltip' : '''\
+                    Normally a frozen eye switch spawns some platforms
+                    that you can use to climb down, but there's actually
+                    a small piece of ground that you can stand on that
+                    you can just jump down to.
+                    '''},
+    'Backflip over Mido as Adult': {
+        'name'    : 'logic_mido_backflip',
         'tooltip' : '''\
                     With a specific position and angle, you can
                     backflip over Mido.
@@ -531,18 +556,44 @@ logic_tricks = {
                     If you stand on the very edge of the platform, this
                     Gold Skulltula can be obtained with only the Hookshot.
                     '''},
+    'Water Temple Serpent River GS without Iron Boots': {
+        'name'    : 'logic_water_river_gs',
+        'tooltip' : '''\
+                    Standing on the exposed ground toward the end of
+                    the river, a precise Longhost use can obtain the
+                    token. The Longshot cannot normally reach far
+                    enough to kill the Skulltula, however. You'll
+                    first have to find some other way of killing it.
+                    '''},
+    'Water Temple Entry without Iron Boots using Hookshot': {
+        'name'    : 'logic_water_hookshot_entry',
+        'tooltip' : '''\
+                    When entering Water Temple using Gold Scale instead
+                    of Iron Boots, the Longshot is usually used to be
+                    able to hit the switch and open the gate. But, by
+                    standing in a particular spot, the switch can be hit
+                    with only the reach of the Hookshot.
+                    '''},
     'Death Mountain Trail Upper Red Rock GS without Hammer': {
         'name'    : 'logic_trail_gs_upper',
         'tooltip' : '''\
                     After killing the Skulltula, the token can be collected
                     by backflipping into the rock at the correct angle.
                     '''},
-    'Death Mountain Trail Lower Red Rock GS without Hammer': {
-        'name'    : 'logic_trail_gs_lower',
+    'Death Mountain Trail Lower Red Rock GS with Hookshot': {
+        'name'    : 'logic_trail_gs_lower_hookshot',
         'tooltip' : '''\
                     After killing the Skulltula, the token can be fished
                     out of the rock without needing to destroy it, by
                     using the Hookshot in the correct way.
+                    '''},
+    'Death Mountain Trail Lower Red Rock GS with Magic Bean': {
+        'name'    : 'logic_trail_gs_lower_bean',
+        'tooltip' : '''\
+                    After killing the Skulltula, the token can be
+                    collected without needing to destroy the rock by
+                    jumping down onto it from the bean plant,
+                    midflight, with precise timing and positioning.
                     '''},
     'Death Mountain Crater Upper to Lower with Hammer': {
         'name'    : 'logic_crater_upper_to_lower',
@@ -574,7 +625,7 @@ logic_tricks = {
         'tooltip' : '''\
                     A precise jump can be used to reach this room.
                     '''},
-    'Climb Fire Temple without Strength': {
+    'Fire Temple Climb without Strength': {
         'name'    : 'logic_fire_strength',
         'tooltip' : '''\
                     A precise jump can be used to skip
@@ -640,6 +691,17 @@ logic_tricks = {
                     Skulltula somehow first. It can be killed
                     using Longshot, Bow, Bombchus or Din's Fire.
                     '''},
+    'Jabu Near Boss GS without Boomerang as Adult': {
+        'name'    : 'logic_jabu_boss_gs_adult',
+        'tooltip' : '''\
+                    You can easily get over to the door to the
+                    near boss area early with Hover Boots. The
+                    tricky part is getting through the door
+                    without being able to use a box to keep the
+                    switch pressed. One way is to quickly roll
+                    from the switch and open the door before it
+                    closes.
+                    '''},
     'Graveyard Freestanding PoH with Boomerang': {
         'name'    : 'logic_graveyard_poh',
         'tooltip' : '''\
@@ -692,16 +754,6 @@ logic_tricks = {
                     relevant if "Gerudo Training Grounds Left Side Silver Rupees
                     without Hookshot" is enabled.
                     '''},
-    'Water Temple Boss Key Jump Dive': {
-        'name'    : 'logic_water_bk_jump_dive',
-        'tooltip' : '''\
-                    Stand on the very edge of raised corridor leading from the
-                    push block room to the rolling boulder corridor. Face the
-                    gold skulltula on the waterfall and jump over the boulder
-                    corridor floor into the pool of water, swimming right once
-                    underwater. This allows access to the boss key room without
-                    Iron boots. 
-                    '''},
     'Water Temple Cracked Wall with No Additional Items': {
         'name'    : 'logic_water_cracked_wall_nothing',
         'tooltip' : '''\
@@ -729,6 +781,40 @@ logic_tricks = {
                     the torches on the bottom level. Swim through the corridor
                     and float up to the top level. This allows access to this
                     area and lower water levels without Iron Boots.
+                    The majority of the tricks that allow you to skip Iron Boots
+                    in the Water Temple are not going to be relevant unless this
+                    trick is first enabled.
+                    '''},
+    'Water Temple Boss Key Jump Dive': {
+        'name'    : 'logic_water_bk_jump_dive',
+        'tooltip' : '''\
+                    Stand on the very edge of raised corridor leading from the
+                    push block room to the rolling boulder corridor. Face the
+                    gold skulltula on the waterfall and jump over the boulder
+                    corridor floor into the pool of water, swimming right once
+                    underwater. This allows access to the boss key room without
+                    Iron boots.
+                    '''},
+    'Water Temple Dragon Statue Jump Dive': {
+        'name'    : 'logic_water_dragon_jump_dive',
+        'tooltip' : '''\
+                    If you come into the dragon statue room from the
+                    serpent river, you can jump down from above and get
+                    into the tunnel without needing either Iron Boots
+                    or a Scale. You must shoot the switch from above
+                    with the Bow, and then quickly get through the
+                    tunnel before the gate closes.
+                    '''},
+    'Water Temple Dragon Statue with Bombchu': {
+        'name'    : 'logic_water_dragon_bombchu',
+        'tooltip' : '''\
+                    You can hit the switch in the dragon statue room
+                    with a Bombchu. Use the time that the Bombchu is
+                    traveling to the switch to begin a dive (with at
+                    least Silver Scale) into the tunnel. This allows
+                    you to reach the chest without Iron Boots or
+                    coming into this room from above by going through
+                    the serpent river.
                     '''},
     'Goron City Leftmost Maze Chest with Hover Boots': {
         'name'    : 'logic_goron_city_leftmost',
@@ -791,12 +877,33 @@ logic_tricks = {
                     you also enable the Adult variant: "Dodongo's
                     Cavern Spike Trap Room Jump without Hover Boots."
                     '''},
+    'Rolling Goron (Hot Rodder Goron) as Child with Strength': {
+        'name'    : 'logic_child_rolling_with_strength',
+        'tooltip' : '''\
+                    Use the bombflower on the stairs or near Medigoron.
+                    Timing is tight, especially without backwalking.
+                    '''},
     'Goron City Spinning Pot PoH with Bombchu': {
         'name'    : 'logic_goron_city_pot',
         'tooltip' : '''\
                     A Bombchu can be used to stop the spinning
                     pot, but it can be quite finicky to get it
                     to work.
+                    '''},
+    'Gerudo Valley Crate PoH as Adult with Hover Boots': {
+        'name'    : 'logic_valley_crate_hovers',
+        'tooltip' : '''\
+                    From the far side of Gerudo Valley, a precise
+                    Hover Boots movement and jumpslash recoil can
+                    allow adult to reach the ledge with the crate
+                    PoH without needing Longshot.
+                    '''},
+    'Jump onto the Lost Woods Bridge as Adult with Nothing': {
+        'name'    : 'logic_lost_woods_bridge',
+        'tooltip' : '''\
+                    With very precise movement it's possible for
+                    adult to jump onto the bridge without needing
+                    Longshot, Hover Boots, or Bean.
                     '''},
     'Spirit Trial without Hookshot': {
         'name'    : 'logic_spirit_trial_hookshot',
@@ -820,6 +927,8 @@ logic_tricks = {
                     switch from the floor above. Then, you
                     can jump down into the hallway and make
                     through it before the gate closes.
+                    It can also be done as child, using the
+                    Slingshot instead of the Bow.
                     '''},
     'Fire Temple East Tower without Scarecrow\'s Song': {
         'name'    : 'logic_fire_scarecrow',
@@ -836,13 +945,6 @@ logic_tricks = {
                     open the Shadow Temple entrance with just Fire
                     Arrows, but you must be very quick, precise,
                     and strategic with how you take your shots.
-                    '''},
-    'Second Dampe Race as Child': {
-        'name'    : 'logic_child_dampe_race_poh',
-        'tooltip' : '''\
-                    It is possible to complete the second dampe
-                    race as child in under a minute, but it is
-                    a strict time limit.
                     '''},
 }
 

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -5,7 +5,7 @@
         "locations": {
             "Deku Tree MQ Lobby Chest": "True",
             "Deku Tree MQ Slingshot Chest": "is_adult or can_child_attack",
-            "Deku Tree MQ Slingshot Room Back Chest": "has_fire_source_with_torch",
+            "Deku Tree MQ Slingshot Room Back Chest": "has_fire_source_with_torch or can_use(Bow)",
             "Deku Tree MQ Basement Chest": "has_fire_source_with_torch or can_use(Bow)",
             "GS Deku Tree MQ Lobby": "is_adult or can_child_attack",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
@@ -19,7 +19,7 @@
                 here(can_use(Slingshot) or can_use(Bow)) and
                 here(has_fire_source_with_torch or can_use(Bow))",
             "Deku Tree Basement Water Room": "
-                here(can_use(Slingshot) or can_use(Bow)) and has_fire_source_with_torch",
+                here(can_use(Slingshot) or can_use(Bow)) and here(has_fire_source_with_torch)",
             "Deku Tree Basement Ledge": "logic_deku_b1_skip or here(is_adult)"
         }
     },

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -6,22 +6,24 @@
             "Fire Temple MQ Entrance Hallway Small Chest": "
                 is_adult or Kokiri_Sword or can_use(Sticks) or can_use(Slingshot)",
             "Fire Temple MQ Chest Near Boss": "
-                ((can_use(Hover_Boots) or (logic_fire_mq_near_boss and can_use(Bow))) and has_fire_source) or 
-                (can_use(Hookshot) and (can_use(Fire_Arrows) or 
-                    (can_use(Dins_Fire) and 
-                    ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or can_use(Goron_Tunic) or 
-                        can_use(Bow) or (Progressive_Hookshot, 2)))))",
+                (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and
+                    ((can_use(Hover_Boots) or (logic_fire_mq_near_boss and can_use(Bow))) and has_fire_source) or 
+                    (can_use(Hookshot) and (can_use(Fire_Arrows) or 
+                        (can_use(Dins_Fire) and 
+                        ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or can_use(Goron_Tunic) or 
+                            can_use(Bow) or (Progressive_Hookshot, 2)))))",
             "Fairy Pot": "has_bottle and (Small_Key_Fire_Temple, 5)"
         },
         "exits": {
             "Fire Temple Entrance": "True",
             "Fire Boss Room": "
-                has_fire_source and can_use(Goron_Tunic) and can_use(Hammer) and Boss_Key_Fire_Temple and
-                (logic_fire_boss_door_jump or Hover_Boots or at('Fire Temple Upper', True))",
+                can_use(Goron_Tunic) and can_use(Hammer) and Boss_Key_Fire_Temple and
+                ((has_fire_source and (logic_fire_boss_door_jump or Hover_Boots)) or at('Fire Temple Upper', True))",
             "Fire Lower Locked Door": "
                 (Small_Key_Fire_Temple, 5) and 
                 (has_explosives or can_use(Hammer) or can_use(Hookshot))",
-            "Fire Big Lava Room": "can_use(Hammer)"
+            "Fire Big Lava Room": "
+                (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and can_use(Hammer)"
         }
     },
     {
@@ -51,7 +53,8 @@
         },
         "exits": {
             "Fire Lower Maze": "
-                can_use(Goron_Tunic) and (Small_Key_Fire_Temple, 2) and has_fire_source"
+                can_use(Goron_Tunic) and (Small_Key_Fire_Temple, 2) and
+                (has_fire_source or (logic_fire_mq_climb and Hover_Boots))"
         }
     },
     {

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -4,7 +4,7 @@
         "dungeon": "Forest Temple",
         "locations": {
             "Forest Temple MQ First Chest": "
-                is_adult or can_use(Bombs) or can_use(Sticks) or
+                is_adult or has_bombs or can_use(Sticks) or has_nuts or can_use(Boomerang) or
                 can_use(Dins_Fire) or Kokiri_Sword or can_use(Slingshot)",
             "GS Forest Temple MQ First Hallway": "can_use(Hookshot) or can_use(Boomerang)"
         },

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -46,7 +46,7 @@
                 at('Forest Temple Falling Room', True) or
                 (logic_forest_outdoors_ledge and can_use(Hover_Boots) and at('Forest Temple Outdoors High Balconies', True))",
             "GS Forest Temple Outdoor East": "
-                can_use(Hookshot) or 
+                can_use(Hookshot) or (logic_forest_outdoor_east_gs and can_use(Boomerang)) or
                 at('Forest Temple Falling Room', can_use(Bow) or can_use(Dins_Fire) or has_explosives)",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
             "Deku Baba Nuts": "

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -18,7 +18,8 @@
         "locations": {
             "Jabu Jabus Belly MQ Second Room Lower Chest": "True",
             "Jabu Jabus Belly MQ Second Room Upper Chest": "
-                can_use(Hover_Boots) or at('Jabu Jabus Belly Boss Area', is_child)",
+                can_use(Hover_Boots) or can_use(Hookshot) or
+                at('Jabu Jabus Belly Boss Area', is_child)",
             "Jabu Jabus Belly MQ Compass Chest": "True",
             "Jabu Jabus Belly MQ Basement South Chest": "True",
             "Jabu Jabus Belly MQ Basement North Chest": "True",

--- a/data/World/Jabu Jabus Belly.json
+++ b/data/World/Jabu Jabus Belly.json
@@ -21,7 +21,8 @@
         },
         "exits": {
             "Jabu Jabus Belly Beginning": "True",
-            "Jabu Jabus Belly Depths": "can_use(Boomerang)"
+            "Jabu Jabus Belly Depths": "can_use(Boomerang)",
+            "Jabu Jabus Belly Boss Area": "logic_jabu_boss_gs_adult and can_use(Hover_Boots)"
         }
     },
     {
@@ -40,8 +41,8 @@
         "region_name": "Jabu Jabus Belly Boss Area",
         "dungeon": "Jabu Jabus Belly",
         "locations": {
-            "Barinade Heart": "True",
-            "Barinade": "True",
+            "Barinade Heart": "can_use(Boomerang)",
+            "Barinade": "can_use(Boomerang)",
             "GS Jabu Jabu Near Boss": "True",
             "Nut Pot": "True"
         },

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -165,9 +165,9 @@
             "Lost Woods Bridge": "
                 is_adult and
                 (can_use(Hover_Boots) or can_use(Longshot) or
-                    here(can_plant_bean))",
+                    here(can_plant_bean) or logic_lost_woods_bridge)",
             "Zora River": "can_leave_forest and (can_dive or can_use(Iron_Boots))",
-            "Lost Woods Beyond Mido": "is_child or logic_adult_meadow_access or can_play(Sarias_Song)",
+            "Lost Woods Beyond Mido": "is_child or logic_mido_backflip or can_play(Sarias_Song)",
             "Lost Woods Generic Grotto": "here(can_blast_or_smash)"
         }
     },
@@ -319,8 +319,9 @@
                 is_child or can_use(Scarecrow) or
                 here(can_plant_bean) or 'Water Temple Clear'",
             "Water Temple Lobby": "
-                (can_use(Hookshot) and can_use(Iron_Boots)) or
-                (can_use(Longshot) and (Progressive_Scale, 2))",
+                can_use(Hookshot) and
+                (can_use(Iron_Boots) or
+                    ((can_use(Longshot) or logic_water_hookshot_entry) and (Progressive_Scale, 2)))",
             "Lake Hylia Grotto": "True"
         }
     },
@@ -364,13 +365,13 @@
         "hint": "Gerudo Valley",
         "time_passes": true,
         "locations": {
-            "Gerudo Valley Crate Freestanding PoH": "is_child or can_use(Longshot)",
             "GS Gerudo Valley Small Bridge": "can_use(Boomerang) and at_night",
             "Bug Rock": "is_child and has_bottle"
         },
         "exits": {
             "Hyrule Field": "True",
             "Gerudo Valley Stream": "True",
+            "Gerudo Valley Crate Ledge": "is_child or can_use(Longshot)",
             "Gerudo Valley Octorok Grotto": "can_use(Silver_Gauntlets)",
             "Gerudo Valley Far Side": "
                 is_adult and 
@@ -395,6 +396,15 @@
         }
     },
     {
+        "region_name": "Gerudo Valley Crate Ledge",
+        "scene": "Gerudo Valley",
+        "hint": "Gerudo Valley",
+        "time_passes": true,
+        "locations": {
+            "Gerudo Valley Crate Freestanding PoH": "True"
+        }
+    },
+    {
         "region_name": "Gerudo Valley Far Side",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
@@ -410,6 +420,7 @@
         "exits": {
             "Gerudo Fortress": "True",
             "Gerudo Valley Stream": "True",
+            "Gerudo Valley Crate Ledge": "logic_valley_crate_hovers and can_use(Hover_Boots)",
             "Gerudo Valley": "
                 is_child or can_use(Epona) or can_use(Longshot) or
                 gerudo_fortress == 'open' or 'Carpenter Rescue'",
@@ -858,7 +869,6 @@
             "Carpenter Boss House": "True",
             "House of Skulltula": "True",
             "Impas House": "True",
-            "Impas House Back": "is_child or logic_visible_collisions or can_use(Hookshot)",
             "Windmill": "True",
             "Kakariko Bazaar": "is_adult and at_day",
             "Kakariko Shooting Gallery": "is_adult and at_day",
@@ -866,6 +876,8 @@
                 'Drain Well' and (is_child or shuffle_dungeon_entrances)",
             "Kakariko Potion Shop Front": "is_child or at_day",
             "Kakariko Bombable Grotto": "can_blast_or_smash",
+            "Kakariko Impa Ledge": "
+                (is_child and at_day) or (is_adult and logic_visible_collisions) or can_use(Hookshot)",
             "Kakariko Rooftop": "
                 can_use(Hookshot) or 
                 (logic_man_on_roof and 
@@ -875,6 +887,15 @@
             "Kakariko Village Backyard": "is_adult or (is_child and at_day)",
             "Graveyard": "True",
             "Kakariko Village Behind Gate": "is_adult or 'Kakariko Village Gate Open'"
+        }
+    },
+    {
+        "region_name": "Kakariko Impa Ledge",
+        "scene": "Kakariko Village",
+        "hint": "Kakariko Village",
+        "exits": {
+            "Impas House Back": "True",
+            "Kakariko Village": "True"
         }
     },
     {
@@ -939,7 +960,7 @@
             "Impas House Cow": "can_play(Eponas_Song)"
         },
         "exits": {
-            "Kakariko Village": "True"
+            "Kakariko Impa Ledge": "True"
         }
     },
     {
@@ -976,7 +997,7 @@
     {
         "region_name": "Kakariko Shooting Gallery",
         "locations": {
-            "Adult Shooting Gallery": "can_use(Bow)"
+            "Adult Shooting Gallery": "is_adult and Bow"
         },
         "exits": {
             "Kakariko Village": "True"
@@ -1126,17 +1147,17 @@
         "locations": {
             "Death Mountain Bombable Chest": "
                 can_blast_or_smash or 
-                (logic_dmt_bombable and Progressive_Strength_Upgrade)",
-            "DM Trail Freestanding PoH": "
-                is_child or (damage_multiplier != 'ohko') or 
-                can_use(Nayrus_Love) or has_fairy or Hover_Boots",
+                (logic_dmt_bombable and is_child and Progressive_Strength_Upgrade)",
+            "DM Trail Freestanding PoH": "True",
             "GS Mountain Trail Bean Patch": "
                 can_plant_bugs and
                     (has_explosives or Progressive_Strength_Upgrade or
                     (logic_dmt_soil_gs and can_use(Boomerang)))",
             "GS Mountain Trail Bomb Alcove": "can_blast_or_smash",
             "GS Mountain Trail Above Dodongo's Cavern": "
-                (can_use(Hammer) or (logic_trail_gs_lower and can_use(Hookshot))) and at_night",
+                is_adult and at_night and
+                (can_use(Hammer) or (logic_trail_gs_lower_hookshot and can_use(Hookshot)) or
+                    (logic_trail_gs_lower_bean and here(can_plant_bean and (has_explosives or Progressive_Strength_Upgrade))))",
             "Bean Plant Fairy": "
                 can_plant_bean and can_play(Song_of_Storms) and has_bottle and
                 (has_explosives or Progressive_Strength_Upgrade)"
@@ -1144,7 +1165,8 @@
         "exits": {
             "Kakariko Village Behind Gate": "True",
             "Goron City": "True",
-            "Death Mountain Summit": "here(can_blast_or_smash)",
+            "Death Mountain Summit": "
+                here(can_blast_or_smash) or (is_adult and here(can_plant_bean and Progressive_Strength_Upgrade))",
             "Dodongos Cavern Entryway": "
                 has_explosives or Progressive_Strength_Upgrade or is_adult",
             "Mountain Storms Grotto": "can_play(Song_of_Storms)"
@@ -1165,7 +1187,7 @@
                     (guarantee_trade_path and 
                     ('Eyedrops Access' or (Eyedrops and disable_trade_revert))))",
             "GS Mountain Trail Path to Crater": "
-                (can_use(Hammer) or logic_trail_gs_upper) and at_night",
+                is_adult and (can_use(Hammer) or logic_trail_gs_upper) and at_night",
             "Death Mountain Trail Gossip Stone": "True",
             "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
             "Bug Rock": "is_child and has_bottle"
@@ -1182,7 +1204,7 @@
         "region_name": "Death Mountain Summit Owl Flight",
         "scene": "Death Mountain",
         "exits": {
-            "Kakariko Village": "True"
+            "Kakariko Impa Ledge": "True"
         }
     },
     {
@@ -1230,7 +1252,7 @@
                 can_blast_or_smash or Progressive_Strength_Upgrade",
             "Gossip Stone Fairy": "
                 can_summon_gossip_fairy_without_suns and has_bottle and
-                (can_blast_or_smash or can_use(Silver_Gauntlets) or Progressive_Strength_Upgrade)",
+                (can_blast_or_smash or Progressive_Strength_Upgrade)",
             "Bug Rock": "(can_blast_or_smash or can_use(Silver_Gauntlets)) and has_bottle",
             "Stick Pot": "is_child"
         },
@@ -1319,9 +1341,9 @@
             "Death Mountain Crater Upper Nearby": "True",
             "Death Mountain Crater Ladder Area Nearby": "True",
             "Death Mountain Crater Central Nearby": "
-                can_use(Goron_Tunic) and can_use(Distant_Scarecrow) and 
+                can_use(Goron_Tunic) and can_use(Longshot) and 
                 ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
-                    has_fairy or can_use(Nayrus_Love))"
+                    (has_fairy and not shuffle_dungeon_entrances) or can_use(Nayrus_Love))"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1148,7 +1148,9 @@
             "Death Mountain Bombable Chest": "
                 can_blast_or_smash or 
                 (logic_dmt_bombable and is_child and Progressive_Strength_Upgrade)",
-            "DM Trail Freestanding PoH": "True",
+            "DM Trail Freestanding PoH": "
+                (damage_multiplier != 'ohko') or can_use(Nayrus_Love) or has_fairy or can_use(Hover_Boots) or
+                (is_adult and here(can_plant_bean and (has_explosives or Progressive_Strength_Upgrade)))",
             "GS Mountain Trail Bean Patch": "
                 can_plant_bugs and
                     (has_explosives or Progressive_Strength_Upgrade or

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -48,7 +48,7 @@
             "Shadow Temple MQ Invisible Blades Invisible Chest": "can_play(Song_of_Time)"
         },
         "exits": {
-            "Shadow Temple Lower Huge Pit": "has_fire_source"
+            "Shadow Temple Lower Huge Pit": "has_fire_source or logic_shadow_mq_huge_pit"
         }
     },
     {

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -53,6 +53,7 @@
         },
         "exits": {
             "Water Temple Basement Gated Areas": "
+                (can_use(Zora_Tunic) or logic_fewer_tunic_requirements) and
                 can_use(Dins_Fire) and can_use(Iron_Boots)"
         }
     },

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -37,7 +37,7 @@
         "locations": {
             # This doesn't require anything in its own right, however if the player lowers the water
             # without looting this chest, they need to restore it to top level
-          "Water Temple Map Chest": "
+            "Water Temple Map Chest": "
                 can_use(Hover_Boots) or can_use(Hookshot) or can_use(Bow) or
                 (at('Water Temple Lobby', has_fire_source_with_torch) and
                  at('Water Temple Lobby', can_use_projectile))",
@@ -47,22 +47,18 @@
                 (has_bow or can_use(Dins_Fire) or 
                  (Child_Water_Temple and has_sticks and Kokiri_Sword and Magic_Meter)) and
                 can_play(Zeldas_Lullaby)",
-            "Water Temple Dragon Chest": "
-                Iron_Boots and can_use(Hookshot) and
-                ((Progressive_Strength_Upgrade and can_play(Zeldas_Lullaby)) or 
-                    ((Small_Key_Water_Temple, 6) and 
-                        can_play(Song_of_Time) and has_bow))",
             "Water Temple Central Bow Target Chest": "
-                has_bow and Progressive_Strength_Upgrade and can_play(Zeldas_Lullaby) and 
-                (logic_water_central_bow or Hover_Boots or can_use(Longshot))",
+                Progressive_Strength_Upgrade and can_play(Zeldas_Lullaby) and 
+                ((has_bow and (logic_water_central_bow or Hover_Boots or can_use(Longshot))) or
+                    (logic_water_central_bow and Child_Water_Temple and has_slingshot and at('Water Temple Middle Water Level', True)))",
             "GS Water Temple South Basement": "
                 (can_use(Hookshot) or can_use(Hover_Boots)) and 
                 has_explosives and can_play(Zeldas_Lullaby) and
-                (can_use(Iron_Boots) or (Progressive_Scale, 2))"
+                (can_use(Iron_Boots) or can_dive)"
         },
         "exits": {
             "Water Temple Cracked Wall": "
-                can_play(Zeldas_Lullaby) and
+                can_play(Zeldas_Lullaby) and (can_use(Hookshot) or can_use(Hover_Boots)) and
                 (logic_water_cracked_wall_nothing or (logic_water_cracked_wall_hovers and can_use(Hover_Boots)))",
             "Water Temple Middle Water Level": "
                 (has_bow or can_use(Dins_Fire) or
@@ -72,7 +68,11 @@
             "Water Temple North Basement": "
                 (Small_Key_Water_Temple, 5) and
                 (can_use(Longshot) or (logic_water_boss_key_region and can_use(Hover_Boots))) and
-                (can_use(Iron_Boots) or can_play(Zeldas_Lullaby))"
+                (can_use(Iron_Boots) or can_play(Zeldas_Lullaby))",
+            "Water Temple Dragon Statue": "
+                can_play(Zeldas_Lullaby) and Progressive_Strength_Upgrade and
+                ((Iron_Boots and can_use(Hookshot)) or
+                    (logic_water_dragon_bombchu and has_bombchus and can_dive))"
         }
     },
     {
@@ -102,6 +102,13 @@
         }
     },
     {
+        "region_name": "Water Temple Dragon Statue",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple Dragon Chest": "True"
+        }
+    },
+    {
         "region_name": "Water Temple Middle Water Level",
         "dungeon": "Water Temple",
         "locations": {
@@ -126,12 +133,20 @@
             "Water Temple River Chest": "
                 (Small_Key_Water_Temple, 6) and can_play(Song_of_Time) and has_bow",
             "GS Water Temple Serpent River": "
-                can_play(Song_of_Time) and (Small_Key_Water_Temple, 6) and Iron_Boots",
+                can_play(Song_of_Time) and (Small_Key_Water_Temple, 6) and 
+                (Iron_Boots or (logic_water_river_gs and can_use(Longshot) and (has_bow or has_bombchus)))",
             "GS Water Temple Falling Platform Room": "
                 can_use(Longshot) or
                 (logic_water_falling_platform_gs and can_use(Hookshot))",
             "Fairy Pot": 
                 "has_bottle and (Small_Key_Water_Temple, 6) and can_play(Song_of_Time)"
+        },
+        "exits": {
+            "Water Temple Dragon Statue": "
+                (Small_Key_Water_Temple, 6) and can_play(Song_of_Time) and has_bow and
+                ((Iron_Boots and (can_use(Zora_Tunic) or logic_fewer_tunic_requirements)) or
+                    logic_water_dragon_jump_dive or
+                    (logic_water_dragon_bombchu and has_bombchus and can_dive))"
         }
     }
 ]


### PR DESCRIPTION
Changes:
- Added note to BotW Cage GS without Boomerang, that you can obtain the token prior to being dealt damage by the Like Like.
- Added note to Water Longshot Torch trick that the majority of the Iron Boots skips in Water Temple are not relevant unless you first enable it.
- Renamed "Adult Meadow Access without Saria's or Minuet" to "Backflip over Mido as Adult", since now with ER, it's not likely going to be the Meadow that you access early.
- Renamed Death Mountain Trail Lower Red Rock GS without Hammer to "with Hookshot" to account for the Magic Bean method.
- Renamed "Climb Fire Temple..." trick to "Fire Temple Climb..." just because.
- I arbitrarily reordered the items in the trick list again...

Bug Fixes / Logic Changes:
- The torch that spawns Deku Tree MQ Slingshot Room Back Chest can be lit using Bow.
- The torches to reach Deku Tree MQ Basement Water Room stay lit, but were not wrapped in a here().
- The chests in the heated rooms in the first floor of Fire MQ were not requiring Goron Tunic or FTR.
- The Skulltula in the first room of Forest MQ can be easily stunned and passed underneath using nuts or Boomerang.
- The Skulltula in the first room of Forest MQ had a can_use(Bombs) check, which does not actually work.
- Jabu MQ Second Room Upper Chest can be reached with the Hookshot.
- Water Temple MQ Basement Gated Areas was missing a Zora Tunic or FTR check.
- Water Temple Cracked Wall Chest with Nothing did not previously consider that you might lower the water and not be able to raise it back up. Since middle water level access to this chest is True, the only relevant means of getting to the top water level is with Hookshot or Hovers (and there was already a trick for doing it with Hovers).
- Water Temple Central Bow Target without Longshot or Hover Boots did not previously consider that you might perform the trick as child. Added a note to the trick description as well to alert players of this fact.
- GS Water Temple South Basement, when obtained without Irons, needs only 1 scale, not 2.
- I restructured entry into Impa House Back to account for the fact that child cannot enter at night without coming in from the Owl. I don't believe this fact was actually causing any problems? But it seemed best to make sure the logic was correct anyway.
- I changed Adult archery from can_use(Bow) to is_adult and Bow for basically no reason.
- The strength trick-route for Death Mountain Bombable Chest needed to check for is_child, since the flower is only there as child.
- I removed the child backflip for the DMT PoH on OHKO. There's a tricky jump adult can do, which would make the logic on this just True if both that and the child backflip were in default logic. But both are actually sort-of difficult to do.
- You can reach DMT Summit by riding the Bean.
- The trick route for GS Mountain Trail Path to Crater needed an is_adult check.
- Removed unnecessary Silver Gauntlets check from Goron City Gossip Fairy.
- DMC Scarecrow Route does not actually require Scarecrow. You can easily Longshot the planks.
- I banned the use of a Fairy for DMC "Scarecrow" Route in Dungeon ER, as that might be your only Fairy, and whatever is inside Fire Temple might require another one. Perhaps in the future this could be handled in a more robust way?

New Tricks:
- Fire Temple MQ Climb without Fire Source: A Hover Boots trick to get around to the climbable wall and skip needing to use fire to spawn a Hookshot target.
- Forest Temple East Courtyard GS with Boomerang: A precise Boomerang throw.
- Jabu Near Boss GS without Boomerang as Adult: Use Hover Boots to get over to the door to the preboss room, then maybe roll from the switch to get through the door before it closes.
- Water Temple Dragon Statue Jump Dive: Obtain this chest without Irons by jumping down into the tunnel from above after shooting the switch with Bow.
- Water Temple Dragon Statue with Bombchu: Obtain this chest without Irons by hitting the switch with a Bombchu and then Silver Scale diving through the tunnel.
- Water Temple Serpent River GS without Iron Boots: A precise Longshot can obtain the token, but can't kill the Skulltula. I'm avoiding Hookshot extension tricks, so the logic expects you to kill it with a Bow or a Bombchu. With a Bombchu is actually pretty wild but you're just going to use Hookshot extension anyway.
- Shadow Temple MQ Lower Huge Pit without Fire Source: Before ER I wasn't sure if this was in logic or if it was just an assumed Fire source. So now it's a trick you can enable.
- Jump onto the Lost Woods Bridge as Adult with Nothing: A couple of precise jumps and a jumpslash. It's a really important trick to know in ER since this is two loading zones (and an ocarina? or at least maybe a check) that you might not be able to reach otherwise.
- Water Temple Entry without Iron Boots using Hookshot: You can reach the switch with just Hookshot if you stand in the right spot. You'll need ER or keysanity or something to make use of this trick since otherwise you'll need Longshot to get anything done inside the temple.
- Gerudo Valley Crate PoH as Adult with Hover Boots: Really precise Hover Boots trick.
- Death Mountain Trail Lower Red Rock GS with Magic Bean: This is actually a pretty tricky jump. I just found out this was possible today and it looked pretty funny so I added it lol.

Not Resolved:
- Spirit Temple non-repeatable access issues.
- Impa House Cow: I really think something should be done here before 5.0; probably something along the lines of making sure both sides of the house exit to the same region.
- Anything involving the heat timer in DMC.