### PR TITLE
Ensure settings lists have enough bitwidth

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -74,6 +74,9 @@ class Setting_Info():
     def calc_bitwidth(self, choices):
         count = len(choices)
         if count > 0:
+            if self.type == list:
+                # Need two special values for terminating additive and subtractive lists
+                count = count + 2
             return math.ceil(math.log(count, 2))
         return 0
 


### PR DESCRIPTION
Fixes #1052

When generating settings strings, list settings such as the Starting Inventory Items use [0...0] and [1...1] as special terminating values. However, this was not accounted for in the bitwidth of the setting, resulting in errors for settings with exactly 2^n or 2^n-1 choices, for any n. This fixes the issue by explicitly considering the special terminators when calculating the bitwidth, adding an extra bit only when needed.