### PR TITLE
Plando: Fix placing various items on invalid locations

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -223,6 +223,19 @@ normal_bottles = [
 bottle_count = 4
 
 
+dungeon_rewards = [
+    'Kokiri Emerald',
+    'Goron Ruby',
+    'Zora Sapphire',
+    'Forest Medallion',
+    'Fire Medallion',
+    'Water Medallion',
+    'Shadow Medallion',
+    'Spirit Medallion',
+    'Light Medallion'
+]
+
+
 normal_rupees = (
     ['Rupees (5)'] * 13 +
     ['Rupees (20)'] * 5 +
@@ -681,6 +694,7 @@ item_groups = {
     'WarpSong': songlist[6:],
     'HealthUpgrade': ('Heart Container', 'Piece of Heart'),
     'ProgressItem': [name for (name, data) in item_table.items() if data[0] == 'Item' and data[1]],
+    'DungeonReward': dungeon_rewards,
 
     'ForestFireWater': ('Forest Medallion', 'Fire Medallion', 'Water Medallion'),
     'FireWater': ('Fire Medallion', 'Water Medallion'),

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -494,7 +494,11 @@ class WorldDistribution(object):
 
     def fill_bosses(self, world, prize_locs, prizepool):
         count = 0
-        for (name, record) in pattern_dict_items(self.locations):
+        locations = {loc.name: self.locations[loc.name] for loc in prize_locs if loc.name in self.locations}
+        for (name, record) in pattern_dict_items(locations):
+            if record.item not in item_groups['DungeonReward']:
+                raise RuntimeError('Cannot place non-dungeon reward item in world %d in dungeon reward location.' % (self.id + 1))
+
             boss = pull_item_or_location([prize_locs], world, name)
             if boss is None:
                 try:
@@ -520,9 +524,13 @@ class WorldDistribution(object):
 
     def fill(self, window, worlds, location_pools, item_pools):
         world = worlds[self.id]
-        for (location_name, record) in pattern_dict_items(self.locations):
+        locations = {loc.name: self.locations[loc.name] for pool in location_pools if pool for loc in pool if loc.name in self.locations}
+        for (location_name, record) in pattern_dict_items(locations):
             if record.item is None:
                 continue
+
+            if record.item in item_groups['DungeonReward']:
+                raise RuntimeError('Cannot place dungeon reward in world %d in non-dungeon reward location.' % (self.id + 1))
 
             player_id = self.id if record.player is None else record.player - 1
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -540,7 +540,7 @@ class WorldDistribution(object):
                 try:
                     location = LocationFactory(location_name)
                 except KeyError:
-                    raise RuntimeError('Unknown location in world %d: %s' % (world.id + 1, name))
+                    raise RuntimeError('Unknown location in world %d: %s' % (world.id + 1, location_name))
                 if location.type == 'Boss':
                     continue
                 elif location.name in world.disabled_locations:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -543,6 +543,7 @@ class WorldDistribution(object):
             if record.item == '#Junk' and location.type == 'Song' and not world.shuffle_song_items:
                 record.item = '#JunkSong'
 
+            ignore_pools = None
             is_invert = pattern_matcher(record.item)('!')
             if is_invert and location.type != 'Song' and not world.shuffle_song_items:
                 ignore_pools = [2]

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -546,6 +546,8 @@ class WorldDistribution(object):
             is_invert = pattern_matcher(record.item)('!')
             if is_invert and location.type != 'Song' and not world.shuffle_song_items:
                 ignore_pools = [2]
+            if is_invert and location.type == 'Song' and not world.shuffle_song_items:
+                ignore_pools = [i for i, pools in enumerate(item_pools) if i != 2]
 
             try:
                 item = self.pool_remove_item(item_pools, record.item, 1, world_id=player_id, ignore_pools=ignore_pools)[0]

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -553,7 +553,7 @@ class WorldDistribution(object):
             if is_invert and location.type != 'Song' and not world.shuffle_song_items:
                 ignore_pools = [2]
             if is_invert and location.type == 'Song' and not world.shuffle_song_items:
-                ignore_pools = [i for i, pools in enumerate(item_pools) if i != 2]
+                ignore_pools = [i for i in range(len(item_pools)) if i != 2]
 
             try:
                 item = self.pool_remove_item(item_pools, record.item, 1, world_id=player_id, ignore_pools=ignore_pools)[0]


### PR DESCRIPTION
When using the invert pattern in plandomizer (`!Bow`) on a non-song location and with songsanity off ignore the song item pool when choosing the item to place. It should only do this if a pattern is used to avoid placing an item the user did not intend.

Prior to this change trying to generate 100 seeds with an invert pattern would cause an error due to trying to place a song on a chest location part way through. After this change I could generate over 200 without issues.

The same is done for songs as a user using an invert pattern with songsanity off likely doesn't want to place an item on the song location, and would cause an error anyway since the pool is not modified to remove a song.

Not sure if it is needed for dungeon items being placed with any settings as I haven't run into it myself.

Would probably be a good idea to set up some kind of enum or something for pools so I'm not using 2 (Song pool) as a magic number in case pools ever change.