### PR TITLE
Minor generation speedups

### DIFF
--- a/Item.py
+++ b/Item.py
@@ -51,31 +51,11 @@ class Item(object):
         self.price = self.info.special.get('price')
         self.world = world
         self.looks_like_item = None
-
-
-    @property
-    def advancement(self):
-        return self.info.advancement
-
-
-    @property
-    def priority(self):
-        return self.info.priority
-
-
-    @property
-    def type(self):
-        return self.info.type
-
-
-    @property
-    def special(self):
-        return self.info.special
-
-
-    @property
-    def index(self):
-        return self.info.index
+        self.advancement = self.info.advancement
+        self.priority = self.info.priority
+        self.type = self.info.type
+        self.special = self.info.special
+        self.index = self.info.special
 
 
     item_worlds_to_fix = {}

--- a/Location.py
+++ b/Location.py
@@ -87,6 +87,16 @@ class Location(object):
         return False
 
 
+    def has_item(self):
+        return self.item is not None
+
+    def has_no_item(self):
+        return self.item is None
+
+    def has_progression_item(self):
+        return self.item is not None and self.item.advancement
+
+
     def __str__(self):
         return str(self.__unicode__())
 

--- a/Main.py
+++ b/Main.py
@@ -512,7 +512,7 @@ def create_playthrough(spoiler):
 
     playthrough = RewindablePlaythrough([world.state for world in worlds])
     # Get all item locations in the worlds
-    item_locations = [location for state in playthrough.state_list for location in state.world.get_filled_locations() if location.item.advancement]
+    item_locations = playthrough.progression_locations()
     # Omit certain items from the playthrough
     internal_locations = {location for location in item_locations if location.internal}
     # Generate a list of spheres by iterating over reachable locations without collecting as we go.

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -197,7 +197,7 @@ class Playthrough(object):
 
     # Retrieve all item locations in the worlds that have progression items
     def progression_locations(self):
-        return [location for state in self.state_list for location in state.world.get_filled_locations() if location.item.advancement]
+        return [location for state in self.state_list for location in state.world.get_locations() if location.item and location.item.advancement]
 
 
     # This returns True if every state is beatable. It's important to ensure

--- a/Playthrough.py
+++ b/Playthrough.py
@@ -154,16 +154,6 @@ class Playthrough(object):
     # locations to see if the game is beatable. Collection should be done
     # using internal State (recommended to just call playthrough.collect).
     def iter_reachable_locations(self, item_locations):
-        # tests reachability, skipping recursive can_reach region check
-        def accessible(loc):
-            return (loc not in visited_locations
-                    # Check adult first; it's the most likely.
-                    and (loc.parent_region in adult_regions
-                         and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='adult')
-                         or (loc.parent_region in child_regions
-                             and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='child'))))
-
-
         had_reachable_locations = True
         # will loop as long as any visits were made, and at least once
         while had_reachable_locations:
@@ -171,13 +161,18 @@ class Playthrough(object):
 
             # Get all locations in accessible_regions that aren't visited,
             # and check if they can be reached. Collect them.
-            reachable_locations = filter(accessible, item_locations)
             had_reachable_locations = False
-            for location in reachable_locations:
-                had_reachable_locations = True
-                # Mark it visited for this algorithm
-                visited_locations.add(location)
-                yield location
+            for loc in item_locations:
+                if (loc not in visited_locations
+                    # Check adult first; it's the most likely.
+                    and (loc.parent_region in adult_regions
+                         and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='adult')
+                         or (loc.parent_region in child_regions
+                             and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='child')))):
+                    had_reachable_locations = True
+                    # Mark it visited for this algorithm
+                    visited_locations.add(loc)
+                    yield loc
 
 
     # This collects all item locations available in the state list given that

--- a/World.py
+++ b/World.py
@@ -464,11 +464,15 @@ class World(object):
 
 
     def get_unfilled_locations(self):
-        return [location for location in self.get_locations() if location.item is None]
+        return filter(Location.has_no_item, self.get_locations())
 
 
     def get_filled_locations(self):
-        return [location for location in self.get_locations() if location.item is not None]
+        return filter(Location.has_item, self.get_locations())
+
+
+    def get_progression_locations(self):
+        return filter(Location.has_progression_item, self.get_locations())
 
 
     def get_entrances(self):


### PR DESCRIPTION
* Grabbing a locations list only involves a single iteration.
* Replace an internal function call.
* Cache generated rule functions.

Approximate 17% speed-up total on non-fuzzer unittests.