### PR TITLE
Clarify closed_forest tooltip

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1531,10 +1531,12 @@ setting_infos = [
             needed to clear the Deku Tree will be available within the
             forest, including the Kokiri Sword and access to a Deku
             Shield. A Slingshot will also be available unless the "Deku
-            Tree Basement without Slingshot" trick is enabled. The
-            Starting Age will be forced to Child. If shuffling "All Indoors"
+            Tree Basement without Slingshot" trick is enabled. This setting
+            is incompatible with a Starting Age of Adult, and so Starting
+            Age will be forced to Child. If shuffling "All Indoors"
             and/or "Overworld" entrances, Closed Forest will instead be
-            treated as Closed Deku.
+            treated as Closed Deku with Starting Age of Child and WILL NOT
+            guarantee that these items are available in the forest.
         ''',
         shared         = True,
         disable        = {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1526,10 +1526,15 @@ setting_infos = [
             Deku Tree, requiring Kokiri Sword and Deku Shield to access
             the Deku Tree.
 
-            'Closed Forest': The Kokiri Sword and Slingshot are always
-            available somewhere in the forest. This is incompatible with
-            Start as Adult and shuffling "All Indoors" and/or "Overworld"
-            entrances will force this to Closed Deku if selected.
+            'Closed Forest': The Kokiri boy blocks the path out of the
+            forest, and Mido blocks the path to the Deku Tree. The items
+            needed to clear the Deku Tree will be available within the
+            forest, including the Kokiri Sword and access to a Deku
+            Shield. A Slingshot will also be available unless the "Deku
+            Tree Basement without Slingshot" trick is enabled. The
+            Starting Age will be forced to Child. If shuffling "All Indoors"
+            and/or "Overworld" entrances, Closed Forest will instead be
+            treated as Closed Deku.
         ''',
         shared         = True,
         disable        = {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1528,15 +1528,16 @@ setting_infos = [
 
             'Closed Forest': The Kokiri boy blocks the path out of the
             forest, and Mido blocks the path to the Deku Tree. The items
-            needed to clear the Deku Tree will be available within the
-            forest, including the Kokiri Sword and access to a Deku
-            Shield. A Slingshot will also be available unless the "Deku
-            Tree Basement without Slingshot" trick is enabled. This setting
-            is incompatible with a Starting Age of Adult, and so Starting
-            Age will be forced to Child. If shuffling "All Indoors"
-            and/or "Overworld" entrances, Closed Forest will instead be
-            treated as Closed Deku with Starting Age of Child and WILL NOT
-            guarantee that these items are available in the forest.
+            needed to clear the Deku Tree (including the Kokiri Sword and
+            access to a Deku Shield) will be available within the forest
+            (Kokiri Forest, Lost Woods, Sacred Forest Meadow, or Deku Tree).
+            A Slingshot will also be available unless the "Deku Tree Basement
+            without Slingshot" trick is enabled. This setting is incompatible
+            with a Starting Age of Adult, and so Starting Age will be forced
+            to Child. If shuffling "All Indoors" and/or "Overworld" entrances,
+            Closed Forest will instead be treated as Closed Deku with
+            Starting Age of Child and WILL NOT guarantee that these items
+            are available in the forest.
         ''',
         shared         = True,
         disable        = {


### PR DESCRIPTION
This updates the tooltip copy for the open_forest setting to more
accurately describe what happens in the closed_forest setting.
Specifically, it mentions what is blocked and what happens if you use
incompatible settings.

Fixes #910 