### PR TITLE
Set error code after failure

### DIFF
--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -5,6 +5,7 @@ import logging
 import textwrap
 import time
 import datetime
+import sys
 
 from Gui import guiMain
 from Main import main, from_patch_file, cosmetic_patch
@@ -61,6 +62,7 @@ def start():
             main(settings)
     except Exception as ex:
         logger.exception(ex)
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Set a non-zero error code after printing a caught exception to the logger.

I often use [a shell script](https://pastebin.com/raw/01NuYPCm) to generate seeds until one works, which can often be necessary when testing a plando. However it relies on the output of a failed attempt to be a failure code and a successful one to be 0 so that it can stop after finding the working one.

Currently the randomizer always returns a 0 success exit code even on failure. This PR returns an 1 error exit code instead.