### PR TITLE
Fix gauntlet colors tooltips to not mention rainbow sword trails

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3128,7 +3128,6 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-            'Rainbow': Rainbow sword trails.
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
@@ -3151,7 +3150,6 @@ setting_infos = [
             color from this list of colors.
             'Completely Random': Choose a random
             color from any color the N64 can draw.
-            'Rainbow': Rainbow sword trails.
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',


### PR DESCRIPTION
Copy-paste mistakes were made.