### PR TITLE
Fix "Ice Trap Appearance" Tooltip

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2560,15 +2560,14 @@ setting_infos = [
         },
         gui_tooltip    = '''\
             Changes the categories of items Ice Traps may
-            appear as when freestanding.
-            (With Chest Size Matches Contents enabled,
-            Ice Traps will always appear in large chests.)
+            appear as, both when freestanding and when in
+            chests with Chest Size Matches Contents enabled. 
 
             'Major Items Only': Ice Traps appear as Major
-            Items.
+            Items (and in large chests if CSMC enabled).
 
             'Junk Items Only': Ice Traps appear as Junk
-            Items.
+            Items (and in small chests if CSMC enabled).
 
             'Anything': Ice Traps may appear as anything.
         ''',


### PR DESCRIPTION
This reverts commit ee9e091a6f14123e67117e293838b73d6b200377 so that the tooltip matches the restoration of Ice Trap looks-like items affecting Chest Size Matches Contents.