### PR TITLE
Consider Light Arrows location hinted if Ganondorf hint can be reached.

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -501,8 +501,28 @@ hint_dist_sets = {
 }
 
 
+def buildGossipHints(spoiler, worlds):
+    checkedLocations = dict()
+    # Add Light Arrow locations to "checked" locations if Ganondorf is reachable without it.
+    for world in worlds:
+        location = world.light_arrow_location
+        if location is None:
+            continue
+        # Didn't you know that Ganondorf is a gossip stone?
+        if can_reach_stone(worlds, world.get_location("Ganondorf Hint"), location):
+            light_arrow_world = location.world
+            if light_arrow_world.id not in checkedLocations:
+                checkedLocations[light_arrow_world.id] = set()
+            checkedLocations[light_arrow_world.id].add(location.name)
+
+    # Build all the hints.
+    for world in worlds:
+        world.update_useless_areas(spoiler)
+        buildWorldGossipHints(spoiler, world, checkedLocations.pop(world.id, None))
+
+
 #builds out general hints based on location and whether an item is required or not
-def buildGossipHints(spoiler, world):
+def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     # rebuild hint exclusion list
     hintExclusions(world, clear_cache=True)
 
@@ -515,7 +535,8 @@ def buildGossipHints(spoiler, world):
             playthrough.spot_access(world.get_location(stone.location))
             and playthrough.state_list[world.id].guarantee_hint())
 
-    checkedLocations = set()
+    if checkedLocations is None:
+        checkedLocations = set()
 
     stoneIDs = list(gossipLocations.keys())
 

--- a/LocationList.py
+++ b/LocationList.py
@@ -797,6 +797,8 @@ location_table = {
     "Lost Woods Generic Grotto Gossip Stone":          ("GossipStone", None,  None, None,                     None),
     "Mountain Storms Grotto Gossip Stone":             ("GossipStone", None,  None, None,                     None),
     "Top of Crater Grotto Gossip Stone":               ("GossipStone", None,  None, None,                     None),
+
+    "Ganondorf Hint":                                  ("GossipStone", None,  None, None,                     None),
 }
 
 # Business Scrub Details

--- a/Main.py
+++ b/Main.py
@@ -154,9 +154,7 @@ def generate(settings, window):
         window.update_status('Calculating Hint Data')
         logger.info('Calculating hint data.')
         State.update_required_items(spoiler)
-        for world in worlds:
-            world.update_useless_areas(spoiler)
-            buildGossipHints(spoiler, world)
+        buildGossipHints(spoiler, worlds)
         window.update_progress(55)
     spoiler.build_file_hash()
     return spoiler

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ player.
 * Updated Compressor. The GUI progress bar is now granular. If for some reason, the rom won't fit into 32MB, then the compressor will increase the output size.
 * Cosmetic heart color setting now applies in the file select screen.
 * Ganondorf no longer hints at his Boss Key chest contents.
+* The location containing Light Arrows will be considered a hinted location if Ganondorf's hint can be reached without them.
 * Further seed generation speed improvements.
 
 #### Bug Fixes

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1114,6 +1114,7 @@
         "dungeon": "Ganons Castle",
         "locations": {
             "Ganons Tower Boss Key Chest": "True",
+            "Ganondorf Hint": "Boss_Key_Ganons_Castle",
             "Ganon": "Boss_Key_Ganons_Castle and can_use(Light_Arrows)"
         }
     },

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1638,6 +1638,7 @@
         "dungeon": "Ganons Castle",
         "locations": {
             "Ganons Tower Boss Key Chest": "True",
+            "Ganondorf Hint": "Boss_Key_Ganons_Castle",
             "Ganon": "Boss_Key_Ganons_Castle and can_use(Light_Arrows)"
         }
     },


### PR DESCRIPTION
This makes it so you won't see a Way of the Hero (or a sometimes hint) pointing directly to the Light Arrows location specifically if Ganondorf is reachable logically without Light Arrows. Any items that are only needed for Light Arrows are still fair game to be hinted, of course. This just makes hint logic consider that Ganondorf as a hint.