### PR TITLE
Speed up some bytes-processing issues

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -443,7 +443,7 @@ def cosmetic_patch(settings, window=dummy_window()):
     window.update_status('Creating Patch File')
 
     # base the new patch file on the base patch file
-    rom.original = patched_base_rom
+    rom.original.buffer = patched_base_rom
 
     rom.update_crc()
     create_patch_file(rom, patchfilename)

--- a/Rom.py
+++ b/Rom.py
@@ -145,10 +145,10 @@ class Rom(BigStream):
         u32 = 0xFFFFFFFF
 
         m1 = self.read_bytes(0x1000, 0x100000)
-        words = (map(uint32.value, zip(m1[0::4], m1[1::4], m1[2::4], m1[3::4])))
+        words = map(uint32.value, zip(m1[0::4], m1[1::4], m1[2::4], m1[3::4]))
 
         m2 = self.read_bytes(0x750, 0x100)
-        words2 = (map(uint32.value, zip(m2[0::4], m2[1::4], m2[2::4], m2[3::4])))
+        words2 = map(uint32.value, zip(m2[0::4], m2[1::4], m2[2::4], m2[3::4]))
 
         for d, d2 in zip(words, itertools.cycle(words2)):
             # keep t2 and t6 in u32 for comparisons; others can wait to be truncated

--- a/Rom.py
+++ b/Rom.py
@@ -115,6 +115,11 @@ class Rom(BigStream):
         self.changed_address[self.last_address-1] = value
 
 
+    def write_bytes(self, address, values):
+        super().write_bytes(address, values)
+        self.changed_address.update(zip(range(address, address+len(values)), values))
+
+
     def restore(self):
         self.buffer = copy.copy(self.original.buffer)
         self.changed_address = {}

--- a/ntype.py
+++ b/ntype.py
@@ -161,8 +161,8 @@ class BigStream(object):
     def write_bytes(self, startaddress, values):
         if startaddress == None:
             startaddress = self.last_address
-        for i, value in enumerate(values):
-            self.write_byte(startaddress + i, value)
+        self.last_address = startaddress + len(values)
+        self.buffer[startaddress:startaddress + len(values)] = values
 
 
     def write_int16s(self, startaddress, values):


### PR DESCRIPTION
Most of the improvement comes from finding places where we call a python function for every byte/int32.

- Fixes the error in making a patch file.
- Writes multiple bytes to the buffer at once, instead of one at a time.
- Changes crc calculation to start by reading the whole block and dividing into chunks, instead of reading each chunk separately.
- Delays some bitwise-ands used for truncation. (Verified the crc still computed the same via a visual test.)