### PR TITLE
Plando: Fix "start with" options

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1140,12 +1140,6 @@ def get_pool_core(world):
     pool.append(tradeitem)
 
     pool.extend(songlist)
-    if world.start_with_fast_travel:
-        pool.remove('Prelude of Light')
-        pool.remove('Serenade of Water')
-        pool.remove('Farores Wind')
-        pool.extend(get_junk_item(3))
-        
     if world.free_scarecrow:
         world.state.collect(ItemFactory('Scarecrow Song'))
     
@@ -1233,9 +1227,6 @@ def get_pool_core(world):
 
     for item,max in item_difficulty_max[world.item_pool_value].items():
         replace_max_item(pool, item, max)
-
-    if world.start_with_wallet:
-        replace_max_item(pool, 'Progressive Wallet', 0)
 
     # Make sure our pending_junk_pool is empty. If not, remove some random junk here.
     if pending_junk_pool:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -548,7 +548,10 @@ class WorldDistribution(object):
                     elif starting_item in item_groups['AdultTrade']:
                         item = self.pool_replace_item(item_pools, "#AdultTrade", self.id, "#Junk", worlds)
                     elif IsItem(starting_item):
-                        item = self.pool_replace_item(item_pools, starting_item, self.id, "#Junk", worlds)
+                        try:
+                            item = self.pool_replace_item(item_pools, starting_item, self.id, "#Junk", worlds)
+                        except KeyError:
+                            pass  # If a normal item exceeds the item pool count, continue.
                 except KeyError:
                     raise RuntimeError('Started with too many "%s" in world %d, and not enough "%s" are available in the item pool to be removed.' % (starting_item, self.id + 1, starting_item))
 


### PR DESCRIPTION
The new starting_items changes automatically remove the items from the item pool which broke the start_with_fast_travel and start_with_wallet options as they also remove from the pool.

This first cuts out the removal of the items from the pool from ItemPool.py as it is now automatic.

Second, most items other than bottles or trade quest items should be fine to exceed the item pool amount, so in Plandomizer.py, remove them until the item pool runs out, then ignore the fact you are adding more than are available.

This should fix the "start with" options.
