### PR TITLE
Resolve issue #924

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -540,7 +540,7 @@ vanillaMC = {
     'Forest Temple MQ Map Chest': 'Map (Forest Temple)',
     'Ice Cavern MQ Map Chest': 'Map (Ice Cavern)',
     'Jabu Jabus Belly MQ Map Chest': 'Map (Jabu Jabus Belly)',
-    'Shadow Temple MQ Early Gibdos Chest': 'Map (Shadow Temple)',
+    'Shadow Temple MQ Map Chest': 'Map (Shadow Temple)',
     'Spirit Temple MQ Map Chest': 'Map (Spirit Temple)',
     'Water Temple MQ Map Chest': 'Map (Water Temple)',
 }
@@ -611,7 +611,7 @@ vanillaSK = {
     'Gerudo Training Grounds MQ Underwater Silver Rupee Chest': 'Small Key (Gerudo Training Grounds)',
     'Shadow Temple MQ Falling Spikes Switch Chest': 'Small Key (Shadow Temple)',
     'Shadow Temple MQ Invisible Blades Invisible Chest': 'Small Key (Shadow Temple)',
-    'Shadow Temple MQ Map Chest': 'Small Key (Shadow Temple)',
+    'Shadow Temple MQ Early Gibdos Chest': 'Small Key (Shadow Temple)',
     'Shadow Temple MQ Near Ship Invisible Chest': 'Small Key (Shadow Temple)',
     'Shadow Temple MQ Wind Hint Chest': 'Small Key (Shadow Temple)',
     'Shadow Temple MQ Freestanding Key': 'Small Key (Shadow Temple)',

--- a/LocationList.py
+++ b/LocationList.py
@@ -336,8 +336,8 @@ location_table = {
     # Shadow Temple MQ
     "Shadow Temple MQ Compass Chest":                  ("Chest",       0x07,  0x01, None,                     ("Shadow Temple",)),
     "Shadow Temple MQ Hover Boots Chest":              ("Chest",       0x07,  0x07, None,                     ("Shadow Temple",)),
-    "Shadow Temple MQ Early Gibdos Chest":             ("Chest",       0x07,  0x02, None,                     ("Shadow Temple",)),
-    "Shadow Temple MQ Map Chest":                      ("Chest",       0x07,  0x03, None,                     ("Shadow Temple",)),
+    "Shadow Temple MQ Early Gibdos Chest":             ("Chest",       0x07,  0x03, None,                     ("Shadow Temple",)),
+    "Shadow Temple MQ Map Chest":                      ("Chest",       0x07,  0x02, None,                     ("Shadow Temple",)),
     "Shadow Temple MQ Beamos Silver Rupees Chest":     ("Chest",       0x07,  0x0F, None,                     ("Shadow Temple",)),
     "Shadow Temple MQ Falling Spikes Switch Chest":    ("Chest",       0x07,  0x04, None,                     ("Shadow Temple",)),
     "Shadow Temple MQ Falling Spikes Lower Chest":     ("Chest",       0x07,  0x05, None,                     ("Shadow Temple",)),


### PR DESCRIPTION
The data for the Shadow MQ map and early gibdos chest was backwards.  Vanilla settings were swapping their contents as was plando.  This resolves both issues.