### PR TITLE
Fix logic for the Valley Crate PoH with hovers trick in OHKO

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -896,7 +896,8 @@ logic_tricks = {
                     From the far side of Gerudo Valley, a precise
                     Hover Boots movement and jumpslash recoil can
                     allow adult to reach the ledge with the crate
-                    PoH without needing Longshot.
+                    PoH without needing Longshot. You will take 
+                    fall damage.
                     '''},
     'Jump onto the Lost Woods Bridge as Adult with Nothing': {
         'name'    : 'logic_lost_woods_bridge',

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -420,7 +420,9 @@
         "exits": {
             "Gerudo Fortress": "True",
             "Gerudo Valley Stream": "True",
-            "Gerudo Valley Crate Ledge": "logic_valley_crate_hovers and can_use(Hover_Boots)",
+            "Gerudo Valley Crate Ledge": "
+                logic_valley_crate_hovers and can_use(Hover_Boots) and
+                (damage_multiplier != 'ohko' or has_fairy or can_use(Nayrus_Love))",
             "Gerudo Valley": "
                 is_child or can_use(Epona) or can_use(Longshot) or
                 gerudo_fortress == 'open' or 'Carpenter Rescue'",


### PR DESCRIPTION
Fixes #888.
Also added a mention in the trick tooltip that fall damage is unavoidable. 