### PR TITLE
Make more hints conditionally required based on settings

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -40,10 +40,19 @@ def getHintGroup(group, world):
 
         hint = getHint(name, world.clearer_hints)
 
-        if hint.name in conditional_always and conditional_always[hint.name](world):
+        if hint.name in world.always_hints:
             hint.type = 'always'
 
         if group in hint.type and not (name in hintExclusions(world)):
+            ret.append(hint)
+    return ret
+
+
+def getRequiredHints(world):
+    ret = []
+    for name in hintTable:
+        hint = getHint(name)
+        if 'always' in hint.type or hint.name in conditional_always and conditional_always[hint.name](world):
             ret.append(hint)
     return ret
 

--- a/HintList.py
+++ b/HintList.py
@@ -55,7 +55,7 @@ conditional_always = {
     'Song from Ocarina of Time': lambda world: world.bridge not in ('stones', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_stones', 'lacs_dungeons'),
     'Ocarina of Time':           lambda world: world.bridge not in ('stones', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_stones', 'lacs_dungeons'),
     'Sheik in Kakariko':         lambda world: world.bridge not in ('medallions', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_medallions', 'lacs_dungeons'),
-    'Biggoron':                  lambda world: world.logic_earliest_adult_trade != 'Claim Check',
+    'Biggoron':                  lambda world: world.logic_earliest_adult_trade != 'claim_check' or world.logic_latest_adult_trade != 'claim_check',
     '50 Gold Skulltula Reward':  lambda world: world.bridge != 'tokens' or world.bridge_tokens < 50,
     '40 Gold Skulltula Reward':  lambda world: world.bridge != 'tokens' or world.bridge_tokens < 40,
     '30 Gold Skulltula Reward':  lambda world: world.bridge != 'tokens' or world.bridge_tokens < 30,

--- a/HintList.py
+++ b/HintList.py
@@ -40,15 +40,26 @@ def getHintGroup(group, world):
 
         hint = getHint(name, world.clearer_hints)
 
-        # 10 Big Poes does not require hint if 3 or less required.
-        if name == '10 Big Poes' and world.big_poe_count <= 3:
-            hint.type = ['overworld', 'sometimes']
-        if name == 'Deku Theater Skull Mask' and world.hint_dist == 'tournament':
+        if hint.name in conditional_always and conditional_always[hint.name](world):
             hint.type = 'always'
 
         if group in hint.type and not (name in hintExclusions(world)):
             ret.append(hint)
     return ret
+
+
+# Hints required under certain settings
+conditional_always = {
+    '10 Big Poes':               lambda world: world.big_poe_count > 3,
+    'Deku Theater Skull Mask':   lambda world: world.hint_dist == 'tournament',
+    'Song from Ocarina of Time': lambda world: world.bridge not in ('stones', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_stones', 'lacs_dungeons'),
+    'Ocarina of Time':           lambda world: world.bridge not in ('stones', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_stones', 'lacs_dungeons'),
+    'Sheik in Kakariko':         lambda world: world.bridge not in ('medallions', 'dungeons') and world.shuffle_ganon_bosskey not in ('lacs_medallions', 'lacs_dungeons'),
+    'Biggoron':                  lambda world: world.logic_earliest_adult_trade != 'Claim Check',
+    '50 Gold Skulltula Reward':  lambda world: world.bridge != 'tokens' or world.bridge_tokens < 50,
+    '40 Gold Skulltula Reward':  lambda world: world.bridge != 'tokens' or world.bridge_tokens < 40,
+    '30 Gold Skulltula Reward':  lambda world: world.bridge != 'tokens' or world.bridge_tokens < 30,
+}
 
 
 # table of hints, format is (name, hint text, clear hint text, type of hint) there are special characters that are read for certain in game commands:
@@ -163,16 +174,10 @@ hintTable = {
     'Deku Seeds (30)':                                          (["catapult ammo", "lots-o-seeds"], "Deku Seeds (30 pieces)", 'item'),
     'Gold Skulltula Token':                                     (["proof of destruction", "an arachnid chip", "spider remains", "one percent of a curse"], "a Gold Skulltula Token", 'item'),
 
-    '10 Big Poes':                                              (["#Big Poes# leads to", "#ghost hunters# will be rewarded with"], None, 'always'),
     'Deku Theater Mask of Truth':                               ("the #Mask of Truth# yields", None, 'always'),
-    '30 Gold Skulltula Reward':                                 ("slaying #30 Gold Skulltulas# reveals", None, 'always'),
-    '40 Gold Skulltula Reward':                                 ("slaying #40 Gold Skulltulas# reveals", None, 'always'),
-    '50 Gold Skulltula Reward':                                 ("slaying #50 Gold Skulltulas# reveals", None, 'always'),
-    'Ocarina of Time':                                          ("the #treasure thrown by Princess Zelda# is", None, 'always'),
-    'Song from Ocarina of Time':                                ("the #Ocarina of Time# teaches", None, 'always'),
-    'Biggoron':                                                 ("#Biggoron# crafts", None, 'always'),
     'Frog Ocarina Game':                                        (["an #amphibian feast# yields", "the #croaking choir's magnum opus# awards", "the #froggy finale# yields"], "the final reward from the #Frogs of Zora's River# is", 'always'),
 
+    'Song from Ocarina of Time':                                ("the #Ocarina of Time# teaches", None, ['song', 'sometimes']),
     'Song from Composer Grave':                                 (["in the #Composers' Grave#, ReDead guard", "the #Composer Brothers# wrote"], None, ['song', 'sometimes']),
     'Sheik Forest Song':                                        ("deep in #the forest# Sheik teaches", None, ['song', 'sometimes']),
     'Sheik at Temple':                                          ("Sheik waits at a #monument to time# to teach", None, ['song', 'sometimes']),
@@ -191,7 +196,13 @@ hintTable = {
     'Horseback Archery 1500 Points':                            ("mastery of #horseback archery# grants", "scoring 1500 in #horseback archery# grants", ['minigame', 'sometimes']),
     'Links House Cow':                                          ("the #bovine bounty of a horseback hustle# gifts", None, ['minigame', 'sometimes']),
 
-    'Deku Theater Skull Mask':                                  ("the #Skull Mask# yields", None, 'overworld'),
+    '10 Big Poes':                                              (["#Big Poes# leads to", "#ghost hunters# will be rewarded with"], None, ['overworld', 'sometimes']),
+    'Deku Theater Skull Mask':                                  ("the #Skull Mask# yields", None, ['overworld', 'sometimes']),
+    'Ocarina of Time':                                          ("the #treasure thrown by Princess Zelda# is", None, ['overworld', 'sometimes']),
+    'Biggoron':                                                 ("#Biggoron# crafts", None, ['overworld', 'sometimes']),
+    '50 Gold Skulltula Reward':                                 ("slaying #50 Gold Skulltulas# reveals", None, ['overworld', 'sometimes']),
+    '40 Gold Skulltula Reward':                                 ("slaying #40 Gold Skulltulas# reveals", None, ['overworld', 'sometimes']),
+    '30 Gold Skulltula Reward':                                 ("slaying #30 Gold Skulltulas# reveals", None, ['overworld', 'sometimes']),
     '20 Gold Skulltula Reward':                                 ("slaying #20 Gold Skulltulas# reveals", None, ['overworld', 'sometimes']),
     'Anjus Chickens':                                           ("#collecting cuccos# rewards", None, 'sometimes'),
     'Darunias Joy':                                             ("#Darunia's dance# leads to", None, ['overworld', 'sometimes']),

--- a/Rules.py
+++ b/Rules.py
@@ -41,6 +41,9 @@ def set_rules(world):
         if location.type == 'GossipStone' and world.hints == 'mask':
             location.add_rule(lambda state, age=None, **kwargs: age == 'child')
 
+        if location.name in world.always_hints:
+            location.add_rule(lambda state, **kwargs: state.guarantee_hint())
+
     for location in world.disabled_locations:
         try:
             world.get_location(location).disabled = DisableType.PENDING

--- a/World.py
+++ b/World.py
@@ -9,6 +9,7 @@ from Rules import set_rules, set_shop_rules
 from Item import Item, ItemFactory, MakeEventItem
 from RuleParser import Rule_AST_Transformer
 from SettingsList import get_setting_info
+from HintList import getRequiredHints
 import logging
 import copy
 import io
@@ -99,6 +100,8 @@ class World(object):
         self.can_take_damage = True
 
         self.resolve_random_settings()
+
+        self.always_hints = [hint.name for hint in getRequiredHints(self)]
 
 
     def copy(self):

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -197,10 +197,8 @@
         "hint": "Hyrule Field",
         "time_passes": true,
         "locations": {
-            "Ocarina of Time": "
-                is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
-            "Song from Ocarina of Time": "
-                is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
+            "Ocarina of Time": "is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire",
+            "Song from Ocarina of Time": "is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire",
             "Big Poe Kill": "can_use(Bow) and can_use(Epona) and has_bottle"
         },
         "exits": {
@@ -514,8 +512,7 @@
         "locations": {
             "10 Big Poes": "
                 is_adult and 
-                ((has_big_poe_drop and (big_poe_count <= 3 or guarantee_hint)) or 
-                    (Bottle_with_Big_Poe, big_poe_count))",
+                (Big_Poe or (Bottle_with_Big_Poe, big_poe_count))",
             "GS Castle Market Guard House": "is_child"
         }
     },
@@ -646,16 +643,11 @@
     {
         "region_name": "House of Skulltula",
         "locations": {
-            "10 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 10)",
-            "20 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 20)",
-            "30 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 30) and guarantee_hint",
-            "40 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 40) and guarantee_hint",
-            "50 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 50) and guarantee_hint"
+            "10 Gold Skulltula Reward": "(Gold_Skulltula_Token, 10)",
+            "20 Gold Skulltula Reward": "(Gold_Skulltula_Token, 20)",
+            "30 Gold Skulltula Reward": "(Gold_Skulltula_Token, 30)",
+            "40 Gold Skulltula Reward": "(Gold_Skulltula_Token, 40)",
+            "50 Gold Skulltula Reward": "(Gold_Skulltula_Token, 50)"
         }
     },
     {
@@ -817,7 +809,7 @@
         "time_passes": true,
         "locations": {
             "Biggoron": "
-                is_adult and guarantee_hint and
+                is_adult and
                 (Claim_Check or (
                     at('Death Mountain Crater Upper', is_adult) and
                     at('Zoras Domain', is_adult) and (
@@ -1011,7 +1003,7 @@
             "Frog Ocarina Game": "
                 is_child and can_play(Zeldas_Lullaby) and can_play(Sarias_Song) and 
                 can_play(Suns_Song) and can_play(Eponas_Song) and 
-                can_play(Song_of_Time) and can_play(Song_of_Storms) and guarantee_hint",
+                can_play(Song_of_Time) and can_play(Song_of_Storms)",
             "Frogs in the Rain": "is_child and can_play(Song_of_Storms)",
             "Zora River Lower Freestanding PoH": "True",
             "Zora River Upper Freestanding PoH": "True",
@@ -1166,8 +1158,8 @@
     {
         "region_name": "Deku Theater",
         "locations": {
-            "Deku Theater Skull Mask": "is_child and 'Skull Mask' and (hint_dist != 'tournament' or guarantee_hint)",
-            "Deku Theater Mask of Truth": "is_child and 'Mask of Truth' and guarantee_hint"
+            "Deku Theater Skull Mask": "is_child and 'Skull Mask'",
+            "Deku Theater Mask of Truth": "is_child and 'Mask of Truth'"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -255,10 +255,8 @@
         "hint": "Hyrule Field",
         "time_passes": true,
         "locations": {
-            "Ocarina of Time": "
-                is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
-            "Song from Ocarina of Time": "
-                is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire and guarantee_hint",
+            "Ocarina of Time": "is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire",
+            "Song from Ocarina of Time": "is_child and Kokiri_Emerald and Goron_Ruby and Zora_Sapphire",
             "Big Poe Kill": "can_use(Bow) and can_use(Epona) and has_bottle"
         },
         "exits": {
@@ -729,8 +727,7 @@
         "locations": {
             "10 Big Poes": "
                 is_adult and 
-                ((Big_Poe and (big_poe_count <= 3 or guarantee_hint)) or 
-                    (Bottle_with_Big_Poe, big_poe_count))",
+                (Big_Poe or (Bottle_with_Big_Poe, big_poe_count))",
             "GS Castle Market Guard House": "is_child"
         },
         "exits": {
@@ -934,16 +931,11 @@
     {
         "region_name": "House of Skulltula",
         "locations": {
-            "10 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 10)",
-            "20 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 20)",
-            "30 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 30) and guarantee_hint",
-            "40 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 40) and guarantee_hint",
-            "50 Gold Skulltula Reward": "
-                (Gold_Skulltula_Token, 50) and guarantee_hint"
+            "10 Gold Skulltula Reward": "(Gold_Skulltula_Token, 10)",
+            "20 Gold Skulltula Reward": "(Gold_Skulltula_Token, 20)",
+            "30 Gold Skulltula Reward": "(Gold_Skulltula_Token, 30)",
+            "40 Gold Skulltula Reward": "(Gold_Skulltula_Token, 40)",
+            "50 Gold Skulltula Reward": "(Gold_Skulltula_Token, 50)"
         },
         "exits": {
             "Kakariko Village": "True"
@@ -1197,7 +1189,7 @@
         },
         "locations": {
             "Biggoron": "
-                is_adult and guarantee_hint and 
+                is_adult and 
                 (Claim_Check or 
                     (guarantee_trade_path and 
                     ('Eyedrops Access' or (Eyedrops and disable_trade_revert))))",
@@ -1482,7 +1474,7 @@
             "Frog Ocarina Game": "
                 is_child and can_play(Zeldas_Lullaby) and can_play(Sarias_Song) and 
                 can_play(Suns_Song) and can_play(Eponas_Song) and 
-                can_play(Song_of_Time) and can_play(Song_of_Storms) and guarantee_hint",
+                can_play(Song_of_Time) and can_play(Song_of_Storms)",
             "Frogs in the Rain": "is_child and can_play(Song_of_Storms)",
             "Zora River Lower Freestanding PoH": "
                 is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_lower)",
@@ -1717,8 +1709,8 @@
     {
         "region_name": "Deku Theater",
         "locations": {
-            "Deku Theater Skull Mask": "is_child and 'Skull Mask' and (hint_dist != 'tournament' or guarantee_hint)",
-            "Deku Theater Mask of Truth": "is_child and 'Mask of Truth' and guarantee_hint"
+            "Deku Theater Skull Mask": "is_child and 'Skull Mask'",
+            "Deku Theater Mask of Truth": "is_child and 'Mask of Truth'"
         },
         "exits": {
             "Lost Woods Beyond Mido": "True"


### PR DESCRIPTION
Currently, the only instances of conditionally required hints are: 10 Big Poes which is only required if more than 3 poes are needed for the check, and Skull Mask which is only required in Tournament distribution.

This PR adds the same kind of flexibility to other hints such as OoT locations for example, which only need to be required when getting Spiritual Stones is out of the usual way to complete the seed. So if the Rainbow Bridge is set to "All stones" or "All dungeons" instead of the usual "All medallions", it should be a hint that only shows up sometimes instead of being hard-required.
Similarly, the "Sheik at Kakariko" location should be a required hint in settings where you may not need to collect the Forest, Fire and Water medallions in order to complete the seed, in which case it becomes an equivalent to the OoT song location by requiring 3 additional dungeons typically not required to beat the game with the chosen settings.

The same kind of dependency applies to a few other "always" required location hints so I tried to handle all of them here. The general rule used is that if the conditions to complete the check are already hard-required to finish the seed based on settings (ie the bridge requirement), then the location should not be an "always" required hint, but instead just a "sometimes" required hint.

Biggoron is also changed to not be required if the Claim Check is guaranteed to be the first trade item based on settings, since in that case the Biggoron location arguably doesn't need a required hint.