### PR TITLE
Move time-of-day checking into Playthrough

### DIFF
--- a/Entrance.py
+++ b/Entrance.py
@@ -50,8 +50,8 @@ class Entrance(object):
         return self.access_rule(state, spot=self, age=age, tod=tod) and state.can_reach(self.parent_region, age=age, tod=tod)
 
 
-    def can_reach_simple(self, state, age=None):
-        return self.access_rule(state, age=age, spot=self)
+    def can_reach_simple(self, state, age=None, tod=None):
+        return self.access_rule(state, spot=self, age=age, tod=tod)
 
 
     def connect(self, region):

--- a/Entrance.py
+++ b/Entrance.py
@@ -9,7 +9,6 @@ class Entrance(object):
         self.world = parent.world
         self.connected_region = None
         self.spot_type = 'Entrance'
-        self.recursion_count = { 'child': 0, 'adult': 0 }
         self.access_rule = lambda state, **kwargs: True
         self.access_rules = []
         self.reverse = None

--- a/Entrance.py
+++ b/Entrance.py
@@ -1,3 +1,6 @@
+from Region import TimeOfDay
+
+
 class Entrance(object):
 
     def __init__(self, name='', parent=None):
@@ -46,11 +49,11 @@ class Entrance(object):
 
 
     # tod is passed explicitly only when we want to test for it
-    def can_reach(self, state, age=None, tod=None):
+    def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
         return self.access_rule(state, spot=self, age=age, tod=tod) and state.can_reach(self.parent_region, age=age, tod=tod)
 
 
-    def can_reach_simple(self, state, age=None, tod=None):
+    def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):
         return self.access_rule(state, spot=self, age=age, tod=tod)
 
 

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -3,6 +3,7 @@ import logging
 from Fill import ShuffleError
 from collections import OrderedDict
 from Playthrough import Playthrough
+from Region import TimeOfDay
 from Rules import set_entrances_based_rules
 from Entrance import Entrance
 from State import State
@@ -469,7 +470,7 @@ def split_entrances_by_requirements(worlds, entrances_to_split, assumed_entrance
 
     for entrance in entrances_to_split:
         # Here, we find entrances that may be unreachable under certain conditions
-        if not max_playthrough.state_list[entrance.world.id].as_both(entrance, tod='all'):
+        if not max_playthrough.state_list[entrance.world.id].as_both(entrance, tod=TimeOfDay.ALL):
             restrictive_entrances.append(entrance)
             continue
         # If an entrance is reachable as both ages and all times of day with all the other entrances disconnected,
@@ -589,7 +590,7 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
         # In ER, Time of day logic normally considers that the player always has access to time passing from the root so this is important to ensure
         # This also means that, in order to test for this, we have to temporarily remove that assumption about root access to time passing
         for world in worlds:
-            world.get_region('Root').can_reach = lambda state, tod=None, **kwargs: tod == None
+            world.get_region('Root').can_reach = lambda state, tod=TimeOfDay.NONE, **kwargs: tod == TimeOfDay.NONE
         no_time_passing_playthrough = Playthrough.with_items([world.state for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
         for world in worlds:
             world.get_region('Root').can_reach = lambda state, **kwargs: True

--- a/Fill.py
+++ b/Fill.py
@@ -198,9 +198,6 @@ def fill_dungeons_restrictive(window, worlds, playthrough, shuffled_locations, d
     # place dungeon items
     fill_restrictive(window, worlds, base_playthrough, shuffled_locations, dungeon_items)
 
-    for world in worlds:
-        world.state.clear_cached_unreachable()
-
 
 # Places items into dungeon locations. This is used when there should be exactly
 # one progression item per dungeon. This should be ran before all the progression

--- a/Location.py
+++ b/Location.py
@@ -1,4 +1,5 @@
 from LocationList import location_table
+from Region import TimeOfDay
 from enum import Enum
 
 
@@ -71,7 +72,7 @@ class Location(object):
 
 
     # tod is passed explicitly only when we want to test for it
-    def can_reach(self, state, age=None, tod=None):
+    def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
         if self.is_disabled():
             return False
 

--- a/Location.py
+++ b/Location.py
@@ -15,7 +15,6 @@ class Location(object):
         self.type = type
         self.scene = scene
         self.spot_type = 'Location'
-        self.recursion_count = { 'child': 0, 'adult': 0 }
         self.staleness_count = 0
         self.access_rule = lambda state, **kwargs: True
         self.access_rules = []
@@ -80,8 +79,6 @@ class Location(object):
 
 
     def can_reach_simple(self, state, age=None):
-        # todo: raw evaluation of access_rule? requires nonrecursive tod checks in state
-        # and GS Token and Gossip Stone Fairy have special checks as well
         return self.access_rule(state, age=age, spot=self)
 
 

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -93,10 +93,10 @@ class Playthrough(object):
 
     # simplified exit.can_reach(state), bypasses can_become_age
     # which we've already accounted for
-    def validate_child(self, exit, tod=None):
+    def validate_child(self, exit, tod=TimeOfDay.NONE):
         return exit.can_reach_simple(self.state_list[exit.parent_region.world.id], age='child', tod=tod)
 
-    def validate_adult(self, exit, tod=None):
+    def validate_adult(self, exit, tod=TimeOfDay.NONE):
         return exit.can_reach_simple(self.state_list[exit.parent_region.world.id], age='adult', tod=tod)
 
 

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -126,7 +126,7 @@ class Playthrough(object):
         for exit in exit_queue:
             # We don't look for new regions, just spreading the tod to our existing regions
             if exit.connected_region in regions and tod & ~regions[exit.connected_region]:
-                if validate(exit, tod=tod.name):
+                if validate(exit, tod=tod):
                     regions[exit.connected_region] |= tod
                     if exit.connected_region == goal_region:
                         return True
@@ -236,15 +236,15 @@ class Playthrough(object):
     # Use the cache in the playthrough to determine region reachability.
     def can_reach(self, region, age=None, tod=TimeOfDay.NONE):
         if age == 'adult':
-            if tod == TimeOfDay.NONE:
-                return region in self._cache['adult_regions']
-            else:
+            if tod:
                 return region in self._cache['adult_regions'] and (self._cache['adult_regions'][region] & tod or Playthrough._expand_tod_regions(self._cache['adult_regions'], region, self.validate_adult, tod))
-        elif age == 'child':
-            if tod == TimeOfDay.NONE:
-                return region in self._cache['child_regions']
             else:
+                return region in self._cache['adult_regions']
+        elif age == 'child':
+            if tod:
                 return region in self._cache['child_regions'] and (self._cache['child_regions'][region] & tod or Playthrough._expand_tod_regions(self._cache['child_regions'], region, self.validate_child, tod))
+            else:
+                return region in self._cache['child_regions']
         elif age == 'both':
             return self.can_reach(region, age='adult', tod=tod) and self.can_reach(region, age='child', tod=tod)
         else:

--- a/Region.py
+++ b/Region.py
@@ -1,4 +1,4 @@
-from enum import Enum, Flag, auto, unique
+from enum import Enum, IntFlag, auto, unique
 
 
 @unique
@@ -17,7 +17,7 @@ class RegionType(Enum):
 
 
 @unique
-class TimeOfDay(Flag):
+class TimeOfDay(IntFlag):
     NONE = 0
     DAY = auto()
     DAMPE = auto()

--- a/Region.py
+++ b/Region.py
@@ -36,7 +36,6 @@ class Region(object):
         self.world = None
         self.hint = None
         self.spot_type = 'Region'
-        self.recursion_count = { 'child': 0, 'adult': 0 }
         self.price = None
         self.world = None
         self.time_passes = False

--- a/Region.py
+++ b/Region.py
@@ -1,4 +1,4 @@
-from enum import Enum, IntFlag, auto, unique
+from enum import Enum, unique
 
 
 @unique
@@ -16,11 +16,11 @@ class RegionType(Enum):
         return self in (RegionType.Interior, RegionType.Dungeon, RegionType.Grotto)
 
 
-@unique
-class TimeOfDay(IntFlag):
+# Pretends to be an enum, but when the values are raw ints, it's much faster
+class TimeOfDay(object):
     NONE = 0
-    DAY = auto()
-    DAMPE = auto()
+    DAY = 1
+    DAMPE = 2
     ALL = DAY | DAMPE
 
 

--- a/Region.py
+++ b/Region.py
@@ -1,4 +1,4 @@
-from enum import Enum, unique
+from enum import Enum, Flag, auto, unique
 
 
 @unique
@@ -14,6 +14,14 @@ class RegionType(Enum):
     def is_indoors(self):
         """Shorthand for checking if Interior or Dungeon"""
         return self in (RegionType.Interior, RegionType.Dungeon, RegionType.Grotto)
+
+
+@unique
+class TimeOfDay(Flag):
+    NONE = 0
+    DAY = auto()
+    DAMPE = auto()
+    ALL = DAY | DAMPE
 
 
 class Region(object):
@@ -32,6 +40,7 @@ class Region(object):
         self.price = None
         self.world = None
         self.time_passes = False
+        self.provides_time = TimeOfDay.NONE
         self.scene = None
 
 
@@ -43,6 +52,7 @@ class Region(object):
         new_region.can_reach = self.can_reach
         new_region.hint = self.hint
         new_region.time_passes = self.time_passes
+        new_region.provides_time = self.provides_time
         new_region.scene = self.scene
 
         if self.dungeon:

--- a/Region.py
+++ b/Region.py
@@ -64,7 +64,7 @@ class Region(object):
 
 
     # tod is passed explicitly only when we want to test it
-    def can_reach(self, state, age=None, tod=None):
+    def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
         for entrance in self.entrances:
             if entrance.can_reach(state, age=age, tod=tod):
                 return True

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -374,14 +374,14 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if self.world.ensure_tod_access:
             # tod == 'day' or (tod == None and (ss or find a path from a provider))
             # obviously faster than constructing this expression by hand
-            return ast.parse("(tod == 'day') if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod='day'))", mode='eval').body
+            return ast.parse("(tod == 'DAY') if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod='DAY'))", mode='eval').body
         return ast.NameConstant(True)
 
     def at_dampe_time(self, node):
         if self.world.ensure_tod_access:
             # tod == 'dampe' or (tod == None and (find a path from a provider))
             # obviously faster than constructing this expression by hand
-            return ast.parse("(tod == 'dampe') if tod != None else state.can_reach(age=age, spot=spot.parent_region, tod='dampe')", mode='eval').body
+            return ast.parse("(tod == 'DAMPE') if tod != None else state.can_reach(age=age, spot=spot.parent_region, tod='DAMPE')", mode='eval').body
         return ast.NameConstant(True)
 
     def at_night(self, node):
@@ -390,7 +390,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if self.world.ensure_tod_access:
             # tod == 'dampe' or (tod == None and (ss or find a path from a provider))
             # obviously faster than constructing this expression by hand
-            return ast.parse("(tod == 'dampe') if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod='dampe'))", mode='eval').body
+            return ast.parse("(tod == 'DAMPE') if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod='DAMPE'))", mode='eval').body
         return ast.NameConstant(True)
 
 

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -322,7 +322,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
 
     def make_access_rule(self, body):
         # requires consistent iteration on dicts
-        kwargs = list(map(ast.arg, kwarg_defaults.keys()))
+        kwargs = [ast.arg(arg=k) for k in kwarg_defaults.keys()]
         kwd = list(map(ast.Constant, kwarg_defaults.values()))
         return eval(compile(
             ast.fix_missing_locations(

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -374,14 +374,14 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if self.world.ensure_tod_access:
             # tod == 'day' or (tod == None and (ss or find a path from a provider))
             # obviously faster than constructing this expression by hand
-            return ast.parse("(tod == 'DAY') if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod='DAY'))", mode='eval').body
+            return ast.parse("(tod & 1) if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod=1))", mode='eval').body
         return ast.NameConstant(True)
 
     def at_dampe_time(self, node):
         if self.world.ensure_tod_access:
             # tod == 'dampe' or (tod == None and (find a path from a provider))
             # obviously faster than constructing this expression by hand
-            return ast.parse("(tod == 'DAMPE') if tod != None else state.can_reach(age=age, spot=spot.parent_region, tod='DAMPE')", mode='eval').body
+            return ast.parse("(tod & 2) if tod != None else state.can_reach(age=age, spot=spot.parent_region, tod=2)", mode='eval').body
         return ast.NameConstant(True)
 
     def at_night(self, node):
@@ -390,7 +390,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if self.world.ensure_tod_access:
             # tod == 'dampe' or (tod == None and (ss or find a path from a provider))
             # obviously faster than constructing this expression by hand
-            return ast.parse("(tod == 'DAMPE') if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod='DAMPE'))", mode='eval').body
+            return ast.parse("(tod & 2) if tod != None else (state.can_play('Suns Song') or state.can_reach(age=age, spot=spot.parent_region, tod=2))", mode='eval').body
         return ast.NameConstant(True)
 
 

--- a/State.py
+++ b/State.py
@@ -68,15 +68,12 @@ class State(object):
 
         if tod == 'all':
             # If a spot is reachable at day and at dampe's time, then it's reachable at all times of day
-            return self.can_reach(spot, age=age, tod='DAY') and self.can_reach(spot, age=age, tod='DAMPE')
+            return self.can_reach(spot, age=age, tod=1) and self.can_reach(spot, age=age, tod=2)
 
         if not isinstance(spot, Region):
             return spot.can_reach(self, age=age, tod=tod)
 
-        if tod != None:
-            return self.playthrough.can_reach(spot, age=age, tod=getattr(TimeOfDay, tod))
-
-        return self.playthrough.can_reach(spot, age=age)
+        return self.playthrough.can_reach(spot, age=age, tod=tod)
 
         # If we are currently checking for reachability with a specific time of day and the needed time can be obtained here,
         # we want to continue the reachability test without a time of day, to make sure we could actually get there

--- a/State.py
+++ b/State.py
@@ -58,7 +58,7 @@ class State(object):
             return spot
 
 
-    def can_reach(self, spot=None, resolution_hint='Region', tod=None, age=None):
+    def can_reach(self, spot=None, resolution_hint='Region', tod=TimeOfDay.NONE, age=None):
         assert spot != None
         spot = self.get_spot(spot, resolution_hint)
 
@@ -66,9 +66,9 @@ class State(object):
         if age == None:
             return self.can_reach(spot, tod=tod, age='adult') or self.can_reach(spot, tod=tod, age='child')
 
-        if tod == 'all':
+        if tod == TimeOfDay.ALL:
             # If a spot is reachable at day and at dampe's time, then it's reachable at all times of day
-            return self.can_reach(spot, age=age, tod=1) and self.can_reach(spot, age=age, tod=2)
+            return self.can_reach(spot, age=age, tod=TimeOfDay.DAY) and self.can_reach(spot, age=age, tod=TimeOfDay.DAMPE)
 
         if not isinstance(spot, Region):
             return spot.can_reach(self, age=age, tod=tod)
@@ -108,14 +108,14 @@ class State(object):
         return can_reach
 
 
-    def as_both(self, spot, tod=None):
+    def as_both(self, spot, tod=TimeOfDay.NONE):
         if self.can_become_adult() and self.can_become_child():
             return self.can_reach(spot, age='adult', tod=tod) and self.can_reach(spot, age='child', tod=tod)
         else:
             return False
 
 
-    def as_age(self, spot, age, tod=None):
+    def as_age(self, spot, age, tod=TimeOfDay.NONE):
         if (self.can_become_adult() if age == 'adult' else self.can_become_child()):
             return self.can_reach(spot, tod=tod, age=age)
         return False

--- a/State.py
+++ b/State.py
@@ -4,7 +4,7 @@ import itertools
 
 from Item import ItemInfo
 from Playthrough import Playthrough
-from Region import Region
+from Region import Region, TimeOfDay
 
 
 
@@ -68,10 +68,15 @@ class State(object):
 
         if tod == 'all':
             # If a spot is reachable at day and at dampe's time, then it's reachable at all times of day
-            return self.can_reach(spot, age=age, tod='day') and self.can_reach(spot, age=age, tod='dampe')
+            return self.can_reach(spot, age=age, tod='DAY') and self.can_reach(spot, age=age, tod='DAMPE')
 
         if not isinstance(spot, Region):
             return spot.can_reach(self, age=age, tod=tod)
+
+        if tod != None:
+            return self.playthrough.can_reach(spot, age=age, tod=getattr(TimeOfDay, tod))
+
+        return self.playthrough.can_reach(spot, age=age)
 
         # If we are currently checking for reachability with a specific time of day and the needed time can be obtained here,
         # we want to continue the reachability test without a time of day, to make sure we could actually get there

--- a/World.py
+++ b/World.py
@@ -1,5 +1,5 @@
 from State import State
-from Region import Region
+from Region import Region, TimeOfDay
 from Entrance import Entrance
 from Hints import get_hint_area
 from Location import Location, LocationFactory
@@ -203,6 +203,9 @@ class World(object):
                 new_region.dungeon = region['dungeon']
             if 'time_passes' in region:
                 new_region.time_passes = region['time_passes']
+                new_region.provides_time = TimeOfDay.ALL
+            if new_region.name == 'Ganons Castle Grounds':
+                new_region.provides_time = TimeOfDay.DAMPE
             if 'locations' in region:
                 for location, rule in region['locations'].items():
                     new_location = LocationFactory(location)


### PR DESCRIPTION
The graph algorithm behind playthrough works for ToD as well, just with the caveat that we don't want to do it all the time, due to the low rate of ToD checks. But we can do the following:

1.  Make the region sets actually dictionaries, with available times of day as the value. Presence in the dictionary means the same thing as it did before for the set, but now when we reach a new region, we add its natural available times.
1.  When we need to know if a ToD is available in a region, we start with the regions in its world that have the appropriate time, and expand outward until we reach the target region or run out of exits.
1.  For space reasons, we use an enum value. For performance reasons, the enum is actually just raw integers.

(Theoretically, we could also provide the ToD we lazily cached this way to the normal evaluation functions, but it turns out that looking that up from the dict is more expensive than the savings we get.)

With this, the Playthrough cache can now handle all the tail end of `State.can_reach`, allowing us to eliminate the `region_cache` and `recursion_count`. There are still some extent calls that can be migrated, but they form a very low percentage of the remaining time.

This improves unittest runtimes around 20%, but mostly affects entrance shuffles. I haven't checked impact on memory usage.

@Roman971 if you have any comments, always appreciated.