### PR TITLE
Possible plando lists fix/implementation

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -521,8 +521,7 @@ class WorldDistribution(object):
     def fill(self, window, worlds, location_pools, item_pools):
         world = worlds[self.id]
         locations = {loc: self.locations[loc] for loc in random.sample(self.locations.keys(), len(self.locations))}
-        exhausted = []
-        for (location_name, record) in pattern_dict_items(locations, world.itempool, exhausted):
+        for (location_name, record) in pattern_dict_items(locations, world.itempool, []):
             if record.item is None:
                 continue
 
@@ -878,14 +877,9 @@ def pattern_dict_items(pattern_dict, itempool=None, exhausted=None):
     for (key, value) in pattern_dict.items():
         if isinstance(value.item, list):
             if itempool is not None:
-                available_items = []
-                for item in itempool:
-                    available_items.append(item.name)
-                valid_items = [item for item in available_items if item in value.item]
+                valid_items = [item.name for item in itempool if item.name in value.item]
                 if exhausted is not None:
-                    for item in exhausted:
-                        if item in valid_items:
-                            valid_items.remove(item)
+                    [valid_items.remove(item) for item in exhausted if item in valid_items]
             else:
                 valid_items = value.item
             if not valid_items and exhausted is None:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -53,6 +53,8 @@ def SimpleRecord(props):
         def update(self, src_dict, update_all=False):
             if src_dict is None:
                 src_dict = {}
+            if isinstance(src_dict, list):
+                src_dict = {"item": src_dict}
             for k, p in props.items():
                 if update_all or k in src_dict:
                     setattr(self, k, src_dict.get(k, p))

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -522,7 +522,9 @@ class WorldDistribution(object):
 
     def fill(self, window, worlds, location_pools, item_pools):
         world = worlds[self.id]
-        locations = {loc: self.locations[loc] for loc in random.sample(self.locations.keys(), len(self.locations))}
+        locations = {}
+        if self.locations:
+            locations = {loc: self.locations[loc] for loc in random.sample(self.locations.keys(), len(self.locations))}
         for (location_name, record) in pattern_dict_items(locations, world.itempool, []):
             if record.item is None:
                 continue

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -875,7 +875,7 @@ def pattern_matcher(pattern):
 def pattern_dict_items(pattern_dict, itempool=None):
     for (key, value) in pattern_dict.items():
         if isinstance(value.item, list):
-            if itempool:
+            if itempool is not None:
                 # Currently only used by boss prize placement
                 available_items = []
                 for item in itempool:
@@ -883,6 +883,8 @@ def pattern_dict_items(pattern_dict, itempool=None):
                 valid_items = [item for item in value.item if item in available_items]
             else:
                 valid_items = value.item
+            if not valid_items:
+                continue
             value.item = random_choices(valid_items)[0]
         if is_pattern(key):
             pattern = lambda loc: pattern_matcher(key)(loc.name)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -494,7 +494,7 @@ class WorldDistribution(object):
 
     def fill_bosses(self, world, prize_locs, prizepool):
         count = 0
-        for (name, record) in pattern_dict_items(self.locations):
+        for (name, record) in pattern_dict_items(self.locations, prizepool):
             boss = pull_item_or_location([prize_locs], world, name)
             if boss is None:
                 try:
@@ -872,10 +872,18 @@ def pattern_matcher(pattern):
             return lambda s: invert != (s == pattern)
 
 
-def pattern_dict_items(pattern_dict):
+def pattern_dict_items(pattern_dict, itempool=None):
     for (key, value) in pattern_dict.items():
         if isinstance(value.item, list):
-            value.item = random_choices(value.item)[0]
+            if itempool:
+                # Currently only used by boss prize placement
+                available_items = []
+                for item in itempool:
+                    available_items.append(item.name)
+                valid_items = [item for item in value.item if item in available_items]
+            else:
+                valid_items = value.item
+            value.item = random_choices(valid_items)[0]
         if is_pattern(key):
             pattern = lambda loc: pattern_matcher(key)(loc.name)
             for location in LocationIterator(pattern):

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -520,8 +520,9 @@ class WorldDistribution(object):
 
     def fill(self, window, worlds, location_pools, item_pools):
         world = worlds[self.id]
+        locations = {loc: self.locations[loc] for loc in random.sample(self.locations.keys(), len(self.locations))}
         exhausted = []
-        for (location_name, record) in pattern_dict_items(self.locations, world.itempool, exhausted):
+        for (location_name, record) in pattern_dict_items(locations, world.itempool, exhausted):
             if record.item is None:
                 continue
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -874,6 +874,8 @@ def pattern_matcher(pattern):
 
 def pattern_dict_items(pattern_dict):
     for (key, value) in pattern_dict.items():
+        if isinstance(value.item, list):
+            value.item = random_choices(value.item)[0]
         if is_pattern(key):
             pattern = lambda loc: pattern_matcher(key)(loc.name)
             for location in LocationIterator(pattern):

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ player.
 * Updated Compressor. The GUI progress bar is now granular. If for some reason, the rom won't fit into 32MB, then the compressor will increase the output size.
 * Refactored Logic once again. It now uses helper json rules and rules can reference other rules.
 * Disabled settings don't show up in the spoiler.
+* Plando will now accept JSON lists for `item` in the location dictionary to randomly choose between for placement.
+  * Attempts to not exceed item pool values until all the pool counts for the items in the list are reached.
 * Further seed generation speed improvements.
 
 #### Bug Fixes


### PR DESCRIPTION
Used this plando as a test
```json
{
  "locations":
  {
    "Mido Chest Top Left":                                   {"item": ["Bow", "Light Arrows", "Magic Meter"]},
    "Mido Chest Top Right":                                  {"item": ["Bow", "Light Arrows", "Magic Meter"]},
    "Mido Chest Bottom Left":                                {"item": ["Bow", "Light Arrows", "Magic Meter"]},
    "Mido Chest Bottom Right":                               {"item": ["Bow", "Light Arrows", "Magic Meter"]},
    "Skull Kid":                                             {"item": ["Bow", "Light Arrows", "Magic Meter"]},
    "Ocarina Memory Game":                                   {"item": ["Bow", "Light Arrows", "Magic Meter"]},
    "Target in Woods":                                       {"item": ["Bow", "Light Arrows", "Magic Meter"]}
  }
}
```
Seems to work. It will not put bows on other locations once three have been filled, same with two magic meters as would be expected; however the lists themselves can have as many of an item placed as is randomly chosen as plando allows this in general.

An improvement might be making it so lists specifically don't exceed the item pool unless no item pool slots are left.

Scrubs and Shops were not tested but should work the same.