### PR TITLE
Copy distribution file to output when using a distribution file.

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -303,7 +303,7 @@ def patch_and_output(settings, window, spoiler, rom, start):
         cosmetics_log.to_file(cosmetic_path)
         logger.info("Created cosmetic log at: %s" % cosmetic_path)
 
-    if settings.using_distribution_file:
+    if settings.enable_distribution_file:
         window.update_status('Copying Distribution File')
         try:
             filename = os.path.join(output_dir, '%s_Distribution.json' % outfilebase)

--- a/Main.py
+++ b/Main.py
@@ -7,6 +7,7 @@ import logging
 import os, os.path
 import platform
 import random
+import shutil
 import subprocess
 import sys
 import struct
@@ -301,6 +302,15 @@ def patch_and_output(settings, window, spoiler, rom, start):
         cosmetic_path = os.path.join(output_dir, filename)
         cosmetics_log.to_file(cosmetic_path)
         logger.info("Created cosmetic log at: %s" % cosmetic_path)
+
+    if settings.using_distribution_file:
+        window.update_status('Copying Distribution File')
+        try:
+            filename = os.path.join(output_dir, '%s_Distribution.json' % outfilebase)
+            shutil.copyfile(settings.distribution_file, filename)
+            logger.info("Copied distribution file to: %s" % filename)
+        except:
+            logger.info('Distribution file copy failed.')
 
     window.update_progress(100)
     if cosmetics_log and cosmetics_log.error:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -927,6 +927,7 @@ class Distribution(object):
             'file_hash': CollapseList(self.file_hash),
             ':seed': self.settings.seed,
             ':settings_string': self.settings.settings_string,
+            ':enable_distribution_file': self.settings.enable_distribution_file,
             'settings': self.settings.to_json(),
         }
 

--- a/Settings.py
+++ b/Settings.py
@@ -189,16 +189,16 @@ class Settings:
         self.numeric_seed = self.get_numeric_seed()
 
     def load_distribution(self):
-        self.using_distribution_file = False
         if self.enable_distribution_file:
             if self.distribution_file:
                 try:
                     self.distribution = Distribution.from_file(self, self.distribution_file)
-                    self.using_distribution_file = True
                 except FileNotFoundError:
                     logging.getLogger('').warning("Distribution file not found at %s" % (self.distribution_file))
+                    self.enable_distribution_file = False
             else:
                 logging.getLogger('').warning("Plandomizer enabled, but no distribution file provided.")
+                self.enable_distribution_file = False
         elif self.distribution_file:
             logging.getLogger('').warning("Distribution file provided, but using it not enabled. "
                     "Did you mean to set enable_distribution_file?")

--- a/Settings.py
+++ b/Settings.py
@@ -189,6 +189,7 @@ class Settings:
         self.numeric_seed = self.get_numeric_seed()
 
     def load_distribution(self):
+        self.using_distribution_file = False
         if self.enable_distribution_file:
             if self.distribution_file:
                 try:


### PR DESCRIPTION
This is a simple commit that creates a copy of the distribution file used in the output folder using the same naming conventions as the spoiler and cosmetic logs.