### PR TITLE
Fix Maximum Wallet Logic

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -164,16 +164,14 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
 
     for world in worlds:
         for location in world.get_filled_locations():
-            # Get the maximum amount of wallets required to purchase a major item.
-            if world.maximum_wallets < 3 and location.price and location.item.majoritem:
+            # Get the maximum amount of wallets required to purchase an advancement item.
+            if world.maximum_wallets < 3 and location.price and location.item.advancement:
                 if location.price > 500:
                     world.maximum_wallets = 3
                 elif world.maximum_wallets < 2 and location.price > 200:
                     world.maximum_wallets = 2
                 elif world.maximum_wallets < 1 and location.price > 99:
                     world.maximum_wallets = 1
-                else:
-                    world.maximum_wallets = 0
 
             # Get Light Arrow location for later usage.
             if location.item and location.item.name == 'Light Arrows':

--- a/World.py
+++ b/World.py
@@ -32,7 +32,7 @@ class World(object):
         self.required_locations = []
         self.shop_prices = {}
         self.scrub_prices = {}
-        self.maximum_wallets = 2
+        self.maximum_wallets = 0
         self.light_arrow_location = None
 
         self.parser = Rule_AST_Transformer(self)


### PR DESCRIPTION
I hate making PRs fixing my previous PRs but I botched the heck out of this. Now it should work.

Default shop items (e.g. tunics and Buy Blue Fire) aren't classed as major items, so we should check for advancement items instead. Also fixed a really dumb mistake in the if/else because boolean logic is hard.