### PR TITLE
Change order for adult altar

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -615,12 +615,12 @@ def buildBossRewardHints(world, messages):
 
     # text that appears at altar as an adult.
     bossRewardsMedallions = [
-        ('Light Medallion',  'Light Blue'),
         ('Forest Medallion', 'Green'),
         ('Fire Medallion',   'Red'),
         ('Water Medallion',  'Blue'),
-        ('Shadow Medallion', 'Pink'),
         ('Spirit Medallion', 'Yellow'),
+        ('Shadow Medallion', 'Pink'),
+        ('Light Medallion',  'Light Blue'),
     ]
     adult_text = '\x08'
     adult_text += getHint('Medallion Text Start', world.clearer_hints).text


### PR DESCRIPTION
I'd like to propose this again, since it has been bugging me ever since #248 
I know this debate is age old, but I know I'm not the only one annoyed by the current order.

The in-game places where the order could be discerned from:
1) Title screen medallion order
![EmuHawk_2019-08-20_15-22-49](https://user-images.githubusercontent.com/6303487/63354247-65963700-c364-11e9-877e-08381cb094f1.png)
2) Song order
![EmuHawk_2019-08-20_15-43-41](https://user-images.githubusercontent.com/6303487/63354183-47c8d200-c364-11e9-92cd-59678cbf5b5e.png)
3) Quest screen medallions
![EmuHawk_2019-08-20_15-42-10](https://user-images.githubusercontent.com/6303487/63354281-78107080-c364-11e9-8060-991555436514.png)
4) Sheik telling you about the sages after you become adult for the 1st time. This one goes `Forest > Fire > Water > Shadow > Spirit`.

So 1-3 go `Forest > Fire > Water > Spirit > Shadow > Light`, a clear order for all 6 medallions. Admittedly, you can chose any starting point for the circular quest screen display, but it still goes `Spirit > Shadow`.

The only one that matches the current order is 4, but that is the only source that doesn't even include Light and **we never see this cutscene in rando**, whereas we see the other 3 quite regularly while menuing or save warping.

Sadly I don't know how to edit the pause menu overlay (A button while pause) to match the new order. I'll try and figure it out.