### PR TITLE
Restore Readme button

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -542,6 +542,10 @@ export class GeneratorComponent implements OnInit {
     });
   }
 
+  openWikiReadme() {
+      window.open("https://wiki.ootrandomizer.com/index.php?title=Readme", "_blank");
+  }
+
   browseForFile(setting: any) { //Electron only
     this.global.browseForFile(setting.file_types).then(res => {
       this.global.generator_settingsMap[setting.name] = res;

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -776,6 +776,7 @@ export class GUIGlobal {
     delete settingsFile["presets"];
     delete settingsFile["open_output_dir"];
     delete settingsFile["open_python_dir"];
+    delete settingsFile["open_wiki_readme"];
     delete settingsFile["generate_from_file"];
 
     //Delete fromPatchFile keys if mode is fromSeed

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1228,6 +1228,12 @@ setting_infos = [
     Setting_Info('open_python_dir',   str, "Open App Directory", "Button", False, {},
         gui_params = {
             'function' : "openPythonDir",
+            'no_line_break' : True,
+        }
+    ),
+    Setting_Info('open_wiki_readme',  str, "Open Wiki Readme", "Button", False, {},
+        gui_params = {
+            'function' : "openWikiReadme",
         }
     ),
     Checkbutton(

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -20,7 +20,8 @@
             "create_cosmetics_log",
             "compress_rom",
             "open_output_dir",
-            "open_python_dir"
+            "open_python_dir",
+            "open_wiki_readme"
           ]
         },
         {


### PR DESCRIPTION
The old GUI had a link to launch the readme wiki page. This was lost during the transition to the electron angular gui. This restores that button.

The button should also appear on the website, however I'm not entirely sure how it will look in that case as I don't have the means to test it.

I also didn't try to do any sort of error handling. I believe the browser that is launched (or the new tab in the case of the website (hopefully)) handles that in a user-friendly enough manner already.
