### PR TITLE
editing lens logic for scrubs settings

### DIFF
--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -215,7 +215,6 @@
       "logic_lens_castle",
       "logic_lens_gtg",
       "logic_lens_shadow",
-      "logic_lens_shadow_back",
       "logic_lens_spirit"
     ],
     "no_escape_sequence": true,


### PR DESCRIPTION
small edit to scrubs setting preset - removes the trick "logic_lens_shadow_back" to require lens for logic for the back half of shadow temple (invisible platform and beyond)