### PR TITLE
Stringify the seed before using it in the OoTRandomizer.py call

### DIFF
--- a/GUI/electron/src/modules/generator.js
+++ b/GUI/electron/src/modules/generator.js
@@ -60,7 +60,7 @@ function romBuilding(pythonPath, randoPath, settings) {
     //Using a user defined static seed
     if (seedString.length > 0) {
 
-      let args = ['--seed', seedString];
+      let args = ['--seed', JSON.stringify(seedString)];
       //args["checked_version"] = false;
 
       romBuildingGenerator = spawn('"' + pythonPath + '"' + ' ' + '"' + randoPath + '"', args, { shell: true });

--- a/GUI/electron/src/modules/generator.js
+++ b/GUI/electron/src/modules/generator.js
@@ -60,7 +60,7 @@ function romBuilding(pythonPath, randoPath, settings) {
     //Using a user defined static seed
     if (seedString.length > 0) {
 
-      let args = ['--seed', JSON.stringify(seedString)];
+      let args = ['--seed', seedString];
       //args["checked_version"] = false;
 
       romBuildingGenerator = spawn('"' + pythonPath + '"' + ' ' + '"' + randoPath + '"', args, { shell: true });

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -171,6 +171,7 @@ export class GeneratorComponent implements OnInit {
   generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false) {
 
     this.generateSeedButtonEnabled = false;
+    this.seedString = this.seedString.trim().replace(/[^a-zA-Z0-9_-]/g, '')
 
     //console.log("fromPatchFile:", fromPatchFile);
     //console.log(this.global.generator_settingsMap);

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -171,7 +171,7 @@ export class GeneratorComponent implements OnInit {
   generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false) {
 
     this.generateSeedButtonEnabled = false;
-    this.seedString = this.seedString.trim().replace(/[^a-zA-Z0-9_-]/g, '')
+    this.seedString = this.seedString.trim().replace(/[^a-zA-Z0-9_-]/g, '');
 
     //console.log("fromPatchFile:", fromPatchFile);
     //console.log(this.global.generator_settingsMap);
@@ -196,7 +196,7 @@ export class GeneratorComponent implements OnInit {
         autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dashboardRef: this, totalGenerationCount: this.global.generator_settingsMap["count"] }
       });
 
-      this.global.generateSeedElectron(dialogRef && dialogRef.componentRef && dialogRef.componentRef.instance ? dialogRef.componentRef.instance : null, fromPatchFile, fromPatchFile == false && this.seedString.trim().length > 0 ? this.seedString.trim() : "").then(res => {
+      this.global.generateSeedElectron(dialogRef && dialogRef.componentRef && dialogRef.componentRef.instance ? dialogRef.componentRef.instance : null, fromPatchFile, fromPatchFile == false && this.seedString.length > 0 ? this.seedString : "").then(res => {
         console.log('[Electron] Gen Success');
 
         this.generateSeedButtonEnabled = true;
@@ -230,7 +230,7 @@ export class GeneratorComponent implements OnInit {
     }
     else { //Web
 
-      this.global.generateSeedWeb(webRaceSeed, this.seedString.trim().length > 0 ? this.seedString.trim() : "").then(seedID => {
+      this.global.generateSeedWeb(webRaceSeed, this.seedString.length > 0 ? this.seedString : "").then(seedID => {
 
         //Save last seed id in browser cache
         localStorage.setItem("lastSeed", seedID);

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ player.
 * Hints that should come in multiples (duplicates) no longer come in singletons in certain corner cases.
 * Randomizing main rules now works correctly.
 * Removed a misleading random "trials" value from the non-randomized settings in the spoiler.
+* Fix seed values with spaces no longer working.
 * Miscellaneous logic fixes.
 
 ### 5.1


### PR DESCRIPTION
Allows spaces and other characters to be used in seeds again without causing errors.
Should avoid other errors that could be caused by entering strange data into the seed field.

Hopefully this is something @dragonbane0 and @TreZc0 are good with since I'm not really a JavaScript guy. This seems like the best solution to me but I'm not sure.