### PR TITLE
Hints: select duplicate from unreachable locations if necessary

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -108,10 +108,7 @@ def add_hint(spoiler, world, IDs, gossip_text, count, location=None, force_reach
     total = int(random.random() + count)
     while total:
         if IDs:
-            if not first and duplicates:
-                id = duplicates.pop(0)
-            else:
-                id = IDs.pop(0)
+            id = IDs.pop(0)
 
             if gossipLocations[id].reachable:
                 stone_name = gossipLocations[id].location


### PR DESCRIPTION
By choosing the additional entries from `duplicates` first in this way, the randomness is much better preserved: you can envision the process of hint selection like so:

1. Shuffle the list of stones.
1. The first reachable stone gets a copy of the hint.
1. The first stone that isn't the one above gets the other copy. (This step used to be more like "The first stone *after* the one above gets the other copy.")

So now, given the identity of the first reachable stone, it should be equally likely among eligible remaining stones which one is the duplicate. Previously, it was *less likely* that a stone locked by a hinted item would have the duplicate of that item hint. (Doing some math, the worst case might be 50% less likely than it should be.)

I believe correcting this will slightly increase early hint variety.