### PR TITLE
Fix pattern_dict_item

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -942,7 +942,7 @@ def pattern_matcher(pattern):
 
 def pattern_dict_items(pattern_dict, itempool=None, exhausted=None):
     for (key, value) in pattern_dict.items():
-        if isinstance(value.item, list):
+        if hasattr(value, 'item') and isinstance(value.item, list):
             if itempool is not None:
                 valid_items = [item.name for item in itempool if item.name in value.item]
                 if exhausted is not None:


### PR DESCRIPTION
Looks like I made pattern_dict_item attempt to use an attribute of an object that may not exist without properly checking for it.

I don't think this is a major issue for starting_items in plandos so I didn't revert the change that removed the pattern_dict_items usage, though I may choose to later as maybe patterns in starting_items would be neat, but for now this fix is necessary as this issue breaks other things such as custom gossip stone text in plandos.