### PR TITLE
Plando: case-insensitive location matching

### DIFF
--- a/Location.py
+++ b/Location.py
@@ -112,12 +112,13 @@ def LocationFactory(locations, world=None):
         locations = [locations]
         singleton = True
     for location in locations:
-        if location in location_table:
-            type, scene, default, addresses, filter_tags = location_table[location]
+        match_location = [k for k in location_table if k.lower() == location.lower()][0]
+        if match_location:
+            type, scene, default, addresses, filter_tags = location_table[match_location]
             if addresses is None:
                 addresses = (None, None)
             address, address2 = addresses
-            ret.append(Location(location, address, address2, default, type, scene, filter_tags=filter_tags))
+            ret.append(Location(match_location, address, address2, default, type, scene, filter_tags=filter_tags))
         else:
             raise KeyError('Unknown Location: %s', location)
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -591,7 +591,7 @@ class WorldDistribution(object):
 
             player_id = self.id if record.player is None else record.player - 1
 
-            location_matcher = lambda loc: loc.world.id == world.id and loc.name == location_name
+            location_matcher = lambda loc: loc.world.id == world.id and loc.name.lower() == location_name.lower()
             location = pull_first_element(location_pools, location_matcher)
             if location is None:
                 try:


### PR DESCRIPTION
People often make case mistakes when using location names. i.e: "Gift From Saria" instead of the proper location name "Gift from Saria"

This change should match location names case insensitively but still use the proper case the location actually uses.