### PR TITLE
Fix plandomizer itemsetting error message

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -894,7 +894,7 @@ class Distribution(object):
                     else:
                         raise KeyError("invalid special item: {}".format(item.itemname))
             else:
-                raise KeyError("invalid starting item: {}".format(item.itemname))
+                raise KeyError("invalid starting item: {}".format(itemsetting))
 
         # add ammo
         for item in list(data.keys()):


### PR DESCRIPTION
The plando file
```
"starting_items": [
  "lens",
  "hammer"
]
```
produced the error
```
KeyError: 'invalid starting item: Lens of Truth'
```
when the actual problem was that "hammer" should be "megaton_hammer".

This change fixes the error to
```
KeyError: 'invalid starting item: hammer'
```