### PR TITLE
Lower progression limits for item requirements.

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -569,7 +569,7 @@ def create_playthrough(spoiler):
             location.item = None
 
             # An item can only be required if it isn't already obtained or if it's progressive
-            if search.state_list[old_item.world.id].item_count(old_item.name) < old_item.world.max_progressions.get(old_item.name, 1):
+            if search.state_list[old_item.world.id].item_count(old_item.name) < old_item.world.max_progressions[old_item.name]:
                 # Test whether the game is still beatable from here.
                 logger.debug('Checking if %s is required to beat the game.', old_item.name)
                 if not search.can_beat_game():

--- a/Main.py
+++ b/Main.py
@@ -569,7 +569,7 @@ def create_playthrough(spoiler):
             location.item = None
 
             # An item can only be required if it isn't already obtained or if it's progressive
-            if search.state_list[old_item.world.id].item_count(old_item.name) < old_item.special.get('progressive', 1):
+            if search.state_list[old_item.world.id].item_count(old_item.name) < old_item.world.max_progressions.get(old_item.name, 1):
                 # Test whether the game is still beatable from here.
                 logger.debug('Checking if %s is required to beat the game.', old_item.name)
                 if not search.can_beat_game():

--- a/World.py
+++ b/World.py
@@ -108,9 +108,8 @@ class World(object):
 
         # Allows us to cut down on checking whether some items are required
         self.max_progressions = {
-                item: value[3]['progressive']
+                item: value[3].get('progressive', 1) if value[3] else 1
                 for item, value in item_table.items()
-                if value[3] and 'progressive' in value[3]
         }
         max_tokens = 0
         if self.bridge == 'tokens':

--- a/World.py
+++ b/World.py
@@ -7,6 +7,7 @@ from Entrance import Entrance
 from HintList import getRequiredHints
 from Hints import get_hint_area
 from Item import Item, ItemFactory, MakeEventItem
+from ItemList import item_table
 from Location import Location, LocationFactory
 from LocationList import business_scrubs
 from Region import Region, TimeOfDay
@@ -105,6 +106,21 @@ class World(object):
 
         self.always_hints = [hint.name for hint in getRequiredHints(self)]
 
+        # Allows us to cut down on checking whether some items are required
+        self.max_progressions = {
+                item: value[3]['progressive']
+                for item, value in item_table.items()
+                if value[3] and 'progressive' in value[3]
+        }
+        max_tokens = 0
+        if self.bridge == 'tokens':
+            max_tokens = self.bridge_tokens
+        tokens = [50, 40, 30, 20, 10]
+        for t in tokens:
+            if t > max_tokens and f'{t} Gold Skulltula Reward' not in self.disabled_locations:
+                max_tokens = t
+        self.max_progressions['Gold Skulltula Token'] = max_tokens
+
 
     def copy(self):
         new_world = World(self.id, self.settings)
@@ -135,6 +151,7 @@ class World(object):
             setattr(new_world, randomized_item, getattr(self, randomized_item))
 
         new_world.always_hints = list(self.always_hints)
+        new_world.max_progressions = copy.copy(self.max_progressions)
 
         return new_world
 


### PR DESCRIPTION
Mainly, determine the largest Skulltula token check per-world
and set that as the limit.

This results in a ~6-7% performance improvement for a 5-world seed,
and negligible difference for a 1-world shuffle-tokens seed.

(We could obviously do even better by checking what's *placed* at those
locations, but this will do for now.)