### PR TITLE
Update signs and other messages to reflect entrance randomizer

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -20,7 +20,7 @@ from OcarinaSongs import replace_songs
 from MQ import patch_files, File, update_dmadata, insert_space, add_relocations
 from SaveContext import SaveContext
 import StartingItems
-from SignUpdater import replace_overworld_signs, sign_actor_table
+from SignUpdater import update_entrance_messages, sign_actor_table
 
 
 def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
@@ -1678,8 +1678,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     write_shop_items(rom, shop_item_file.start + 0x1DEC, shop_items)
 
     # Replace the signs and dialogue to reflect entrance randomizer
-    replace_overworld_signs(messages, world)
-    revise_entrance_signs(rom)
+    update_entrance_messages(messages, world)
+    update_entrance_msg_actors(rom)
 
     permutation = None
 
@@ -1934,7 +1934,7 @@ def count_zero_bits(num):
         count += 1
     return count
 
-def revise_entrance_signs(rom):
+def update_entrance_msg_actors(rom):
     def change_sign_msg(rom, actor_id, actor, scene):
         for sign in sign_actor_table:
             # Match actor id and scene

--- a/Patches.py
+++ b/Patches.py
@@ -20,6 +20,7 @@ from OcarinaSongs import replace_songs
 from MQ import patch_files, File, update_dmadata, insert_space, add_relocations
 from SaveContext import SaveContext
 import StartingItems
+from SignUpdater import replace_overworld_signs
 
 
 def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
@@ -1534,6 +1535,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
         # Update grotto actors based on their new entrance
         set_grotto_shuffle_data(rom, world)
+
+    if True: # This should be changed later to check for entrance randomizer
+        replace_overworld_signs(messages, world)
 
     if world.shuffle_cows:
         rom.write_byte(rom.sym('SHUFFLE_COWS'), 0x01)

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -1,257 +1,204 @@
+from collections import namedtuple
 from World import World
 from Messages import update_message_by_id, get_message_by_id
 
-# Complex things to replace
-# 0x300A - has an option to ask about dc
-# 0x300D - Comes up when you ask about dc in 0x300A
+# New messages added to the table at 0x0390-0x0394, 0x0290-0x0293
 
 # COULD ADD A NEW FUNCTION TO CENTER TEXT.
 # - Would need to know length of each character in pixels
 # - Would need max length of text in pixels
 # - Can then compute how much spec to prepend to a line.
 
-# CHANGE WHERE SIGN ACTORS POINT FOR DUPLICATES, NEW MESSAGES SHOULD BE 0X9000+
-# - 0x9000-0x9003 are used.
+# THINGS REMAINING TO DO
+# - owls
+# - Fix the doors no longer being locked after changing msg
+# - Deal with the front/back kak potion shop doors
+# - Write a function to center text
+# - Add grotto region names
 
-DUNGEON_SIGNS = {
-    0x0307: [['Kakariko Village -> Bottom of the Well']," Dark! Narrow! Scary!\x01{}", 0x13],
-    0x030A: [['Dodongos Cavern Entryway -> Dodongos Cavern Beginning'], "{}\x01Don't enter without permission!", 0x13],
-    0x0312: [['KF Outside Deku Tree -> Deku Tree Lobby'], "Just ahead:\x01{}", 0x13],
-    0x031B: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'], "{}\x01Only registered members are\x01allowed!", 0x13],
-    # 0x6013: GTG with no card
-    # 0x6014: GTG with card
-}
+#   id      Entrance list                                                   opts    category    Message
+SIGN_LIST = {
+    # Dungeon
+    0x0307: [['Kakariko Village -> Bottom of the Well'],                    0x13,   'dungeon',      "Dark! Narrow! Scary!\x01{}"], # Square sign in front of well
+    0x030A: [['Dodongos Cavern Entryway -> Dodongos Cavern Beginning'],     0x13,   'dungeon',      "{}\x01Don't enter without permission!"], # Sign pointing into dodongo's cavern
+    0x030F: [['Zoras Fountain -> Jabu Jabus Belly Beginning'],              0x13,   'dungeon',      "{}\x01Don't disturb Lord Jabu-Jabu!\x01--King Zora XVI"], # Sign outside of jabu as child
+    0x0312: [['KF Outside Deku Tree -> Deku Tree Lobby'],                   0x13,   'dungeon',      "Just ahead:\x01{}"], # Sign in kokiri pointing towards deku tree
+    0x031B: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'],          0x13,   'dungeon',      "{}\x01Only registered members are\x01allowed!"], # Sign outside of gtg
+    0x6013: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'],          0x00,   'dungeon',      "This is the\x01{}\x04Nobody is allowed to enter\x01without a membership card."], # Talk to gtg entrance without card
+    0x6014: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'],          0x00,   'dungeon',      "This is the\x01{}\x04Membership card verified.\x04One try for 10 Rupees!\x04\x1b\x01Try\x01Don't try"], # Talk to npc to enter gtg with card LOOKS BAD
 
-INDOORS_SIGNS = {
-    0x020E: [['Kakariko Village -> Kak Potion Shop Front'], "kakdoor:{}\x01Closed until morning", 0x20], # Potion Shop at night ALSO USED IN MARKET
-    0x020F: [['Kakariko Village -> Kak Shooting Gallery'], "kakdoor:{}\x01Open only during the day", 0x20], # Kak shooting gallery (check child message)
-    0x0210: [['Market -> Market Mask Shop'], "{}\x01Now hiring part-time\x01Apply during the day", 0x20], # Mask shop door ALSO USED IN MARKET
-    0x0211: [['Kakariko Village -> Kak Bazaar'], "kakdoor:{}\x01Open only during the day", 0x20], # Kak Bazaar at night ALSO USED IN MARKET
-    0x023A: [['Lake Hylia -> LH Fishing Hole'], "{}", 0x20],
-    # 0x0301: Hyrule Field (GV -> field, lake->field, kak->field)
-    # 0x0302: Hyrule Castle Town
-    # 0x0303: The Temple of Time
-    # 0x030F: Zoras fountain dont disturb lord jabu jabu --king zora xvi
-    # 0x0313: Forest Temple
-    0x0318: [['Lake Hylia -> LH Lab'], "{}", 0x13],
-    
-    # 0x031D: Spirit Temple
-    0x031E: [['Kokiri Forest -> KF Kokiri Shop'], "{}", 0x13],
-    0x031F: [['Kokiri Forest -> KF Links House'], "{}", 0x13],
-    # 0x032D: moutain summit danger ahead - keep out
-    0x0333: [['Zoras Domain -> ZD Shop'], "{}", 0x13],
-    0x033C: [['Kokiri Forest -> KF Midos House'], "{}", 0x13],
-    0x033D: [['Kokiri Forest -> KF Know It All House'], "{}", 0x13],
-    0x033E: [['Kokiri Forest -> KF House of Twins'], "{}", 0x13],
-    0x033F: [['Kokiri Forest -> KF Sarias House'], "{}", 0x13],
-    # 0x0345: visit the house of the know it all brothers to get answers to all your item-related questions
-}
+    # Indoors
+    # The kak potion shop doors read the same message, have the same scene, and the same actor_id. How do I tell them apart??
+    # 0x020E: [['Kakariko Village -> Kak Potion Shop Front'],                 0x20,   'indoor',   "{}\x01Closed until morning"], # Kak Potion Shop at night (msg 0290 and 0293 splits off here)
+    0x0290: [['Market -> Market Potion Shop'],                              0x20,   'indoor',       "{}\x01Closed until morning"], # New message for Market Potion shop at night
+    # 0x0293: [['Kak Backyard -> Kak Potion Shop Back']], # New message for Kak potion shop back at night
+    0x020F: [['Kakariko Village -> Kak Shooting Gallery'],                  0x20,   'indoor',       "{}\x01Open only during the day"], # Kak shooting gallery at night (msg 0291 splits off here)
+    0x0291: [['Market -> Market Shooting Gallery'],                         0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market shooting gallery at night
+    0x0210: [['Market -> Market Mask Shop'],                                0x20,   'indoor',       "{}\x01Now hiring part-time\x01Apply during the day"], # Mask shop at night
+    0x0211: [['Kakariko Village -> Kak Bazaar'],                            0x20,   'indoor',       "{}\x01Open only during the day"], # Kak Bazaar at night (msg 0x0292 splits off here)
+    0x0292: [['Market -> Market Bazaar'],                                   0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market bazaar at night
+    0x023A: [['Lake Hylia -> LH Fishing Hole'],                             0x20,   'indoor',       "{}"],
+    0x0318: [['Lake Hylia -> LH Lab'],                                      0x13,   'indoor',       "{}"],
+    0x031E: [['Kokiri Forest -> KF Kokiri Shop'],                           0x13,   'indoor',       "{}"],
+    0x031F: [['Kokiri Forest -> KF Links House'],                           0x13,   'indoor',       "{}"],
+    0x0333: [['Zoras Domain -> ZD Shop'],                                   0x13,   'indoor',       "{}"],
+    0x033C: [['Kokiri Forest -> KF Midos House'],                           0x13,   'indoor',       "{}"],
+    0x033D: [['Kokiri Forest -> KF Know It All House'],                     0x13,   'indoor',       "{}"],
+    0x033E: [['Kokiri Forest -> KF House of Twins'],                        0x13,   'indoor',       "{}"],
+    0x033F: [['Kokiri Forest -> KF Sarias House'],                          0x13,   'indoor',       "{}"],
+    0x5020: [['Graveyard -> Graveyard Composers Grave'],                    0x20,   'indoor',       "{}"], # Read the gravestone atop the composer grave
+    0x020D: [['Market -> Market Treasure Chest Game'],                      0x20,   'indoor',       "{}\x01Temporarily Closed\x01Open Tonight!"], # Treasure chest game at night
+    0x0226: [['Kak Backyard -> Kak Odd Medicine Building'],                 0x20,   'indoor',       "{}\x01Closed\x04Gone for Field Study\x01Please come again!\x01--Granny"], # Granny's Potion Shop as child
 
-OW_SIGNS = {
-    # 0x0305: [['Hyrule Field -> Kakariko Village'], "{}"], # This sign is in 2 spots. I think I need to make a new one! field->kak and dmt->kak
-    0x0306: [['Kakariko Village -> Graveyard'], "{}", 0x13],
-    0x0308: [['Kak Behind Gate -> Death Mountain'], "{}", 0x13],
-    0x030B: [['Death Mountain -> Goron City'], "{}", 0x13],
-    0x030C: [['Hyrule Field -> ZR Front'], "{}", 0x13],
-    # 0x030E: [['Zoras Fountain -> ZD Behind King Zora'], "zf->zd: {}", 0x13], # ZF pointing into ZD (DUPLICATE IN ZD) - leave this ID and associate the sign actor in ZF to 0x9004
-    0x9004: [['Zoras Fountain -> ZD Behind King Zora'], "mega dong: {}", 0x13],
-    0x0314: [['Kokiri Forest -> Lost Woods'], "{}", 0x13],
-    0x0315: [['Hyrule Field -> Lon Lon Ranch'], "{}", 0x13],
-    0x0316: [['Hyrule Field -> Lon Lon Ranch'], "{}", 0x13],
-    0x0317: [['Hyrule Field -> Lake Hylia'], "{}", 0x13],
-    # 0x0319: [['Hyrule Field -> Gerudo Valley'], "{}", 0x13], # This sign is also in gf pointing to gv
-    0x031C: [['GF Outside Gate -> Wasteland Near Fortress'], "{}", 0x13], # hw if you chase a mirage... MAKE SUR EITS NOT IN COLOSSSUS
-    0x0320: [['Kokiri Forest -> LW Bridge From Forest'], "{}", 0x13],
-    0x0321: [['Death Mountain -> Goron City'], "Follow the trail along the edge of\x01the cliff and you will reach\x01{}", 0x13],
-    0x0323: [['Death Mountain Summit -> DMC Upper Local'], "Death Mountain Summit\x01Entrance to {}\x01ahead", 0x13], # Color 'Death Mountain Summit'
-    0x0339: [['Hyrule Field -> Market Entrance', 'Hyrule Field -> Lon Lon Ranch'], "{}\x01{}", 0x13], # Sign outside of Kokiri Forest in Hyrule Field
-    0x033A: [['Hyrule Field -> Market Entrance', 'Hyrule Field -> Lon Lon Ranch'], "You are here: {}\x01This way to {}", 0x13], # Sign between market and llr
-    0x6069: [['GV Fortress Side -> Gerudo Fortress'], "{} is located beyond this gate.\x01A kid like you has no business there.", 0x13],
-}
+    # Overworld
+    0x0301: [['Gerudo Valley -> Hyrule Field'],                             0x13,   'overworld',    "{}"], # Arrow sign GV -> field (msgs 391 and 392 split off here)
+    0x0391: [['Lake Hylia -> Hyrule Field'],                                0x13,   'overworld',    "{}"], # New msg for Arrow sign lake -> field
+    0x0392: [['Kakariko Village -> Hyrule Field'],                          0x13,   'overworld',    "{}"], # New msg for arrow sign kak -> field
+    0x0305: [['Death Mountain -> Kak Behind Gate'],                         0x13,   'overworld',    "{}"], # Arrow sign DMT-> kak (msg 390 splits off here)
+    0x0390: [['Hyrule Field -> Kakariko Village'],                          0x13,   'overworld',    "{}"], # New message for field -> kak arrow sign
+    0x0306: [['Kakariko Village -> Graveyard'],                             0x13,   'overworld',    "{}"],
+    0x0308: [['Kak Behind Gate -> Death Mountain'],                         0x13,   'overworld',    "{}"],
+    0x030B: [['Death Mountain -> Goron City'],                              0x13,   'overworld',    "{}"],
+    0x030C: [['Hyrule Field -> ZR Front'],                                  0x13,   'overworld',    "{}"],
+    0x0393: [['Zoras Fountain -> ZD Behind King Zora'],                     0x13,   'overworld',    "{}"], # New msg for arrow sign zf -> zd
+    0x0314: [['Kokiri Forest -> Lost Woods'],                               0x13,   'overworld',    "{}"],
+    0x0315: [['Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "{}"],
+    0x0316: [['Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "{}"],
+    0x0317: [['Hyrule Field -> Lake Hylia'],                                0x13,   'overworld',    "{}"],
+    0x0319: [['Hyrule Field -> Gerudo Valley'],                             0x13,   'overworld',    "{}"], # Arrow sign field -> gv (msg 394 splits off here)
+    0x0394: [['Gerudo Fortress -> GV Fortress Side'],                       0x13,   'overworld',    "{}"], # New msg for arrow sign gf -> gv
+    0x031C: [['GF Outside Gate -> Wasteland Near Fortress'],                0x13,   'overworld',    "{}"],
+    0x0320: [['Kokiri Forest -> LW Bridge From Forest'],                    0x13,   'overworld',    "{}"],
+    0x0321: [['Death Mountain -> Goron City'],                              0x13,   'overworld',    "Follow the trail along the edge of\x01the cliff and you will reach\x01{}"], # Sign half-way up dmt
+    0x0323: [['Death Mountain Summit -> DMC Upper Local'],                  0x13,   'overworld',    "\x05\41Death Mountain Summit\x05\40\x01Entrance to {}\x01ahead"], # Square sign dmt -> crater
+    0x0339: [['Hyrule Field -> Market Entrance',
+              'Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "{}\x01{}"], # Sign outside of Kokiri Forest in Hyrule Field
+    0x033A: [['Hyrule Field -> Market Entrance',
+              'Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "You are here: {}\x01This way to {}"], # Sign in field between market and llr
+    0x6069: [['GV Fortress Side -> Gerudo Fortress'],                       0x13,   'overworld',    "{} is located beyond\x01this gate.\x01A kid like you has no business there."], # Gerudo gaurd on the gv bridge as child
 
-SPECIAL_OW_SIGNS = {
-    #0x4003: # lake owl
-        #What are you doing? You've come 
-        #a long way to get up here...You should look at the Map 
-        #Subscreen sometimes.
-        #
-        #[Link], this is a beautiful
-        #lake full of pure, clear water.
-        #
-        #At the lake bottom there is
-        #a Water Temple used to worship 
-        #the water spirits. The Zoras are
-        #guardians of the temple. Hoo hoo.
-
-        #The Zoras come from Zora's
-        #Domain in northeast Hyrule. An
-        #aquatic race, they are longtime
-        #allies of Hyrule's Royal Family.
-
-        #I heard that only the Royal Family
-        #of Hyrule can enter Zora's Domain...
-        #Hoo hoo!
-
-        #I'm on my way back to the castle.
-        #If you want to come with me, hold
-        #on to my talons!
-    #DMT owl
+    # Owls
+    # 0x4003: [[],], # Lake owl
+    # DMT owl
 }
 
 REGION_NAMES = {
     # Dungeons
-    'Deku Tree Lobby': "\x05\42Deku Tree\x05\40",
-    'Dodongos Cavern Beginning': "\x05\41Dodongo's Cavern\x05\40",
-    'Jabu Jabus Belly Beginning': "\x05\43Jabu Jabu's Belly\x05\40",
-    'Forest Temple Lobby': "\x05\42Forest Temple\x05\40",
-    'Fire Temple Lower': "\x05\41Fire Temple\x05\40",
-    'Water Temple Lobby': "\x05\43Water Temple\x05\40",
-    'Spirit Temple Lobby': "\x05\46Spirit Temple\x05\40",
-    'Shadow Temple Entryway': "\x05\45Shadow Temple\x05\40",
-    'Bottom of the Well': "\x05\41Bottom of the Well\x05\40",
-    'Ice Cavern Beginning': "\x05\43Ice Cavern\x05\40",
-    'Gerudo Training Grounds Lobby': "\x05\46Gerudo Training Grounds\x05\40",
+    "\x05\42Deku Tree\x05\40":                  ['Deku Tree Lobby'],
+    "\x05\41Dodongo's Cavern\x05\40":           ['Dodongos Cavern Beginning'],
+    "\x05\43Jabu Jabu's Belly\x05\40":          ['Jabu Jabus Belly Beginning'],
+    "\x05\42Forest Temple\x05\40":              ['Forest Temple Lobby'],
+    "\x05\41Fire Temple\x05\40":                ['Fire Temple Lower'],
+    "\x05\43Water Temple\x05\40":               ['Water Temple Lobby'],
+    "\x05\46Spirit Temple\x05\40":              ['Spirit Temple Lobby'],
+    "\x05\45Shadow Temple\x05\40":              ['Shadow Temple Entryway'],
+    "\x05\41Bottom of the Well\x05\40":         ['Bottom of the Well'],
+    "\x05\43Ice Cavern\x05\40":                 ['Ice Cavern Beginning'],
+    "\x05\46Gerudo Training Grounds\x05\40":    ['Gerudo Training Grounds Lobby'],
 
     # Indoors
-    'KF Midos House': "\x05\44Mido's House\x05\40",
-    'KF Sarias House': "\x05\44Saria's House\x05\40",
-    'KF House of Twins': "\x05\44House of Twins\x05\40",
-    'KF Know It All House': "\x05\44Know It All House\x05\40",
-    'KF Kokiri Shop': "\x05\44Kokiri Shop\x05\40",
-    'LH Lab': "\x05\44Lakeside Laboratory\x05\40",
-    'LH Fishing Hole': "\x05\44Fishing Pond\x05\40",
-    'GV Carpenter Tent': "\x05\44Carpenter's Tent\x05\40",
-    'Market Guard House': "\x05\44Guard House\x05\40",
-    'Market Mask Shop': "\x05\44Mask Shop\x05\40",
-    'Market Bombchu Bowling': "\x05\44Bombchu Bowling\x05\40",
-    'Market Potion Shop': "\x05\44Potion Shop\x05\40",
-    'Market Treasure Chest Game': "\x05\44Treasure Chest Game\x05\40",
-    'Market Bombchu Shop': "\x05\44Bombchu Shop\x05\40",
-    'Market Man in Green House': "\x05\44House\x05\40", # Better name for this?
-    'Kak Carpenter Boss House': "\x05\44House\x05\40", # Better name for this?
-    'Kak House of Skulltula': "\x05\44House of Skulltula\x05\40",
-    'Kak Impas House': "\x05\44Impa's House\x05\40",
-    'Kak Impas House Back': "\x05\44Impa's House\x05\40", # Differentiate or nah?
-    'Kak Odd Medicine Building': "\x05\44Oddity Shop\x05\40", # Better name?
-    'Graveyard Dampes House': "\x05\44Dampe's House\x05\40",
-    'GC Shop': "\x05\44Goron Shop\x05\40",
-    'ZD Shop': "\x05\44Zora Shop\x05\40",
-    'LLR Talons House': "\x05\44Talon's House\x05\40",
-    'LLR Stables': "\x05\44Lon Lon Stable\x05\40",
-    'LLR Tower': "\x05\44Lon Long Tower\x05\40",
-    'Market Bazaar': "\x05\44Bazaar\x05\40",
-    'Market Shooting Gallery': "\x05\44Shooting Gallery\x05\40",
-    'Kak Bazaar': "\x05\44Bazaar\x05\40",
-    'Kak Shooting Gallery': "\x05\44Shooting Gallery\x05\40",
-    'Colossus Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
-    'HC Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
-    'OGC Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
-    'DMC Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
-    'DMT Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
-    'ZF Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
-    'KF Links House': "\x05\44\x0F's House\x05\40",
-    'Temple of Time': "\x05\44Temple of Time\x05\40",
-    'Kak Windmill': "\x05\44Windmill\x05\40",
-    'Kak Potion Shop Front': "\x05\44Potion Shop\x05\40",
-    'Kak Potion Shop Back': "\x05\44Potion Shop\x05\40",
+    "\x05\44Mido's House\x05\40":               ['KF Midos House'],
+    "\x05\44Saria's House\x05\40":              ['KF Sarias House'],
+    "\x05\44House of Twins\x05\40":             ['KF House of Twins'],
+    "\x05\44Know It All House\x05\40":          ['KF Know It All House'],
+    "\x05\44Kokiri Shop\x05\40":                ['KF Kokiri Shop'],
+    "\x05\44Lakeside Laboratory\x05\40":        ['LH Lab'],
+    "\x05\44Fishing Pond\x05\40":               ['LH Fishing Hole'],
+    "\x05\44Carpenter's Tent\x05\40":           ['GV Carpenter Tent'],
+    "\x05\44Guard House\x05\40":                ['Market Guard House'],
+    "\x05\44Mask Shop\x05\40":                  ['Market Mask Shop'],
+    "\x05\44Bombchu Bowling\x05\40":            ['Market Bombchu Bowling'],
+    "\x05\44Potion Shop\x05\40":                ['Market Potion Shop', 'Kak Potion Shop Front', 'Kak Potion Shop Back'],
+    "\x05\44Treasure Chest Game\x05\40":        ['Market Treasure Chest Game'],
+    "\x05\44Bombchu Shop\x05\40":               ['Market Bombchu Shop'],
+    "\x05\44Back Alley House\x05\40":           ['Market Man in Green House'],
+    "\x05\44Carpenter's House\x05\40":          ['Kak Carpenter Boss House'],
+    "\x05\44House of Skulltula\x05\40":         ['Kak House of Skulltula'],
+    "\x05\44Impa's House\x05\40":               ['Kak Impas House', 'Kak Impas House Back'],
+    "\x05\44Oddity Shop\x05\40":                ['Kak Odd Medicine Building'],
+    "\x05\44Dampe's House\x05\40":              ['Graveyard Dampes House'],
+    "\x05\44Goron Shop\x05\40":                 ['GC Shop'],
+    "\x05\44Zora Shop\x05\40":                  ['ZD Shop'],
+    "\x05\44Talon's House\x05\40":              ['LLR Talons House'],
+    "\x05\44Lon Lon Stable\x05\40":             ['LLR Stables'],
+    "\x05\44Lon Lon Tower\x05\40":              ['LLR Tower'],
+    "\x05\44Bazaar\x05\40":                     ['Market Bazaar', 'Kak Bazaar'],
+    "\x05\44Shooting Gallery\x05\40":           ['Market Shooting Gallery', 'Kak Shooting Gallery'],
+    "\x05\44Great Fairy Fountain\x05\40":       ['Colossus Great Fairy Fountain', 'HC Great Fairy Fountain', 'OGC Great Fairy Fountain', 'DMC Great Fairy Fountain', 'DMT Great Fairy Fountain', 'ZF Great Fairy Fountain'],
+    "\x05\44\x0F's House\x05\40":               ['KF Links House'],
+    "\x05\44Temple of Time\x05\40":             ['Temple of Time'],
+    "\x05\44Windmill\x05\40":                   ['Kak Windmill'],
+    
+    # Overworld
+    "\x05\41Kokiri Forest\x05\x40":             ['Kokiri Forest'],
+    "\x05\42Lost Woods Bridge\x05\x40":         ['LW Bridge From Forest', 'LW Bridge'],
+    "\x05\42Lost Woods\x05\x40":                ['Lost Woods', 'LW Beyond Mido', 'LW Forest Exit'],
+    "\x05\41Goron City\x05\x40":                ['GC Woods Warp', 'GC Darunias Chamber', 'Goron City'],
+    "\x05\43Zora River\x05\x40":                ['Zora River', 'ZR Behind Waterfall', 'ZR Front'],
+    "\x05\41Sacred Forest Meadow\x05\x40":      ['SFM Entryway'],
+    "\x05\44Hyrule Field\x05\x40":              ['Hyrule Field'],
+    "\x05\43Lake Hylia\x05\x40":                ['Lake Hylia'],
+    "\x05\46Gerudo Valley\x05\x40":             ['Gerudo Valley', 'GV Fortress Side'],
+    "\x05\44Market Entrance\x05\x40":           ['Market Entrance'],
+    "\x05\45Kakariko Village\x05\x40":          ['Kakariko Village', 'Kak Behind Gate', 'Kak Impas Ledge'],
+    "\x05\46Lon Lon Ranch\x05\x40":             ['Lon Lon Ranch'],
+    "\x05\43Zora's Domain\x05\x40":             ['Zoras Domain', 'ZD Behind King Zora'],
+    "\x05\41Gerudo Fortress\x05\x40":           ['Gerudo Fortress', 'GF Outside Gate'],
+    "\x05\46Haunted Wasteland\x05\x40":         ['Wasteland Near Fortress', 'Wasteland Near Colossus'],
+    "\x05\44Desert Colossus\x05\x40":           ['Desert Colossus'],
+    "\x05\44Market\x05\x40":                    ['Market'],
+    "\x05\44Castle Grounds\x05\x40":            ['Castle Grounds'],
+    "\x05\44Temple of Time Entrance\x05\x40":   ['ToT Entrance'],
+    "\x05\45Graveyard\x05\x40":                 ['Graveyard'],
+    "\x05\41Death Mountain Trail\x05\x40":      ['Death Mountain', 'Death Mountain Summit'],
+    "\x05\41Death Mountain Crater\x05\x40":     ['DMC Lower Local', 'DMC Lower Nearby', 'DMC Upper Local', 'DMC Upper Nearby'],
+    "\x05\43Zora's Fountain\x05\x40":           ['Zoras Fountain'],
 
-    # Overworld - THESE SHOULD ALL BE COLORED APPROPRIATELY
-    'Kokiri Forest': "\x05\41Kokiri Forest\x05\x40",
-
-    'LW Bridge From Forest': "\x05\42Lost Woods Bridge\x05\x40",
-    'LW Bridge':             "\x05\42Lost Woods Bridge\x05\x40",
-
-    'Lost Woods':     "\x05\42Lost Woods\x05\x40",
-    'LW Forest Exit': "\x05\42Lost Woods\x05\x40", # Is this right?
-    'LW Beyond Mido': "\x05\42Lost Woods\x05\x40",
-
-    'GC Woods Warp':       "\x05\41Goron City\x05\x40",
-    'Goron City':          "\x05\41Goron City\x05\x40",
-    'GC Darunias Chamber': "\x05\41Goron City\x05\x40",
-
-    'Zora River':          "\x05\43Zora River\x05\x40",
-    'ZR Front':            "\x05\43Zora River\x05\x40",
-    'ZR Behind Waterfall': "\x05\43Zora River\x05\x40",
-
-    'SFM Entryway': "\x05\41Sacred Forest Meadow\x05\x40",
-
-    'Hyrule Field': "\x05\44Hyrule Field\x05\x40",
-
-    'Lake Hylia':    "\x05\43Lake Hylia\x05\x40",
-    'LH Owl Flight': "\x05\43Lake Hylia\x05\x40",
-
-    'Gerudo Valley':    "\x05\46Gerudo Valley\x05\x40",
-    'GV Fortress Side': "\x05\46Gerudo Valley\x05\x40",
-
-    'Market Entrance': "\x05\44Market Entrance\x05\x40",
-
-    'Kakariko Village': "\x05\45Kakariko Village\x05\x40",
-    'Kak Behind Gate':  "\x05\45Kakariko Village\x05\x40",
-    'Kak Impas Ledge':  "\x05\45Kakariko Village\x05\x40",
-
-    'Lon Lon Ranch': "\x05\46Lon Lon Ranch\x05\x40",
-
-    'Zoras Domain':        "\x05\43Zora's Domain\x05\x40",
-    'ZD Behind King Zora': "\x05\43Zora's Domain\x05\x40",
-
-    'Gerudo Fortress': "\x05\41Gerudo Fortress\x05\x40",
-    'GF Outside Gate': "\x05\41Gerudo Fortress\x05\x40",
-
-    'Wasteland Near Fortress': "\x05\46Haunted Wasteland\x05\x40",
-    'Wasteland Near Colossus': "\x05\46Haunted Wasteland\x05\x40",
-
-    'Desert Colossus': "\x05\44Desert Colossus\x05\x40",
-
-    'Market': "\x05\44Market\x05\x40",
-
-    'Castle Grounds': "\x05\44Castle Grounds\x05\x40",
-
-    'ToT Entrance': "\x05\44Temple of Time Entrance\x05\x40",
-
-    'Graveyard': "\x05\45Graveyard\x05\x40",
-
-    'Death Mountain':        "\x05\41Death Mountain Trail\x05\x40",
-    'Death Mountain Summit': "\x05\41Death Mountain Trail\x05\x40", # I think...
-    'DMT Owl Flight':        "\x05\41Death Mountain Trail\x05\x40",
-
-    'DMC Lower Local':  "\x05\41Death Mountain Crater\x05\x40",
-    'DMC Lower Nearby': "\x05\41Death Mountain Crater\x05\x40",
-    'DMC Upper Local':  "\x05\41Death Mountain Crater\x05\x40",
-    'DMC Upper Nearby': "\x05\41Death Mountain Crater\x05\x40",
-
-    'Zoras Fountain': "\x05\43Zora's Fountain\x05\x40",
-
-
-    # Grotto
-    # Fill these in eventually, not needed until I worry about mixed pools
+    # Grottos
+    "Royal Family's Tomb":                      ['Graveyard Composers Grave'],
 }
+
+SignActor = namedtuple('SignActor', ['origmsg', 'newmsg', 'actor_id', 'scene', 'mask', 'actorprops'])
+sign_actor_table = [
+    #         origmsg   newmsg      actorid     scene   mask        actorprops
+    SignActor(0x01,     0x91,       0x0039,     0x57,   0xFF00,     None),          # Arrow sign from lake -> field
+    SignActor(0x01,     0x92,       0x0039,     0x52,   0xFF00,     None),          # Arrow sign from kak -> field
+    SignActor(0x05,     0x90,       0x0039,     0x51,   0xFF00,     None),          # Arrow sign from Field -> Kak
+    SignActor(0x0E,     0x93,       0x0039,     0x59,   0xFF00,     None),          # Arrow sign from fountain -> domain
+    SignActor(0x0E,     0x90,       0x0009,     0x21,   0x003F,     (0x0380, 0x5)), # Market potion at night
+    SignActor(0x0F,     0x91,       0x0009,     0x21,   0x003F,     (0x0380, 0x5)), # Market shooting gallery at night
+    SignActor(0x11,     0x92,       0x0009,     0x21,   0x003F,     (0x0380, 0x5)), # Market bazaar at night
+]
 
 
 def replace_overworld_signs(messages, world):
-    SIGNS = {**INDOORS_SIGNS, **OW_SIGNS, **DUNGEON_SIGNS}
-
-    testid = 0x030f
+    testid = 0x6014
     print('--------------------------------')
     print(get_message_by_id(messages, testid))
     print('--------------------------------')
 
-    for sign_id, entrance_info in SIGNS.items():
-        entrance_list, sign_text, opts = entrance_info
+    for sign_id, entrance_info in SIGN_LIST.items():
+        entrance_list, opts, category, sign_text = entrance_info
         destination_list = [world.get_entrance(entr).connected_region.name for entr in entrance_list]
 
-
-        # Replace the text with cleaner, formatted text
+        # Replace the text with cleaner, formatted text (there HAS to be a better way to do this...)
         for idx in range(len(destination_list)):
-            try:
-                clean_dest = REGION_NAMES[destination_list[idx]]
-            except KeyError:
-                clean_dest = world.get_entrance(entrance[0]).connected_region.name
-                print("MISSING REGION NAME: " + dest)
+            clean_dest = None
+            for formatted_region, raw_region_list in REGION_NAMES.items():
+                if destination_list[idx] in raw_region_list:
+                    clean_dest = formatted_region
+                    break
+
+            # Print a message if not found
+            if clean_dest is None:
+                print("MISSING REGION NAME: " + destination_list[idx])
+                clean_dest = destination_list[idx]
+
             destination_list[idx] = clean_dest
 
         # Update the messages table
-        update_message_by_id(messages, sign_id, sign_text.format(*destination_list), opts) # Opts at the end are the text box type and position values WRAP THIS INTO THE TABLE ABOVE
-
+        teststr = entrance_list[0]+"\x01"
+        update_message_by_id(messages, sign_id, teststr+sign_text.format(*destination_list), opts) # Opts at the end are the text box type and position values WRAP THIS INTO THE TABLE ABOVE
 
     print('--------------------------------')
     print(get_message_by_id(messages, testid))

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -1,0 +1,103 @@
+from World import World
+from Messages import update_message_by_id
+
+# Color can be added to dungeons and whatnot in the REGION NAMES section
+
+# Complex things to replace
+# 0x300A - has an option to ask about dc
+# 0x300D - Comes up when you ask about dc in 0x300A
+
+DUNGEON_SIGNS = {
+    0x0307: ['Kakariko Village -> Bottom of the Well'," Dark! Narrow! Scary!\x01%s"],
+    0x030A: ['Dodongos Cavern Entryway -> Dodongos Cavern Beginning', "%s\x01Don't enter without permission!"],
+    0x0312: ['KF Outside Deku Tree -> Deku Tree Lobby', "Just ahead:\x01%s"],
+}
+
+INDOORS_SIGNS = {
+    0x023A: ['Lake Hylia -> LH Fishing Hole', "%s"],
+    # 0x0301: Hyrule Field (GV -> field, lake->field, kak->field)
+    # 0x0302: Hyrule Castle Town
+    # 0x0303: The Temple of Time
+    # 0x030F: Zoras fountain dont disturb lord jabu jabu --king zora xvi
+    # 0x0311: All those reckless enough to venture into the desert--please drop by our shop. Carpet merchant
+    # 0x0313: Forest Temple
+    # 0x0315: Talon and Malons Lon Lon Rang
+    # 0x0316: The Great Ingos Ingo Ranch
+    0x0318: ['Lake Hylia -> LH Lab', "%s"],
+    # 0x031B: Gerudo Training Ground only registered members are allowed
+    # 0x031C: haunted wasteland if you chase a mirage, the desert will swallow you. Only on path is true
+    # 0x031D: Spirit Temple
+    0x031E: ['Kokiri Forest -> KF Kokiri Shop', "%s"],
+    0x031F: ['Kokiri Forest -> KF Links House', "%s"],
+    # 0x032D: moutain summit danger ahead - keep out
+    0x0333: ['Zoras Domain -> ZD Shop', "%s"],
+    0x033C: ['Kokiri Forest -> KF Midos House', "%s"],
+    0x033D: ['Kokiri Forest -> KF Know It All House', "%s"],
+    0x033E: ['Kokiri Forest -> KF House of Twins', "%s"],
+    0x033F: ['Kokiri Forest -> KF Sarias House', "%s"],
+    # 0x0345: visit the house of the know it all brothers to get answers to all your item-related questions
+}
+
+OW_SIGNS = {
+    # 0x0305: ['Hyrule Field -> Kakariko Village', "%s"], # This sign is in 2 spots. I think I need to make a new one! field->kak and dmt->kak
+    0x0306: ['Kakariko Village -> Graveyard', "%s"],
+    0x0308: ['Kak Behind Gate -> Death Mountain', "%s"],
+    0x030B: ['Death Mountain -> Goron City', "%s"],
+    0x030C: ['Hyrule Field -> ZR Front', "%s"],
+    0x0314: ['Kokiri Forest -> Lost Woods', "%s"],
+    0x0317: ['Hyrule Field -> Lake Hylia', "%s"],
+    0x0319: ['Hyrule Field -> Gerudo Valley', "%s"], # MAKE SURE THIS ISN'T ALSO IN GERUDO FORTRESS
+    0x0320: ['Kokiri Forest -> LW Bridge From Forest', "%s"],
+    0x0321: ['Death Mountain -> Goron City', "Follow the trail along the edge of\x01the cliff and you will reach\x01%s"],
+    0x0323: ['Death Mountain Summit -> DMC Upper Local', "Death Mountain Summit\x01Entrance to %s\x01ahead"], # Color 'Death Mountain Summit'
+    0x6069: ['GV Fortress Side -> Gerudo Fortress', "%s is located beyond this gate.\x01A kid like you has no business there."],
+}
+
+SPECIAL_OW_SIGNS = {
+    # 0x033A: you are here: hyrule castle this way to lon lon Ranch (this should have the market and llr entrances on it)
+    #0x4003: 
+        #What are you doing? You've come 
+        #a long way to get up here...You should look at the Map 
+        #Subscreen sometimes.
+        #
+        #[Link], this is a beautiful
+        #lake full of pure, clear water.
+        #
+        #At the lake bottom there is
+        #a Water Temple used to worship 
+        #the water spirits. The Zoras are
+        #guardians of the temple. Hoo hoo.
+
+        #The Zoras come from Zora's
+        #Domain in northeast Hyrule. An
+        #aquatic race, they are longtime
+        #allies of Hyrule's Royal Family.
+
+        #I heard that only the Royal Family
+        #of Hyrule can enter Zora's Domain...
+        #Hoo hoo!
+
+        #I'm on my way back to the castle.
+        #If you want to come with me, hold
+        #on to my talons!
+    # 0x0339: hyrule castle lon lon Ranch (in field after leaving kokiri)
+    #DMT owl
+}
+
+REGION_NAMES = {
+    'Market Shooting Gallery': 'Shooting Gallery'
+}
+
+
+
+def replace_overworld_signs(messages, world):
+    # print("-----------------------------------------")
+    # print(world.get_entrance('Kokiri Forest -> KF Kokiri Shop').connected_region.name)
+    # print("-----------------------------------------")
+
+    SIGNS = {**INDOORS_SIGNS, **OW_SIGNS, **DUNGEON_SIGNS}
+
+    for sign_id, entrance in SIGNS.items():
+        # destination = REGION_NAMES[world.get_entrance(entrance).connected_region.name]
+        destination = world.get_entrance(entrance[0]).connected_region.name
+        update_message_by_id(messages, sign_id, entrance[1]%destination)

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -14,9 +14,9 @@ from Messages import update_message_by_id, get_message_by_id
 # - Fix the doors no longer being locked after changing msg
 # - Deal with the front/back kak potion shop doors
 # - Write a function to center text
-# - Add grotto region names
+# - Make a dict of easy to change locations (i.e. fort -> gtg is only queried once and then that is referenced everywhere that entrance is needed. This hsould ease future maintenence)
 
-#   id      Entrance list                                                   opts    category    Message
+#   id      Entrance list                                                   opts    category        Message
 SIGN_LIST = {
     # Dungeon
     0x0307: [['Kakariko Village -> Bottom of the Well'],                    0x13,   'dungeon',      "Dark! Narrow! Scary!\x01{}"], # Square sign in front of well
@@ -156,6 +156,20 @@ REGION_NAMES = {
 
     # Grottos
     "Royal Family's Tomb":                      ['Graveyard Composers Grave'],
+    "Dampe's Grave":                            ['Graveyard Dampes Grave'],
+    "Wolfos Grotto":                            ['SFM Wolfos Grotto'],
+    "Redead Grotto":                            ['Kak Redead Grotto'],
+    "Deku Scrub Grotto":                        ['GV Storms Grotto', 'Colossus Grotto', 'LLR Grotto', 'SFM Storms Grotto', 'HF Inside Fence Grotto', 'GC Grotto', 'DMC Hammer Grotto', 'LW Scrubs Grotto', 'LH Grotto', 'ZR Storms Grotto'],
+    "Tektite Grotto":                           ['HF Tektite Grotto'],
+    "Deku Theater":                             ['Deku Theater'],
+    "Generic Grotto":                           ['KF Storms Grotto', 'HF Near Market Grotto', 'HF Southeast Grotto', 'ZR Open Grotto', 'DMC Upper Grotto', 'Kak Open Grotto', 'DMT Storms Grotto', 'LW Near Shortcuts Grotto', 'HF Open Grotto'],
+    "Fairy Fountain":                           ['SFM Fairy Grotto', 'HF Fairy Grotto', 'ZD Storms Grotto', 'GF Storms Grotto', 'ZR Fairy Grotto'],
+    "Octorok Grotto":                           ['GV Octorok Grotto'],
+    "Skulltula Grotto":                         ['HF Near Kak Grotto', 'HC Storms Grotto'],
+    "Shield Grave":                             ['Graveyard Shield Grave'],
+    "Redead Grave":                             ['Graveyard Heart Piece Grave'],
+    "Cow Grotto":                               ['DMT Cow Grotto'],
+    "Spider Cow Grotto":                        ['HF Cow Grotto'],
 }
 
 SignActor = namedtuple('SignActor', ['origmsg', 'newmsg', 'actor_id', 'scene', 'mask', 'actorprops'])

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -11,9 +11,15 @@ DUNGEON_SIGNS = {
     0x0307: ['Kakariko Village -> Bottom of the Well'," Dark! Narrow! Scary!\x01%s"],
     0x030A: ['Dodongos Cavern Entryway -> Dodongos Cavern Beginning', "%s\x01Don't enter without permission!"],
     0x0312: ['KF Outside Deku Tree -> Deku Tree Lobby', "Just ahead:\x01%s"],
+    0x031B: ['Gerudo Fortress -> Gerudo Training Grounds Lobby', "%s\x01Only registered members are\x01allowed!"],
+    # 0x6013: GTG with no card
+    # 0x6014: GTG with card
 }
 
 INDOORS_SIGNS = {
+    0x020E: ['Kakariko Village -> Kak Potion Shop Front', "%s\x01Closed until morning"], # Potion Shop at night, Color the location name light blue
+    0x020F: ['Kakariko Village -> Kak Shooting Gallery', "%s\x01Open only during the day"], # Kak shooting gallery (check child message), color location light blue
+    0x0211: ['Kakariko Village -> Kak Bazaar', "%s\x01Open only during the day"], # Kak Bazaar at night (is this the same message as child?), color location light blue
     0x023A: ['Lake Hylia -> LH Fishing Hole', "%s"],
     # 0x0301: Hyrule Field (GV -> field, lake->field, kak->field)
     # 0x0302: Hyrule Castle Town
@@ -21,11 +27,8 @@ INDOORS_SIGNS = {
     # 0x030F: Zoras fountain dont disturb lord jabu jabu --king zora xvi
     # 0x0311: All those reckless enough to venture into the desert--please drop by our shop. Carpet merchant
     # 0x0313: Forest Temple
-    # 0x0315: Talon and Malons Lon Lon Rang
-    # 0x0316: The Great Ingos Ingo Ranch
     0x0318: ['Lake Hylia -> LH Lab', "%s"],
-    # 0x031B: Gerudo Training Ground only registered members are allowed
-    # 0x031C: haunted wasteland if you chase a mirage, the desert will swallow you. Only on path is true
+    
     # 0x031D: Spirit Temple
     0x031E: ['Kokiri Forest -> KF Kokiri Shop', "%s"],
     0x031F: ['Kokiri Forest -> KF Links House', "%s"],
@@ -45,8 +48,11 @@ OW_SIGNS = {
     0x030B: ['Death Mountain -> Goron City', "%s"],
     0x030C: ['Hyrule Field -> ZR Front', "%s"],
     0x0314: ['Kokiri Forest -> Lost Woods', "%s"],
+    0x0315: ['Hyrule Field -> Lon Lon Ranch', "%s"],
+    0x0316: ['Hyrule Field -> Lon Lon Ranch', "%s"],
     0x0317: ['Hyrule Field -> Lake Hylia', "%s"],
-    0x0319: ['Hyrule Field -> Gerudo Valley', "%s"], # MAKE SURE THIS ISN'T ALSO IN GERUDO FORTRESS
+    # 0x0319: ['Hyrule Field -> Gerudo Valley', "%s"], # This sign is also in gf pointing to gv
+    0x031C: ['GF Outside Gate -> Wasteland Near Fortress', "%s"], # hw if you chase a mirage... MAKE SUR EITS NOT IN COLOSSSUS
     0x0320: ['Kokiri Forest -> LW Bridge From Forest', "%s"],
     0x0321: ['Death Mountain -> Goron City', "Follow the trail along the edge of\x01the cliff and you will reach\x01%s"],
     0x0323: ['Death Mountain Summit -> DMC Upper Local', "Death Mountain Summit\x01Entrance to %s\x01ahead"], # Color 'Death Mountain Summit'
@@ -85,7 +91,109 @@ SPECIAL_OW_SIGNS = {
 }
 
 REGION_NAMES = {
-    'Market Shooting Gallery': 'Shooting Gallery'
+    # Dungeons
+    'Deku Tree Lobby': "\x05\42Deku Tree\x05\40",
+    'Dodongos Cavern Beginning': "\x05\41Dodongo's Cavern\x05\40",
+    'Jabu Jabus Belly Beginning': "\x05\43Jabu Jabu's Belly\x05\40",
+    'Forest Temple Lobby': "\x05\42Forest Temple\x05\40",
+    'Fire Temple Lower': "\x05\41Fire Temple\x05\40",
+    'Water Temple Lobby': "\x05\43Water Temple\x05\40",
+    'Spirit Temple Lobby': "\x05\46Spirit Temple\x05\40",
+    'Shadow Temple Entryway': "\x05\45Shadow Temple\x05\40",
+    'Bottom of the Well': "\x05\41Bottom of the Well\x05\40",
+    'Ice Cavern Beginning': "\x05\43Ice Cavern\x05\40",
+    'Gerudo Training Grounds Lobby': "\x05\46Gerudo Training Grounds\x05\40",
+
+    # Indoors
+    'KF Midos House': "\x05\44Mido's House\x05\40",
+    'KF Sarias House': "\x05\44Saria's House\x05\40",
+    'KF House of Twins': "\x05\44House of Twins\x05\40",
+    'KF Know It All House': "\x05\44Know It All House\x05\40",
+    'KF Kokiri Shop': "\x05\44Kokiri Shop\x05\40",
+    'LH Lab': "\x05\44Lakeside Laboratory\x05\40",
+    'LH Fishing Hole': "\x05\44Fishing Pond\x05\40",
+    'GV Carpenter Tent': "\x05\44Carpenter's Tent\x05\40",
+    'Market Guard House': "\x05\44Guard House\x05\40",
+    'Market Mask Shop': "\x05\44Mask Shop\x05\40",
+    'Market Bombchu Bowling': "\x05\44Bombchu Bowling\x05\40",
+    'Market Potion Shop': "\x05\44Potion Shop\x05\40",
+    'Market Treasure Chest Game': "\x05\44Treasure Chest Game\x05\40",
+    'Market Bombchu Shop': "\x05\44Bombchu Shop\x05\40",
+    'Market Man in Green House': "\x05\44House\x05\40", # Better name for this?
+    'Kak Carpenter Boss House': "\x05\44House\x05\40", # Better name for this?
+    'Kak House of Skulltula': "\x05\44House of Skulltula\x05\40",
+    'Kak Impas House': "\x05\44Impa's House\x05\40",
+    'Kak Impas House Back': "\x05\44Impa's House\x05\40", # Differentiate or nah?
+    'Kak Odd Medicine Building': "\x05\44Oddity Shop\x05\40", # Better name?
+    'Graveyard Dampes House': "\x05\44Dampe's House\x05\40",
+    'GC Shop': "\x05\44Goron Shop\x05\40",
+    'ZD Shop': "\x05\44Zora Shop\x05\40",
+    'LLR Talons House': "\x05\44Talon's House\x05\40",
+    'LLR Stables': "\x05\44Lon Lon Stable\x05\40",
+    'LLR Tower': "\x05\44Lon Long Tower\x05\40",
+    'Market Bazaar': "\x05\44Bazaar\x05\40",
+    'Market Shooting Gallery': "\x05\44Shooting Gallery\x05\40",
+    'Kak Bazaar': "\x05\44Bazaar\x05\40",
+    'Kak Shooting Gallery': "\x05\44Shooting Gallery\x05\40",
+    'Colossus Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
+    'HC Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
+    'OGC Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
+    'DMC Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
+    'DMT Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
+    'ZF Great Fairy Fountain': "\x05\44Great Fairy Fountain\x05\40",
+    'KF Links House': "\x05\44\x0F's House\x05\40",
+    'Temple of Time': "\x05\44Temple of Time\x05\40",
+    'Kak Windmill': "\x05\44Windmill\x05\40",
+    'Kak Potion Shop Front': "\x05\44Potion Shop\x05\40",
+    'Kak Potion Shop Back': "\x05\44Potion Shop\x05\40",
+
+    # Overworld - THESE SHOULD ALL BE COLORED APPROPRIATELY
+    'Kokiri Forest': "\x05\40Kokiri Forest\x05\x40",
+    'LW Bridge From Forest': "\x05\40Lost Woods Bridge\x05\x40",
+    'LW Bridge': "\x05\40Lost Woods Bridge\x05\x40",
+    'Lost Woods': "\x05\40Lost Woods\x05\x40",
+    'LW Forest Exit': "\x05\40Lost Woods\x05\x40", # Is this right?
+    'GC Woods Warp': "\x05\40Goron City\x05\x40",
+    'Zora River': "\x05\40Zora River\x05\x40",
+    'LW Beyond Mido': "\x05\40Lost Woods\x05\x40",
+    'SFM Entryway': "\x05\40Sacred Forest Meadow\x05\x40",
+    'Hyrule Field': "\x05\40Hyrule Field\x05\x40",
+    'Lake Hylia': "\x05\40Lake Hylia\x05\x40",
+    'Gerudo Valley': "\x05\40Gerudo Valley\x05\x40",
+    'Market Entrance': "\x05\40Market Entrance\x05\x40",
+    'Kakariko Village': "\x05\40Kakariko Village\x05\x40",
+    'ZR Front': "\x05\40Zora River\x05\x40",
+    'Lon Lon Ranch': "\x05\40Lon Lon Ranch\x05\x40",
+    'Zoras Domain': "\x05\40Zora's Domain\x05\x40",
+    'GV Fortress Side': "\x05\40Gerudo Valley\x05\x40",
+    'Gerudo Fortress': "\x05\40Gerudo Fortress\x05\x40",
+    'GF Outside Gate': "\x05\40Gerudo Fortress\x05\x40",
+    'Wasteland Near Fortress': "\x05\40Haunted Wasteland\x05\x40",
+    'Wasteland Near Colossus': "\x05\40Haunted Wasteland\x05\x40",
+    'Desert Colossus': "\x05\40Desert Colossus\x05\x40",
+    'Market': "\x05\40Market\x05\x40",
+    'Castle Grounds': "\x05\40Castle Grounds\x05\x40",
+    'ToT Entrance': "\x05\40Temple of Time Entrance\x05\x40",
+    'Graveyard': "\x05\40Graveyard\x05\x40",
+    'Kak Behind Gate': "\x05\40Kakariko Village\x05\x40",
+    'Death Mountain': "\x05\40Death Mountain Trail\x05\x40",
+    'Goron City': "\x05\40Goron City\x05\x40",
+    'GC Darunias Chamber': "\x05\40Goron City\x05\x40",
+    'DMC Lower Local': "\x05\40Death Mountain Crater\x05\x40",
+    'DMC Lower Nearby': "\x05\40Death Mountain Crater\x05\x40",
+    'Death Mountain Summit': "\x05\40Death Mountain Trail\x05\x40", # I think...
+    'DMC Upper Local': "\x05\40Death Mountain Crater\x05\x40",
+    'DMC Upper Nearby': "\x05\40Death Mountain Crater\x05\x40",
+    'ZR Behind Waterfall': "\x05\40Zora River\x05\x40",
+    'Zoras Domain': "\x05\40Zora's Domain\x05\x40",
+    'ZD Behind King Zora': "\x05\40Zora's Domain\x05\x40",
+    'Zoras Fountain': "\x05\40Zora's Fountain\x05\x40",
+    'LH Owl Flight': "\x05\40Lake Hylia\x05\x40",
+    'DMT Owl Flight': "\x05\40Death Mountain Trail\x05\x40",
+    'Kak Impas Ledge': "\x05\40Kakariko Village\x05\x40",
+
+    # Grotto
+    # Fill these in eventually, not needed until I worry about mixed pools
 }
 
 
@@ -98,6 +206,9 @@ def replace_overworld_signs(messages, world):
     SIGNS = {**INDOORS_SIGNS, **OW_SIGNS, **DUNGEON_SIGNS}
 
     for sign_id, entrance in SIGNS.items():
-        # destination = REGION_NAMES[world.get_entrance(entrance).connected_region.name]
-        destination = world.get_entrance(entrance[0]).connected_region.name
+        try:
+            destination = REGION_NAMES[world.get_entrance(entrance[0]).connected_region.name]
+        except KeyError:
+            destination = world.get_entrance(entrance[0]).connected_region.name
+            print("MISSING REGION NAME: " + destination)
         update_message_by_id(messages, sign_id, entrance[1]%destination)

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -15,7 +15,6 @@ from Messages import update_message_by_id, get_message_by_id
 # - Fix the doors no longer being locked after changing msg
 # - Deal with the front/back kak potion shop doors
 # - Write a function to center text
-# - Make a dict of easy to change locations (i.e. fort -> gtg is only queried once and then that is referenced everywhere that entrance is needed. This hsould ease future maintenence)
 
 
 # Dictionary to convert OoTR names for entrances into english for use in SIGN_LIST below
@@ -90,7 +89,7 @@ SIGN_LIST = {
     # The kak potion shop doors read the same message, have the same scene, and the same actor_id. How do I tell them apart??
     # 0x020E: [['kak pot front'],                     0x20,   'indoor',   "{}\x01Closed until morning"], # Kak Potion Shop at night (msg 0290 and 0293 splits off here)
     0x0290: [['market pot'],                        0x20,   'indoor',       "{}\x01Closed until morning"], # New message for Market Potion shop at night
-    # 0x0293: [['kak pot back']], # New message for Kak potion shop back at night
+    # 0x0293: [['kak pot back'],                      0x20,   'indoor',       "{}\x01Closed until morning"], # New message for Kak potion shop back at night
     0x020F: [['kak shooting'],                      0x20,   'indoor',       "{}\x01Open only during the day"], # Kak shooting gallery at night (msg 0291 splits off here)
     0x0291: [['market shooting'],                   0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market shooting gallery at night
     0x0210: [['mask shop'],                         0x20,   'indoor',       "{}\x01Now hiring part-time\x01Apply during the day"], # Mask shop at night
@@ -146,8 +145,8 @@ REGION_NAMES = {
     "\x05\43Water Temple\x05\40":               ['Water Temple Lobby'],
     "\x05\46Spirit Temple\x05\40":              ['Spirit Temple Lobby'],
     "\x05\45Shadow Temple\x05\40":              ['Shadow Temple Entryway'],
-    "\x05\41Bottom of the Well\x05\40":         ['Bottom of the Well'],
-    "\x05\43Ice Cavern\x05\40":                 ['Ice Cavern Beginning'],
+    "\x05\45Bottom of the Well\x05\40":         ['Bottom of the Well'],
+    "\x05\44Ice Cavern\x05\40":                 ['Ice Cavern Beginning'],
     "\x05\46Gerudo Training Grounds\x05\40":    ['Gerudo Training Grounds Lobby'],
 
     # Indoors
@@ -239,12 +238,7 @@ sign_actor_table = [
 ]
 
 
-def replace_overworld_signs(messages, world):
-    testid = 0x4003
-    print('--------------------------------')
-    print(get_message_by_id(messages, testid))
-    print('--------------------------------')
-
+def update_entrance_messages(messages, world):
     for sign_id, entrance_info in SIGN_LIST.items():
         entrance_list, opts, category, sign_text = entrance_info
         destination_list = [world.get_entrance(ENTRANCE_REFERENCES[entr]).connected_region.name for entr in entrance_list]
@@ -266,8 +260,4 @@ def replace_overworld_signs(messages, world):
 
         # Update the messages table
         teststr = entrance_list[0]+"\x01"
-        update_message_by_id(messages, sign_id, teststr+sign_text.format(*destination_list), opts) # Opts at the end are the text box type and position values WRAP THIS INTO THE TABLE ABOVE
-
-    print('--------------------------------')
-    print(get_message_by_id(messages, testid))
-    print('--------------------------------')
+        update_message_by_id(messages, sign_id, teststr+sign_text.format(*destination_list), opts)

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 from World import World
 from Messages import update_message_by_id, get_message_by_id
 
+# If an entrance or region name is changed, it only needs to be updated in ENTRANCE_REFERENCES and added to the appropriate spot in REGION_NAMES
+
 # New messages added to the table at 0x0390-0x0394, 0x0290-0x0293
 
 # COULD ADD A NEW FUNCTION TO CENTER TEXT.
@@ -10,76 +12,128 @@ from Messages import update_message_by_id, get_message_by_id
 # - Can then compute how much spec to prepend to a line.
 
 # THINGS REMAINING TO DO
-# - owls
 # - Fix the doors no longer being locked after changing msg
 # - Deal with the front/back kak potion shop doors
 # - Write a function to center text
 # - Make a dict of easy to change locations (i.e. fort -> gtg is only queried once and then that is referenced everywhere that entrance is needed. This hsould ease future maintenence)
 
-#   id      Entrance list                                                   opts    category        Message
-SIGN_LIST = {
-    # Dungeon
-    0x0307: [['Kakariko Village -> Bottom of the Well'],                    0x13,   'dungeon',      "Dark! Narrow! Scary!\x01{}"], # Square sign in front of well
-    0x030A: [['Dodongos Cavern Entryway -> Dodongos Cavern Beginning'],     0x13,   'dungeon',      "{}\x01Don't enter without permission!"], # Sign pointing into dodongo's cavern
-    0x030F: [['Zoras Fountain -> Jabu Jabus Belly Beginning'],              0x13,   'dungeon',      "{}\x01Don't disturb Lord Jabu-Jabu!\x01--King Zora XVI"], # Sign outside of jabu as child
-    0x0312: [['KF Outside Deku Tree -> Deku Tree Lobby'],                   0x13,   'dungeon',      "Just ahead:\x01{}"], # Sign in kokiri pointing towards deku tree
-    0x031B: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'],          0x13,   'dungeon',      "{}\x01Only registered members are\x01allowed!"], # Sign outside of gtg
-    0x6013: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'],          0x00,   'dungeon',      "This is the\x01{}\x04Nobody is allowed to enter\x01without a membership card."], # Talk to gtg entrance without card
-    0x6014: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'],          0x00,   'dungeon',      "This is the\x01{}\x04Membership card verified.\x04One try for 10 Rupees!\x04\x1b\x01Try\x01Don't try"], # Talk to npc to enter gtg with card LOOKS BAD
+
+# Dictionary to convert OoTR names for entrances into english for use in SIGN_LIST below
+ENTRANCE_REFERENCES = {
+    # Dungeons
+    'botw':                 'Kakariko Village -> Bottom of the Well',
+    'dc':                   'Dodongos Cavern Entryway -> Dodongos Cavern Beginning',
+    'jabu':                 'Zoras Fountain -> Jabu Jabus Belly Beginning',
+    'deku':                 'KF Outside Deku Tree -> Deku Tree Lobby',
+    'gtg':                  'Gerudo Fortress -> Gerudo Training Grounds Lobby',
+    'water':                'Lake Hylia -> Water Temple Lobby',
 
     # Indoors
-    # The kak potion shop doors read the same message, have the same scene, and the same actor_id. How do I tell them apart??
-    # 0x020E: [['Kakariko Village -> Kak Potion Shop Front'],                 0x20,   'indoor',   "{}\x01Closed until morning"], # Kak Potion Shop at night (msg 0290 and 0293 splits off here)
-    0x0290: [['Market -> Market Potion Shop'],                              0x20,   'indoor',       "{}\x01Closed until morning"], # New message for Market Potion shop at night
-    # 0x0293: [['Kak Backyard -> Kak Potion Shop Back']], # New message for Kak potion shop back at night
-    0x020F: [['Kakariko Village -> Kak Shooting Gallery'],                  0x20,   'indoor',       "{}\x01Open only during the day"], # Kak shooting gallery at night (msg 0291 splits off here)
-    0x0291: [['Market -> Market Shooting Gallery'],                         0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market shooting gallery at night
-    0x0210: [['Market -> Market Mask Shop'],                                0x20,   'indoor',       "{}\x01Now hiring part-time\x01Apply during the day"], # Mask shop at night
-    0x0211: [['Kakariko Village -> Kak Bazaar'],                            0x20,   'indoor',       "{}\x01Open only during the day"], # Kak Bazaar at night (msg 0x0292 splits off here)
-    0x0292: [['Market -> Market Bazaar'],                                   0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market bazaar at night
-    0x023A: [['Lake Hylia -> LH Fishing Hole'],                             0x20,   'indoor',       "{}"],
-    0x0318: [['Lake Hylia -> LH Lab'],                                      0x13,   'indoor',       "{}"],
-    0x031E: [['Kokiri Forest -> KF Kokiri Shop'],                           0x13,   'indoor',       "{}"],
-    0x031F: [['Kokiri Forest -> KF Links House'],                           0x13,   'indoor',       "{}"],
-    0x0333: [['Zoras Domain -> ZD Shop'],                                   0x13,   'indoor',       "{}"],
-    0x033C: [['Kokiri Forest -> KF Midos House'],                           0x13,   'indoor',       "{}"],
-    0x033D: [['Kokiri Forest -> KF Know It All House'],                     0x13,   'indoor',       "{}"],
-    0x033E: [['Kokiri Forest -> KF House of Twins'],                        0x13,   'indoor',       "{}"],
-    0x033F: [['Kokiri Forest -> KF Sarias House'],                          0x13,   'indoor',       "{}"],
-    0x5020: [['Graveyard -> Graveyard Composers Grave'],                    0x20,   'indoor',       "{}"], # Read the gravestone atop the composer grave
-    0x020D: [['Market -> Market Treasure Chest Game'],                      0x20,   'indoor',       "{}\x01Temporarily Closed\x01Open Tonight!"], # Treasure chest game at night
-    0x0226: [['Kak Backyard -> Kak Odd Medicine Building'],                 0x20,   'indoor',       "{}\x01Closed\x04Gone for Field Study\x01Please come again!\x01--Granny"], # Granny's Potion Shop as child
+    'kak pot front':        'Kakariko Village -> Kak Potion Shop Front',
+    'kak pot back':         'Kak Backyard -> Kak Potion Shop Back',
+    'market pot':           'Market -> Market Potion Shop',
+    'kak shooting':         'Kakariko Village -> Kak Shooting Gallery',
+    'market shooting':      'Market -> Market Shooting Gallery',
+    'mask shop':            'Market -> Market Mask Shop',
+    'kak bazaar':           'Kakariko Village -> Kak Bazaar',
+    'market bazaar':        'Market -> Market Bazaar',
+    'fishing':              'Lake Hylia -> LH Fishing Hole',
+    'lab':                  'Lake Hylia -> LH Lab',
+    'kok shop':             'Kokiri Forest -> KF Kokiri Shop',
+    'links house':          'Kokiri Forest -> KF Links House',
+    'zora shop':            'Zoras Domain -> ZD Shop',
+    'midos house':          'Kokiri Forest -> KF Midos House',
+    'know it all':          'Kokiri Forest -> KF Know It All House',
+    'twins house':          'Kokiri Forest -> KF House of Twins',
+    'sarias house':         'Kokiri Forest -> KF Sarias House',
+    'comp grave':           'Graveyard -> Graveyard Composers Grave',
+    'chest game':           'Market -> Market Treasure Chest Game',
+    'granny pot shop':      'Kak Backyard -> Kak Odd Medicine Building',
 
     # Overworld
-    0x0301: [['Gerudo Valley -> Hyrule Field'],                             0x13,   'overworld',    "{}"], # Arrow sign GV -> field (msgs 391 and 392 split off here)
-    0x0391: [['Lake Hylia -> Hyrule Field'],                                0x13,   'overworld',    "{}"], # New msg for Arrow sign lake -> field
-    0x0392: [['Kakariko Village -> Hyrule Field'],                          0x13,   'overworld',    "{}"], # New msg for arrow sign kak -> field
-    0x0305: [['Death Mountain -> Kak Behind Gate'],                         0x13,   'overworld',    "{}"], # Arrow sign DMT-> kak (msg 390 splits off here)
-    0x0390: [['Hyrule Field -> Kakariko Village'],                          0x13,   'overworld',    "{}"], # New message for field -> kak arrow sign
-    0x0306: [['Kakariko Village -> Graveyard'],                             0x13,   'overworld',    "{}"],
-    0x0308: [['Kak Behind Gate -> Death Mountain'],                         0x13,   'overworld',    "{}"],
-    0x030B: [['Death Mountain -> Goron City'],                              0x13,   'overworld',    "{}"],
-    0x030C: [['Hyrule Field -> ZR Front'],                                  0x13,   'overworld',    "{}"],
-    0x0393: [['Zoras Fountain -> ZD Behind King Zora'],                     0x13,   'overworld',    "{}"], # New msg for arrow sign zf -> zd
-    0x0314: [['Kokiri Forest -> Lost Woods'],                               0x13,   'overworld',    "{}"],
-    0x0315: [['Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "{}"],
-    0x0316: [['Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "{}"],
-    0x0317: [['Hyrule Field -> Lake Hylia'],                                0x13,   'overworld',    "{}"],
-    0x0319: [['Hyrule Field -> Gerudo Valley'],                             0x13,   'overworld',    "{}"], # Arrow sign field -> gv (msg 394 splits off here)
-    0x0394: [['Gerudo Fortress -> GV Fortress Side'],                       0x13,   'overworld',    "{}"], # New msg for arrow sign gf -> gv
-    0x031C: [['GF Outside Gate -> Wasteland Near Fortress'],                0x13,   'overworld',    "{}"],
-    0x0320: [['Kokiri Forest -> LW Bridge From Forest'],                    0x13,   'overworld',    "{}"],
-    0x0321: [['Death Mountain -> Goron City'],                              0x13,   'overworld',    "Follow the trail along the edge of\x01the cliff and you will reach\x01{}"], # Sign half-way up dmt
-    0x0323: [['Death Mountain Summit -> DMC Upper Local'],                  0x13,   'overworld',    "\x05\41Death Mountain Summit\x05\40\x01Entrance to {}\x01ahead"], # Square sign dmt -> crater
-    0x0339: [['Hyrule Field -> Market Entrance',
-              'Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "{}\x01{}"], # Sign outside of Kokiri Forest in Hyrule Field
-    0x033A: [['Hyrule Field -> Market Entrance',
-              'Hyrule Field -> Lon Lon Ranch'],                             0x13,   'overworld',    "You are here: {}\x01This way to {}"], # Sign in field between market and llr
-    0x6069: [['GV Fortress Side -> Gerudo Fortress'],                       0x13,   'overworld',    "{} is located beyond\x01this gate.\x01A kid like you has no business there."], # Gerudo gaurd on the gv bridge as child
+    'gv @ field':           'Gerudo Valley -> Hyrule Field',
+    'field @ gv':           'Hyrule Field -> Gerudo Valley',
+    'lake @ field':         'Lake Hylia -> Hyrule Field',
+    'field @ lake':         'Hyrule Field -> Lake Hylia',
+    'kak @ field':          'Kakariko Village -> Hyrule Field',
+    'field @ kak':          'Hyrule Field -> Kakariko Village',
+    'dmt @ kak':            'Death Mountain -> Kak Behind Gate',
+    'kak @ dmt':            'Kak Behind Gate -> Death Mountain',
+    'kak @ gy':             'Kakariko Village -> Graveyard',
+    'dmt @ goron':          'Death Mountain -> Goron City',
+    'field @ river':        'Hyrule Field -> ZR Front',
+    'fountain @ domain':    'Zoras Fountain -> ZD Behind King Zora',
+    'kok @ lw':             'Kokiri Forest -> Lost Woods',
+    'field @ llr':          'Hyrule Field -> Lon Lon Ranch',
+    'fort @ gv':            'Gerudo Fortress -> GV Fortress Side',
+    'gv @ fort':            'GV Fortress Side -> Gerudo Fortress',
+    'fort @ hw':            'GF Outside Gate -> Wasteland Near Fortress',
+    'kok @ lwbridge':       'Kokiri Forest -> LW Bridge From Forest',
+    'dmt @ crater':         'Death Mountain Summit -> DMC Upper Local',
+    'field @ market':       'Hyrule Field -> Market Entrance',
 
-    # Owls
-    # 0x4003: [[],], # Lake owl
-    # DMT owl
+    # Owl
+    'lake owl':             'LH Owl Flight -> Hyrule Field',
+}
+
+
+#   id      Entrance list                           opts    category        Message
+SIGN_LIST = {
+    0x0307: [['botw'],                              0x13,   'dungeon',      "Dark! Narrow! Scary!\x01{}"], # Square sign in front of well
+    0x030A: [['dc'],                                0x13,   'dungeon',      "{}\x01Don't enter without permission!"], # Sign pointing into dodongo's cavern
+    0x030F: [['jabu'],                              0x13,   'dungeon',      "{}\x01Don't disturb Lord Jabu-Jabu!\x01--King Zora XVI"], # Sign outside of jabu as child
+    0x0312: [['deku'],                              0x13,   'dungeon',      "Just ahead:\x01{}"], # Sign in kokiri pointing towards deku tree
+    0x031B: [['gtg'],                               0x13,   'dungeon',      "{}\x01Only registered members are\x01allowed!"], # Sign outside of gtg
+    0x6013: [['gtg'],                               0x00,   'dungeon',      "This is the\x01{}\x04Nobody is allowed to enter\x01without a membership card."], # Talk to gtg entrance without card
+    0x6014: [['gtg'],                               0x00,   'dungeon',      "This is the\x01{}\x04Membership card verified.\x04One try for 10 Rupees!\x04\x1b\x01Try\x01Don't try"], # Talk to npc to enter gtg with card LOOKS BAD
+
+    # The kak potion shop doors read the same message, have the same scene, and the same actor_id. How do I tell them apart??
+    # 0x020E: [['kak pot front'],                     0x20,   'indoor',   "{}\x01Closed until morning"], # Kak Potion Shop at night (msg 0290 and 0293 splits off here)
+    0x0290: [['market pot'],                        0x20,   'indoor',       "{}\x01Closed until morning"], # New message for Market Potion shop at night
+    # 0x0293: [['kak pot back']], # New message for Kak potion shop back at night
+    0x020F: [['kak shooting'],                      0x20,   'indoor',       "{}\x01Open only during the day"], # Kak shooting gallery at night (msg 0291 splits off here)
+    0x0291: [['market shooting'],                   0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market shooting gallery at night
+    0x0210: [['mask shop'],                         0x20,   'indoor',       "{}\x01Now hiring part-time\x01Apply during the day"], # Mask shop at night
+    0x0211: [['kak bazaar'],                        0x20,   'indoor',       "{}\x01Open only during the day"], # Kak Bazaar at night (msg 0x0292 splits off here)
+    0x0292: [['market bazaar'],                     0x20,   'indoor',       "{}\x01Open only during the day"], # New message for Market bazaar at night
+    0x023A: [['fishing'],                           0x20,   'indoor',       "{}"],
+    0x0318: [['lab'],                               0x13,   'indoor',       "{}"],
+    0x031E: [['kok shop'],                          0x13,   'indoor',       "{}"],
+    0x031F: [['links house'],                       0x13,   'indoor',       "{}"],
+    0x0333: [['zora shop'],                         0x13,   'indoor',       "{}"],
+    0x033C: [['midos house'],                       0x13,   'indoor',       "{}"],
+    0x033D: [['know it all'],                       0x13,   'indoor',       "{}"],
+    0x033E: [['twins house'],                       0x13,   'indoor',       "{}"],
+    0x033F: [['sarias house'],                      0x13,   'indoor',       "{}"],
+    0x5020: [['comp grave'],                        0x20,   'indoor',       "{}"], # Read the gravestone atop the composer grave
+    0x020D: [['chest game'],                        0x20,   'indoor',       "{}\x01Temporarily Closed\x01Open Tonight!"], # Treasure chest game at night
+    0x0226: [['granny pot shop'],                   0x20,   'indoor',       "{}\x01Closed\x04Gone for Field Study\x01Please come again!\x01--Granny"], # Granny's Potion Shop as child
+
+    0x0301: [['gv @ field'],                        0x13,   'overworld',    "{}"], # Arrow sign GV -> field (msgs 391 and 392 split off here)
+    0x0391: [['lake @ field'],                      0x13,   'overworld',    "{}"], # New msg for Arrow sign lake -> field
+    0x0392: [['kak @ field'],                       0x13,   'overworld',    "{}"], # New msg for arrow sign kak -> field
+    0x0305: [['dmt @ kak'],                         0x13,   'overworld',    "{}"], # Arrow sign DMT-> kak (msg 390 splits off here)
+    0x0390: [['field @ kak'],                       0x13,   'overworld',    "{}"], # New message for field -> kak arrow sign
+    0x0306: [['kak @ gy'],                          0x13,   'overworld',    "{}"],
+    0x0308: [['kak @ dmt'],                         0x13,   'overworld',    "{}"],
+    0x030B: [['dmt @ goron'],                       0x13,   'overworld',    "{}"],
+    0x030C: [['field @ river'],                     0x13,   'overworld',    "{}"],
+    0x0393: [['fountain @ domain'],                 0x13,   'overworld',    "{}"], # New msg for arrow sign zf -> zd
+    0x0314: [['kok @ lw'],                          0x13,   'overworld',    "{}"],
+    0x0315: [['field @ llr'],                       0x13,   'overworld',    "{}"],
+    0x0316: [['field @ llr'],                       0x13,   'overworld',    "{}"],
+    0x0317: [['field @ lake'],                      0x13,   'overworld',    "{}"],
+    0x0319: [['field @ gv'],                        0x13,   'overworld',    "{}"], # Arrow sign field -> gv (msg 394 splits off here)
+    0x0394: [['fort @ gv'],                         0x13,   'overworld',    "{}"], # New msg for arrow sign gf -> gv
+    0x031C: [['fort @ hw'],                         0x13,   'overworld',    "{}"],
+    0x0320: [['kok @ lwbridge'],                    0x13,   'overworld',    "{}"],
+    0x0321: [['dmt @ goron'],                       0x13,   'overworld',    "Follow the trail along the edge of\x01the cliff and you will reach\x01{}"], # Sign half-way up dmt
+    0x0323: [['dmt @ crater'],                      0x13,   'overworld',    "\x05\41Death Mountain Summit\x05\40\x01Entrance to {}\x01ahead"], # Square sign dmt -> crater
+    0x0339: [['field @ market', 'field @ llr'],     0x13,   'overworld',    "{}\x01{}"], # Sign outside of Kokiri Forest in Hyrule Field
+    0x033A: [['field @ market', 'field @ llr'],     0x13,   'overworld',    "You are here: {}\x01This way to {}"], # Sign in field between market and llr
+    0x6069: [['gv @ fort'],                         0x13,   'overworld',    "{} is located beyond\x01this gate.\x01A kid like you has no business there."], # Gerudo gaurd on the gv bridge as child
+
+    0x4003: [['water', 'lake owl'],                 0x03,   'owl',          "What are you doing? You've come\x01a long way to get up here...\x04\x0f, this is a beautiful\x01lake full of pure, clear water.\x04At the lake bottom there is a\x01{}.\x04I am on my way to {}.\x01If you want to come with me, hold\x01on to my talons!"], # Lake owl
 }
 
 REGION_NAMES = {
@@ -134,7 +188,7 @@ REGION_NAMES = {
     "\x05\42Lost Woods Bridge\x05\x40":         ['LW Bridge From Forest', 'LW Bridge'],
     "\x05\42Lost Woods\x05\x40":                ['Lost Woods', 'LW Beyond Mido', 'LW Forest Exit'],
     "\x05\41Goron City\x05\x40":                ['GC Woods Warp', 'GC Darunias Chamber', 'Goron City'],
-    "\x05\43Zora River\x05\x40":                ['Zora River', 'ZR Behind Waterfall', 'ZR Front'],
+    "\x05\43Zora's River\x05\x40":              ['Zora River', 'ZR Behind Waterfall', 'ZR Front'],
     "\x05\41Sacred Forest Meadow\x05\x40":      ['SFM Entryway'],
     "\x05\44Hyrule Field\x05\x40":              ['Hyrule Field'],
     "\x05\43Lake Hylia\x05\x40":                ['Lake Hylia'],
@@ -186,14 +240,14 @@ sign_actor_table = [
 
 
 def replace_overworld_signs(messages, world):
-    testid = 0x6014
+    testid = 0x4003
     print('--------------------------------')
     print(get_message_by_id(messages, testid))
     print('--------------------------------')
 
     for sign_id, entrance_info in SIGN_LIST.items():
         entrance_list, opts, category, sign_text = entrance_info
-        destination_list = [world.get_entrance(entr).connected_region.name for entr in entrance_list]
+        destination_list = [world.get_entrance(ENTRANCE_REFERENCES[entr]).connected_region.name for entr in entrance_list]
 
         # Replace the text with cleaner, formatted text (there HAS to be a better way to do this...)
         for idx in range(len(destination_list)):

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -8,55 +8,54 @@ from Messages import update_message_by_id
 # 0x300D - Comes up when you ask about dc in 0x300A
 
 DUNGEON_SIGNS = {
-    0x0307: ['Kakariko Village -> Bottom of the Well'," Dark! Narrow! Scary!\x01%s"],
-    0x030A: ['Dodongos Cavern Entryway -> Dodongos Cavern Beginning', "%s\x01Don't enter without permission!"],
-    0x0312: ['KF Outside Deku Tree -> Deku Tree Lobby', "Just ahead:\x01%s"],
-    0x031B: ['Gerudo Fortress -> Gerudo Training Grounds Lobby', "%s\x01Only registered members are\x01allowed!"],
+    0x0307: [['Kakariko Village -> Bottom of the Well']," Dark! Narrow! Scary!\x01{}"],
+    0x030A: ['Dodongos Cavern Entryway -> Dodongos Cavern Beginning', "{}\x01Don't enter without permission!"],
+    0x0312: ['KF Outside Deku Tree -> Deku Tree Lobby', "Just ahead:\x01{}"],
+    0x031B: ['Gerudo Fortress -> Gerudo Training Grounds Lobby', "{}\x01Only registered members are\x01allowed!"],
     # 0x6013: GTG with no card
     # 0x6014: GTG with card
 }
 
 INDOORS_SIGNS = {
-    0x020E: ['Kakariko Village -> Kak Potion Shop Front', "%s\x01Closed until morning"], # Potion Shop at night, Color the location name light blue
-    0x020F: ['Kakariko Village -> Kak Shooting Gallery', "%s\x01Open only during the day"], # Kak shooting gallery (check child message), color location light blue
-    0x0211: ['Kakariko Village -> Kak Bazaar', "%s\x01Open only during the day"], # Kak Bazaar at night (is this the same message as child?), color location light blue
-    0x023A: ['Lake Hylia -> LH Fishing Hole', "%s"],
+    0x020E: [['Kakariko Village -> Kak Potion Shop Front'], "{}\x01Closed until morning"], # Potion Shop at night, Color the location name light blue
+    0x020F: [['Kakariko Village -> Kak Shooting Gallery'], "{}\x01Open only during the day"], # Kak shooting gallery (check child message), color location light blue
+    0x0211: [['Kakariko Village -> Kak Bazaar'], "{}\x01Open only during the day"], # Kak Bazaar at night (is this the same message as child?), color location light blue
+    0x023A: [['Lake Hylia -> LH Fishing Hole'], "{}"],
     # 0x0301: Hyrule Field (GV -> field, lake->field, kak->field)
     # 0x0302: Hyrule Castle Town
     # 0x0303: The Temple of Time
     # 0x030F: Zoras fountain dont disturb lord jabu jabu --king zora xvi
-    # 0x0311: All those reckless enough to venture into the desert--please drop by our shop. Carpet merchant
     # 0x0313: Forest Temple
-    0x0318: ['Lake Hylia -> LH Lab', "%s"],
+    0x0318: [['Lake Hylia -> LH Lab'], "{}"],
     
     # 0x031D: Spirit Temple
-    0x031E: ['Kokiri Forest -> KF Kokiri Shop', "%s"],
-    0x031F: ['Kokiri Forest -> KF Links House', "%s"],
+    0x031E: [['Kokiri Forest -> KF Kokiri Shop'], "{}"],
+    0x031F: [['Kokiri Forest -> KF Links House'], "{}"],
     # 0x032D: moutain summit danger ahead - keep out
-    0x0333: ['Zoras Domain -> ZD Shop', "%s"],
-    0x033C: ['Kokiri Forest -> KF Midos House', "%s"],
-    0x033D: ['Kokiri Forest -> KF Know It All House', "%s"],
-    0x033E: ['Kokiri Forest -> KF House of Twins', "%s"],
-    0x033F: ['Kokiri Forest -> KF Sarias House', "%s"],
+    0x0333: [['Zoras Domain -> ZD Shop'], "{}"],
+    0x033C: [['Kokiri Forest -> KF Midos House'], "{}"],
+    0x033D: [['Kokiri Forest -> KF Know It All House'], "{}"],
+    0x033E: [['Kokiri Forest -> KF House of Twins'], "{}"],
+    0x033F: [['Kokiri Forest -> KF Sarias House'], "{}"],
     # 0x0345: visit the house of the know it all brothers to get answers to all your item-related questions
 }
 
 OW_SIGNS = {
-    # 0x0305: ['Hyrule Field -> Kakariko Village', "%s"], # This sign is in 2 spots. I think I need to make a new one! field->kak and dmt->kak
-    0x0306: ['Kakariko Village -> Graveyard', "%s"],
-    0x0308: ['Kak Behind Gate -> Death Mountain', "%s"],
-    0x030B: ['Death Mountain -> Goron City', "%s"],
-    0x030C: ['Hyrule Field -> ZR Front', "%s"],
-    0x0314: ['Kokiri Forest -> Lost Woods', "%s"],
-    0x0315: ['Hyrule Field -> Lon Lon Ranch', "%s"],
-    0x0316: ['Hyrule Field -> Lon Lon Ranch', "%s"],
-    0x0317: ['Hyrule Field -> Lake Hylia', "%s"],
-    # 0x0319: ['Hyrule Field -> Gerudo Valley', "%s"], # This sign is also in gf pointing to gv
-    0x031C: ['GF Outside Gate -> Wasteland Near Fortress', "%s"], # hw if you chase a mirage... MAKE SUR EITS NOT IN COLOSSSUS
-    0x0320: ['Kokiri Forest -> LW Bridge From Forest', "%s"],
-    0x0321: ['Death Mountain -> Goron City', "Follow the trail along the edge of\x01the cliff and you will reach\x01%s"],
-    0x0323: ['Death Mountain Summit -> DMC Upper Local', "Death Mountain Summit\x01Entrance to %s\x01ahead"], # Color 'Death Mountain Summit'
-    0x6069: ['GV Fortress Side -> Gerudo Fortress', "%s is located beyond this gate.\x01A kid like you has no business there."],
+    # 0x0305: [['Hyrule Field -> Kakariko Village'], "{}"], # This sign is in 2 spots. I think I need to make a new one! field->kak and dmt->kak
+    0x0306: [['Kakariko Village -> Graveyard'], "{}"],
+    0x0308: [['Kak Behind Gate -> Death Mountain'], "{}"],
+    0x030B: [['Death Mountain -> Goron City'], "{}"],
+    0x030C: [['Hyrule Field -> ZR Front'], "{}"],
+    0x0314: [['Kokiri Forest -> Lost Woods'], "{}"],
+    0x0315: [['Hyrule Field -> Lon Lon Ranch'], "{}"],
+    0x0316: [['Hyrule Field -> Lon Lon Ranch'], "{}"],
+    0x0317: [['Hyrule Field -> Lake Hylia'], "{}"],
+    # 0x0319: [['Hyrule Field -> Gerudo Valley'], "{}"], # This sign is also in gf pointing to gv
+    0x031C: [['GF Outside Gate -> Wasteland Near Fortress'], "{}"], # hw if you chase a mirage... MAKE SUR EITS NOT IN COLOSSSUS
+    0x0320: [['Kokiri Forest -> LW Bridge From Forest'], "{}"],
+    0x0321: [['Death Mountain -> Goron City'], "Follow the trail along the edge of\x01the cliff and you will reach\x01{}"],
+    0x0323: [['Death Mountain Summit -> DMC Upper Local'], "Death Mountain Summit\x01Entrance to {}\x01ahead"], # Color 'Death Mountain Summit'
+    0x6069: [['GV Fortress Side -> Gerudo Fortress'], "{} is located beyond this gate.\x01A kid like you has no business there."],
 }
 
 SPECIAL_OW_SIGNS = {
@@ -199,16 +198,29 @@ REGION_NAMES = {
 
 
 def replace_overworld_signs(messages, world):
-    # print("-----------------------------------------")
-    # print(world.get_entrance('Kokiri Forest -> KF Kokiri Shop').connected_region.name)
-    # print("-----------------------------------------")
-
     SIGNS = {**INDOORS_SIGNS, **OW_SIGNS, **DUNGEON_SIGNS}
 
-    for sign_id, entrance in SIGNS.items():
-        try:
-            destination = REGION_NAMES[world.get_entrance(entrance[0]).connected_region.name]
-        except KeyError:
-            destination = world.get_entrance(entrance[0]).connected_region.name
-            print("MISSING REGION NAME: " + destination)
-        update_message_by_id(messages, sign_id, entrance[1]%destination)
+    for sign_id, entrance_info in SIGNS.items():
+        entrance_list = entrance_info[0]
+        sign_text = entrance_info[1]
+        destination_list = [world.get_entrance(entr).connected_region.name for entr in entrance_list]
+
+        # Replace the text with cleaner, formatted text
+        for idx in range(len(destination_list)):
+            try:
+                clean_dest = REGION_NAMES[destination_list[idx]]
+            except KeyError:
+                clean_dest = world.get_entrance(entrance[0]).connected_region.name
+                print("MISSING REGION NAME: " + dest)
+            destination_list[idx] = clean_dest
+
+        # Update the messages table
+        update_message_by_id(messages, sign_id, sign_text.format(*destination_list))
+
+
+        # try:
+        #     destination = REGION_NAMES[world.get_entrance(entrance[0]).connected_region.name]
+        # except KeyError:
+        #     destination = world.get_entrance(entrance[0]).connected_region.name
+        #     print("MISSING REGION NAME: " + destination)
+        # update_message_by_id(messages, sign_id, entrance[1]%destination)

--- a/SignUpdater.py
+++ b/SignUpdater.py
@@ -1,66 +1,76 @@
 from World import World
-from Messages import update_message_by_id
-
-# Color can be added to dungeons and whatnot in the REGION NAMES section
+from Messages import update_message_by_id, get_message_by_id
 
 # Complex things to replace
 # 0x300A - has an option to ask about dc
 # 0x300D - Comes up when you ask about dc in 0x300A
 
+# COULD ADD A NEW FUNCTION TO CENTER TEXT.
+# - Would need to know length of each character in pixels
+# - Would need max length of text in pixels
+# - Can then compute how much spec to prepend to a line.
+
+# CHANGE WHERE SIGN ACTORS POINT FOR DUPLICATES, NEW MESSAGES SHOULD BE 0X9000+
+# - 0x9000-0x9003 are used.
+
 DUNGEON_SIGNS = {
-    0x0307: [['Kakariko Village -> Bottom of the Well']," Dark! Narrow! Scary!\x01{}"],
-    0x030A: ['Dodongos Cavern Entryway -> Dodongos Cavern Beginning', "{}\x01Don't enter without permission!"],
-    0x0312: ['KF Outside Deku Tree -> Deku Tree Lobby', "Just ahead:\x01{}"],
-    0x031B: ['Gerudo Fortress -> Gerudo Training Grounds Lobby', "{}\x01Only registered members are\x01allowed!"],
+    0x0307: [['Kakariko Village -> Bottom of the Well']," Dark! Narrow! Scary!\x01{}", 0x13],
+    0x030A: [['Dodongos Cavern Entryway -> Dodongos Cavern Beginning'], "{}\x01Don't enter without permission!", 0x13],
+    0x0312: [['KF Outside Deku Tree -> Deku Tree Lobby'], "Just ahead:\x01{}", 0x13],
+    0x031B: [['Gerudo Fortress -> Gerudo Training Grounds Lobby'], "{}\x01Only registered members are\x01allowed!", 0x13],
     # 0x6013: GTG with no card
     # 0x6014: GTG with card
 }
 
 INDOORS_SIGNS = {
-    0x020E: [['Kakariko Village -> Kak Potion Shop Front'], "{}\x01Closed until morning"], # Potion Shop at night, Color the location name light blue
-    0x020F: [['Kakariko Village -> Kak Shooting Gallery'], "{}\x01Open only during the day"], # Kak shooting gallery (check child message), color location light blue
-    0x0211: [['Kakariko Village -> Kak Bazaar'], "{}\x01Open only during the day"], # Kak Bazaar at night (is this the same message as child?), color location light blue
-    0x023A: [['Lake Hylia -> LH Fishing Hole'], "{}"],
+    0x020E: [['Kakariko Village -> Kak Potion Shop Front'], "kakdoor:{}\x01Closed until morning", 0x20], # Potion Shop at night ALSO USED IN MARKET
+    0x020F: [['Kakariko Village -> Kak Shooting Gallery'], "kakdoor:{}\x01Open only during the day", 0x20], # Kak shooting gallery (check child message)
+    0x0210: [['Market -> Market Mask Shop'], "{}\x01Now hiring part-time\x01Apply during the day", 0x20], # Mask shop door ALSO USED IN MARKET
+    0x0211: [['Kakariko Village -> Kak Bazaar'], "kakdoor:{}\x01Open only during the day", 0x20], # Kak Bazaar at night ALSO USED IN MARKET
+    0x023A: [['Lake Hylia -> LH Fishing Hole'], "{}", 0x20],
     # 0x0301: Hyrule Field (GV -> field, lake->field, kak->field)
     # 0x0302: Hyrule Castle Town
     # 0x0303: The Temple of Time
     # 0x030F: Zoras fountain dont disturb lord jabu jabu --king zora xvi
     # 0x0313: Forest Temple
-    0x0318: [['Lake Hylia -> LH Lab'], "{}"],
+    0x0318: [['Lake Hylia -> LH Lab'], "{}", 0x13],
     
     # 0x031D: Spirit Temple
-    0x031E: [['Kokiri Forest -> KF Kokiri Shop'], "{}"],
-    0x031F: [['Kokiri Forest -> KF Links House'], "{}"],
+    0x031E: [['Kokiri Forest -> KF Kokiri Shop'], "{}", 0x13],
+    0x031F: [['Kokiri Forest -> KF Links House'], "{}", 0x13],
     # 0x032D: moutain summit danger ahead - keep out
-    0x0333: [['Zoras Domain -> ZD Shop'], "{}"],
-    0x033C: [['Kokiri Forest -> KF Midos House'], "{}"],
-    0x033D: [['Kokiri Forest -> KF Know It All House'], "{}"],
-    0x033E: [['Kokiri Forest -> KF House of Twins'], "{}"],
-    0x033F: [['Kokiri Forest -> KF Sarias House'], "{}"],
+    0x0333: [['Zoras Domain -> ZD Shop'], "{}", 0x13],
+    0x033C: [['Kokiri Forest -> KF Midos House'], "{}", 0x13],
+    0x033D: [['Kokiri Forest -> KF Know It All House'], "{}", 0x13],
+    0x033E: [['Kokiri Forest -> KF House of Twins'], "{}", 0x13],
+    0x033F: [['Kokiri Forest -> KF Sarias House'], "{}", 0x13],
     # 0x0345: visit the house of the know it all brothers to get answers to all your item-related questions
 }
 
 OW_SIGNS = {
     # 0x0305: [['Hyrule Field -> Kakariko Village'], "{}"], # This sign is in 2 spots. I think I need to make a new one! field->kak and dmt->kak
-    0x0306: [['Kakariko Village -> Graveyard'], "{}"],
-    0x0308: [['Kak Behind Gate -> Death Mountain'], "{}"],
-    0x030B: [['Death Mountain -> Goron City'], "{}"],
-    0x030C: [['Hyrule Field -> ZR Front'], "{}"],
-    0x0314: [['Kokiri Forest -> Lost Woods'], "{}"],
-    0x0315: [['Hyrule Field -> Lon Lon Ranch'], "{}"],
-    0x0316: [['Hyrule Field -> Lon Lon Ranch'], "{}"],
-    0x0317: [['Hyrule Field -> Lake Hylia'], "{}"],
-    # 0x0319: [['Hyrule Field -> Gerudo Valley'], "{}"], # This sign is also in gf pointing to gv
-    0x031C: [['GF Outside Gate -> Wasteland Near Fortress'], "{}"], # hw if you chase a mirage... MAKE SUR EITS NOT IN COLOSSSUS
-    0x0320: [['Kokiri Forest -> LW Bridge From Forest'], "{}"],
-    0x0321: [['Death Mountain -> Goron City'], "Follow the trail along the edge of\x01the cliff and you will reach\x01{}"],
-    0x0323: [['Death Mountain Summit -> DMC Upper Local'], "Death Mountain Summit\x01Entrance to {}\x01ahead"], # Color 'Death Mountain Summit'
-    0x6069: [['GV Fortress Side -> Gerudo Fortress'], "{} is located beyond this gate.\x01A kid like you has no business there."],
+    0x0306: [['Kakariko Village -> Graveyard'], "{}", 0x13],
+    0x0308: [['Kak Behind Gate -> Death Mountain'], "{}", 0x13],
+    0x030B: [['Death Mountain -> Goron City'], "{}", 0x13],
+    0x030C: [['Hyrule Field -> ZR Front'], "{}", 0x13],
+    # 0x030E: [['Zoras Fountain -> ZD Behind King Zora'], "zf->zd: {}", 0x13], # ZF pointing into ZD (DUPLICATE IN ZD) - leave this ID and associate the sign actor in ZF to 0x9004
+    0x9004: [['Zoras Fountain -> ZD Behind King Zora'], "mega dong: {}", 0x13],
+    0x0314: [['Kokiri Forest -> Lost Woods'], "{}", 0x13],
+    0x0315: [['Hyrule Field -> Lon Lon Ranch'], "{}", 0x13],
+    0x0316: [['Hyrule Field -> Lon Lon Ranch'], "{}", 0x13],
+    0x0317: [['Hyrule Field -> Lake Hylia'], "{}", 0x13],
+    # 0x0319: [['Hyrule Field -> Gerudo Valley'], "{}", 0x13], # This sign is also in gf pointing to gv
+    0x031C: [['GF Outside Gate -> Wasteland Near Fortress'], "{}", 0x13], # hw if you chase a mirage... MAKE SUR EITS NOT IN COLOSSSUS
+    0x0320: [['Kokiri Forest -> LW Bridge From Forest'], "{}", 0x13],
+    0x0321: [['Death Mountain -> Goron City'], "Follow the trail along the edge of\x01the cliff and you will reach\x01{}", 0x13],
+    0x0323: [['Death Mountain Summit -> DMC Upper Local'], "Death Mountain Summit\x01Entrance to {}\x01ahead", 0x13], # Color 'Death Mountain Summit'
+    0x0339: [['Hyrule Field -> Market Entrance', 'Hyrule Field -> Lon Lon Ranch'], "{}\x01{}", 0x13], # Sign outside of Kokiri Forest in Hyrule Field
+    0x033A: [['Hyrule Field -> Market Entrance', 'Hyrule Field -> Lon Lon Ranch'], "You are here: {}\x01This way to {}", 0x13], # Sign between market and llr
+    0x6069: [['GV Fortress Side -> Gerudo Fortress'], "{} is located beyond this gate.\x01A kid like you has no business there.", 0x13],
 }
 
 SPECIAL_OW_SIGNS = {
-    # 0x033A: you are here: hyrule castle this way to lon lon Ranch (this should have the market and llr entrances on it)
-    #0x4003: 
+    #0x4003: # lake owl
         #What are you doing? You've come 
         #a long way to get up here...You should look at the Map 
         #Subscreen sometimes.
@@ -85,7 +95,6 @@ SPECIAL_OW_SIGNS = {
         #I'm on my way back to the castle.
         #If you want to come with me, hold
         #on to my talons!
-    # 0x0339: hyrule castle lon lon Ranch (in field after leaving kokiri)
     #DMT owl
 }
 
@@ -147,63 +156,89 @@ REGION_NAMES = {
     'Kak Potion Shop Back': "\x05\44Potion Shop\x05\40",
 
     # Overworld - THESE SHOULD ALL BE COLORED APPROPRIATELY
-    'Kokiri Forest': "\x05\40Kokiri Forest\x05\x40",
-    'LW Bridge From Forest': "\x05\40Lost Woods Bridge\x05\x40",
-    'LW Bridge': "\x05\40Lost Woods Bridge\x05\x40",
-    'Lost Woods': "\x05\40Lost Woods\x05\x40",
-    'LW Forest Exit': "\x05\40Lost Woods\x05\x40", # Is this right?
-    'GC Woods Warp': "\x05\40Goron City\x05\x40",
-    'Zora River': "\x05\40Zora River\x05\x40",
-    'LW Beyond Mido': "\x05\40Lost Woods\x05\x40",
-    'SFM Entryway': "\x05\40Sacred Forest Meadow\x05\x40",
-    'Hyrule Field': "\x05\40Hyrule Field\x05\x40",
-    'Lake Hylia': "\x05\40Lake Hylia\x05\x40",
-    'Gerudo Valley': "\x05\40Gerudo Valley\x05\x40",
-    'Market Entrance': "\x05\40Market Entrance\x05\x40",
-    'Kakariko Village': "\x05\40Kakariko Village\x05\x40",
-    'ZR Front': "\x05\40Zora River\x05\x40",
-    'Lon Lon Ranch': "\x05\40Lon Lon Ranch\x05\x40",
-    'Zoras Domain': "\x05\40Zora's Domain\x05\x40",
-    'GV Fortress Side': "\x05\40Gerudo Valley\x05\x40",
-    'Gerudo Fortress': "\x05\40Gerudo Fortress\x05\x40",
-    'GF Outside Gate': "\x05\40Gerudo Fortress\x05\x40",
-    'Wasteland Near Fortress': "\x05\40Haunted Wasteland\x05\x40",
-    'Wasteland Near Colossus': "\x05\40Haunted Wasteland\x05\x40",
-    'Desert Colossus': "\x05\40Desert Colossus\x05\x40",
-    'Market': "\x05\40Market\x05\x40",
-    'Castle Grounds': "\x05\40Castle Grounds\x05\x40",
-    'ToT Entrance': "\x05\40Temple of Time Entrance\x05\x40",
-    'Graveyard': "\x05\40Graveyard\x05\x40",
-    'Kak Behind Gate': "\x05\40Kakariko Village\x05\x40",
-    'Death Mountain': "\x05\40Death Mountain Trail\x05\x40",
-    'Goron City': "\x05\40Goron City\x05\x40",
-    'GC Darunias Chamber': "\x05\40Goron City\x05\x40",
-    'DMC Lower Local': "\x05\40Death Mountain Crater\x05\x40",
-    'DMC Lower Nearby': "\x05\40Death Mountain Crater\x05\x40",
-    'Death Mountain Summit': "\x05\40Death Mountain Trail\x05\x40", # I think...
-    'DMC Upper Local': "\x05\40Death Mountain Crater\x05\x40",
-    'DMC Upper Nearby': "\x05\40Death Mountain Crater\x05\x40",
-    'ZR Behind Waterfall': "\x05\40Zora River\x05\x40",
-    'Zoras Domain': "\x05\40Zora's Domain\x05\x40",
-    'ZD Behind King Zora': "\x05\40Zora's Domain\x05\x40",
-    'Zoras Fountain': "\x05\40Zora's Fountain\x05\x40",
-    'LH Owl Flight': "\x05\40Lake Hylia\x05\x40",
-    'DMT Owl Flight': "\x05\40Death Mountain Trail\x05\x40",
-    'Kak Impas Ledge': "\x05\40Kakariko Village\x05\x40",
+    'Kokiri Forest': "\x05\41Kokiri Forest\x05\x40",
+
+    'LW Bridge From Forest': "\x05\42Lost Woods Bridge\x05\x40",
+    'LW Bridge':             "\x05\42Lost Woods Bridge\x05\x40",
+
+    'Lost Woods':     "\x05\42Lost Woods\x05\x40",
+    'LW Forest Exit': "\x05\42Lost Woods\x05\x40", # Is this right?
+    'LW Beyond Mido': "\x05\42Lost Woods\x05\x40",
+
+    'GC Woods Warp':       "\x05\41Goron City\x05\x40",
+    'Goron City':          "\x05\41Goron City\x05\x40",
+    'GC Darunias Chamber': "\x05\41Goron City\x05\x40",
+
+    'Zora River':          "\x05\43Zora River\x05\x40",
+    'ZR Front':            "\x05\43Zora River\x05\x40",
+    'ZR Behind Waterfall': "\x05\43Zora River\x05\x40",
+
+    'SFM Entryway': "\x05\41Sacred Forest Meadow\x05\x40",
+
+    'Hyrule Field': "\x05\44Hyrule Field\x05\x40",
+
+    'Lake Hylia':    "\x05\43Lake Hylia\x05\x40",
+    'LH Owl Flight': "\x05\43Lake Hylia\x05\x40",
+
+    'Gerudo Valley':    "\x05\46Gerudo Valley\x05\x40",
+    'GV Fortress Side': "\x05\46Gerudo Valley\x05\x40",
+
+    'Market Entrance': "\x05\44Market Entrance\x05\x40",
+
+    'Kakariko Village': "\x05\45Kakariko Village\x05\x40",
+    'Kak Behind Gate':  "\x05\45Kakariko Village\x05\x40",
+    'Kak Impas Ledge':  "\x05\45Kakariko Village\x05\x40",
+
+    'Lon Lon Ranch': "\x05\46Lon Lon Ranch\x05\x40",
+
+    'Zoras Domain':        "\x05\43Zora's Domain\x05\x40",
+    'ZD Behind King Zora': "\x05\43Zora's Domain\x05\x40",
+
+    'Gerudo Fortress': "\x05\41Gerudo Fortress\x05\x40",
+    'GF Outside Gate': "\x05\41Gerudo Fortress\x05\x40",
+
+    'Wasteland Near Fortress': "\x05\46Haunted Wasteland\x05\x40",
+    'Wasteland Near Colossus': "\x05\46Haunted Wasteland\x05\x40",
+
+    'Desert Colossus': "\x05\44Desert Colossus\x05\x40",
+
+    'Market': "\x05\44Market\x05\x40",
+
+    'Castle Grounds': "\x05\44Castle Grounds\x05\x40",
+
+    'ToT Entrance': "\x05\44Temple of Time Entrance\x05\x40",
+
+    'Graveyard': "\x05\45Graveyard\x05\x40",
+
+    'Death Mountain':        "\x05\41Death Mountain Trail\x05\x40",
+    'Death Mountain Summit': "\x05\41Death Mountain Trail\x05\x40", # I think...
+    'DMT Owl Flight':        "\x05\41Death Mountain Trail\x05\x40",
+
+    'DMC Lower Local':  "\x05\41Death Mountain Crater\x05\x40",
+    'DMC Lower Nearby': "\x05\41Death Mountain Crater\x05\x40",
+    'DMC Upper Local':  "\x05\41Death Mountain Crater\x05\x40",
+    'DMC Upper Nearby': "\x05\41Death Mountain Crater\x05\x40",
+
+    'Zoras Fountain': "\x05\43Zora's Fountain\x05\x40",
+
 
     # Grotto
     # Fill these in eventually, not needed until I worry about mixed pools
 }
 
 
-
 def replace_overworld_signs(messages, world):
     SIGNS = {**INDOORS_SIGNS, **OW_SIGNS, **DUNGEON_SIGNS}
 
+    testid = 0x030f
+    print('--------------------------------')
+    print(get_message_by_id(messages, testid))
+    print('--------------------------------')
+
     for sign_id, entrance_info in SIGNS.items():
-        entrance_list = entrance_info[0]
-        sign_text = entrance_info[1]
+        entrance_list, sign_text, opts = entrance_info
         destination_list = [world.get_entrance(entr).connected_region.name for entr in entrance_list]
+
 
         # Replace the text with cleaner, formatted text
         for idx in range(len(destination_list)):
@@ -215,12 +250,9 @@ def replace_overworld_signs(messages, world):
             destination_list[idx] = clean_dest
 
         # Update the messages table
-        update_message_by_id(messages, sign_id, sign_text.format(*destination_list))
+        update_message_by_id(messages, sign_id, sign_text.format(*destination_list), opts) # Opts at the end are the text box type and position values WRAP THIS INTO THE TABLE ABOVE
 
 
-        # try:
-        #     destination = REGION_NAMES[world.get_entrance(entrance[0]).connected_region.name]
-        # except KeyError:
-        #     destination = world.get_entrance(entrance[0]).connected_region.name
-        #     print("MISSING REGION NAME: " + destination)
-        # update_message_by_id(messages, sign_id, entrance[1]%destination)
+    print('--------------------------------')
+    print(get_message_by_id(messages, testid))
+    print('--------------------------------')


### PR DESCRIPTION
There are a lot of signs throughout the world that say things like "Hyrule Field" and point towards an entrance. I started by updating each of these signs to reflect their final entrance when entrance randomizer is enabled.

I have set up a couple of objects to do this:
1. `SIGN_LIST`: Dictionary that holds information on each message that needs to be updated. This includes the id in the message table, the entrance to reference in the rando code, options for the message box, a category tag for the type of ER, and the text to put into that message box.
2. `REGION_NAMES`: The way the rando references regions is messy and inconsistent. So this dictionary has a nicely formatted string for each region as keys and a list of rando region names as the values. For instance, we can consider Zora River. A sign should say "Zora River" (colored blue), however, rando has three different regions that are all Zora River `['Zora River', 'ZR Behind Waterfall', 'ZR Front']`. This dictionary just matches these up. If names change or new regions are added for a zone in the future, this can be updated simply by adding the new region into the list (don't even have to delete the changed/unused ones, although leaving them is gross).
3. `sign_actor_table`: This is a list of namedtuples that hold information on the sign actors that need to be edited. There are several signs that reference the same line in the message table. Each named tuple in the list holds all the information needed to both identify the actor that needs to be changed and how exactly to change the bitpacked actor variable.

From here, I run the function `replace_overworld_signs` and `revise_entrance_signs` (I need to rename these functions lol). The former of which updates the message table according to a particular seed and the latter updates the actor lists.

**NOTE: As of now, each sign prints super messy information to the first line of the sign. THIS IS ENTIRELY FOR TESTING, PLEASE DISREGARD THOSE LINES. The final versions will only have the "clean" region names in the REGION_NAMES dictionary.**

I wanted to open this draft PR for discussion but there are still a couple of things left to do.
- [x] Rename functions
- [x] Owls
- [ ] When I changed the msgs on locked doors, this also changes the locked/unlocked flag. I need to add the new flag to the list of locked doors?
- [ ] The method I use to identify actors cannot differentiate between the front and back doors of the Kak Potion Shop. Need to get around this.
- [ ] SWAG FEATURE: Write a function that can center text (in default, the signs are all manually centered. This doesn't work when a sign line length is variable). It looks fine as is, it would just look nicer to be able to center things.
- [x] Grottos are not yet in REGION_NAMES
- [x] To make this more maintainable, I am going to make another dictionary that contains each entrance in "rando-speak" (`'Gerudo Fortress -> Gerudo Training Grounds Lobby'`) and keys it to the randomized destination in english. i.e. If GTG contains DC, an example entry may look like `{'gtg': 'Gerudo Fortress -> Gerudo Training Grounds Lobby'}`. I can then reference this dictionary at the gtg key anywhere I want this entrance. If this entrance changes name in rando, this then only needs to be changed in one place.
- [ ] Make it a toggle-able setting. When off, signs should say something like "To an unknown land" or something along those lines.
- [ ] Add the setting to the GUI (this is likely well beyond my ability)