### PR TITLE
Fix Hyrule Castle Grounds logic not using the right entrance

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -646,7 +646,7 @@
             "Bug Rock": "has_bottle"
         },
         "exits": {
-            "Market": "True",
+            "Castle Grounds": "True",
             "HC Garden": "Weird_Egg or (not shuffle_weird_egg)",
             "HC Great Fairy Fountain": "has_explosives",
             "HC Storms Grotto": "can_open_storm_grotto"


### PR DESCRIPTION
This bug appears to be an oversight from the spoiler log cleanup (#1021).
Fixes #1056 and probably #1053.