### PR TITLE
Issue908: Fix for randomized main rules

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -237,7 +237,7 @@ class Settings:
             if cosmetic == info.shared:
                 continue
 
-            if not self.check_dependency(info.name, check_random=False):
+            if self.check_dependency(info.name, check_random=True):
                 continue
 
             if 'randomize_key' in info.gui_params and self.__dict__[info.gui_params['randomize_key']]:               

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1286,7 +1286,7 @@ setting_infos = [
         disable        = {
             True : {
                 'sections' : ['open_section', 'shuffle_section', 'shuffle_dungeon_section'],
-                'settings' : ['starting_age', 'entrance_shuffle', 'bombchus_in_logic', 'one_item_per_dungeon'],
+                'settings' : ['starting_age', 'triforce_hunt', 'triforce_goal_per_world', 'entrance_shuffle', 'bombchus_in_logic', 'one_item_per_dungeon'],
             }
         },
         shared         = True,
@@ -3297,7 +3297,7 @@ for info in setting_infos:
         for option, disabling in info.disable.items():
             for setting in disabling.get('settings', []):
                 create_dependency(setting, info, option)
-            for section in disabling.get('setions', []):
+            for section in disabling.get('sections', []):
                 for setting in get_settings_from_section(section):
                     create_dependency(setting, info, option)
             for tab in disabling.get('tabs', []):


### PR DESCRIPTION
This fixes the 'Randomize Main Rules' setting.

This includes Triforce Hunt as a randomized setting and disables it while the randomize main rule settings switch is on.

As a note, if randomized main rules triggers Triforce Hunt to be enabled, it will only take the default of 20 triforce pieces. This was left as is because using the min and max of 1 and 100 would sometimes prevent the rom from successfully generating due to lack of item space left over.