### PR TITLE
Add 'internal' marker to internal Locations.

### DIFF
--- a/Entrance.py
+++ b/Entrance.py
@@ -5,7 +5,6 @@ class Entrance(object):
         self.parent_region = parent
         self.world = parent.world
         self.connected_region = None
-        self.spot_type = 'Entrance'
         self.recursion_count = { 'child': 0, 'adult': 0 }
         self.access_rule = lambda state, **kwargs: True
         self.access_rules = []
@@ -21,7 +20,6 @@ class Entrance(object):
     def copy(self, new_region):
         new_entrance = Entrance(self.name, new_region)
         new_entrance.connected_region = self.connected_region.name
-        new_entrance.spot_type = self.spot_type
         new_entrance.access_rule = self.access_rule
         new_entrance.access_rules = list(self.access_rules)
         new_entrance.reverse = self.reverse

--- a/Item.py
+++ b/Item.py
@@ -183,6 +183,8 @@ def MakeEventItem(name, location):
     item = ItemFactory(name, location.world, event=True)
     location.world.push_item(location, item)
     location.locked = True
+    if name not in item_table:
+        location.internal = True
     location.world.event_items.add(name)
     return item
 

--- a/Location.py
+++ b/Location.py
@@ -40,6 +40,7 @@ class Location(object):
         new_location.access_rules = list(self.access_rules)
         new_location.item_rule = self.item_rule
         new_location.locked = self.locked
+        new_location.internal = self.internal
         new_location.minor_only = self.minor_only
         new_location.disabled = self.disabled
 

--- a/Location.py
+++ b/Location.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 class Location(object):
 
-    def __init__(self, name='', address=None, address2=None, default=None, type='Chest', scene=None, parent=None, filter_tags=None):
+    def __init__(self, name='', address=None, address2=None, default=None, type='Chest', scene=None, parent=None, filter_tags=None, internal=False):
         self.name = name
         self.parent_region = parent
         self.item = None
@@ -13,7 +13,7 @@ class Location(object):
         self.default = default
         self.type = type
         self.scene = scene
-        self.spot_type = 'Location'
+        self.internal = internal
         self.recursion_count = { 'child': 0, 'adult': 0 }
         self.staleness_count = 0
         self.access_rule = lambda state, **kwargs: True
@@ -36,7 +36,6 @@ class Location(object):
         if self.item:
             new_location.item = self.item.copy(new_region.world)
             new_location.item.location = new_location
-        new_location.spot_type = self.spot_type
         new_location.access_rule = self.access_rule
         new_location.access_rules = list(self.access_rules)
         new_location.item_rule = self.item_rule

--- a/Main.py
+++ b/Main.py
@@ -21,7 +21,6 @@ from Cosmetics import patch_cosmetics
 from DungeonList import create_dungeons
 from Fill import distribute_items_restrictive, ShuffleError
 from Item import Item
-from ItemList import item_table
 from ItemPool import generate_itempool
 from Hints import buildGossipHints
 from Utils import default_output_path, is_bundled, subprocess_args, data_path
@@ -511,7 +510,7 @@ def create_playthrough(spoiler):
     # Get all item locations in the worlds
     item_locations = [location for state in playthrough.state_list for location in state.world.get_filled_locations() if location.item.advancement]
     # Omit certain items from the playthrough
-    internal_locations = {location for location in item_locations if location.item.name not in item_table}
+    internal_locations = {location for location in item_locations if location.internal}
     # Generate a list of spheres by iterating over reachable locations without collecting as we go.
     # Collecting every item in one sphere means that every item
     # in the next sphere is collectable. Will contain every reachable item this way.
@@ -553,7 +552,7 @@ def create_playthrough(spoiler):
             # Generic events might show up or not, as usual, but since we don't
             # show them in the final output, might as well skip over them. We'll
             # still need them in the final pass, so make sure to include them.
-            if old_item.name not in item_table:
+            if location.internal:
                 required_locations.append(location)
                 continue
 

--- a/Region.py
+++ b/Region.py
@@ -27,7 +27,6 @@ class Region(object):
         self.dungeon = None
         self.world = None
         self.hint = None
-        self.spot_type = 'Region'
         self.recursion_count = { 'child': 0, 'adult': 0 }
         self.price = None
         self.world = None
@@ -38,7 +37,6 @@ class Region(object):
     def copy(self, new_world):
         new_region = Region(self.name, self.type)
         new_region.world = new_world
-        new_region.spot_type = self.spot_type
         new_region.price = self.price
         new_region.can_reach = self.can_reach
         new_region.hint = self.hint

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -298,7 +298,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
     def create_delayed_rules(self):
         for region_name, node, subrule_name in self.delayed_rules:
             region = self.world.get_region(region_name)
-            event = Location(subrule_name, type='Event', parent=region)
+            event = Location(subrule_name, type='Event', parent=region, internal=True)
             event.world = self.world
 
             self.current_spot = event

--- a/World.py
+++ b/World.py
@@ -6,7 +6,7 @@ from Location import Location, LocationFactory
 from LocationList import business_scrubs
 from DungeonList import create_dungeons
 from Rules import set_rules, set_shop_rules
-from Item import Item, ItemFactory
+from Item import Item, ItemFactory, MakeEventItem
 from RuleParser import Rule_AST_Transformer
 from SettingsList import get_setting_info
 import logging
@@ -222,9 +222,7 @@ class World(object):
                         self.parser.parse_spot_rule(new_location)
                     new_location.world = self
                     new_region.locations.append(new_location)
-                    self.push_item(new_location, ItemFactory(event, self, event=True))
-                    new_location.locked = True
-                    self.event_items.add(event)
+                    MakeEventItem(event, new_location)
             if 'exits' in region:
                 for exit, rule in region['exits'].items():
                     new_exit = Entrance('%s -> %s' % (new_region.name, exit), new_region)


### PR DESCRIPTION
Allows checking if a location is internal, more simply than checking if it has an item name in item_table.

Also removes another unused attribute.