### PR TITLE
Minor fixes

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1609,9 +1609,6 @@ setting_infos = [
         ''',
         shared         = True,
         disabled_default = 0,
-        gui_params     = {
-            'randomize_key': 'randomize_settings',
-        },
     ),
     Checkbutton(
         name           = 'no_escape_sequence',

--- a/Unittest.py
+++ b/Unittest.py
@@ -46,7 +46,7 @@ bottles = {
 junk = set(remove_junk_items)
 
 
-def load_settings(settings_file):
+def load_settings(settings_file, seed=None):
     sfile = os.path.join(test_dir, settings_file)
     ofile = os.path.join(test_dir, 'Output', os.path.splitext(settings_file)[0])
     with open(sfile) as f:
@@ -58,6 +58,8 @@ def load_settings(settings_file):
         'create_spoiler': True,
         'output_file': ofile,
     })
+    if seed and 'seed' not in j:
+        j['seed'] = seed
     return Settings(j)
 
 
@@ -187,7 +189,7 @@ class TestValidSpoilers(unittest.TestCase):
                       if filename.endswith('.sav')]
         for filename in test_files:
             with self.subTest(filename=filename):
-                settings = load_settings(filename)
+                settings = load_settings(filename, seed='TESTTESTTEST')
                 main(settings)
                 # settings.output_file contains the first part of the filename
                 spoiler = load_spoiler('%s_Spoiler.json' % settings.output_file)

--- a/tests/ac-mq.sav
+++ b/tests/ac-mq.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "count": 1,
 "world_count": 1,

--- a/tests/accessible.sav
+++ b/tests/accessible.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "count": 1,
 "world_count": 1,

--- a/tests/disables.sav
+++ b/tests/disables.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "count": 10,
 "world_count": 1,

--- a/tests/entrance.sav
+++ b/tests/entrance.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "create_spoiler": true,
 "compress_rom": "None",
 "randomize_settings": false,

--- a/tests/entrance2.sav
+++ b/tests/entrance2.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "create_spoiler": true,
 "compress_rom": "None",
 "distribution_file": "tests/cfairy.dist",

--- a/tests/glitched-standard.sav
+++ b/tests/glitched-standard.sav
@@ -1,4 +1,5 @@
 {
+    "seed": "TESTTESTTEST",
     "create_spoiler": true,
     "world_count": 1,
     "randomize_settings": false,

--- a/tests/multiworld.sav
+++ b/tests/multiworld.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "world_count": 3,
 "player_num": 1,

--- a/tests/nightforest.sav
+++ b/tests/nightforest.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "count": 1,
 "world_count": 1,

--- a/tests/triforce-multiworld.sav
+++ b/tests/triforce-multiworld.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "world_count": 2,
 "player_num": 1,

--- a/tests/triforce.sav
+++ b/tests/triforce.sav
@@ -1,4 +1,5 @@
 {
+"seed": "TESTTESTTEST",
 "cosmetics_only": false,
 "count": 1,
 "world_count": 1,


### PR DESCRIPTION
* Don't include a separate value for `trials` in both the settings and the randomized settings when `trials_random` is on.
* Use the same seed for non-fuzz unittests.