### PR TITLE
Some GUI style tweaks for UX and consistency

### DIFF
--- a/GUI/src/app/@theme/styles/styles.scss
+++ b/GUI/src/app/@theme/styles/styles.scss
@@ -37,12 +37,17 @@
         animation-duration: 600ms;
     }
     //Scrollbar style for Combobox
-    .cdk-overlay-pane>nb-card>nb-card-body::-webkit-scrollbar-track {
-        background: #eee;
-        box-shadow: 0px 0px 3px #dfdfdf inset;
-    }
-    .cdk-overlay-pane>nb-card>nb-card-body::-webkit-scrollbar-thumb {
-        background: #337ab7;
+    .cdk-overlay-pane>nb-card>nb-card-body {
+        &::-webkit-scrollbar {
+            width: 7px;
+        }
+        &::-webkit-scrollbar-track {
+            background: #eee;
+            box-shadow: 0px 0px 3px #dfdfdf inset;
+        }
+        &::-webkit-scrollbar-thumb {
+            background: #337ab7;
+        }
     }
     @include bootstrap-rtl();
 }

--- a/GUI/src/app/@theme/styles/styles.scss
+++ b/GUI/src/app/@theme/styles/styles.scss
@@ -164,3 +164,12 @@ nb-option:hover {
 .form-control:focus {
     background-color: white !important;
 }
+
+.btn, .btn-info, .btn-primary, .btn-success, .btn-hero, .btn-danger {
+    cursor: pointer !important;
+    outline: none !important;
+}
+
+.btn-disabled {
+    cursor: default !important;
+}

--- a/GUI/src/app/components/guiListbox/guiListbox.scss
+++ b/GUI/src/app/components/guiListbox/guiListbox.scss
@@ -28,19 +28,21 @@ div.pickerWithTagFilter {
   }
 }
 
-/* http://www.ourtuts.com/how-to-customize-browser-scrollbars-using-css3/ */
+//Scrollbar style for record-picker (
+//http://www.ourtuts.com/how-to-customize-browser-scrollbars-using-css3/
+div.record-picker {
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
 
-div.record-picker::-webkit-scrollbar {
-    width: 5px;
-}
+  &::-webkit-scrollbar-track {
+      background: #eee;
+      box-shadow: 0px 0px 3px #dfdfdf inset;
+  }
 
-div.record-picker::-webkit-scrollbar-track {
-    background: #eee;
-    box-shadow: 0px 0px 3px #dfdfdf inset;
-}
-
-div.record-picker::-webkit-scrollbar-thumb {
-    background: #337ab7;
+  &::-webkit-scrollbar-thumb {
+      background: #337ab7;
+  }
 }
 
 .record-picker ul {

--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -267,14 +267,21 @@ nb-card-body {
     height: calc(100% - 7px);
   }
 }
-//Scrollbar style for tileContainers
-.tileContainer::-webkit-scrollbar-track {
-  background: #eee;
-  box-shadow: 0px 0px 3px #dfdfdf inset;
-}
 
-.tileContainer::-webkit-scrollbar-thumb {
-  background: #06A77D;
+//Scrollbar style for tileContainers
+.tileContainer {
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: #eee;
+    box-shadow: 0px 0px 3px #dfdfdf inset;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: #06A77D;
+  }
 }
 
 .subheaderLabel {

--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -280,7 +280,7 @@ nb-card-body {
   }
   
   &::-webkit-scrollbar-thumb {
-    background: #06A77D;
+    background: #337ab7;
   }
 }
 

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -136,7 +136,7 @@
         {
           "name": "open_section",
           "text": "Open",
-          "row_span": 6,
+          "row_span": 9,
           "settings": [
             "open_forest",
             "open_door_of_time",
@@ -150,7 +150,7 @@
         {
           "name": "world_section",
           "text": "World",
-          "row_span": 6,
+          "row_span": 9,
           "settings": [
             "starting_age",
             "entrance_shuffle",
@@ -163,7 +163,7 @@
         {
           "name": "shuffle_section",
           "text": "Shuffle",
-          "row_span": 6,
+          "row_span": 9,
           "settings": [
             "shopsanity",
             "tokensanity",
@@ -180,7 +180,7 @@
         {
           "name": "shuffle_dungeon_section",
           "text": "Shuffle Dungeon Items",
-          "row_span": 6,
+          "row_span": 9,
           "settings": [
             "shuffle_mapcompass",
             "shuffle_smallkeys",
@@ -210,7 +210,7 @@
         {
           "name": "disabled_locations_section",
           "text": "Exclude Locations",
-          "row_span": 8,
+          "row_span": 10,
           "settings": [
             "disabled_locations"
           ]
@@ -218,7 +218,7 @@
         {
           "name": "allowed_tricks_section",
           "text": "Enable Tricks",
-          "row_span": 8,
+          "row_span": 10,
           "settings": [
             "allowed_tricks"
           ]
@@ -361,7 +361,7 @@
           "name": "generalsfx_section",
           "text": "General",
           "is_sfx": true,
-          "row_span": 6,
+          "row_span": 10,
           "settings": [
             "background_music",
             "fanfares",
@@ -377,7 +377,7 @@
           "name": "menusfx_section",
           "text": "Menu",
           "is_sfx": true,
-          "row_span": 6,
+          "row_span": 10,
           "settings": [
             "sfx_menu_cursor",
             "sfx_menu_select"
@@ -387,7 +387,7 @@
           "name": "npcsfx_section",
           "text": "NPC",
           "is_sfx": true,
-          "row_span": 6,
+          "row_span": 10,
           "settings": [
             "sfx_navi_overworld",
             "sfx_navi_enemy"


### PR DESCRIPTION
- All button-like elements now have a "pointer" cursor on hover to emphasize they can be interacted with (better for UX and also what is generally done for all buttons). They also no longer have an outline when on focus. Their color already changes in that situation so the outline just looks a bit weird for no real gain. This applies to all buttons on the UI as well as all dropdowns.
- Scrollbars are now a bit thicker, based on how much they should stand out. They also now all use the same blue-ish color to keep the UI consistent and differentiate them from the many other UI elements using the exact same green as the main scrollbar used.
- Row spans are adjusted for each tab to prevent the top section from taking more space than required, which saves space for the rest of the sections below and I think it looks better overall.

Those changes were based on the feedback I saw on the new GUI and my own observations. There might be other things I missed that should be changed in terms of styling but those are the ones I could find.