### PR TITLE
Add a new option for random music while omitting vanilla OoT music

### DIFF
--- a/Music.py
+++ b/Music.py
@@ -158,7 +158,7 @@ def process_sequences(rom, sequences, target_sequences, ids, seq_type = 'bgm'):
 def shuffle_music(sequences, target_sequences, log):
     # Shuffle the sequences
     if len(sequences) < len(target_sequences):
-        random.choices(sequences, k=len(target_sequences))
+        sequences = random.choices(sequences, k=len(target_sequences))
     else:
         random.shuffle(sequences)
 

--- a/Music.py
+++ b/Music.py
@@ -158,9 +158,8 @@ def process_sequences(rom, sequences, target_sequences, ids, seq_type = 'bgm'):
 def shuffle_music(sequences, target_sequences, log):
     # Shuffle the sequences
     if len(sequences) < len(target_sequences):
-        sequences = random.choices(sequences, k=len(target_sequences))
-    else:
-        random.shuffle(sequences)
+        raise IndexError("Not enough custom music/fanfares to omit base Ocarina of Time sequences.")
+    random.shuffle(sequences)
 
     for i in range(len(target_sequences)):
         sequences[i].replaces = target_sequences[i].replaces
@@ -339,19 +338,13 @@ def randomize_music(rom, settings):
             sequences, target_sequences = process_sequences(rom, sequences, target_sequences, bgm_sequence_ids)
             if settings.background_music == 'random_custom_only':
                 sequences = [seq for seq in sequences if seq.cosmetic_name not in [x[0] for x in bgm_sequence_ids]]
-            if len(sequences) == 0:
-                disable_music(rom, bgm_sequence_ids)
-            else:
-                sequences, log = shuffle_music(sequences, target_sequences, log)
+            sequences, log = shuffle_music(sequences, target_sequences, log)
 
         if settings.fanfares in ['random', 'random_custom_only']:
             fanfare_sequences, fanfare_target_sequences = process_sequences(rom, fanfare_sequences, fanfare_target_sequences, ff_ids, 'fanfare')
             if settings.fanfares == 'random_custom_only':
                 fanfare_sequences = [seq for seq in fanfare_sequences if seq.cosmetic_name not in [x[0] for x in fanfare_sequence_ids]]
-            if len(fanfare_sequences) == 0:
-                disable_music(rom, ff_ids)
-            else:
-                fanfare_sequences, log = shuffle_music(fanfare_sequences, fanfare_target_sequences, log)
+            fanfare_sequences, log = shuffle_music(fanfare_sequences, fanfare_target_sequences, log)
 
         log = rebuild_sequences(rom, sequences + fanfare_sequences, log)
 

--- a/Music.py
+++ b/Music.py
@@ -158,7 +158,7 @@ def process_sequences(rom, sequences, target_sequences, ids, seq_type = 'bgm'):
 def shuffle_music(sequences, target_sequences, log):
     # Shuffle the sequences
     if len(sequences) < len(target_sequences):
-        raise IndexError("Not enough custom music/fanfares to omit base Ocarina of Time sequences.")
+        raise Exception("Not enough custom music/fanfares to omit base Ocarina of Time sequences.")
     random.shuffle(sequences)
 
     for i in range(len(target_sequences)):

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2898,9 +2898,10 @@ setting_infos = [
         gui_text       = 'Background Music',
         default        = 'normal',
         choices        = {
-            'normal': 'Normal',
-            'off':    'No Music',
-            'random': 'Random',
+            'normal':               'Normal',
+            'off':                  'No Music',
+            'random':               'Random',
+            'random_custom_only':   'Random (Custom Only)',
         },
         gui_tooltip    = '''\
             'No Music': No background music is played.
@@ -2920,9 +2921,10 @@ setting_infos = [
         gui_text       = 'Fanfares',
         default        = 'normal',
         choices        = {
-            'normal': 'Normal',
-            'off':    'No Fanfares',
-            'random': 'Random',
+            'normal':               'Normal',
+            'off':                  'No Fanfares',
+            'random':               'Random',
+            'random_custom_only':   'Random (Custom Only)',
         },
         disable        = {
             'normal' : {'settings' : ['ocarina_fanfares']},


### PR DESCRIPTION
This was posted in the suggestions channel and was a feature I also wanted. It was easy to do so I figured I would do it =)

Add a new option for Background Music: Randomize (Custom Only)
- Do not shuffle any of the base Ocarina of Time music into the game.
- If not enough custom music sequences are provided, raise an exception stating such.

I also added this features for fanfares as well.