### PR TITLE
Minor text fixes

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -90,7 +90,7 @@ def main(settings, window=dummy_window()):
     settings.resolve_random_settings(cosmetic=False)
     logger.debug(settings.get_settings_display())
     max_attempts = 1
-    for attempt in range(1, max_attemptgss + 1):
+    for attempt in range(1, max_attempts + 1):
         try:
             spoiler = generate(settings, window)
             break

--- a/Main.py
+++ b/Main.py
@@ -80,7 +80,7 @@ def main(settings, window=dummy_window()):
         settings.player_num = 1
     if settings.player_num > settings.world_count:
         if settings.compress_rom not in ['None', 'Patch']:
-            raise Exception(f'Player count: {settings.player_num} must be between (1, {settings.world_count})')
+            raise Exception(f'Player Num: {settings.player_num} must be between (1, {settings.world_count})')
         settings.player_num = settings.world_count
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)

--- a/Main.py
+++ b/Main.py
@@ -49,8 +49,6 @@ def main(settings, window=dummy_window()):
 
     logger = logging.getLogger('')
 
-    worlds = []
-
     old_tricks = settings.allowed_tricks
     settings.load_distribution()
 
@@ -74,13 +72,15 @@ def main(settings, window=dummy_window()):
 
     if not settings.world_count:
         settings.world_count = 1
-    if settings.world_count < 1 or settings.world_count > 255:
+    elif settings.world_count < 1 or settings.world_count > 255:
         raise Exception('World Count must be between 1 and 255')
-    if settings.player_num > settings.world_count or settings.player_num < 1:
-        if settings.compress_rom not in ['None', 'Patch']:
-            raise Exception('Player Num must be between 1 and %d' % settings.world_count)
-        else:
-            settings.player_num = 1
+    if settings.compress_rom not in ['None', 'Patch']:
+        raise Exception(f'Invalid rom compression setting: {settings.compress_rom}')
+    # Bounds-check the player_num settings. If they're invalid, snap them to something semi-sane.
+    if settings.player_num > settings.world_count:
+        settings.player_num = settings.world_count
+    elif settings.player_num < 1:
+        settings.player_num = 1
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)
     settings.remove_disabled()
@@ -528,7 +528,7 @@ def create_playthrough(spoiler):
     collection_spheres = []
     entrance_spheres = []
     remaining_entrances = set(entrance for world in worlds for entrance in world.get_shuffled_entrances())
-    
+
     while True:
         search.checkpoint()
         # Not collecting while the generator runs means we only get one sphere at a time

--- a/Main.py
+++ b/Main.py
@@ -74,13 +74,14 @@ def main(settings, window=dummy_window()):
         settings.world_count = 1
     elif settings.world_count < 1 or settings.world_count > 255:
         raise Exception('World Count must be between 1 and 255')
-    if settings.compress_rom not in ['None', 'Patch']:
-        raise Exception(f'Invalid rom compression setting: {settings.compress_rom}')
+
     # Bounds-check the player_num settings. If they're invalid, snap them to something semi-sane.
-    if settings.player_num > settings.world_count:
-        settings.player_num = settings.world_count
-    elif settings.player_num < 1:
+    if settings.player_num < 1:
         settings.player_num = 1
+    if settings.player_num > settings.world_count:
+        if settings.compress_rom not in ['None', 'Patch']:
+            raise Exception(f'Invalid player count: {settings.player_num} and compression setting: {settings.compress_rom}')
+        settings.player_num = settings.world_count
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)
     settings.remove_disabled()
@@ -89,7 +90,7 @@ def main(settings, window=dummy_window()):
     settings.resolve_random_settings(cosmetic=False)
     logger.debug(settings.get_settings_display())
     max_attempts = 1
-    for attempt in range(1, max_attempts + 1):
+    for attempt in range(1, max_attemptgss + 1):
         try:
             spoiler = generate(settings, window)
             break

--- a/Main.py
+++ b/Main.py
@@ -80,7 +80,7 @@ def main(settings, window=dummy_window()):
         settings.player_num = 1
     if settings.player_num > settings.world_count:
         if settings.compress_rom not in ['None', 'Patch']:
-            raise Exception(f'Invalid player count: {settings.player_num} and compression setting: {settings.compress_rom}')
+            raise Exception(f'Player count: {settings.player_num} must be between (1, {settings.world_count})')
         settings.player_num = settings.world_count
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -2,15 +2,13 @@
 import argparse
 import os
 import logging
-import random
 import textwrap
-import sys
 import time
 import datetime
 
 from Gui import guiMain
 from Main import main, from_patch_file, cosmetic_patch
-from Utils import is_bundled, close_console, check_version, VersionError, check_python_version, local_path
+from Utils import check_version, VersionError, check_python_version, local_path
 from Settings import get_settings_from_command_line_args
 
 
@@ -23,15 +21,6 @@ class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 def start():
 
     settings, gui, args_loglevel, no_log_file = get_settings_from_command_line_args()
-
-    if is_bundled() and len(sys.argv) == 1:
-        # for the bundled builds, if we have no arguments, the user
-        # probably wants the gui. Users of the bundled build who want the command line
-        # interface shouuld specify at least one option, possibly setting a value to a
-        # default if they like all the defaults
-        close_console()
-        guiMain()
-        sys.exit(0)
 
     # set up logger
     loglevel = {'error': logging.ERROR, 'info': logging.INFO, 'warning': logging.WARNING, 'debug': logging.DEBUG}[args_loglevel]
@@ -52,7 +41,7 @@ def start():
 
     if not settings.check_version:
         try:
-            version_error = check_version(settings.checked_version)
+            check_version(settings.checked_version)
         except VersionError as e:
             logger.warning(str(e))
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2298,10 +2298,9 @@ setting_infos = [
             Locations in the left column may contain items
             required to complete the game. 
             
-            Locations in the right column will never contain 
-            items required for game completion. 
-            
-            Only junk items will appear at those locations.
+            Locations in the right column will never have 
+            items that are required to complete the game, 
+            and will only contain junk
 
             Most dungeon locations have a MQ alternative.
             If the location does not exist because of MQ
@@ -2326,10 +2325,10 @@ setting_infos = [
             'choice_tooltip': {choice['name']: choice['tooltip'] for choice in logic_tricks.values()},
         },
         gui_tooltip='''
-            Tricks moved to the right column are added to
-            the logic, and may be required in to complete the game.
+            Tricks moved to the right column are in-logic
+            and MAY be required in to complete the game.
             
-            Tricks in the left column are removed from logic consideration.
+            Tricks in the left column are NEVER required.
         '''
     ),
     Combobox(

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2329,9 +2329,11 @@ setting_infos = [
         },
         gui_tooltip='''
             Tricks moved to the right column are in-logic
-            and MAY be required in to complete the game.
+            and MAY be required to complete the game.
             
             Tricks in the left column are NEVER required.
+            
+            Tricks are only relevant for Glitchless logic.
         '''
     ),
     Combobox(

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2283,7 +2283,7 @@ setting_infos = [
 
             12: All dungeons will have
             Master Quest redesigns.
-         ''',
+        ''',
         shared         = True,
     ),
     Setting_Info(

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1513,19 +1513,22 @@ setting_infos = [
             'none':       'No Logic',
             },
         gui_tooltip    = '''\
-            Sets the rules the logic uses to determine accessibility.
+            Logic provides guiding sets of rules for world generation
+            which the Randomizer uses to ensure the generated seeds 
+            are beatable.
 
             'Glitchless': No glitches are required, but may require 
-            some minor tricks.
+            some minor tricks. Add minor tricks to consider for logic
+            in the 'Detailed Logic' tab.
 
-            'Glitched': Movement oriented glitches are likely required.
+            'Glitched': Movement-oriented glitches are likely required.
             No locations excluded.
 
-            'No Logic': All locations are considered available. 
-            May not be beatable.
+            'No Logic': Maximize randomization, All locations are 
+            considered available. MAY BE IMPOSSIBLE TO BEAT.
         ''',
         disable        = {
-            'glitched'  : {'settings' : ['entrance_shuffle', 'mq_dungeons_random', 'mq_dungeons']},
+            'glitched'  : {'settings' : ['entrance_shuffle', 'mq_dungeons_random', 'mq_dungeons', 'allowed_tricks']},
             'none'      : {'tabs'     : ['detailed_tab']},
         },
         shared         = True,

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -77,7 +77,7 @@ class Setting_Info():
 
 class Checkbutton(Setting_Info):
 
-    def __init__(self, name, gui_text, gui_tooltip=None, disable=None, 
+    def __init__(self, name, gui_text, gui_tooltip=None, disable=None,
             disabled_default=None, default=False, shared=False, gui_params=None):
 
         choices = {
@@ -90,7 +90,7 @@ class Checkbutton(Setting_Info):
 
 class Combobox(Setting_Info):
 
-    def __init__(self, name, gui_text, choices, default, gui_tooltip=None, 
+    def __init__(self, name, gui_text, choices, default, gui_tooltip=None,
             disable=None, disabled_default=None, shared=False, gui_params=None):
 
         super().__init__(name, str, gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params)
@@ -99,14 +99,14 @@ class Combobox(Setting_Info):
 class Scale(Setting_Info):
 
     def __init__(self, name, gui_text, min, max, default, step=1,
-            gui_tooltip=None, disable=None, disabled_default=None, 
+            gui_tooltip=None, disable=None, disabled_default=None,
             shared=False, gui_params=None):
 
         choices = {
             i: str(i) for i in range(min, max+1, step)
         }
         if gui_params == None:
-            gui_params = {}       
+            gui_params = {}
         gui_params['min']    = min
         gui_params['max']    = max
         gui_params['step']   = step
@@ -967,10 +967,10 @@ logic_tricks = {
 setting_infos = [
     # Web Only Settings
     Setting_Info(
-        name        = 'web_wad_file',   
-        type        = str, 
-        gui_text    = "WAD File", 
-        gui_type    = "Fileinput", 
+        name        = 'web_wad_file',
+        type        = str,
+        gui_text    = "WAD File",
+        gui_type    = "Fileinput",
         shared      = False,
         choices     = {},
         gui_tooltip = "Your original OoT 1.2 NTSC-U / NTSC-J WAD file (.wad)",
@@ -989,11 +989,11 @@ setting_infos = [
         }
     ),
     Setting_Info(
-        name        = 'web_common_key_file',   
-        type        = str, 
-        gui_text    = "Wii Common Key File", 
-        gui_type    = "Fileinput", 
-        shared      = False, 
+        name        = 'web_common_key_file',
+        type        = str,
+        gui_text    = "Wii Common Key File",
+        gui_type    = "Fileinput",
+        shared      = False,
         choices     = {},
         gui_tooltip = """\
             The Wii Common Key is a copyrighted 32 character string needed for WAD encryption.
@@ -1011,14 +1011,14 @@ setting_infos = [
                 }
             ],
             "hide_when_disabled": True,
-        }        
+        }
     ),
     Setting_Info(
-        name        = 'web_common_key_string',   
-        type        = str, 
-        gui_text    = "Alternatively Enter Wii Common Key", 
-        gui_type    = "Textinput", 
-        shared      = False, 
+        name        = 'web_common_key_string',
+        type        = str,
+        gui_text    = "Alternatively Enter Wii Common Key",
+        gui_type    = "Textinput",
+        shared      = False,
         choices     = {},
         gui_tooltip = """\
             The Wii Common Key is a copyrighted 32 character string needed for WAD encryption.
@@ -1031,9 +1031,9 @@ setting_infos = [
         }
     ),
     Setting_Info(
-        name        = 'web_wad_channel_id',   
-        type        = str, 
-        gui_text    = "WAD Channel ID", 
+        name        = 'web_wad_channel_id',
+        type        = str,
+        gui_text    = "WAD Channel ID",
         gui_type    = "Textinput",
         shared      = False,
         choices     = {},
@@ -1050,9 +1050,9 @@ setting_infos = [
         }
     ),
     Setting_Info(
-        name        = 'web_wad_channel_title',   
-        type        = str, 
-        gui_text    = "WAD Channel Title", 
+        name        = 'web_wad_channel_title',
+        type        = str,
+        gui_text    = "WAD Channel Title",
         gui_type    = "Textinput",
         shared      = False,
         choices     = {},
@@ -1065,9 +1065,9 @@ setting_infos = [
         }
     ),
     Setting_Info(
-        name       = 'web_output_type',   
-        type       = str, 
-        gui_text   = "Output Type", 
+        name       = 'web_output_type',
+        type       = str,
+        gui_text   = "Output Type",
         gui_type   = "Radiobutton",
         shared     = False,
         choices    = {
@@ -1076,7 +1076,7 @@ setting_infos = [
         },
         gui_params  = {
             "hide_when_disabled" : True,
-        },        
+        },
         default    = "z64",
         disable    = {
             'z64' : {'settings' : [
@@ -1094,7 +1094,7 @@ setting_infos = [
         default        = True,
         shared         = False,
     ),
-    
+
     # Non-GUI Settings
     Checkbutton('cosmetics_only', None),
     Checkbutton('check_version', None),
@@ -1117,11 +1117,11 @@ setting_infos = [
             'web:disable' : {
                 False : {
                     'settings' : [
-                        'rom','web_output_type','player_num', 
+                        'rom','web_output_type','player_num',
                         'web_wad_file', 'web_common_key_file', 'web_common_key_string',
                         'web_wad_channel_id','web_wad_channel_title'
                     ],
-                },          
+                },
             }
         },
         shared         = False,
@@ -1155,7 +1155,7 @@ setting_infos = [
                   "extensions": [ "*" ]
                 }
             ],
-            "hide_when_disabled" : True,    
+            "hide_when_disabled" : True,
         }),
     Setting_Info('checked_version',   str, None, None, False, {}),
     Setting_Info('rom',               str, "Base ROM", "Fileinput", False, {},
@@ -1188,23 +1188,23 @@ setting_infos = [
                 }
             ],
         }),
-    Setting_Info('count',             int, "Generation Count", "Numberinput", False, {}, 
+    Setting_Info('count',             int, "Generation Count", "Numberinput", False, {},
         default        = 1,
         gui_params = {
             'min' : 1,
         }
     ),
-    Setting_Info('world_count',       int, "Player Count", "Numberinput", True, {}, 
+    Setting_Info('world_count',       int, "Player Count", "Numberinput", True, {},
         default        = 1,
         gui_params = {
             'min' : 1,
             'max' : 255,
             'no_line_break'     : True,
             'web:max'           : 15,
-            'web:no_line_break' : True,            
+            'web:no_line_break' : True,
         }
     ),
-    Setting_Info('player_num',        int, "Player ID", "Numberinput", False, {}, 
+    Setting_Info('player_num',        int, "Player ID", "Numberinput", False, {},
         default        = 1,
         gui_params = {
             'min' : 1,
@@ -1222,12 +1222,12 @@ setting_infos = [
             'function' : "openOutputDir",
             'no_line_break' : True,
         }
-    ), 
+    ),
     Setting_Info('open_python_dir',   str, "Open App Directory", "Button", False, {},
         gui_params = {
             'function' : "openPythonDir",
         }
-    ), 
+    ),
     Checkbutton(
         name           = 'repatch_cosmetics',
         gui_text       = 'Update Cosmetics',
@@ -1235,7 +1235,7 @@ setting_infos = [
         disable        = {
             False : {
                 'tabs': ['cosmetics_tab','sfx_tab'],
-                'settings' : ['create_cosmetics_log'],    
+                'settings' : ['create_cosmetics_log'],
             },
         },
         shared         = False,
@@ -1331,7 +1331,7 @@ setting_infos = [
         shared         = True,
         disable        = {
             'closed' : {'settings' : ['starting_age']}
-        },        
+        },
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution': [
@@ -1462,7 +1462,7 @@ setting_infos = [
             True  : {'settings' : ['shuffle_ganon_bosskey']},
             False : {'settings' : ['triforce_goal_per_world']}
         },
-    ),    
+    ),
     Scale(
         name           = 'triforce_goal_per_world',
         gui_text       = 'Required Triforces Per World',
@@ -1749,7 +1749,7 @@ setting_infos = [
         ''',
         disable        = {
             True : {'settings' : ['chicken_count']}
-        },        
+        },
         shared         = True,
     ),
     Scale(
@@ -2111,7 +2111,7 @@ setting_infos = [
         default        = 'dungeon',
         choices        = {
             'remove':    'Remove (Keysy)',
-            'vanilla':   'Vanilla Locations',            
+            'vanilla':   'Vanilla Locations',
             'dungeon':   'Dungeon Only',
             'keysanity': 'Anywhere (Keysanity)'
         },
@@ -2150,7 +2150,7 @@ setting_infos = [
         default        = 'dungeon',
         choices        = {
             'remove':    'Remove (Keysy)',
-            'vanilla':   'Vanilla Locations',            
+            'vanilla':   'Vanilla Locations',
             'dungeon':   'Dungeon Only',
             'keysanity': 'Anywhere (Keysanity)',
         },
@@ -2228,7 +2228,7 @@ setting_infos = [
                 ('lacs_medallions', 1),
                 ('lacs_stones',     1),
                 ('lacs_dungeons',   1),
-            ],            
+            ],
         },
     ),
     Checkbutton(
@@ -2272,7 +2272,7 @@ setting_infos = [
         min            = 0,
         max            = 12,
         gui_tooltip    = '''\
-            Select a number of Master Quest
+            Specify the number of Master Quest
             dungeons to appear in the game.
 
             0: All dungeon will have their
@@ -2283,11 +2283,11 @@ setting_infos = [
 
             12: All dungeons will have
             Master Quest redesigns.
-            ''',
+         ''',
         shared         = True,
     ),
     Setting_Info(
-        name           = 'disabled_locations', 
+        name           = 'disabled_locations',
         type           = list,
         gui_text       = "Exclude Locations",
         gui_type       = "SearchBox",
@@ -2295,7 +2295,12 @@ setting_infos = [
         choices        = [location.name for location in LocationIterator(lambda loc: loc.filter_tags is not None)],
         default        = [],
         gui_tooltip    = '''
-            Prevent locations from being required.
+            Locations in the left column may contain items
+            required to complete the game. 
+            
+            Locations in the right column will never contain 
+            items required for game completion. 
+            
             Only junk items will appear at those locations.
 
             Most dungeon locations have a MQ alternative.
@@ -2319,7 +2324,13 @@ setting_infos = [
         default        = [],
         gui_params     = {
             'choice_tooltip': {choice['name']: choice['tooltip'] for choice in logic_tricks.values()},
-        }
+        },
+        gui_tooltip='''
+            Tricks moved to the right column are added to
+            the logic, and may be required in to complete the game.
+            
+            Tricks in the left column are removed from logic consideration.
+        '''
     ),
     Combobox(
         name           = 'logic_earliest_adult_trade',


### PR DESCRIPTION
This Pull Request: 

- Cleans up some unused imports

`Main.py:`
- Removes the unused worlds array in Main.py
- Moves the settings.compress_rom check from out of under the player_num check, to above it.
- Snaps the player_num down to world_count if it's > world_count

`OoTRandomizer.py` 
- Removes the unused/uncalled Gui section
- Removes the variable assignment from check_version - that func doesn't return anything.

`SettingsList.py`
- Stripped some trailing spaces (I can revert this if it's annoying)
- Add clarifying statements to `disabled_locations` and `allowed_tricks`
- Disable the tricks menu, when glitchless is chosen, because glitched logic doesn't take into account the 'Enabled Tricks' settings at all, and would be confusing for users.