### PR TITLE
Allow Impas House to straddle hint regions in ER, while only using the back entrance for hints

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -631,7 +631,6 @@ def validate_worlds(worlds, entrance_placed, locations_to_ensure_reachable, item
             if world.shuffle_cows:
                 impas_front_entrance = get_entrance_replacing(world.get_region('Kak Impas House'), 'Kakariko Village -> Kak Impas House')
                 impas_back_entrance = get_entrance_replacing(world.get_region('Kak Impas House Back'), 'Kak Impas Ledge -> Kak Impas House Back')
-                check_same_hint_region(impas_front_entrance, impas_back_entrance)
 
     return
 

--- a/Hints.py
+++ b/Hints.py
@@ -265,15 +265,16 @@ def colorText(gossip_text):
 
 
 def get_hint_area(spot):
-    if spot.parent_region.dungeon:
-        return spot.parent_region.dungeon.hint
-    elif spot.parent_region.hint:
-        return spot.parent_region.hint
+    region = spot.parent_region.get_hint_region()
+    if region.dungeon:
+        return region.dungeon.hint
+    elif region.hint:
+        return region.hint
     #Breadth first search for connected regions with a max depth of 2
-    for entrance in spot.parent_region.entrances:
+    for entrance in region.entrances:
         if entrance.parent_region.hint:
             return entrance.parent_region.hint
-    for entrance in spot.parent_region.entrances:
+    for entrance in region.entrances:
         for entrance2 in entrance.parent_region.entrances:
             if entrance2.parent_region.hint:
                 return entrance2.parent_region.hint

--- a/Region.py
+++ b/Region.py
@@ -35,6 +35,7 @@ class Region(object):
         self.dungeon = None
         self.world = None
         self.hint = None
+        self.hint_region = None
         self.price = None
         self.world = None
         self.time_passes = False
@@ -47,6 +48,7 @@ class Region(object):
         new_region.world = new_world
         new_region.price = self.price
         new_region.hint = self.hint
+        new_region.hint_region = self.hint_region
         new_region.time_passes = self.time_passes
         new_region.provides_time = self.provides_time
         new_region.scene = self.scene
@@ -77,6 +79,13 @@ class Region(object):
             return item.world.id == self.world.id
 
         return True
+
+
+    def get_hint_region(self):
+        """Returns the region we consider this region "as" for hinting purposes."""
+        if self.hint_region:
+            return self.world.get_region(self.hint_region)
+        return self
 
 
     def __str__(self):

--- a/Unittest.py
+++ b/Unittest.py
@@ -7,10 +7,11 @@ import os
 import random
 import unittest
 
+from Hints import get_hint_area
 from ItemList import item_table
 from ItemPool import remove_junk_items, item_groups
 from LocationList import location_groups
-from Main import main
+from Main import main, resolve_settings, build_world_graphs
 from Settings import Settings
 
 test_dir = os.path.join(os.path.dirname(__file__), 'tests')
@@ -119,6 +120,15 @@ def get_actual_pool(spoiler):
         except KeyError:
             actual_pool[test_item] = 1
     return actual_pool
+
+
+class TestGraphGeneration(unittest.TestCase):
+    def test_impas_cow_hint(self):
+        settings = load_settings('house-cow.sav', seed='TESTTESTTEST')
+        _ = resolve_settings(settings)
+        world = build_world_graphs(settings)[0]
+        self.assertEqual('Kak Impas House Back', world.get_region('Kak Impas House Near Cow').hint_region)
+        self.assertEqual("Zora's Domain", get_hint_area(world.get_location('Kak Impas House Cow')))
 
 
 class TestPlandomizer(unittest.TestCase):

--- a/World.py
+++ b/World.py
@@ -230,6 +230,8 @@ class World(object):
                 new_region.scene = region['scene']
             if 'hint' in region:
                 new_region.hint = region['hint']
+            if 'hint_region' in region:
+                new_region.hint_region = region['hint_region']
             if 'dungeon' in region:
                 new_region.dungeon = region['dungeon']
             if 'time_passes' in region:

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -936,12 +936,9 @@
     },
     {
         "region_name": "Kak Impas House Near Cow",
+        "hint_region": "Kak Impas House Back",
         "locations": {
             "Kak Impas House Cow": "can_play(Eponas_Song)"
-        },
-        "exits": {
-            #For hints purposes
-            "Kak Impas House Back": "False"
         }
     },
     {

--- a/tests/house-cow.sav
+++ b/tests/house-cow.sav
@@ -1,0 +1,8 @@
+{
+"seed": "TESTTESTTEST",
+"enable_distribution_file": true,
+"compress_rom": "None",
+"distribution_file": "tests/plando/house-cow.json",
+"shuffle_cows": true,
+"entrance_shuffle": "simple-indoors"
+}

--- a/tests/plando/house-cow.json
+++ b/tests/plando/house-cow.json
@@ -1,0 +1,6 @@
+{
+"entrances": {
+"Desert Colossus -> Colossus Great Fairy Fountain": "Kak Impas House",
+"Zoras Domain -> ZD Shop": "Kak Impas House Back"
+}
+}


### PR DESCRIPTION
based on a conversation yesterday with @r0bd0g, and fixes #1047.

This is done with a "hint_region" annotation, that allows us to specify when a region should be given hints as though its another. Namely, locations in the region where the cow is (`Kak Impas House Near Cow`) will find their hint area by searching for a hint area from `Kak Impas House Back`.

Without this annotation, the hint area for the `Kak Impas House Near Cow` region would be dependent on the ordering of its entrances...

Includes a minor refactor of `main()` to set up a unittest that has access to the World object.