### PR TITLE
Fixed an oversight in glitched spirit logic

### DIFF
--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -1,5 +1,5 @@
-[    
-	{
+[
+    {
         "region_name": "Spirit Temple Lobby",
         "dungeon": "Spirit Temple",
         "exits": {
@@ -61,7 +61,7 @@
         "locations": {
             "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
                 (can_use(Hookshot) or can_hover) and has_projectile(either)",
-            "Spirit Temple Early Adult Right Chest": "has_projectile(either)", 
+            "Spirit Temple Early Adult Right Chest": "has_projectile(either)",
             "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 2)",
             "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 2)",
             "Spirit Temple GS Boulder Room": "has_projectile(either) and
@@ -90,7 +90,8 @@
             # access via Early Adult Spirit Temple requires 2 keys (+ jumpslash + explosives)
             # access to Early Adult Spirit Temple guaranteed via can_jumpslash from here
             "Spirit Temple Beyond Central Locked Door": "can_jumpslash and (
-                (Small_Key_Spirit_Temple, 2) or
+                (Small_Key_Spirit_Temple,
+            2) or
                 can_hover or
                 can_use(Hookshot)) and has_explosives",
             "Child Spirit Temple Climb": "True",
@@ -143,7 +144,7 @@
             "Spirit Temple Beyond Final Locked Door": "(Small_Key_Spirit_Temple,5) and
                 (can_use(Hookshot) or has_explosives)",
             "Mirror Shield Hand": "True",
-            "Spirit Temple Central Chamber": "has_explosives" 
+            "Spirit Temple Central Chamber": "has_explosives"
         }
     },
     {
@@ -153,7 +154,7 @@
             "Spirit Temple Boss Key Chest": "
                 can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or (Bow and 
                 Progressive_Hookshot))",
-            "Spirit Temple Topmost Chest": "Mirror_Shield"
+            "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {
             "Spirit Temple Boss": "can_use(Mirror_Shield)",

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -90,8 +90,7 @@
             # access via Early Adult Spirit Temple requires 2 keys (+ jumpslash + explosives)
             # access to Early Adult Spirit Temple guaranteed via can_jumpslash from here
             "Spirit Temple Beyond Central Locked Door": "can_jumpslash and (
-                (Small_Key_Spirit_Temple,
-            2) or
+                (Small_Key_Spirit_Temple, 2) or
                 can_hover or
                 can_use(Hookshot)) and has_explosives",
             "Child Spirit Temple Climb": "True",


### PR DESCRIPTION
It expected child link to be able to use mirror shield.