### PR TITLE
Tokensanity: Overworld Only

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -918,6 +918,12 @@ def get_pool_core(world):
                 placed_items[location] = 'Gold Skulltula Token'
             else:
                 pool.append('Gold Skulltula Token')
+    elif world.tokensanity == 'overworld':
+        for location in skulltula_locations_final:
+            if world.get_location(location).scene < 0x0A:
+                placed_items[location] = 'Gold Skulltula Token'
+            else:
+                pool.append('Gold Skulltula Token')
     else:
         pool.extend(['Gold Skulltula Token'] * 100)
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1865,9 +1865,10 @@ setting_infos = [
         gui_text       = 'Tokensanity',
         default        = 'off',
         choices        = {
-            'off':      'Off',
-            'dungeons': 'Dungeons Only',
-            'all':      'All Tokens',
+            'off':       'Off',
+            'dungeons':  'Dungeons Only',
+            'overworld': 'Overworld Only',
+            'all':       'All Tokens',
             },
         gui_tooltip    = '''\
             Token reward from Gold Skulltulas are
@@ -1878,6 +1879,10 @@ setting_infos = [
             dungeons, increasing the value of
             most dungeons and making internal
             dungeon exploration more diverse.
+
+            'Overworld Only': This only shuffles
+            the GS locations that are outside
+            of dungeons.
 
             'All Tokens': Effectively adds 100
             new locations for items to appear.


### PR DESCRIPTION
Adds an "Overworld Only" option to Tokensanity, shuffling the opposite set of skulltulas from "Dungeons Only".