### PR TITLE
Remove State.can_reach

### DIFF
--- a/Entrance.py
+++ b/Entrance.py
@@ -45,10 +45,6 @@ class Entrance(object):
         self.access_rules = [lambda_rule]
 
 
-    def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):
-        return self.access_rule(state, spot=self, age=age, tod=tod)
-
-
     def connect(self, region):
         self.connected_region = region
         region.entrances.append(self)

--- a/Entrance.py
+++ b/Entrance.py
@@ -45,11 +45,6 @@ class Entrance(object):
         self.access_rules = [lambda_rule]
 
 
-    # tod is passed explicitly only when we want to test for it
-    def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
-        return state.playthrough.spot_access(self, age=age, tod=tod)
-
-
     def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):
         return self.access_rule(state, spot=self, age=age, tod=tod)
 

--- a/Entrance.py
+++ b/Entrance.py
@@ -47,7 +47,7 @@ class Entrance(object):
 
     # tod is passed explicitly only when we want to test for it
     def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
-        return self.access_rule(state, spot=self, age=age, tod=tod) and state.can_reach(self.parent_region, age=age, tod=tod)
+        return state.playthrough.spot_access(self, age=age, tod=tod)
 
 
     def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -531,7 +531,6 @@ def shuffle_entrances(worlds, entrances, target_entrances, rollbacks, locations_
 def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, itempool):
 
     max_playthrough = None
-    no_items_time_travel_playthrough = None
 
     if locations_to_ensure_reachable:
         max_playthrough = Playthrough.max_explore([world.state for world in worlds], itempool)
@@ -577,6 +576,7 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
             check_same_hint_region(potion_front_entrance, potion_back_entrance)
 
         # At least one valid starting region with all basic refills should be reachable without using any items at the beginning of the seed
+        # Note this creates an empty State rather than reuse world.state (which already has starting items).
         no_items_playthrough = Playthrough([State(world) for world in worlds])
 
         valid_starting_regions = ['Kokiri Forest', 'Kakariko Village']
@@ -585,26 +585,26 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
                 raise EntranceShuffleError('Invalid starting area')
 
         # Check that a region where time passes is always reachable as both ages without having collected any items (except in closed forest)
-        no_items_time_travel_playthrough = Playthrough.with_items([world.state for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
+        time_travel_playthrough = Playthrough.with_items([world.state for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
 
         for world in worlds:
-            if not (any(region for region in no_items_time_travel_playthrough.reachable_regions('child') if region.time_passes and region.world == world) and
-                    any(region for region in no_items_time_travel_playthrough.reachable_regions('adult') if region.time_passes and region.world == world)):
+            if not (any(region for region in time_travel_playthrough.reachable_regions('child') if region.time_passes and region.world == world) and
+                    any(region for region in time_travel_playthrough.reachable_regions('adult') if region.time_passes and region.world == world)):
                 raise EntranceShuffleError('Time passing is not guaranteed as both ages')
 
         # When starting as adult, child Link should be able to reach ToT without having collected any items
         # This is important to ensure that the player never loses access to the pedestal after going child
         if any(world.starting_age == 'adult' for world in worlds):
             for world in worlds:
-                if world.starting_age == 'adult' and not no_items_time_travel_playthrough.can_reach(world.get_region('Temple of Time'), age='child'):
+                if world.starting_age == 'adult' and not time_travel_playthrough.can_reach(world.get_region('Temple of Time'), age='child'):
                     raise EntranceShuffleError('Links House to Temple of Time path as child is not guaranteed')
 
     if entrance_placed == None or (entrance_placed != None and entrance_placed.type in ['Interior', 'SpecialInterior', 'Overworld']):
         # The Big Poe Shop should always be accessible as adult without the need to use any bottles
         # Since we can't guarantee that items in the pool won't be placed behind bottles, we guarantee the access without using any items
         # This is important to ensure that players can never lock their only bottles by filling them with Big Poes they can't sell
-        if no_items_time_travel_playthrough == None:
-            no_items_time_travel_playthrough = Playthrough.with_items([world.state for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
+        no_items_time_travel_playthrough = Playthrough.with_items([State(world) for world in worlds], [ItemFactory('Time Travel', world=world) for world in worlds])
+
         for world in worlds:
             if not no_items_time_travel_playthrough.can_reach(world.get_region('Castle Town Rupee Room'), age='adult'):
                 raise EntranceShuffleError('Big Poe Shop access is not guaranteed as adult')

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -470,7 +470,7 @@ def split_entrances_by_requirements(worlds, entrances_to_split, assumed_entrance
 
     for entrance in entrances_to_split:
         # Here, we find entrances that may be unreachable under certain conditions
-        if not max_playthrough.state_list[entrance.world.id].as_both(entrance, tod=TimeOfDay.ALL):
+        if not max_playthrough.spot_access(entrance, age='both', tod=TimeOfDay.ALL):
             restrictive_entrances.append(entrance)
             continue
         # If an entrance is reachable as both ages and all times of day with all the other entrances disconnected,
@@ -550,27 +550,27 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
         for world in worlds:
             # Links House entrance should be reachable as child at some point in the seed
             links_house_entrance = get_entrance_replacing(world.get_region('Links House'), 'Kokiri Forest -> Links House')
-            if not max_playthrough.state_list[world.id].as_age(links_house_entrance, age='child'):
+            if not max_playthrough.spot_access(links_house_entrance, age='child'):
                 raise EntranceShuffleError('Links House Entrance is never reachable as child')
 
             # Temple of Time entrance should be reachable as both ages at some point in the seed
             temple_of_time_entrance = get_entrance_replacing(world.get_region('Temple of Time'), 'Temple of Time Exterior -> Temple of Time')
-            if not max_playthrough.state_list[world.id].as_both(temple_of_time_entrance):
+            if not max_playthrough.spot_access(temple_of_time_entrance, age='both'):
                 raise EntranceShuffleError('Temple of Time Entrance is never reachable as both ages')
 
             # Windmill door entrance should be reachable as both ages at some point in the seed
             windmill_door_entrance = get_entrance_replacing(world.get_region('Windmill'), 'Kakariko Village -> Windmill')
-            if not max_playthrough.state_list[world.id].as_both(windmill_door_entrance):
+            if not max_playthrough.spot_access(windmill_door_entrance, age='both'):
                 raise EntranceShuffleError('Windmill Door Entrance is never reachable as both ages')
 
             # Potion Shop front door should be reachable as both ages at some point in the seed
             potion_front_entrance = get_entrance_replacing(world.get_region('Kakariko Potion Shop Front'), 'Kakariko Village -> Kakariko Potion Shop Front')
-            if not max_playthrough.state_list[world.id].as_both(potion_front_entrance):
+            if not max_playthrough.spot_access(potion_front_entrance, age='both'):
                 raise EntranceShuffleError('Adult Potion Front Entrance is never reachable as both ages')
 
             # Potion Shop back door should be reachable as adult at some point in the seed
             potion_back_entrance = get_entrance_replacing(world.get_region('Kakariko Potion Shop Back'), 'Kakariko Village Backyard -> Kakariko Potion Shop Back')
-            if not max_playthrough.state_list[world.id].as_age(potion_back_entrance, age='adult'):
+            if not max_playthrough.spot_access(potion_back_entrance, age='adult'):
                 raise EntranceShuffleError('Adult Potion Back Entrance is never reachable as Adult')
 
             check_same_hint_region(potion_front_entrance, potion_back_entrance)

--- a/Location.py
+++ b/Location.py
@@ -70,14 +70,6 @@ class Location(object):
         return (self.parent_region.can_fill(item, manual) and self.item_rule(self, item))
 
 
-    # tod is passed explicitly only when we want to test for it
-    def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
-        if self.is_disabled():
-            return False
-
-        return state.playthrough.spot_access(self, age=age, tod=tod)
-
-
     def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):
         return self.access_rule(state, age=age, spot=self, tod=tod)
 

--- a/Location.py
+++ b/Location.py
@@ -70,10 +70,6 @@ class Location(object):
         return (self.parent_region.can_fill(item, manual) and self.item_rule(self, item))
 
 
-    def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):
-        return self.access_rule(state, age=age, spot=self, tod=tod)
-
-
     def is_disabled(self):
         return (self.disabled == DisableType.DISABLED) or \
                (self.disabled == DisableType.PENDING and self.locked)

--- a/Location.py
+++ b/Location.py
@@ -75,11 +75,11 @@ class Location(object):
         if self.is_disabled():
             return False
 
-        return self.access_rule(state, spot=self, age=age, tod=tod) and state.can_reach(self.parent_region, age=age, tod=tod)
+        return state.playthrough.spot_access(self, age=age, tod=tod)
 
 
-    def can_reach_simple(self, state, age=None):
-        return self.access_rule(state, age=age, spot=self)
+    def can_reach_simple(self, state, age=None, tod=TimeOfDay.NONE):
+        return self.access_rule(state, age=age, spot=self, tod=tod)
 
 
     def is_disabled(self):

--- a/Main.py
+++ b/Main.py
@@ -528,7 +528,7 @@ def create_playthrough(spoiler):
         if not collected: break
         # Gather the new entrances before collecting items.
         collection_spheres.append(collected)
-        accessed_entrances = set(filter(lambda entrance: playthrough.state_list[entrance.world.id].can_reach(entrance), remaining_entrances))
+        accessed_entrances = set(filter(playthrough.spot_access, remaining_entrances))
         entrance_spheres.append(accessed_entrances)
         remaining_entrances -= accessed_entrances
         for location in collected:
@@ -605,7 +605,7 @@ def create_playthrough(spoiler):
             continue
         # Gather the new entrances before collecting items.
         collection_spheres.append(list(collected))
-        accessed_entrances = set(filter(lambda entrance: playthrough.state_list[entrance.world.id].can_reach(entrance), remaining_entrances))
+        accessed_entrances = set(filter(playthrough.spot_access, remaining_entrances))
         entrance_spheres.append(accessed_entrances)
         remaining_entrances -= accessed_entrances
         for location in collected:

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -235,6 +235,7 @@ class Playthrough(object):
 
 
     # Use the cache in the playthrough to determine region reachability.
+    # Implicitly requires is_starting_age or Time_Travel.
     def can_reach(self, region, age=None, tod=TimeOfDay.NONE):
         if age == 'adult':
             if tod:
@@ -267,21 +268,21 @@ class Playthrough(object):
         else:
             return self._cache['adult_regions'].keys() + self._cache['child_regions'].keys()
 
-    # Returns whether the given age can access the spot at this age,
+    # Returns whether the given age can access the spot at this age and tod,
     # by checking whether the playthrough has reached the containing region, and evaluating the spot's access rule.
-    def spot_access(self, spot, age):
+    def spot_access(self, spot, age, tod=TimeOfDay.NONE):
         if age == 'both':
-            return (self.can_reach(spot.parent_region, age=age)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age='adult')
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age='child'))
+            return (self.can_reach(spot.parent_region, age=age, tod=tod)
+                    and spot.can_reach_simple(self.state_list[spot.world.id], age='adult', tod=tod)
+                    and spot.can_reach_simple(self.state_list[spot.world.id], age='child', tod=tod))
         elif age == 'either':
-            return (self.can_reach(spot.parent_region, age='adult')
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age='adult')) or (
-                            self.can_reach(spot.parent_region, age='child')
-                            and spot.can_reach_simple(self.state_list[spot.world.id], age='child'))
+            return (self.can_reach(spot.parent_region, age='adult', tod=tod)
+                    and spot.can_reach_simple(self.state_list[spot.world.id], age='adult', tod=tod)) or (
+                            self.can_reach(spot.parent_region, age='child', tod=tod)
+                            and spot.can_reach_simple(self.state_list[spot.world.id], age='child', tod=tod))
         else:
-            return (self.can_reach(spot.parent_region, age=age)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age=age))
+            return (self.can_reach(spot.parent_region, age=age, tod=tod)
+                    and spot.can_reach_simple(self.state_list[spot.world.id], age=age, tod=tod))
 
 
 class RewindablePlaythrough(Playthrough):

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -95,10 +95,10 @@ class Playthrough(object):
     # simplified exit.can_reach(state), bypasses can_become_age
     # which we've already accounted for
     def validate_child(self, exit, tod=TimeOfDay.NONE):
-        return exit.can_reach_simple(self.state_list[exit.parent_region.world.id], age='child', tod=tod)
+        return exit.access_rule(self.state_list[exit.parent_region.world.id], spot=exit, age='child', tod=tod)
 
     def validate_adult(self, exit, tod=TimeOfDay.NONE):
-        return exit.can_reach_simple(self.state_list[exit.parent_region.world.id], age='adult', tod=tod)
+        return exit.access_rule(self.state_list[exit.parent_region.world.id], spot=exit, age='adult', tod=tod)
 
 
     # Internal to the iteration. Modifies the exit_queue, regions. 
@@ -168,9 +168,9 @@ class Playthrough(object):
             return (loc not in visited_locations
                     # Check adult first; it's the most likely.
                     and (loc.parent_region in adult_regions
-                         and loc.can_reach_simple(self.state_list[loc.world.id], age='adult')
+                         and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='adult')
                          or (loc.parent_region in child_regions
-                             and loc.can_reach_simple(self.state_list[loc.world.id], age='child'))))
+                             and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='child'))))
 
 
         had_reachable_locations = True
@@ -273,16 +273,16 @@ class Playthrough(object):
     def spot_access(self, spot, age=None, tod=TimeOfDay.NONE):
         if age == 'adult' or age == 'child':
             return (self.can_reach(spot.parent_region, age=age, tod=tod)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age=age, tod=tod))
+                    and spot.access_rule(self.state_list[spot.world.id], spot=spot, age=age, tod=tod))
         elif age == 'both':
             return (self.can_reach(spot.parent_region, age=age, tod=tod)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age='adult', tod=tod)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age='child', tod=tod))
+                    and spot.access_rule(self.state_list[spot.world.id], spot=spot, age='adult', tod=tod)
+                    and spot.access_rule(self.state_list[spot.world.id], spot=spot, age='child', tod=tod))
         else:
             return (self.can_reach(spot.parent_region, age='adult', tod=tod)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age='adult', tod=tod)) or (
+                    and spot.access_rule(self.state_list[spot.world.id], spot=spot, age='adult', tod=tod)) or (
                             self.can_reach(spot.parent_region, age='child', tod=tod)
-                            and spot.can_reach_simple(self.state_list[spot.world.id], age='child', tod=tod))
+                            and spot.access_rule(self.state_list[spot.world.id], spot=spot, age='child', tod=tod))
 
 
 class RewindablePlaythrough(Playthrough):

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -270,19 +270,19 @@ class Playthrough(object):
 
     # Returns whether the given age can access the spot at this age and tod,
     # by checking whether the playthrough has reached the containing region, and evaluating the spot's access rule.
-    def spot_access(self, spot, age, tod=TimeOfDay.NONE):
-        if age == 'both':
+    def spot_access(self, spot, age=None, tod=TimeOfDay.NONE):
+        if age == 'adult' or age == 'child':
+            return (self.can_reach(spot.parent_region, age=age, tod=tod)
+                    and spot.can_reach_simple(self.state_list[spot.world.id], age=age, tod=tod))
+        elif age == 'both':
             return (self.can_reach(spot.parent_region, age=age, tod=tod)
                     and spot.can_reach_simple(self.state_list[spot.world.id], age='adult', tod=tod)
                     and spot.can_reach_simple(self.state_list[spot.world.id], age='child', tod=tod))
-        elif age == 'either':
+        else:
             return (self.can_reach(spot.parent_region, age='adult', tod=tod)
                     and spot.can_reach_simple(self.state_list[spot.world.id], age='adult', tod=tod)) or (
                             self.can_reach(spot.parent_region, age='child', tod=tod)
                             and spot.can_reach_simple(self.state_list[spot.world.id], age='child', tod=tod))
-        else:
-            return (self.can_reach(spot.parent_region, age=age, tod=tod)
-                    and spot.can_reach_simple(self.state_list[spot.world.id], age=age, tod=tod))
 
 
 class RewindablePlaythrough(Playthrough):

--- a/Region.py
+++ b/Region.py
@@ -46,7 +46,6 @@ class Region(object):
         new_region = Region(self.name, self.type)
         new_region.world = new_world
         new_region.price = self.price
-        new_region.can_reach = self.can_reach
         new_region.hint = self.hint
         new_region.time_passes = self.time_passes
         new_region.provides_time = self.provides_time
@@ -58,15 +57,6 @@ class Region(object):
         new_region.exits = [exit.copy(new_region) for exit in self.exits]
 
         return new_region
-
-
-    # tod is passed explicitly only when we want to test it
-    def can_reach(self, state, age=None, tod=TimeOfDay.NONE):
-        for entrance in self.entrances:
-            if entrance.can_reach(state, age=age, tod=tod):
-                return True
-
-        return False
 
 
     def can_fill(self, item, manual=False):

--- a/Rules.py
+++ b/Rules.py
@@ -11,9 +11,6 @@ def set_rules(world):
     # ganon can only carry triforce
     world.get_location('Ganon').item_rule = lambda location, item: item.name == 'Triforce'
 
-    # the root of the world graph is always considered reachable because the player can save&quit
-    world.get_region('Root').can_reach = lambda state, **kwargs: True
-
     for location in world.get_locations():
         if not world.shuffle_song_items:
             if location.type == 'Song':

--- a/State.py
+++ b/State.py
@@ -30,43 +30,6 @@ class State(object):
         return new_state
 
 
-    def get_spot(self, spot, resolution_hint='Region'):
-        if isinstance(spot, str):
-            # try to resolve a name
-            if resolution_hint == 'Location':
-                return self.world.get_location(spot)
-            elif resolution_hint == 'Entrance':
-                return self.world.get_entrance(spot)
-            elif resolution_hint == 'Region':
-                return self.world.get_region(spot)
-            else:
-                raise AttributeError('Unknown resolution hint type: ' + str(resolution_hint))
-        else:
-            return spot
-
-
-    def can_reach(self, spot=None, resolution_hint='Region', tod=TimeOfDay.NONE, age=None):
-        assert spot != None
-        spot = self.get_spot(spot, resolution_hint)
-
-        # If the current age is not defined, we try either
-        if age == None:
-            return self.can_reach(spot, tod=tod, age='adult') or self.can_reach(spot, tod=tod, age='child')
-
-        if tod == TimeOfDay.ALL:
-            # If a spot is reachable at day and at dampe's time, then it's reachable at all times of day
-            return self.can_reach(spot, age=age, tod=TimeOfDay.DAY) and self.can_reach(spot, age=age, tod=TimeOfDay.DAMPE)
-
-        if not isinstance(spot, Region):
-            return spot.can_reach(self, age=age, tod=tod)
-
-        # At this point, we're looking to verify access to the region at a specific age and time.
-        # If we have a playthrough (we do), it should already be able to tell us fast if we have access.
-        # We can also be confident when it says no, since otherwise this recursion would
-        # find a path the playthrough should have found.
-        return self.playthrough.can_reach(spot, age=age, tod=tod)
-
-
     def item_name(self, location):
         location = self.world.get_location(location)
         if location.item is None:

--- a/State.py
+++ b/State.py
@@ -67,19 +67,6 @@ class State(object):
         return self.playthrough.can_reach(spot, age=age, tod=tod)
 
 
-    def as_both(self, spot, tod=TimeOfDay.NONE):
-        if self.can_become_adult() and self.can_become_child():
-            return self.can_reach(spot, age='adult', tod=tod) and self.can_reach(spot, age='child', tod=tod)
-        else:
-            return False
-
-
-    def as_age(self, spot, age, tod=TimeOfDay.NONE):
-        if (self.can_become_adult() if age == 'adult' else self.can_become_child()):
-            return self.can_reach(spot, tod=tod, age=age)
-        return False
-
-
     def item_name(self, location):
         location = self.world.get_location(location)
         if location.item is None:
@@ -101,14 +88,6 @@ class State(object):
 
     def item_count(self, item):
         return self.prog_items[item]
-
-
-    def can_become_adult(self):
-        return self.world.starting_age == 'adult' or self.has('Time Travel')
-
-
-    def can_become_child(self):
-        return self.world.starting_age == 'child' or self.has('Time Travel')
 
 
     def can_child_attack(self, age=None):


### PR DESCRIPTION
It is done.

----

Mostly cleanup without behavior changes.
*  An ER check is improved to take into account Playthrough ToD behavior, and its playthrough deduplicated.
*  `Playthrough.can_reach` is the only `can_reach` function remaining.
*  A bunch of functions that just passed their arguments on were removed, for a small gain in performance.
*  In total, ~10% performance improvement.