### PR TITLE
Assorted Fixes

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -855,7 +855,8 @@ class CosmeticsLog(object):
         for key, value in self.sfx.items():
             output += format_string.format(key=key+':', value=value, width=padding)
 
-        if self.settings.background_music == 'random' or self.settings.fanfares == 'random':
+        if self.settings.background_music == 'random' or self.settings.fanfares == 'random' or \
+            self.settings.compress_rom != 'Patch' and (self.settings.background_music == 'random_custom_only' or self.settings.fanfares == 'random_custom_only'):
             #music_padding = 1 + len(max(self.bgm.keys(), key=len))
             music_padding = 40
             output += '\n\nBackground Music:\n'

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -6,6 +6,7 @@ from Utils import random_choices
 from Item import ItemFactory
 from ItemList import item_table
 from LocationList import location_groups
+from decimal import Decimal, ROUND_HALF_UP
 
 
 #This file sets the item pools for various modes. Timed modes and triforce hunt are enforced first, and then extra items are specified per mode to fill in the remaining space.
@@ -121,10 +122,10 @@ item_difficulty_max = {
 }
 
 TriforceCounts = {
-    'plentiful': 2.00,
-    'balanced':  1.50,
-    'scarce':    1.25,
-    'minimal':   1.00,
+    'plentiful': Decimal(2.00),
+    'balanced':  Decimal(1.50),
+    'scarce':    Decimal(1.25),
+    'minimal':   Decimal(1.00),
 }
 
 DT_vanilla = (
@@ -1283,7 +1284,7 @@ def get_pool_core(world):
         world.state.collect(ItemFactory('Small Key (Water Temple)'))
 
     if world.triforce_hunt:
-        triforce_count = int(round(world.triforce_goal_per_world * TriforceCounts[world.item_pool_value]))
+        triforce_count = int((TriforceCounts[world.item_pool_value] * world.triforce_goal_per_world).to_integral_value(rounding=ROUND_HALF_UP))
         pending_junk_pool.extend(['Triforce Piece'] * triforce_count)
 
     if world.shuffle_ganon_bosskey in ['lacs_vanilla', 'lacs_medallions', 'lacs_stones', 'lacs_dungeons']:


### PR DESCRIPTION
### Fix "Random (Custom Only)" Music/Fanares in Cosmetics Log
Currently it only shows the random music in the cosmetics log if one of music/fanfares is set to the normal "Random" setting.

### Triforce Hunt: Round number of Triforce Pieces to next whole number.
Default behavior for Python when rounding a .5 is to round it to the next even number (up or down) instead of always rounding up to the next whole number.

Example, previously a goal of 3 pieces on Balanced item pool (4.5 pieces) would result in 4 pieces in the pool. Now it would result in 5.