### PR TITLE
Fix the logic check for custom token bridge requirements

### DIFF
--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -102,7 +102,7 @@
         (bridge == 'stones' and has_all_stones) or
         (bridge == 'medallions' and has_all_medallions) or
         (bridge == 'dungeons' and has_all_stones and has_all_medallions) or
-        (bridge == 'tokens' and (Gold_Skulltula_Token, 100)))",
+        (bridge == 'tokens' and (Gold_Skulltula_Token, bridge_tokens)))",
     "can_trigger_lacs": "(
         (lacs_condition == 'vanilla' and Shadow_Medallion and Spirit_Medallion) or
         (lacs_condition == 'stones' and has_all_stones) or


### PR DESCRIPTION
This seems to have been missed in a merge conflict a while ago when TH was merged.