### PR TITLE
Minor performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,13 @@
 /build
 /dist
 /Logs
-/__pychache__
+/testlogs
+/__pycache__
 ARCHIVE.bin
 
 *.[nz]64
 *.[nz]64.bak
+*.prof
 *.pyc
 *.pyo
 *.sav

--- a/Entrance.py
+++ b/Entrance.py
@@ -17,6 +17,8 @@ class Entrance(object):
         self.shuffled = False
         self.data = None
         self.primary = False
+        self.always = False
+        self.never = False
 
 
     def copy(self, new_region):
@@ -31,11 +33,19 @@ class Entrance(object):
         new_entrance.shuffled = self.shuffled
         new_entrance.data = self.data
         new_entrance.primary = self.primary
+        new_entrance.always = self.always
+        new_entrance.never = self.never
 
         return new_entrance
 
 
     def add_rule(self, lambda_rule):
+        if self.always:
+            self.set_rule(lambda_rule)
+            self.always = False
+            return
+        if self.never:
+            return
         self.access_rules.append(lambda_rule)
         self.access_rule = lambda state, **kwargs: all(rule(state, **kwargs) for rule in self.access_rules)
 

--- a/Location.py
+++ b/Location.py
@@ -24,6 +24,8 @@ class Location(object):
         self.minor_only = False
         self.world = None
         self.disabled = DisableType.ENABLED
+        self.always = False
+        self.never = False
         if filter_tags is None:
             self.filter_tags = None
         else:
@@ -43,11 +45,19 @@ class Location(object):
         new_location.internal = self.internal
         new_location.minor_only = self.minor_only
         new_location.disabled = self.disabled
+        new_location.always = self.always
+        new_location.never = self.never
 
         return new_location
 
 
     def add_rule(self, lambda_rule):
+        if self.always:
+            self.set_rule(lambda_rule)
+            self.always = False
+            return
+        if self.never:
+            return
         self.access_rules.append(lambda_rule)
         self.access_rule = lambda state, **kwargs: all(rule(state, **kwargs) for rule in self.access_rules)
 

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -365,11 +365,18 @@ class Rule_AST_Transformer(ast.NodeTransformer):
 
             self.current_spot = event
             # This could, in theory, create further subrules.
-            event.access_rule = self.make_access_rule(self.visit(node))
-            event.set_rule(event.access_rule)
-            region.locations.append(event)
+            access_rule = self.make_access_rule(self.visit(node))
+            if access_rule is self.rule_cache.get('NameConstant(False)'):
+                event.access_rule = None
+                event.never = True
+                logging.getLogger('').debug('Dropping unreachable delayed event: %s', event.name)
+            else:
+                if access_rule is self.rule_cache.get('NameConstant(True)'):
+                    event.always = True
+                event.set_rule(access_rule)
+                region.locations.append(event)
 
-            MakeEventItem(subrule_name, event)
+                MakeEventItem(subrule_name, event)
         # Safeguard in case this is called multiple times per world
         self.delayed_rules.clear()
 
@@ -455,5 +462,9 @@ class Rule_AST_Transformer(ast.NodeTransformer):
     def parse_spot_rule(self, spot):
         rule = spot.rule_string.split('#', 1)[0].strip()
 
-        spot.access_rule = self.parse_rule(rule, spot)
-        spot.set_rule(spot.access_rule)
+        access_rule = self.parse_rule(rule, spot)
+        spot.set_rule(access_rule)
+        if access_rule is self.rule_cache.get('NameConstant(False)'):
+            spot.never = True
+        elif access_rule is self.rule_cache.get('NameConstant(True)'):
+            spot.always = True

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -268,7 +268,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
     def visit_BoolOp(self, node):
         # Everything else must be visited, then can be removed/reduced to.
         early_return = isinstance(node.op, ast.Or)
-        groupable = 'has_any_if' if early_return else 'has_all_of'
+        groupable = 'has_any_of' if early_return else 'has_all_of'
         items = set()
         new_values = []
         # if any elt is True(And)/False(Or), we can omit it

--- a/Search.py
+++ b/Search.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import itertools
 
 from Region import TimeOfDay
-
+from State import State
 
 class Search(object):
 
@@ -210,16 +210,8 @@ class Search(object):
     # or just a function(state_list)
     def can_beat_game(self, scan_for_items=True):
 
-        # This currently assumed all worlds have the same win condition.
-        # This might not be true in the future
-        def won(state):
-            if state.world.triforce_hunt:
-                return state.has('Triforce Piece', state.world.triforce_count)
-            else:
-                return state.has('Triforce')
-
         # Check if already beaten
-        if all(map(won, self.state_list)):
+        if all(map(State.won, self.state_list)):
             return True
 
         if scan_for_items:
@@ -228,7 +220,7 @@ class Search(object):
             search = self.copy()
             search.collect_locations()
             # if every state got the Triforce, then return True
-            return all(map(won, search.state_list))
+            return all(map(State.won, search.state_list))
         else:
             return False
 

--- a/Search.py
+++ b/Search.py
@@ -163,12 +163,18 @@ class Search(object):
             # and check if they can be reached. Collect them.
             had_reachable_locations = False
             for loc in item_locations:
-                if (loc not in visited_locations
-                    # Check adult first; it's the most likely.
-                    and (loc.parent_region in adult_regions
-                         and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='adult')
-                         or (loc.parent_region in child_regions
-                             and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='child')))):
+                if loc in visited_locations:
+                    continue
+                # Check adult first; it's the most likely.
+                if (loc.parent_region in adult_regions
+                        and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='adult')):
+                    had_reachable_locations = True
+                    # Mark it visited for this algorithm
+                    visited_locations.add(loc)
+                    yield loc
+
+                elif (loc.parent_region in child_regions
+                      and loc.access_rule(self.state_list[loc.world.id], spot=loc, age='child')):
                     had_reachable_locations = True
                     # Mark it visited for this algorithm
                     visited_locations.add(loc)

--- a/State.py
+++ b/State.py
@@ -1,10 +1,7 @@
-from collections import Counter, defaultdict
+from collections import Counter
 import copy
-from functools import partial
-import itertools
 
 from Item import ItemInfo
-from Search import Search
 from Region import Region, TimeOfDay
 
 
@@ -15,6 +12,7 @@ class State(object):
         self.prog_items = Counter()
         self.world = parent
         self.search = None
+        self._won = self.won_triforce_hunt if self.world.triforce_hunt else self.won_normal
 
 
     ## Ensure that this will always have a value
@@ -36,6 +34,18 @@ class State(object):
         if location.item is None:
             return None
         return location.item.name
+
+
+    def won(self):
+        return self._won()
+
+
+    def won_triforce_hunt(self):
+        return self.has('Triforce Piece', self.world.triforce_count)
+
+
+    def won_normal(self):
+        return self.has('Triforce')
 
 
     def has(self, item, count=1):
@@ -125,48 +135,3 @@ class State(object):
         self.__dict__.update(state)
 
 
-    @staticmethod
-    def can_beat_game(state_list):
-        return Search(state_list).can_beat_game()
-
-
-    @staticmethod
-    def update_required_items(spoiler):
-        worlds = spoiler.worlds
-
-        # get list of all of the progressive items that can appear in hints
-        # all_locations: all progressive items. have to collect from these
-        # item_locations: only the ones that should appear as "required"/WotH
-        all_locations = [location for world in worlds for location in world.get_filled_locations()]
-        # Set to test inclusion against
-        item_locations = {location for location in all_locations if location.item.majoritem and not location.locked and location.item.name != 'Triforce Piece'}
-
-        # if the playthrough was generated, filter the list of locations to the
-        # locations in the playthrough. The required locations is a subset of these
-        # locations. Can't use the locations directly since they are location to the
-        # copied spoiler world, so must compare via name and world id
-        if spoiler.playthrough:
-            translate = lambda loc: worlds[loc.world.id].get_location(loc.name)
-            spoiler_locations = set(map(translate, itertools.chain.from_iterable(spoiler.playthrough.values())))
-            item_locations &= spoiler_locations
-
-        required_locations = []
-
-        search = Search([world.state for world in worlds])
-        for location in search.iter_reachable_locations(all_locations):
-            # Try to remove items one at a time and see if the game is still beatable
-            if location in item_locations:
-                old_item = location.item
-                location.item = None
-                # copies state! This is very important as we're in the middle of a search
-                # already, but beneficially, has search it can start from
-                if not search.can_beat_game():
-                    required_locations.append(location)
-                location.item = old_item
-            search.state_list[location.item.world.id].collect(location.item)
-
-        # Filter the required location to only include location in the world
-        required_locations_dict = {}
-        for world in worlds:
-            required_locations_dict[world.id] = list(filter(lambda location: location.world.id == world.id, required_locations))
-        spoiler.required_locations = required_locations_dict

--- a/World.py
+++ b/World.py
@@ -24,7 +24,6 @@ class World(object):
         self.dungeons = []
         self.regions = []
         self.itempool = []
-        self.state = State(self)
         self._cached_locations = None
         self._entrance_cache = {}
         self._region_cache = {}
@@ -104,6 +103,7 @@ class World(object):
         self.resolve_random_settings()
 
         self.always_hints = [hint.name for hint in getRequiredHints(self)]
+        self.state = State(self)
 
 
     def copy(self):

--- a/World.py
+++ b/World.py
@@ -217,6 +217,9 @@ class World(object):
                     new_location.rule_string = rule
                     if self.logic_rules != 'none':
                         self.parser.parse_spot_rule(new_location)
+                    if new_location.never:
+                        # We still need to fill the location even if ALR is off.
+                        logging.getLogger('').debug('Unreachable location: %s', new_location.name)
                     new_location.world = self
                     new_region.locations.append(new_location)
             if 'events' in region:
@@ -227,9 +230,12 @@ class World(object):
                     new_location.rule_string = rule
                     if self.logic_rules != 'none':
                         self.parser.parse_spot_rule(new_location)
-                    new_location.world = self
-                    new_region.locations.append(new_location)
-                    MakeEventItem(event, new_location)
+                    if new_location.never:
+                        logging.getLogger('').debug('Dropping unreachable event: %s', new_location.name)
+                    else:
+                        new_location.world = self
+                        new_region.locations.append(new_location)
+                        MakeEventItem(event, new_location)
             if 'exits' in region:
                 for exit, rule in region['exits'].items():
                     new_exit = Entrance('%s -> %s' % (new_region.name, exit), new_region)
@@ -237,7 +243,10 @@ class World(object):
                     new_exit.rule_string = rule
                     if self.logic_rules != 'none':
                         self.parser.parse_spot_rule(new_exit)
-                    new_region.exits.append(new_exit)
+                    if new_exit.never:
+                        logging.getLogger('').debug('Dropping unreachable exit: %s', new_exit.name)
+                    else:
+                        new_region.exits.append(new_exit)
             self.regions.append(new_region)
 
 


### PR DESCRIPTION
(and typo fixes)

- Cache per-world which 'won' metric to use.
- Move static State method `update_required_items` to Main, the only place it's used, so we can reference State in Search more easily. Remove `State.can_beat_game` entirely.
- After parsing and condensing rules based on settings, drop entrances that can't be used, events that can't be reached, etc. Mark always-true locations, but only use this for simplifying rules added later (hint access, wallet size for shops, etc).
- Minor code changes to Search alg that had small boosts to perf.
- Fix a typo affecting rule parsing.
- Fix a typo in the .gitignore and add a few more things to it.

These changes result in a ~1-2% speedup for 5-player and 20-player multiworlds.