### PR TITLE
Avoid Exceeding 4 Bottles and 1 Trade Item; Properly Update Item Pool Automatically

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -436,6 +436,16 @@ class WorldDistribution(object):
                 state.collect(item)
 
 
+    def pool_replace_item(self, item_pools, item_group, player_id, new_item, worlds):
+        removed_item = self.pool_remove_item(item_pools, item_group, 1, world_id=player_id)[0]
+        item_matcher = lambda item: pattern_matcher(new_item)(item.name)
+        if self.item_pool[removed_item.name].count > 1:
+            self.item_pool[removed_item.name].count -= 1
+        else:
+            del self.item_pool[removed_item.name]
+        return random.choice(list(ItemIterator(item_matcher, worlds[player_id])))
+
+
     def set_shuffled_entrances(self, worlds, entrance_pools, target_entrance_pools, locations_to_ensure_reachable, itempool):
         for (name, record) in self.entrances.items():
             if record.region is None:
@@ -527,6 +537,31 @@ class WorldDistribution(object):
         locations = {}
         if self.locations:
             locations = {loc: self.locations[loc] for loc in random.sample(self.locations.keys(), len(self.locations))}
+        for starting_item, record in pattern_dict_items(self.starting_items):
+            for _ in range(record.count):
+                try:
+                    if starting_item in item_groups['DungeonReward']:
+                        continue
+                    item = None
+                    if starting_item in item_groups['Bottle']:
+                        item = self.pool_replace_item(item_pools, "#Bottle", self.id, "#Junk", worlds)
+                    elif starting_item in item_groups['AdultTrade']:
+                        item = self.pool_replace_item(item_pools, "#AdultTrade", self.id, "#Junk", worlds)
+                    elif IsItem(starting_item):
+                        item = self.pool_replace_item(item_pools, starting_item, self.id, "#Junk", worlds)
+                except KeyError:
+                    raise RuntimeError('Started with too many "%s" in world %d, and not enough "%s" are available in the item pool to be removed.' % (starting_item, self.id + 1, starting_item))
+
+                if starting_item in item_groups['Song']:
+                    self.song_as_items = True
+
+                # Update item_pool
+                if item is not None:
+                    if item not in self.item_pool:
+                        self.item_pool[item.name] = ItemPoolRecord({'type': 'set', 'count': 1})
+                    else:
+                        self.item_pool[item.name].count += 1
+                    item_pools[5].append(ItemFactory(item.name, world))
         for (location_name, record) in pattern_dict_items(locations, world.itempool, []):
             if record.item is None:
                 continue
@@ -563,14 +598,28 @@ class WorldDistribution(object):
             try:
                 item = self.pool_remove_item(item_pools, record.item, 1, world_id=player_id, ignore_pools=ignore_pools)[0]
             except KeyError:
-                try:
-                    self.pool_remove_item(item_pools, "#Junk", 1, world_id=player_id)
-                    item_matcher = lambda item: pattern_matcher(record.item)(item.name)
-                    item = random.choice(list(ItemIterator(item_matcher, worlds[player_id])))
-                except KeyError:
-                    raise RuntimeError('Too many items were added to world %d, and not enough junk is available to be removed.' % (self.id + 1))
-                except IndexError:
-                    raise RuntimeError('Unknown item %s being placed on location %s in world %d.' % (record.item, location, self.id + 1))
+                if record.item in item_groups['Bottle']:
+                    try:
+                        item = self.pool_replace_item(item_pools, "#Bottle", player_id, record.item, worlds)
+                    except KeyError:
+                        raise RuntimeError('Too many bottles were added to world %d, and not enough bottles are available in the item pool to be removed.' % (self.id + 1))
+                elif record.item in item_groups['AdultTrade']:
+                    try:
+                        item = self.pool_replace_item(item_pools, "#AdultTrade", player_id, record.item, worlds)
+                    except KeyError:
+                        raise RuntimeError('Too many adult trade items were added to world %d, and not enough adult trade items are available in the item pool to be removed.' % (self.id + 1))
+                else:
+                    try:
+                        item = self.pool_replace_item(item_pools, "#Junk", player_id, record.item, worlds)
+                    except KeyError:
+                        raise RuntimeError('Too many items were added to world %d, and not enough junk is available to be removed.' % (self.id + 1))
+                # Update item_pool
+                if item.name not in self.item_pool:
+                    self.item_pool[item.name] = ItemPoolRecord({'type': 'set', 'count': 1})
+                else:
+                    self.item_pool[item.name].count += 1
+            except IndexError:
+                raise RuntimeError('Unknown item %s being placed on location %s in world %d.' % (record.item, location, self.id + 1))
 
             if record.price is not None and item.type != 'Shop':
                 location.price = record.price

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -537,8 +537,8 @@ class WorldDistribution(object):
         locations = {}
         if self.locations:
             locations = {loc: self.locations[loc] for loc in random.sample(self.locations.keys(), len(self.locations))}
-        for starting_item, record in pattern_dict_items(self.starting_items):
-            for _ in range(record.count):
+        for starting_item in self.starting_items:
+            for _ in range(self.starting_items[starting_item].count):
                 try:
                     if starting_item in item_groups['DungeonReward']:
                         continue


### PR DESCRIPTION
This PR should ensure that you cannot place more than 3 bottles in `closed_fountain` and 4 bottles in `open_fountain` along with disallowing duplicate adult trade items.

As a bonus of implementing this to a degree I'm happy with I think I ended up solving the issue where `item_pool` doesn't update when adding more items than the given `item_pool`. This may be undesired for custom item_pool definitions, in which I can raise an error on if desired. However I believe most users expect it to work this way when using the default base pool at the very least.

-----

ToxicOxygen on the Discord brought up the fact that `starting_items` should work similarly. As such, starting items will now remove from the item_pool too and be replaced with junk. Examples of this for normal items:
- Starting items = 3 bows. Item pool = 3 bows. No bows are placed in the world by fill.
- Starting items = 1 bow. Item pool = 3 bows. 2 bows are placed in the world by fill.
- Starting items = 1 bow. Item pool = 3 bows. Plando'd bows = 1. 1 bow is placed into the world by fill. 2 bows are in the world in total
- Starting items = 3 bows. Item pool = 3 bows. Plando'd bows = 4. 0 bows are placed into the world by fill. 4 bows are in the world in total.

If the `starting_item` value for an item exceeds the `item_pool` value, it will error. Adding that item to the item pool in the plando will ensure it does not error.