### PR TITLE
Minor Setting Fixes

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2125,9 +2125,8 @@ setting_infos = [
         choices        = [location.name for location in LocationIterator(lambda loc: loc.filter_tags is not None)],
         default        = [],
         gui_tooltip    = '''
-            Prevent locations from being required. Major
-            items can still appear there, however they
-            will never be required to beat the game.
+            Prevent locations from being required.
+            Only junk items will appear at those locations.
 
             Most dungeon locations have a MQ alternative.
             If the location does not exist because of MQ

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1404,18 +1404,20 @@ setting_infos = [
         name           = 'one_item_per_dungeon',
         gui_text       = 'Dungeons Have One Major Item',
         gui_tooltip    = '''\
-            Dungeons have exactly one major
-            item. This naturally makes each
-            dungeon similar in value instead
-            of valued based on chest count.
+            Dungeons have exactly one major item. 
+            This naturally makes each dungeon similar in 
+            value instead of valued based on chest count.
 
-            Spirit Temple Colossus hands count
-            as part of the dungeon. Spirit
-            Temple has TWO items to match
-            vanilla distribution.
+            Spirit Temple Colossus hands count as part 
+            of the dungeon. Spirit Temple has TWO items 
+            to match vanilla distribution.
 
-            Dungeon items and GS Tokens do
-            not count as major items.
+            Keys only count as major items if they are 
+            shuffled everywhere (ie. in keysanity).
+            GS Tokens only count as major items if the 
+            bridge condition is set to "All GS Tokens".
+            Bombchus only count as major items if they
+            are considered in logic.
         ''',
         shared         = True,
         gui_params     = {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2005,10 +2005,10 @@ setting_infos = [
         gui_text       = 'Ganon\'s Boss Key',
         default        = 'dungeon',
         choices        = {
-            'remove':          "Remove",
-            'dungeon':         "Dungeon Only",
+            'remove':          "Remove (Keysy)",
             'vanilla':         "Vanilla Location",
-            'keysanity':       "Anywhere",
+            'dungeon':         "Dungeon Only",
+            'keysanity':       "Anywhere (Keysanity)",
             'lacs_vanilla':    "On LACS: Vanilla",
             'lacs_medallions': "On LACS: Medallions",
             'lacs_stones':     "On LACS: Stones",

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1371,9 +1371,6 @@ setting_infos = [
 
             When disabled, only required items and locations
             to beat the game will be guaranteed reachable.
-
-            Even when enabled, some locations may still be able
-            to hold the keys needed to reach them.
         ''',
         default        = True,
         shared         = True


### PR DESCRIPTION
- Fixed the "Disabled Locations" tooltip to properly reflect that those locations now only hold junk items instead of items not required to beat the game. Fixes #879.
- Made the "Ganon's Boss Key" setting a bit more consistent with other key settings (in the order and naming of options).
- Fixed the "All Locations Reachable" tooltip to no longer mention that key-for-key situations are possible since it hasn't been the case for a long time now.
- Updated the "Dungeons Have One Major Item" tooltip when it comes to the circumstances in which some items count as major item (keys, GS tokens and bombchus).