### PR TITLE
Fix and reenable global retry

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -89,7 +89,7 @@ def main(settings, window=dummy_window()):
     random.seed(settings.numeric_seed)
     settings.resolve_random_settings(cosmetic=False)
     logger.debug(settings.get_settings_display())
-    max_attempts = 1
+    max_attempts = 10
     for attempt in range(1, max_attempts + 1):
         try:
             spoiler = generate(settings, window)
@@ -100,6 +100,7 @@ def main(settings, window=dummy_window()):
                 raise
             else:
                 logger.info('Retrying...\n\n')
+            settings.reset_distribution()
     return patch_and_output(settings, window, spoiler, rom, start)
 
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -796,11 +796,26 @@ class WorldDistribution(object):
 
 class Distribution(object):
     def __init__(self, settings, src_dict=None):
-        if src_dict is None:
-            src_dict = {}
+        self.src_dict = src_dict or {}
         self.settings = settings
         self.world_dists = [WorldDistribution(self, id) for id in range(settings.world_count)]
-        self.update(src_dict, update_all=True)
+        # One-time init
+        update_dict = {
+            'file_hash': (self.src_dict.get('file_hash', []) + [None, None, None, None, None])[0:5],
+            'playthrough': None,
+            'entrance_playthrough': None,
+            '_settings': self.src_dict.get('settings', {}),
+        }
+
+        self.settings.__dict__.update(update_dict['_settings'])
+        if 'settings' in self.src_dict:
+            self.src_dict['_settings'] = self.src_dict['settings']
+            del self.src_dict['settings']
+
+        self.__dict__.update(update_dict)
+
+        # Init we have to do every time we retry
+        self.reset()
 
 
     # adds the location entry only if there is no record for that location already
@@ -843,41 +858,27 @@ class Distribution(object):
             raise RuntimeError('Too many Triforce Pieces in starting items. There should be at most %d and there are %d.' % (worlds[0].triforce_goal - 1, total_starting_count))
 
 
-    def update(self, src_dict, update_all=False):
-        update_dict = {
-            'file_hash': (src_dict.get('file_hash', []) + [None, None, None, None, None])[0:5],
-            'playthrough': None,
-            'entrance_playthrough': None,
-            '_settings': src_dict.get('settings', {}),
-        }
+    def reset(self):
+        for world in self.world_dists:
+            world.update({}, update_all=True)
 
-        self.settings.__dict__.update(update_dict['_settings'])
-        if 'settings' in src_dict:
-            src_dict['_settings'] = src_dict['settings']
-            del src_dict['settings']
-
-        if update_all:
-            self.__dict__.update(update_dict)
-            for world in self.world_dists:
-                world.update({}, update_all=True)
-        else:
-            for k in src_dict:
-                setattr(self, k, update_dict[k])
-
-
-        if 'starting_items' not in src_dict:
+        if 'starting_items' not in self.src_dict:
             self.populate_starting_items_from_settings()
 
+        world_names = ['World %d' % (i + 1) for i in range(len(self.world_dists))]
+
         for k in per_world_keys:
-            if k in src_dict:
-                for world_id, world in enumerate(self.world_dists):
-                    world_key = 'World %d' % (world_id + 1)
-                    if world_key in src_dict[k]:
-                        world.update({k: src_dict[k][world_key]})
-                        del src_dict[k][world_key]
-                for world in self.world_dists:
-                    if src_dict[k]:
-                        world.update({k: src_dict[k]})
+            if k in self.src_dict:
+                # For each entry here of the form 'World %d', apply that entry to that world.
+                # If there are any entries that aren't of this form,
+                # apply them all to each world.
+                for world_id, world_name in enumerate(world_names):
+                    if world_name in self.src_dict[k]:
+                        self.world_dists[world_id].update({k: self.src_dict[k][world_name]})
+                src_all = {key: val for key, val in self.src_dict[k].items() if key not in world_names}
+                if src_all:
+                    for world in self.world_dists:
+                        world.update({k: src_all})
 
 
     def populate_starting_items_from_settings(self):

--- a/Settings.py
+++ b/Settings.py
@@ -204,10 +204,17 @@ class Settings:
         else:
             self.distribution = Distribution(self)
 
+        self.reset_distribution()
+
+        self.numeric_seed = self.get_numeric_seed()
+
+
+    def reset_distribution(self):
+        self.distribution.reset()
+
         for location in self.disabled_locations:
             self.distribution.add_location(location, '#Junk')
 
-        self.numeric_seed = self.get_numeric_seed()
 
     def check_dependency(self, setting_name, check_random=True):
         return self.get_dependency(setting_name, check_random) == None


### PR DESCRIPTION
I set the retry to 10, don't know if that's high or not. I still see fuzzer seeds that fail even that many attempts.

---

Because the distribution is used for spoiler output, when we generate
the item pool, we save it in the distribution. This is a problem when
retrying, because we generate a new item pool, and this could have more
shop items in it than shop locations.

So, to fix that, we split the Distribution update method (only ever
called on init) into once-only init and once-per-retry reset. This was
already clearing the WorldDistributions to start with.

And then remember to forward disabled locations back into the distribution.