### PR TITLE
"Skip First Dampe Race" Convenience Option

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -970,6 +970,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_int16(0x00E1F3CA, 0x5036)
     rom.write_int16(0x00E1F3CC, 0x5036)
 
+    if world.no_first_dampe_race:
+        save_context.write_bits(0x00D4 + 0x48 * 0x1C + 0x08 + 0x3, 0x10) # Beat First Dampe Race (& Chest Spawned)
+
     # Make the Kakariko Gate not open with the MS
     rom.write_int32(0xDD3538, 0x34190000) # li t9, 0
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1488,6 +1488,17 @@ setting_infos = [
         shared         = True,
     ),
     Checkbutton(
+        name           = 'no_first_dampe_race',
+        gui_text       = 'Skip First Dampe Race',
+        gui_tooltip    = '''\
+            Dampe will start with the second race so you can
+            finish the race in under a minute and get both rewards
+            at once. You still get the first reward from the chest
+            even if you don't complete the race in under a minute.
+        ''',
+        shared         = True,
+    ),
+    Checkbutton(
         name           = 'useful_cutscenes',
         gui_text       = 'Enable Useful Cutscenes',
         gui_tooltip    = '''\

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -238,6 +238,7 @@
             "no_escape_sequence",
             "no_guard_stealth",
             "no_epona_race",
+            "no_first_dampe_race",
             "useful_cutscenes",
             "fast_chests",
             "free_scarecrow",


### PR DESCRIPTION
I know this topic is quite controversial but it's also heavily wanted so I'm suggesting a compromise by adding it as a time-saver option.

Basically what this option does is allowing you to get both rewards at once if you complete dampe's race in under a minute the first time. Of course, if you complete the race in over a minute, you are still able to get the first chest reward as usual but you still won't receive the second reward until you manage to complete a race in under a minute.

It doesn't remove any difficulty and the checks require the same amount of skill but it's a good time-saver for players who are good enough to complete it in less than a minute on their first try.

The patch for this option is also very simple since it's just setting the "Beat First Dampe Race" clear flag.