### PR TITLE
Plando: Always override randomized settings

### DIFF
--- a/Unittest.py
+++ b/Unittest.py
@@ -274,6 +274,12 @@ class TestPlandomizer(unittest.TestCase):
             for item in distribution_file['starting_items']:
                 self.assertNotIn(item, actual_pool)
 
+    def test_triforce_hunt_count_randomized_settings(self):
+        distribution_file, spoiler = generate_with_plandomizer("plando-triforce-hunt-required-amount-random-settings")
+        self.assertEqual(distribution_file['settings']['triforce_hunt'], spoiler['randomized_settings']['triforce_hunt'])
+        self.assertEqual(distribution_file['item_pool']['Triforce Piece'], spoiler['item_pool']['Triforce Piece'])
+        self.assertEqual(distribution_file['settings']['triforce_goal_per_world'], spoiler['randomized_settings']['triforce_goal_per_world'])
+
 
 class TestValidSpoilers(unittest.TestCase):
 

--- a/tests/plando/plando-triforce-hunt-required-amount-random-settings.json
+++ b/tests/plando/plando-triforce-hunt-required-amount-random-settings.json
@@ -1,0 +1,10 @@
+{
+  "settings":            {
+    "triforce_hunt":                           true,
+    "triforce_goal_per_world":                 30,
+    "randomize_settings":                      true
+  },
+  "item_pool":           {
+    "Triforce Piece":                       40
+  }
+}


### PR DESCRIPTION
Possibly very extreme, and should probably be thoroughly tested before being merged.

Stores the contents of the distribution file instead of just the distribution created from it. This has been something I've wanted to have for several issues I've run into as the Distribution is mutable, but the settings set with a distribution file should not be. If a method that doesn't require this is available, I'll begrudgingly remove this. :)

Randomized settings should always be overridden with what is set in a distribution file as long as the distribution file value has a valid weight. (It seems all values always have a valid weight currently, allowing situations like closed_forest with adult starting_age with normal randomized settings, so while I do check that the distribution value is a valid choice, it doesn't actually have any effect currently) This is done by just using the value set in the distribution file instead of letting it use random_choices.

Default values don't seem to pass the first check in get_dependency and use the second check, so I made it try to use the value specified in the plandomizer file. This allows the default forced 20 triforce_goal_per_world to be overridden, though I'm not sure if other values that shouldn't be overridden can also be overridden. I assume trial count, master quest dungeon count, and skull bridge count are all values that could be overridden this way, but I'm not sure if unintended ones could sneak in.
