### PR TITLE
Fix item coalescing, emit better error messages

### DIFF
--- a/RuleParser.py
+++ b/RuleParser.py
@@ -245,7 +245,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                     value=ast.Name(id='state', ctx=ast.Load()),
                     attr='has_any_of' if early_return else 'has_all_of',
                     ctx=ast.Load()),
-                args=[ast.Tuple([ast.Str(i) for i in items], ctx=ast.Load())],
+                args=[ast.Tuple(elts=[ast.Str(i) for i in items], ctx=ast.Load())],
                 keywords=[])] + new_values
         else:
             node.values = new_values


### PR DESCRIPTION
If you put something not an AST in an AST, you wind up with a complaint about missing lineno instead of an error pointing out the problem. This exception catching makes it a little easier to debug.