### PR TITLE
Logic

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -186,6 +186,15 @@ logic_tricks = {
         'tooltip' : '''\
                     Jump is adult only.
                     '''},
+    'Dodongo\'s Cavern Vines GS from Below with Longshot': {
+        'name'    : 'logic_dc_vines_gs',
+        'tags'    : ("Dodongo's Cavern", "Skulltulas",),
+        'tooltip' : '''\
+                    The vines upon which this Skulltula rests are one-
+                    sided collision. You can use the Longshot to get it
+                    from below, by shooting it through the vines,
+                    bypassing the need to lower the staircase.
+                    '''},
     'Gerudo Fortress "Kitchen" with No Additional Items': {
         'name'    : 'logic_gerudo_kitchen',
         'tags'    : ("Gerudo's Fortress",),
@@ -291,6 +300,17 @@ logic_tricks = {
                     Precise Boomerang throws can allow child to
                     kill the Skulltula and collect the token.
                     '''},
+    'Forest Temple First Room GS with Difficult-to-Use Weapons': {
+        'name'    : 'logic_forest_first_gs',
+        'tags'    : ("Forest Temple", "Entrance", "Skulltulas",),
+        'tooltip' : '''\
+                    Allows killing this Skulltula with Sword or Sticks by
+                    jumpslashing it as you let go from the vines. You will
+                    take fall damage.
+                    Also allows killing it as Child with a Bomb throw. It's
+                    much more difficult to use a Bomb as child due to
+                    Child Link's shorter height.
+                    '''},
     'Swim Through Forest Temple MQ Well with Hookshot': {
         'name'    : 'logic_forest_well_swim',
         'tags'    : ("Forest Temple",),
@@ -325,15 +345,6 @@ logic_tricks = {
                     Pot using a bomb flower alone, requiring 
                     strength in lieu of inventory explosives.
                     '''},
-    'Water Temple Boss Key Chest with Iron Boots': {
-        'name'    : 'logic_water_bk_chest',
-        'tags'    : ("Water Temple",),
-        'tooltip' : '''\
-                    Stand on the blue switch in the Stinger room with the
-                    Iron Boots, wait for the water to rise all the way up,
-                    and then swim straight to the exit. You should grab the
-                    ledge as you surface. It works best if you don't mash B.
-                    '''},
     'Adult Kokiri Forest GS with Hover Boots': {
         'name'    : 'logic_adult_kokiri_gs',
         'tags'    : ("Kokiri Forest", "Skulltulas",),
@@ -366,6 +377,15 @@ logic_tricks = {
                     Skulltula. You must throw the Boomerang slightly off to
                     the side so that it curves into the Skulltula, as aiming
                     directly at it will clank off of the wall in front.
+                    '''},
+    'Spirit Temple Main Room Jump from Hands to Upper Ledges': {
+        'name'    : 'logic_spirit_lobby_jump',
+        'tags'    : ("Spirit Temple"),
+        'tooltip' : '''\
+                    A precise jump to obtain the following as adult
+                    without needing one of Hookshot or Hover Boots:
+                    - Spirit Temple Statue Room Northeast Chest
+                    - Spirit Temple GS Lobby
                     '''},
     'Spirit Temple MQ Sun Block Room GS with Boomerang': {
         'name'    : 'logic_spirit_mq_sun_block_gs',
@@ -419,7 +439,7 @@ logic_tricks = {
                     '''},
     'Fire Temple MQ Flame Wall Maze Skip': {
         'name'    : 'logic_fire_mq_flame_maze',
-        'tags'    : ("Fire Temple",),
+        'tags'    : ("Fire Temple", "Skulltulas"),
         'tooltip' : '''\
                     If you move quickly you can sneak past the edge of
                     a flame wall before it can rise up to block you.
@@ -630,11 +650,18 @@ logic_tricks = {
                     just the Hover Boots.
                     '''},
     'Water Temple Falling Platform Room GS with Hookshot': {
-        'name'    : 'logic_water_falling_platform_gs',
+        'name'    : 'logic_water_falling_platform_gs_hookshot',
         'tags'    : ("Water Temple", "Skulltulas",),
         'tooltip' : '''\
                     If you stand on the very edge of the platform, this
                     Gold Skulltula can be obtained with only the Hookshot.
+                    '''},
+    'Water Temple Falling Platform Room GS with Boomerang': {
+        'name'    : 'logic_water_falling_platform_gs_boomerang',
+        'tags'    : ("Water Temple", "Skulltulas", "Entrance",),
+        'tooltip' : '''\
+                    If you stand on the very edge of the platform, this
+                    Gold Skulltula can be obtained with only the Boomerang.
                     '''},
     'Water Temple River GS without Iron Boots': {
         'name'    : 'logic_water_river_gs',
@@ -655,6 +682,14 @@ logic_tricks = {
                     able to hit the switch and open the gate. But, by
                     standing in a particular spot, the switch can be hit
                     with only the reach of the Hookshot.
+                    '''},
+    'Death Mountain Trail Climb with Hover Boots': {
+        'name'    : 'logic_dmt_climb_hovers',
+        'tags'    : ("Death Mountain Trail",),
+        'tooltip' : '''\
+                    It is possible to use the Hover Boots to bypass
+                    needing to destroy the boulders blocking the path
+                    to the top of Death Mountain.
                     '''},
     'Death Mountain Trail Upper Red Rock GS without Hammer': {
         'name'    : 'logic_trail_gs_upper',
@@ -693,6 +728,15 @@ logic_tricks = {
         'tags'    : ("Zora's River",),
         'tooltip' : '''\
                     Can hover behind the waterfall as adult.
+                    '''},
+    'Zora\'s Domain GS with No Additional Items': {
+        'name'    : 'logic_domain_gs',
+        'tags'    : ("Zora's Domain", "Skulltulas",),
+        'tooltip' : '''\
+                    A precise jumpslash can kill the Skulltula and
+                    recoil back onto the top of the frozen waterfall.
+                    To kill it, the logic normally guarantees one of
+                    Hookshot, Bow, or Magic.
                     '''},
     'Shadow Temple River Statue with Bombchu': {
         'name'    : 'logic_shadow_statue',
@@ -746,6 +790,13 @@ logic_tricks = {
         'tags'    : ("Ice Cavern", "Skulltulas",),
         'tooltip' : '''\
                     A precise jump can be used to reach this alcove.
+                    '''},
+    'Ice Cavern Block Room GS with Hover Boots': {
+        'name'    : 'logic_ice_block_gs',
+        'tags'    : ("Ice Cavern", "Skulltulas",),
+        'tooltip' : '''\
+                    The Hover Boots can be used to kill the Skulltula
+                    and obtain the Token, without Hookshot or Boomerang.
                     '''},
     'Reverse Wasteland': {
         'name'    : 'logic_reverse_wasteland',
@@ -807,6 +858,14 @@ logic_tricks = {
                     Using a precise moving setup you can obtain
                     the Piece of Heart by having the Boomerang
                     interact with it along the return path.
+                    '''},
+    'Hyrule Castle Storms Grotto GS with Just Boomerang': {
+        'name'    : 'logic_castle_storms_gs',
+        'tags'    : ("Hyrule Castle", "Skulltulas"),
+        'tooltip' : '''\
+                    With precise throws, the Boomerang alone can
+                    kill the Skulltula and collect the token,
+                    without first needing to blow up the wall.
                     '''},
     'Death Mountain Trail Soil GS without Destroying Boulder': {
         'name'    : 'logic_dmt_soil_gs',
@@ -875,8 +934,7 @@ logic_tricks = {
                     vanilla Water Temple, boulders roll out into the room.
                     Normally to jump directly to this ledge logically
                     requires the Hover Boots, but with precise jump, it can
-                    be done without them. This trick supersedes "Water Temple
-                    Boss Key Chest with Iron Boots" and applies to both
+                    be done without them. This trick applies to both
                     Vanilla and Master Quest.
                     '''},
     'Water Temple Torch Longshot': {
@@ -890,6 +948,18 @@ logic_tricks = {
                     The majority of the tricks that allow you to skip Iron Boots
                     in the Water Temple are not going to be relevant unless this
                     trick is first enabled.
+                    '''},
+    'Water Temple Central Pillar GS with Neither Longshot nor Farore\'s Wind': {
+        'name'    : 'logic_water_central_gs_no_fw',
+        'tags'    : ("Water Temple", "Skulltulas",),
+        'tooltip' : '''\
+                    After opening the middle water level door into the
+                    central pillar, the door will stay unbarred so long
+                    as you do not leave the room -- even if you were to
+                    raise the water up to the highest level. With the
+                    Iron Boots to go through the door after the water has
+                    been raised, you can obtain the Skulltula Token with
+                    the Hookshot.
                     '''},
     'Water Temple Boss Key Jump Dive': {
         'name'    : 'logic_water_bk_jump_dive',
@@ -913,17 +983,34 @@ logic_tricks = {
                     with the Bow, and then quickly get through the
                     tunnel before the gate closes.
                     '''},
-    'Water Temple Dragon Statue with Bombchu': {
-        'name'    : 'logic_water_dragon_bombchu',
+    'Water Temple Dragon Statue Switch from Above the Water as Adult': {
+        'name'    : 'logic_water_dragon_adult',
         'tags'    : ("Water Temple",),
         'tooltip' : '''\
-                    You can hit the switch in the dragon statue room
-                    with a Bombchu. Use the time that the Bombchu is
-                    traveling to the switch to begin a dive (with at
-                    least Silver Scale) into the tunnel. This allows
-                    you to reach the chest without Iron Boots or
-                    coming into this room from above by going through
-                    the serpent river.
+                    Normally you need both Hookshot and Iron Boots to hit the
+                    switch and swim through the tunnel to get to the chest. But
+                    by hitting the switch from dry land, using one of Bombchus,
+                    Hookshot, or Bow, it is possible to skip one or both of
+                    those requirements. After the gate has been opened, besides 
+                    just using the Iron Boots, a well-timed dive with at least
+                    the Silver Scale could be used swim through the tunnel. If
+                    coming from the serpent river, a jump dive can also be used
+                    to get into the tunnel, so this trick supersedes "Water
+                    Temple Dragon Statue Jump Dive".
+                    '''},
+    'Water Temple Dragon Statue Switch from Above the Water as Child': {
+        'name'    : 'logic_water_dragon_child',
+        'tags'    : ("Water Temple", "Entrance",),
+        'tooltip' : '''\
+                    It is possible for child to hit the switch from dry land
+                    using one of Bombchus, Slingshot or Boomerang. Then, to
+                    get to the chest, child can dive through the tunnel using
+                    at least the Silver Scale. The timing and positioning of
+                    this dive needs to be perfect to actually make it under the
+                    gate, and it all needs to be done very quickly to be able to
+                    get through before the gate closes. Be sure to enable "Water
+                    Temple Dragon Statue Switch from Above the Water as Adult"
+                    for adult's variant of this trick.
                     '''},
     'Goron City Maze Left Chest with Hover Boots': {
         'name'    : 'logic_goron_city_leftmost',
@@ -933,6 +1020,15 @@ logic_tricks = {
                     crate and ending with a precisely-timed backflip
                     can reach this chest without needing either
                     the Hammer or Silver Gauntlets.
+                    '''},
+    'Goron City Grotto with Hookshot While Taking Damage': {
+        'name'    : 'logic_goron_grotto',
+        'tags'    : ("Goron City", "Entrance"),
+        'tooltip' : '''\
+                    It is possible to reach the Goron City Grotto by
+                    quickly using the Hookshot while in the midst of
+                    taking damage from the lava floor. This trick will
+                    not be expected on OHKO or quadruple damage.
                     '''},
     'Deku Tree Basement without Slingshot': {
         'name'    : 'logic_deku_b1_skip',
@@ -982,6 +1078,15 @@ logic_tricks = {
                     can reach the Bomb Bag area as only child
                     without needing a Slingshot. You will
                     take fall damage.
+                    '''},
+    'Dodongo\'s Cavern Two Scrub Room with Strength': {
+        'name'    : 'logic_dc_scrub_room',
+        'tags'    : ("Dodongo's Cavern",),
+        'tooltip' : '''\
+                    With help from a conveniently-positioned block,
+                    Adult can quickly carry a bomb flower over to
+                    destroy the mud wall blockng the room with two
+                    Deku Scrubs.
                     '''},
     'Dodongo\'s Cavern Child Slingshot Skips': {
         'name'    : 'logic_dc_slingshot_skip',
@@ -1042,6 +1147,17 @@ logic_tricks = {
                     on top of the crushing spikes without
                     needing to pull the block. Applies to
                     both Vanilla and Master Quest.
+                    '''},
+    'Shadow Temple Falling Spikes GS with Hover Boots': {
+        'name'    : 'logic_shadow_umbrella_gs',
+        'tags'    : ("Shadow Temple", "Skulltulas",),
+        'tooltip' : '''\
+                    After killing the Skulltula, a very precise Hover Boots
+                    movement from off of the lower chest can get you on top
+                    of the crushing spikes without needing to pull the block.
+                    From there, another very precise Hover Boots movement can
+                    be used to obtain the token without needing the Hookshot.
+                    Applies to both Vanilla and Master Quest.
                     '''},
     'Water Temple Central Bow Target without Longshot or Hover Boots': {
         'name'    : 'logic_water_central_bow',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -795,8 +795,10 @@ logic_tricks = {
         'name'    : 'logic_ice_block_gs',
         'tags'    : ("Ice Cavern", "Skulltulas",),
         'tooltip' : '''\
-                    The Hover Boots can be used to kill the Skulltula
-                    and obtain the Token, without Hookshot or Boomerang.
+                    The Hover Boots can be used to get in front of the
+                    Skulltula to kill it with a jumpslash. Then, the
+                    Hover Boots can again be used to obtain the Token,
+                    all without Hookshot or Boomerang.
                     '''},
     'Reverse Wasteland': {
         'name'    : 'logic_reverse_wasteland',
@@ -949,8 +951,8 @@ logic_tricks = {
                     in the Water Temple are not going to be relevant unless this
                     trick is first enabled.
                     '''},
-    'Water Temple Central Pillar GS with Neither Longshot nor Farore\'s Wind': {
-        'name'    : 'logic_water_central_gs_no_fw',
+    'Water Temple Central Pillar GS with Iron Boots': {
+        'name'    : 'logic_water_central_gs_irons',
         'tags'    : ("Water Temple", "Skulltulas",),
         'tooltip' : '''\
                     After opening the middle water level door into the
@@ -1085,7 +1087,7 @@ logic_tricks = {
         'tooltip' : '''\
                     With help from a conveniently-positioned block,
                     Adult can quickly carry a bomb flower over to
-                    destroy the mud wall blockng the room with two
+                    destroy the mud wall blocking the room with two
                     Deku Scrubs.
                     '''},
     'Dodongo\'s Cavern Child Slingshot Skips': {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -380,7 +380,7 @@ logic_tricks = {
                     '''},
     'Spirit Temple Main Room Jump from Hands to Upper Ledges': {
         'name'    : 'logic_spirit_lobby_jump',
-        'tags'    : ("Spirit Temple"),
+        'tags'    : ("Spirit Temple", "Skulltulas"),
         'tooltip' : '''\
                     A precise jump to obtain the following as adult
                     without needing one of Hookshot or Hover Boots:
@@ -1023,7 +1023,7 @@ logic_tricks = {
                     '''},
     'Goron City Grotto with Hookshot While Taking Damage': {
         'name'    : 'logic_goron_grotto',
-        'tags'    : ("Goron City", "Entrance"),
+        'tags'    : ("Goron City"),
         'tooltip' : '''\
                     It is possible to reach the Goron City Grotto by
                     quickly using the Hookshot while in the midst of
@@ -1157,7 +1157,9 @@ logic_tricks = {
                     of the crushing spikes without needing to pull the block.
                     From there, another very precise Hover Boots movement can
                     be used to obtain the token without needing the Hookshot.
-                    Applies to both Vanilla and Master Quest.
+                    Applies to both Vanilla and Master Quest. For obtaining
+                    the chests in this room with just Hover Boots, be sure to
+                    enable "Shadow Temple Stone Umbrella Skip".
                     '''},
     'Water Temple Central Bow Target without Longshot or Hover Boots': {
         'name'    : 'logic_water_central_bow',

--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -13,9 +13,6 @@
         "dungeon": "Dodongos Cavern",
         "locations": {
             "Dodongos Cavern Map Chest": "True",
-            "Dodongos Cavern Compass Chest": "
-                is_adult or Sticks or 
-                (can_use(Dins_Fire) and (Slingshot or has_explosives or Kokiri_Sword))",
             "Dodongos Cavern GS Side Room Near Lower Lizalfos": "
                 has_explosives or is_adult or Slingshot or 
                 Boomerang or Sticks or Kokiri_Sword",
@@ -31,13 +28,27 @@
         },
         "exits": {
             "Dodongos Cavern Beginning": "True",
+            "Dodongos Cavern Staircase Room": "
+                here(is_adult or Sticks or
+                    (can_use(Dins_Fire) and (Slingshot or has_explosives or Kokiri_Sword)))",
+            "Dodongos Cavern Far Bridge": "at('Dodongos Cavern Far Bridge', True)"
+        }
+    },
+    {
+        "region_name": "Dodongos Cavern Staircase Room",
+        "dungeon": "Dodongos Cavern",
+        "locations": {
+            "Dodongos Cavern Compass Chest": "True",
+            "Dodongos Cavern GS Vines Above Stairs": "
+                has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire) or
+                (logic_dc_staircase and can_use(Bow)) or
+                (logic_dc_vines_gs and can_use(Longshot))"
+        },
+        "exits": {
+            "Dodongos Cavern Lobby": "True",
             "Dodongos Cavern Climb": "
-                here(
-                    (is_adult or 
-                        ((Sticks or can_use(Dins_Fire)) and 
-                            (Slingshot or Sticks or has_explosives or Kokiri_Sword)))) and 
-                    (has_explosives or Progressive_Strength_Upgrade or 
-                        can_use(Dins_Fire) or (logic_dc_staircase and can_use(Bow)))"
+                has_explosives or Progressive_Strength_Upgrade or 
+                    can_use(Dins_Fire) or (logic_dc_staircase and can_use(Bow))"
         }
     },
     {
@@ -45,16 +56,19 @@
         "dungeon": "Dodongos Cavern",
         "locations": {
             "Dodongos Cavern Bomb Flower Platform Chest": "True",
-            "Dodongos Cavern GS Vines Above Stairs": "True",
-            "Dodongos Cavern Deku Scrub Near Bomb Bag Right": "can_blast_or_smash",
-            "Dodongos Cavern Deku Scrub Near Bomb Bag Left": "can_blast_or_smash"
+            "Dodongos Cavern Deku Scrub Near Bomb Bag Right": "
+                can_blast_or_smash or
+                (logic_dc_scrub_room and is_adult and Progressive_Strength_Upgrade)",
+            "Dodongos Cavern Deku Scrub Near Bomb Bag Left": "
+                can_blast_or_smash or
+                (logic_dc_scrub_room and is_adult and Progressive_Strength_Upgrade)"
         },
         "exits": {
             "Dodongos Cavern Lobby": "True",
             "Dodongos Cavern Far Bridge": "
-                here(is_child and (Slingshot or
+                (is_child and (Slingshot or
                     (logic_dc_slingshot_skip and (Sticks or has_explosives or Kokiri_Sword)))) or 
-                here(is_adult and (Bow or Hover_Boots or can_use(Longshot) or logic_dc_jump))"
+                (is_adult and (Bow or Hover_Boots or can_use(Longshot) or logic_dc_jump))"
         }
     },
     {

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -5,7 +5,10 @@
         "locations": {
             "Forest Temple First Room Chest": "True",
             "Forest Temple First Stalfos Chest": "is_adult or Kokiri_Sword",
-            "Forest Temple GS First Room": "can_use(Dins_Fire) or can_use_projectile",
+            "Forest Temple GS First Room": "
+                (is_adult and (Hookshot or Bow or Bombs)) or (is_child and (Boomerang or Slingshot)) or
+                has_bombchus or can_use(Dins_Fire) or (logic_forest_first_gs and (Bombs or
+                    ((is_adult or Sticks or Kokiri_Sword) and (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))))",
             "Forest Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang)",
             "Fairy Pot": "has_bottle and (is_adult or can_child_attack or Nuts)"
         },
@@ -30,6 +33,9 @@
                 has_explosives or Kokiri_Sword or can_use(Dins_Fire)"
         },
         "exits": {
+            "Forest Temple NE Outdoors": "
+                can_use(Iron_Boots) or can_use(Longshot) or 
+                (Progressive_Scale, 2) or (logic_forest_well_swim and can_use(Hookshot))",
             "Forest Temple Outdoors High Balconies": "
                 is_adult or 
                 (has_explosives or

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -8,7 +8,7 @@
             "Forest Temple GS First Room": "
                 (is_adult and (Hookshot or Bow or Bombs)) or (is_child and (Boomerang or Slingshot)) or
                 has_bombchus or can_use(Dins_Fire) or (logic_forest_first_gs and (Bombs or
-                    ((is_adult or Sticks or Kokiri_Sword) and (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))))",
+                    (can_jumpslash and (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))))",
             "Forest Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang)",
             "Fairy Pot": "has_bottle and (is_adult or can_child_attack or Nuts)"
         },
@@ -33,14 +33,12 @@
                 has_explosives or Kokiri_Sword or can_use(Dins_Fire)"
         },
         "exits": {
-            "Forest Temple NE Outdoors": "
-                can_use(Iron_Boots) or can_use(Longshot) or 
-                (Progressive_Scale, 2) or (logic_forest_well_swim and can_use(Hookshot))",
+            "Forest Temple NE Outdoors": "(Progressive_Scale, 2)",
+            #Other methods of crossing through the well are not currently relevant.
             "Forest Temple Outdoors High Balconies": "
-                is_adult or 
-                (has_explosives or
-                 ((can_use(Boomerang) or Nuts or Buy_Deku_Shield) and
-                  (Sticks or Kokiri_Sword or can_use(Slingshot))))"
+                here(is_adult or has_explosives or
+                        ((Boomerang or Nuts or Deku_Shield) and
+                            (Sticks or Kokiri_Sword or Slingshot)))"
         }
     },
     {

--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -27,7 +27,8 @@
             "Ice Cavern GS Heart Piece Room": "
                 Blue_Fire and (can_use(Hookshot) or can_use(Boomerang))",
             "Ice Cavern GS Push Block Room": "
-                Blue_Fire and (can_use(Hookshot) or can_use(Boomerang))",
+                Blue_Fire and (can_use(Hookshot) or can_use(Boomerang) or
+                    (logic_ice_block_gs and can_use(Hover_Boots)))",
             "Blue Fire": "is_adult and has_bottle"
         }
     }

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -66,10 +66,9 @@
             #placement this is not an issue as Adult can go back to forest for the Baba's there.
             #Entrance rando cannot rely on this for the case forest completion was done on non
             #repeatable access.
-            "Deku Baba Sticks": "(is_adult and not shuffle_dungeon_entrances) or Kokiri_Sword or Boomerang",
-            "Deku Baba Nuts": "
-                (is_adult and not shuffle_dungeon_entrances) or Slingshot or Sticks or 
-                has_explosives or Kokiri_Sword or can_use(Dins_Fire)",
+            "Deku Baba Sticks": "
+                (is_adult and not shuffle_dungeon_entrances) or can_use(Kokiri_Sword) or can_use(Boomerang)",
+            "Deku Baba Nuts": "is_adult and not shuffle_dungeon_entrances",
             "KF Deku Tree Gossip Stone (Left)": "True",
             "KF Deku Tree Gossip Stone (Right)": "True"
         },
@@ -1134,7 +1133,7 @@
                 (damage_multiplier != 'ohko') or can_use(Nayrus_Love) or Fairy or can_use(Hover_Boots) or
                 (is_adult and here(can_plant_bean and (has_explosives or Progressive_Strength_Upgrade)))",
             "DMT GS Bean Patch": "
-                can_plant_bugs and
+                can_plant_bugs and can_child_attack and
                     (has_explosives or Progressive_Strength_Upgrade or
                     (logic_dmt_soil_gs and can_use(Boomerang)))",
             "DMT GS Near Kak": "can_blast_or_smash",
@@ -1150,7 +1149,9 @@
             "Kak Behind Gate": "True",
             "Goron City": "True",
             "Death Mountain Summit": "
-                here(can_blast_or_smash) or (is_adult and here(can_plant_bean and Progressive_Strength_Upgrade))",
+                here(can_blast_or_smash) or
+                    (is_adult and here(can_plant_bean and Progressive_Strength_Upgrade)) or
+                    (logic_dmt_climb_hovers and can_use(Hover_Boots))",
             "Dodongos Cavern Entryway": "
                 has_explosives or Progressive_Strength_Upgrade or is_adult",
             "DMT Storms Grotto": "can_open_storm_grotto"
@@ -1250,12 +1251,14 @@
                 (is_adult and 'Stop GC Rolling Goron as Adult') or
                 (is_child and can_play(Zeldas_Lullaby))",
             "GC Grotto": "
-                is_adult and 
+                is_adult and
                 ((can_play(Song_of_Time) and 
-                    ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
-                        can_use(Goron_Tunic) or can_use(Longshot) or can_use(Nayrus_Love))) or 
-                (damage_multiplier != 'ohko' and can_use(Goron_Tunic) and can_use(Hookshot)) or 
-                (can_use(Nayrus_Love) and can_use(Hookshot)))"
+                        ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
+                            can_use(Goron_Tunic) or can_use(Longshot) or can_use(Nayrus_Love))) or 
+                    (can_use(Hookshot) and
+                        ((damage_multiplier != 'ohko' and can_use(Goron_Tunic)) or
+                            can_use(Nayrus_Love) or
+                            (damage_multiplier != 'ohko' and damage_multiplier != 'quadruple' and logic_goron_grotto))))"
         }
     },
     {
@@ -1465,7 +1468,9 @@
             "Gossip Stone Fairy": "can_summon_gossip_fairy and has_bottle",
             "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Butterfly Fairy": "can_use(Sticks) and has_bottle",
-            "Bug Shrub": "can_cut_shrubs and has_bottle"
+            "Bug Shrub": "
+                (is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_lower)) and
+                can_cut_shrubs and has_bottle"
         },
         "exits": {
             "ZR Front": "True",
@@ -1504,7 +1509,8 @@
                 is_child and Rutos_Letter and zora_fountain != 'open'",
             "ZD King Zora Thawed": "'King Zora Thawed'",
             "ZD GS Frozen Waterfall": "
-                is_adult and at_night and (Progressive_Hookshot or Bow or Magic_Meter)",
+                is_adult and at_night and
+                (Progressive_Hookshot or Bow or Magic_Meter or logic_domain_gs)",
             "ZD Gossip Stone": "True",
             "Gossip Stone Fairy": "can_summon_gossip_fairy_without_suns and has_bottle",
             "Fish Group": "is_child and has_bottle",
@@ -1847,7 +1853,9 @@
     {
         "region_name": "HC Storms Grotto",
         "locations": {
-            "HC GS Storms Grotto": "can_blast_or_smash and (can_use(Boomerang) or can_use(Hookshot))",
+            "HC GS Storms Grotto": "
+                (can_blast_or_smash or (is_child and logic_castle_storms_gs)) and
+                (can_use(Boomerang) or can_use(Hookshot))",
             "HC Storms Grotto Gossip Stone": "can_blast_or_smash",
             "Gossip Stone Fairy": "can_blast_or_smash and can_summon_gossip_fairy and has_bottle",
             "Wandering Bugs": "can_blast_or_smash and has_bottle",

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -62,11 +62,13 @@
             "Shadow Temple MQ Falling Spikes Switch Chest": "
                 (logic_shadow_umbrella and Hover_Boots) or Progressive_Strength_Upgrade",
             "Shadow Temple MQ Invisible Spikes Chest": "
-                Hover_Boots and (logic_lens_shadow_mq_back or can_use(Lens_of_Truth)) and (Small_Key_Shadow_Temple, 3)",
+                Hover_Boots and (Small_Key_Shadow_Temple, 3) and
+                (logic_lens_shadow_mq_back or can_use(Lens_of_Truth))",
             "Shadow Temple MQ Stalfos Room Chest": "
-                Hover_Boots and (logic_lens_shadow_mq_back or can_use(Lens_of_Truth)) and (Small_Key_Shadow_Temple, 3) 
-                and Progressive_Hookshot",
-            "Shadow Temple MQ GS Falling Spikes Room": "Progressive_Hookshot"
+                Hover_Boots and (Small_Key_Shadow_Temple, 3) and Progressive_Hookshot and
+                (logic_lens_shadow_mq_back or can_use(Lens_of_Truth))",
+            "Shadow Temple MQ GS Falling Spikes Room": "
+                (logic_shadow_umbrella_gs and Hover_Boots) or Progressive_Hookshot"
         },
         "exits": {
             "Shadow Temple Wind Tunnel": "

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -42,14 +42,15 @@
             "Shadow Temple Falling Spikes Lower Chest": "True",
             "Shadow Temple Falling Spikes Upper Chest": "logic_shadow_umbrella or Progressive_Strength_Upgrade",
             "Shadow Temple Falling Spikes Switch Chest": "logic_shadow_umbrella or Progressive_Strength_Upgrade",
-            "Shadow Temple Invisible Spikes Chest": "(Small_Key_Shadow_Temple, 2) and (logic_lens_shadow_back or can_use(Lens_of_Truth))",
+            "Shadow Temple Invisible Spikes Chest": "
+                (Small_Key_Shadow_Temple, 2) and (logic_lens_shadow_back or can_use(Lens_of_Truth))",
             "Shadow Temple Freestanding Key": "
                 (Small_Key_Shadow_Temple, 2) and (logic_lens_shadow_back or can_use(Lens_of_Truth)) 
                 and Progressive_Hookshot and 
                 (Bombs or Progressive_Strength_Upgrade or
                     (logic_shadow_freestanding_key and has_bombchus))",
             "Shadow Temple GS Like Like Room": "True",
-            "Shadow Temple GS Falling Spikes Room": "Progressive_Hookshot",
+            "Shadow Temple GS Falling Spikes Room": "logic_shadow_umbrella_gs or Progressive_Hookshot",
             "Shadow Temple GS Single Giant Pot": "
                 (Small_Key_Shadow_Temple, 2) and (logic_lens_shadow_back or can_use(Lens_of_Truth)) 
                 and Progressive_Hookshot"

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -25,7 +25,16 @@
             "Spirit Temple GS Metal Fence": "
                 (Boomerang or Slingshot or (has_bombchus and logic_spirit_child_bombchu)) and 
                 (Sticks or has_explosives or 
-                    ((Nuts or Boomerang) and (Kokiri_Sword or Slingshot)))",
+                    ((Nuts or Boomerang) and (Kokiri_Sword or Slingshot)))"
+        },
+        "exits": {
+            "Child Spirit Before Locked Door": "True"
+        }
+    },
+    {
+        "region_name": "Child Spirit Before Locked Door",
+        "dungeon": "Spirit Temple",
+        "locations": {
             "Nut Crate": "True"
         },
         "exits": {
@@ -63,7 +72,8 @@
                     Fairy or can_use(Nayrus_Love)))"
         },
         "exits": {
-            "Spirit Temple Central Chamber": "has_explosives"
+            "Spirit Temple Central Chamber": "has_explosives",
+            "Child Spirit Before Locked Door": "(Small_Key_Spirit_Temple, 5)"
         }
     },
     {
@@ -112,7 +122,7 @@
                 can_play(Zeldas_Lullaby)",
             "Spirit Temple Statue Room Northeast Chest": "
                 (Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and can_play(Zeldas_Lullaby) and 
-                (Progressive_Hookshot or Hover_Boots)",
+                (Progressive_Hookshot or Hover_Boots or logic_spirit_lobby_jump)",
             "Spirit Temple GS Hall After Sun Block Room": "
                 (has_explosives and Boomerang and Progressive_Hookshot) or 
                 (can_use(Boomerang) and (Small_Key_Spirit_Temple, 5) and has_explosives) or 
@@ -121,9 +131,9 @@
                         ((Small_Key_Spirit_Temple, 2) and Boomerang and bombchus_in_logic and not shuffle_dungeon_entrances)))",
             "Spirit Temple GS Lobby": "
                 ((has_explosives or (Small_Key_Spirit_Temple, 3) or ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not shuffle_dungeon_entrances)) and 
-                    logic_spirit_lobby_gs and Boomerang and (Progressive_Hookshot or Hover_Boots)) or
+                    logic_spirit_lobby_gs and Boomerang and (Progressive_Hookshot or Hover_Boots or logic_spirit_lobby_jump)) or
                 (logic_spirit_lobby_gs and (Small_Key_Spirit_Temple, 5) and has_explosives and can_use(Boomerang)) or
-                ((Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and (Progressive_Hookshot or Hover_Boots))"
+                ((Small_Key_Spirit_Temple, 3) and can_use(Silver_Gauntlets) and (Progressive_Hookshot or Hover_Boots or logic_spirit_lobby_jump))"
         },
         "exits": {
             "Spirit Temple Outdoor Hands": "True",

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -58,7 +58,7 @@
                 can_play(Zeldas_Lullaby) and
                     (((can_use(Longshot) or (can_use(Hookshot) and can_use(Farores_Wind))) and 
                         ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))) or
-                    (logic_water_central_gs_no_fw and can_use(Hookshot) and can_use(Iron_Boots) and
+                    (logic_water_central_gs_irons and can_use(Hookshot) and can_use(Iron_Boots) and
                         (can_use(Bow) or can_use(Dins_Fire))) or
                     (Child_Water_Temple and Boomerang and can_use(Farores_Wind) and
                         (Sticks or can_use(Dins_Fire) or

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -3,14 +3,20 @@
         "region_name": "Water Temple Lobby",
         "dungeon": "Water Temple",
         "events": {
-            "Child Water Temple": "is_child"
+            "Child Water Temple": "is_child",
+                # Child can access only the falling platform room as the sole entrant into Water Temple.
+                # Use Child_Water_Temple for cases where child assists after the water is lowered.
+            "Raise Water Level": "
+                ((is_adult or not shuffle_overworld_entrances) and (Hookshot or Hover_Boots or Bow)) or
+                (has_fire_source_with_torch and can_use_projectile)"
+                # Ensure that the water level can be raised if it were to be lowered.
         },
         "exits": {
             "Lake Hylia": "True",
-            # Child cannot do anything as the only entrant to Water Temple. So leave child
-            # disconnected from here on to simplify logic as assumed adult. Child water assists
-            # are still possible with (Child_Water_Temple and ... )
-            "Water Temple Highest Water Level":"is_adult"
+            "Water Temple Highest Water Level": "Raise_Water_Level",
+            "Water Temple Dive": "
+                (can_use(Zora_Tunic) or logic_fewer_tunic_requirements) and
+                ((logic_water_temple_torch_longshot and can_use(Longshot)) or can_use(Iron_Boots))"
         }
     },
     {
@@ -25,27 +31,19 @@
             "Fairy Pot": "has_bottle and can_use(Longshot)"
         },
         "exits": {
-            "Water Temple Dark Link Region": "(Small_Key_Water_Temple, 5) and can_use(Hookshot)",
-            "Water Temple Dive": "
-                (can_use(Zora_Tunic) or logic_fewer_tunic_requirements) and
-                ((logic_water_temple_torch_longshot and can_use(Longshot)) or Iron_Boots)"
+            "Water Temple Falling Platform Room": "(Small_Key_Water_Temple, 5)"
         }
     },
     {
         "region_name": "Water Temple Dive",
         "dungeon": "Water Temple",
         "locations": {
-            # This doesn't require anything in its own right, however if the player lowers the water
-            # without looting this chest, they need to restore it to top level
-            "Water Temple Map Chest": "
-                can_use(Hover_Boots) or can_use(Hookshot) or can_use(Bow) or
-                (at('Water Temple Lobby', has_fire_source_with_torch) and
-                 at('Water Temple Lobby', can_use_projectile))",
+            "Water Temple Map Chest": "Raise_Water_Level",
             "Water Temple Compass Chest": "
                 (can_play(Zeldas_Lullaby) or Iron_Boots) and can_use(Hookshot)",
             "Water Temple Torches Chest": "
                 (Bow or can_use(Dins_Fire) or 
-                 (Child_Water_Temple and Sticks and Kokiri_Sword and Magic_Meter)) and
+                    (Child_Water_Temple and Sticks and Kokiri_Sword and Magic_Meter)) and
                 can_play(Zeldas_Lullaby)",
             "Water Temple Central Bow Target Chest": "
                 Progressive_Strength_Upgrade and can_play(Zeldas_Lullaby) and 
@@ -54,7 +52,16 @@
             "Water Temple GS Behind Gate": "
                 (can_use(Hookshot) or can_use(Hover_Boots)) and 
                 has_explosives and can_play(Zeldas_Lullaby) and
-                (can_use(Iron_Boots) or can_dive)"
+                (can_use(Iron_Boots) or can_dive)",
+            "Water Temple GS Central Pillar": "
+                can_play(Zeldas_Lullaby) and
+                    (((can_use(Longshot) or (can_use(Hookshot) and can_use(Farores_Wind))) and 
+                        ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))) or
+                    (logic_water_central_gs_no_fw and can_use(Hookshot) and can_use(Iron_Boots) and
+                        (can_use(Bow) or can_use(Dins_Fire))) or
+                    (Child_Water_Temple and Boomerang and can_use(Farores_Wind) and
+                        (Sticks or can_use(Dins_Fire) or
+                        ((Small_Key_Water_Temple, 6) and (can_use(Hover_Boots) or can_use(Bow))))))"
         },
         "exits": {
             "Water Temple Cracked Wall": "
@@ -62,8 +69,8 @@
                 (logic_water_cracked_wall_nothing or (logic_water_cracked_wall_hovers and can_use(Hover_Boots)))",
             "Water Temple Middle Water Level": "
                 (Bow or can_use(Dins_Fire) or
-                 ((Small_Key_Water_Temple, 6) and can_use(Hookshot)) or
-                 (Child_Water_Temple and Sticks)) and
+                    ((Small_Key_Water_Temple, 6) and can_use(Hookshot)) or
+                    (Child_Water_Temple and Sticks)) and
                 can_play(Zeldas_Lullaby)",
             "Water Temple North Basement": "
                 (Small_Key_Water_Temple, 5) and
@@ -72,7 +79,8 @@
             "Water Temple Dragon Statue": "
                 can_play(Zeldas_Lullaby) and Progressive_Strength_Upgrade and
                 ((Iron_Boots and can_use(Hookshot)) or
-                    (logic_water_dragon_bombchu and has_bombchus and can_dive))"
+                    (logic_water_dragon_adult and (has_bombchus or can_use(Bow) or can_use(Hookshot)) and (can_dive or Iron_Boots)) or
+                    (logic_water_dragon_child and Child_Water_Temple and (has_bombchus or Slingshot or Boomerang) and can_dive))"
         }
     },
     {
@@ -82,16 +90,14 @@
             "Water Temple Boss Key Chest": "
                 (Small_Key_Water_Temple, 6) and 
                 (logic_water_bk_jump_dive or can_use(Iron_Boots)) and
-                ((logic_water_bk_chest and Iron_Boots) or logic_water_north_basement_ledge_jump or
-                    (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
+                (logic_water_north_basement_ledge_jump or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
             "Water Temple GS Near Boss Key Chest": "True",
                 # Longshot just reaches without the need to actually go near,
                 # Otherwise you have hovers and just hover over and collect with a jump slash
             "Fairy Pot": "
                 has_bottle and (Small_Key_Water_Temple, 6) and 
                 (logic_water_bk_jump_dive or can_use(Iron_Boots)) and
-                ((logic_water_bk_chest and Iron_Boots) or logic_water_north_basement_ledge_jump or
-                    (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)"
+                (logic_water_north_basement_ledge_jump or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)"
         }
     },
     {
@@ -114,39 +120,42 @@
         "locations": {
             "Water Temple Central Pillar Chest": "
                 can_use(Iron_Boots) and can_use(Zora_Tunic) and can_use(Hookshot) and 
-                ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))",
-            "Water Temple GS Central Pillar": "
-                ((can_use(Longshot) or (can_use(Farores_Wind) and can_use(Hookshot))) and
-                 ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))) or
-                (Child_Water_Temple and Boomerang and can_use(Farores_Wind) and
-                    (can_use(Dins_Fire) or Sticks))"
+                ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))"
         },
         "exits": {
             "Water Temple Cracked Wall": "True"
         }
     },
     {
+        "region_name": "Water Temple Falling Platform Room",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple GS Falling Platform Room": "
+                can_use(Longshot) or
+                (logic_water_falling_platform_gs_hookshot and can_use(Hookshot)) or
+                (logic_water_falling_platform_gs_boomerang and can_use(Boomerang))"
+        },
+        "exits": {
+            "Water Temple Dark Link Region": "(Small_Key_Water_Temple, 6) and can_use(Hookshot)"
+        }
+    },
+    {
         "region_name": "Water Temple Dark Link Region",
         "dungeon": "Water Temple",
         "locations": {
-            "Water Temple Longshot Chest": "(Small_Key_Water_Temple, 6)",
-            "Water Temple River Chest": "
-                (Small_Key_Water_Temple, 6) and can_play(Song_of_Time) and Bow",
+            "Water Temple Longshot Chest": "True",
+            "Water Temple River Chest": "can_play(Song_of_Time) and Bow",
             "Water Temple GS River": "
-                can_play(Song_of_Time) and (Small_Key_Water_Temple, 6) and 
+                can_play(Song_of_Time) and 
                 (Iron_Boots or (logic_water_river_gs and can_use(Longshot) and (Bow or has_bombchus)))",
-            "Water Temple GS Falling Platform Room": "
-                can_use(Longshot) or
-                (logic_water_falling_platform_gs and can_use(Hookshot))",
             "Fairy Pot": 
-                "has_bottle and (Small_Key_Water_Temple, 6) and can_play(Song_of_Time)"
+                "has_bottle and can_play(Song_of_Time)"
         },
         "exits": {
             "Water Temple Dragon Statue": "
-                (Small_Key_Water_Temple, 6) and can_play(Song_of_Time) and Bow and
+                can_play(Song_of_Time) and Bow and
                 ((Iron_Boots and (can_use(Zora_Tunic) or logic_fewer_tunic_requirements)) or
-                    logic_water_dragon_jump_dive or
-                    (logic_water_dragon_bombchu and has_bombchus and can_dive))"
+                    logic_water_dragon_jump_dive or logic_water_dragon_adult)"
         }
     }
 ]

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -7,7 +7,8 @@
                 # Child can access only the falling platform room as the sole entrant into Water Temple.
                 # Use Child_Water_Temple for cases where child assists after the water is lowered.
             "Raise Water Level": "
-                ((is_adult or not shuffle_overworld_entrances) and (Hookshot or Hover_Boots or Bow)) or
+                ((is_adult or (not shuffle_overworld_entrances and not shuffle_special_indoor_entrances)) and
+                    (Hookshot or Hover_Boots or Bow)) or
                 (has_fire_source_with_torch and can_use_projectile)"
                 # Ensure that the water level can be raised if it were to be lowered.
         },


### PR DESCRIPTION
Bugs Fixes / Other Changes:

1. Kokiri Forest Deku Baba Sticks - I added can_use() for the child item checks. Otherwise, having Kokiri Sword or Boomerang would allow adult to get around the check for shuffle dungeon entrances.

2. Kokiri Forest Deku Baba Nuts - Babas that drop nuts don't actually exist as child, so I removed all of the child items from the check.

3. Zora River Bug Shrub needs some additional logic to reach. You can easily jump there from the lower PoH, so I used the same logic as is used to reach that.

4. Killing the DMT Soil Gold Skulltula with only Strength is too difficult, so I added can_child_attack to it. I didn't think it was worth making a trick for doing it with strength.

5. I reworded the logic on the DC Climb to remove checking for sticks twice (this matches how it was written on the DC Compass Chest). But then I also felt the need to add an additional region to DC to better capture what was going on with the vines GS after adding that trick (see trick 5).

6. There's a bug with the staircase in DC where if you lower it with the Bow trick, then hit the elevator switch, nothing is letting child ride that elevator up so he can use the Boomerang on the above stairs GS. I fixed this by adding an exit from the lobby to the far bridge with logic at(Far Bridge, True), which should allow whatever age didn't hit the switch to be able to go in that direction. This makes the "here"s that are currently in place for DC Climb->Far Bridge irrelevant, so I deleted them.

7. I added the exit from vanilla Forest NW to NE Outdoors, through the well. Also wrapped Forest NW to High Balconies in a here(). Essentially, these changes do nothing. This was done so that child would not have to get a weapon to fight the Bubble in order to get to NE Outdoors to do the Boomerang trick for the Skulltula there, if you dive through the well with Gold Scale or kill the Bubble first as adult. Access to such a weapon however is guaranteed since Boomerang is required to get that Skulltula and Boomerang can be used to get sticks from Babas, so this change only allows the to playthrough not to be forced to pick up an extra weapon.

8. I removed child throwing a bomb at the Skulltula in the first room of Forest Temple from default logic. It took some work but I was able to figure out how to do it consistently. But I feel between the timing and positioning of the bomb throw, there are just too many factors that have to be close to perfect. I sort-of added it back in as a trick, but maybe it was a mistake (see trick 7).

9. I added the "Skulltulas" tag to Fire Temple MQ Flame Wall Maze Skip. (I'm doing real MQ updates in the next round of logic changes.) This trick is only relevant to reach a Skulltula. (For now? But it should keep this tag regardless.)

10. I removed Water Temple Boss Key Chest with Iron Boots. While it is an easier method it's not THAT much easier, and anybody who cares just knows the precise jump. In this same temple is the hover boots vs no hover boots tricks for the cracked wall, but in that case there are clearly people who know some methods but not others.

11. I added a missing route for using FW and Boomerang to get the Water Central Pillar Skulltula. If you don't have Din's or even access to Sticks, but you do have the Water Temple keys (or are on keysy), then you could set FW at the bottom of central pillar as child. Child would have no way of raising the water in this state, so Adult must do it. Bow or Hovers are the logically relevant ways of raising the water. (Hookshot would mean you could just use FW and Hookshot instead of messing around as child.) Of note though, is that the Hovers route would provide no access to the middle water level at any point, but the Skulltula was in the middle water level region. I had to move that Skulltula up to the parent region, which only required additionally checking for Lullaby.

12. I've made significant changes to "Water Temple Dragon Statue with Bombchu". I don't know why I'd never realized this before, but this route for Water Temple Dragon Statue not only allows skipping Irons, but Hookshot as well, so I added the possibility of using Irons instead of a Scale for the trick. That this wasn't accounted for before was just a bug that has now been fixed, so nothing controversial there. However, I've also decided to expand the trick to include additional methods of hitting the switch, now using Bow or Hookshot to hit it from above the water. While the Bombchu and Bow/Hook methods are a bit different and do have their unique challenges, I'd always intended for the Jump Dive variant to be the easy version of the trick, while this trick would be used for the more advanced method. But "method" has now become plural. Both take a bit of practice to understand, but I didn't really feel as if either method was much harder or easier than the other. I feel like the Bombchu method is probably more well-known, but after learning both, I don't really see why it should be so much more popular. The new name for the trick is "Water Temple Dragon Statue Switch from Above the Water as Adult", and with this new name it now makes sense for it to fully supersede the Jump Dive variant. It was always kind of strange before, seeing the logic for going from the serpent river to the dragon statue, and it having the harder variant of the trick require additional items over the easier one. (Now you might ask, why "as Adult"? See trick 10.)

13. The Spirit Temple Nut Crate is a possible first logical nuts to be obtained as Adult (rather than only as child), though Adult will need all Spirit keys (or keysy).


New Tricks:

1. Zora's Domain GS with No Additional Items - A precise jumpslash to kill the Skulltula and recoil back to the top of the frozen waterfall.

2. Goron City Grotto with Hookshot While Taking Damage - You take about 5 hits from the lava floor while doing this, so it can be expected in Double Damage (pretty tough though) but not Quadruple Damage or OHKO.

3. Death Mountain Trail Climb with Hover Boots

4. Hyrule Castle Storms Grotto GS with Just Boomerang - I tried but was unsuccessful at fishing out the token as adult.

5. Dodongo's Cavern Vines GS from Below with Longshot - Skip lowering the staircase by using the Longshot to get it through the vines, which are a one-sided collision.

6. Dodongo's Cavern Two Scrub Room with Strength - Uses a block as a stepping-stone in order to have enough time to make the trek. Only works as Adult.

7. Forest Temple First Room GS with Difficult-to-Use Weapons - Kill it using Sword or Sticks (fall damage required) or child Bomb throws. I wanted to add the trick to kill it with a jumpslash, but it felt weird to do that and also completely remove throwing bombs as child, but I really felt the bomb throws were too difficult for default logic... So I ended up going with a combined trick for both Sword items and child Bombs. It's probably a lapse in judgement. The trick name just looks gross; that's how you can tell.

8. Water Temple Central Pillar GS with Neither Longshot nor Farore's Wind - Open the door, raise the water level, then use the Iron Boots to go back into the room, now with the water at the highest level. On a related note: I think it's time that the Farore's Wind route stopped trolling new players and was removed from default logic. I would have preferred to have combined that logic together into this trick, but after thinking about it, the Farore's Wind route has been a thing for so long now that it at least deserves to be a separate trick. To add it would be as simple as anding in the trick next to both Farore's Wind uses in that section. I wonder though how to handle Farore's Wind potentially being foolish and how people would feel about that. To make changes in this regard would likely require community feedback.

9. Water Temple Falling Platform Room GS with Boomerang - Precise Boomerang throw. Seems like it should have been easy to implement, but it wasn't. To enter the Falling Platform room as child was not supported by the logic, so I had to add that. I had to move region access around a bit as well as add a new region to really capture it. I also had to ensure that if the water is somehow lowered, that you can raise it back up again. For Adult to raise the water, you don't actually even need logical access as Adult since Adult had to have been there to have lowered it in the first place, but in that case you have to check for possible non-repeatable access, which on main branch I believe can occur with shuffled overworld and special interior entrances?

10. Water Temple Dragon Statue Switch from Above the Water as Child - Allows using Slingshot, Boomerang, or Bombchus (though Bombchus are logically irrelevant if the adult version of this trick is enabled) to hit the switch to open the gate, and then an incredibly perfect dive can be used to swim under the gate. The dive has to be perfect because child cannot swim through the gate even while it's open -- he has to dive the whole way under. And of course, the gate will shortly close, so you do not get much time to line up your dive. Gold Scale would make it a bit easier, as being able to dive a bit longer gives you some leniency on actually getting under the gate, but it will all still work with Silver Scale. Silver Scale and Slingshot are a particularly tricky combination, since, with Slingshot, you can't really make much progress toward your destination while the projectile is heading for the switch. I made this a separate trick from the Adult variant mainly because the Child routes are just so much harder (even though the Adult version is already supposed to be an advanced method), due to the requirement that you successfully dive all the way past the gate.

11. Shadow Temple Falling Spikes GS with Hover Boots - This is actually pretty tough.

12. Spirit Temple Main Room Jump from Hands to Upper Ledges - Applies to the Upper Chest and the GS in the main room, to skip Hookshot or Hovers.

13. Ice Cavern Block Room GS with Hover Boots


These are the tricks that I investigated but decided not to add:

1. Death Mountain Trail Bombable Wall GS with Just Boomerang - You had to like, throw the Boomerang while Link's hand is through a wall or something? It seemed more directly glitchy than the other times that tricks can call for Boomerangs to go through walls.

2. Gerudo Fortress Archery GS without Gerudo Card - I didn't like that it only worked because the camera was keeping the guard culled. There's always been a lot of debate over this sort of thing. Cat chain? Boulder collision? So the safe play was to leave this one alone.


Please go over the logic changes with the finest-toothed of combs. This stuff is really hard to get right on the first try.
I welcome questions and comments on the tricks that I both did or didn't decide to add.
And finally please weigh in on the FW situation.
MQ Dungeons logic update coming soon/eventually.