### PR TITLE
Add option to shuffle songs in dungeon reward locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -23,10 +23,32 @@ class FillError(ShuffleError):
 
 # Places all items into the world
 def distribute_items_restrictive(window, worlds, fill_locations=None):
-    song_locations = [world.get_location(location) for world in worlds for location in
-        ['Song from Composers Grave', 'Song from Impa', 'Song from Malon', 'Song from Saria',
-        'Song from Ocarina of Time', 'Song from Windmill', 'Sheik in Forest', 'Sheik at Temple',
-        'Sheik in Crater', 'Sheik in Ice Cavern', 'Sheik in Kakariko', 'Sheik at Colossus']]
+    if worlds[0].shuffle_song_items == 'song':
+        song_location_names = [
+            'Song from Composers Grave', 'Song from Impa', 'Song from Malon', 'Song from Saria',
+            'Song from Ocarina of Time', 'Song from Windmill', 'Sheik in Forest', 'Sheik at Temple',
+            'Sheik in Crater', 'Sheik in Ice Cavern', 'Sheik in Kakariko', 'Sheik at Colossus']
+    elif worlds[0].shuffle_song_items == 'dungeon':
+        song_location_names = [
+            'Deku Tree Queen Gohma Heart', 'Dodongos Cavern King Dodongo Heart',
+            'Jabu Jabus Belly Barinade Heart', 'Forest Temple Phantom Ganon Heart',
+            'Fire Temple Volvagia Heart', 'Water Temple Morpha Heart',
+            'Spirit Temple Twinrova Heart', 'Shadow Temple Bongo Bongo Heart',
+            'Sheik in Ice Cavern', 'Song from Impa',
+            'Gerudo Training Grounds MQ Ice Arrows Chest',
+            'Gerudo Training Grounds Maze Path Final Chest',
+            'Bottom of the Well Lens of Truth Chest',
+            'Bottom of the Well MQ Lens of Truth Chest']
+    else:
+        song_location_names = []
+
+    song_locations = []
+    for world in worlds:
+        for location in song_location_names:
+            try:
+                song_locations.append(world.get_location(location))
+            except KeyError:
+                pass
 
     shop_locations = [location for world in worlds for location in world.get_unfilled_locations() if location.type == 'Shop' and location.price == None]
 
@@ -46,11 +68,9 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     songitempool = [item for world in worlds for item in world.itempool if item.type == 'Song']
     itempool =     [item for world in worlds for item in world.itempool if item.type != 'Shop' and item.type != 'Song']
 
-    if worlds[0].shuffle_song_items:
+    if worlds[0].shuffle_song_items == 'any':
         itempool.extend(songitempool)
-        fill_locations.extend(song_locations)
         songitempool = []
-        song_locations = []
 
     # add unrestricted dungeon items to main item pool
     itempool.extend([item for world in worlds for item in world.get_unrestricted_dungeon_items()])
@@ -130,7 +150,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # Placing songs on their own since they have a relatively high chance
     # of failing compared to other item type. So this way we only have retry
     # the song locations only.
-    if not worlds[0].shuffle_song_items:
+    if worlds[0].shuffle_song_items != 'any':
         logger.info('Placing song items.')
         fill_ownworld_restrictive(window, worlds, search, song_locations, songitempool, progitempool, "song")
         search.collect_locations()

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1218,7 +1218,7 @@ def get_pool_core(world):
     pool.append(tradeitem)
 
     pool.extend(songlist)
-    if world.shuffle_song_items and world.item_pool_value == 'plentiful':
+    if world.shuffle_song_items == 'any' and world.item_pool_value == 'plentiful':
         pending_junk_pool.extend(songlist)
 
     if world.free_scarecrow:

--- a/Patches.py
+++ b/Patches.py
@@ -160,7 +160,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_bytes(0x1FC0CF8, Block_code)
 
     # songs as items flag
-    songs_as_items = world.shuffle_song_items or \
+    songs_as_items = world.shuffle_song_items != 'song' or \
                      world.distribution.song_as_items or \
                      world.starting_songs
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -617,14 +617,14 @@ class WorldDistribution(object):
             if record.item in item_groups['DungeonReward']:
                 raise RuntimeError('Cannot place dungeon reward %s in world %d in location %s.' % (record.item, self.id + 1, location_name))
 
-            if record.item == '#Junk' and location.type == 'Song' and not world.shuffle_song_items:
+            if record.item == '#Junk' and location.type == 'Song' and world.shuffle_song_items == 'song':
                 record.item = '#JunkSong'
 
             ignore_pools = None
             is_invert = pattern_matcher(record.item)('!')
-            if is_invert and location.type != 'Song' and not world.shuffle_song_items:
+            if is_invert and location.type != 'Song' and world.shuffle_song_items == 'song':
                 ignore_pools = [2]
-            if is_invert and location.type == 'Song' and not world.shuffle_song_items:
+            if is_invert and location.type == 'Song' and world.shuffle_song_items == 'song':
                 ignore_pools = [i for i in range(len(item_pools)) if i != 2]
             if location.type == 'Shop':
                 ignore_pools = [i for i in range(len(item_pools)) if i != 0]

--- a/Rules.py
+++ b/Rules.py
@@ -15,7 +15,7 @@ def set_rules(world):
     is_child = world.parser.parse_rule('is_child')
 
     for location in world.get_locations():
-        if not world.shuffle_song_items:
+        if world.shuffle_song_items == 'song':
             if location.type == 'Song':
                 # allow junk items, but songs must still have matching world
                 add_item_rule(location, lambda location, item: 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2108,22 +2108,37 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
     ),
-    Checkbutton(
+    Combobox(
         name           = 'shuffle_song_items',
-        gui_text       = 'Shuffle Songs with Items',
+        gui_text       = 'Shuffle Songs',
+        default        = 'song',
+        choices        = {
+            'song':    'Song Locations',
+            'dungeon': 'Dungeon Rewards',
+            'any':     'Anywhere',
+            },
         gui_tooltip    = '''\
-            Enabling this shuffles the songs into the rest of the
-            item pool.
+            This restricts where song items can appear.
 
-            This means that song locations can contain other items,
-            and any location can contain a song. Otherwise, songs
-            are only shuffled among themselves.
+            'Song Locations': Song will only appear at vanilla song
+            locations. In Multiworld, songs will only appear in their
+            own world.
+
+            'Dungeon Rewards': Songs appear at the end of dungeons.
+            For major dungeons, they will be at the boss heart
+            container location. The remaining 4 songs are placed at:
+
+            - Zelda's Lulluby Location
+            - Ice Cavern's Serenade of Water Location
+            - Bottom of the Well's Lens of Truth Location
+            - Gerudo Training Ground's Ice Arrow Location
+
+            'Anywhere': Songs can appear in any location.
         ''',
-        default        = False,
-        shared         = True,
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
+        shared         = True,
     ),
     Checkbutton(
         name           = 'shuffle_cows',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2120,15 +2120,15 @@ setting_infos = [
         gui_tooltip    = '''\
             This restricts where song items can appear.
 
-            'Song Locations': Song will only appear at vanilla song
-            locations. In Multiworld, songs will only appear in their
-            own world.
+            'Song Locations': Song will only appear at locations that
+            normally teach songs. In Multiworld, songs will only 
+            appear in their own world.
 
             'Dungeon Rewards': Songs appear at the end of dungeons.
             For major dungeons, they will be at the boss heart
             container location. The remaining 4 songs are placed at:
 
-            - Zelda's Lulluby Location
+            - Zelda's Lullaby Location
             - Ice Cavern's Serenade of Water Location
             - Bottom of the Well's Lens of Truth Location
             - Gerudo Training Ground's Ice Arrow Location
@@ -2137,6 +2137,11 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_settings',
+            'distribution':  [
+                ('song', 2),
+                ('dungeon', 1),
+                ('any', 1),
+            ],
         },
         shared         = True,
     ),

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -172,11 +172,11 @@
           "text": "Shuffle",
           "row_span": [6,6,9],
           "settings": [
+            "shuffle_song_items",
             "shopsanity",
             "tokensanity",
             "shuffle_scrubs",
             "shuffle_cows",
-            "shuffle_song_items",
             "shuffle_kokiri_sword",
             "shuffle_ocarinas",
             "shuffle_weird_egg",

--- a/tests/ac-mq.sav
+++ b/tests/ac-mq.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/accessible.sav
+++ b/tests/accessible.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/disables.sav
+++ b/tests/disables.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/entrance.sav
+++ b/tests/entrance.sav
@@ -23,7 +23,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "entrance_shuffle": "all",
 "shuffle_scrubs": "off",

--- a/tests/entrance2.sav
+++ b/tests/entrance2.sav
@@ -24,7 +24,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "entrance_shuffle": "simple-indoors",
 "shuffle_scrubs": "off",

--- a/tests/entrance3.sav
+++ b/tests/entrance3.sav
@@ -23,7 +23,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "entrance_shuffle": "all",
 "shuffle_scrubs": "off",

--- a/tests/glitched-standard.sav
+++ b/tests/glitched-standard.sav
@@ -21,7 +21,7 @@
     "tokensanity": "dungeons",
     "shuffle_scrubs": "off",
     "shuffle_cows": false,
-    "shuffle_song_items": false,
+    "shuffle_song_items": "song",
     "shuffle_kokiri_sword": false,
     "shuffle_ocarinas": false,
     "shuffle_weird_egg": false,

--- a/tests/glitched-tokens.sav
+++ b/tests/glitched-tokens.sav
@@ -27,7 +27,7 @@
 "shuffle_ocarinas": true,
 "shuffle_weird_egg": true,
 "shuffle_gerudo_card": true,
-"shuffle_song_items": true,
+"shuffle_song_items": "any",
 "shuffle_cows": true,
 "shuffle_scrubs": "random",
 "shopsanity": "4",

--- a/tests/multiworld.sav
+++ b/tests/multiworld.sav
@@ -27,7 +27,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/nightforest.sav
+++ b/tests/nightforest.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "low",
 "shopsanity": "4",

--- a/tests/plentiful.sav
+++ b/tests/plentiful.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/tokensanity.sav
+++ b/tests/tokensanity.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/triforce-multiworld.sav
+++ b/tests/triforce-multiworld.sav
@@ -28,7 +28,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",

--- a/tests/triforce-startingitems.sav
+++ b/tests/triforce-startingitems.sav
@@ -30,7 +30,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "low",
 "shopsanity": "off",

--- a/tests/triforce.sav
+++ b/tests/triforce.sav
@@ -29,7 +29,7 @@
 "shuffle_ocarinas": false,
 "shuffle_weird_egg": false,
 "shuffle_gerudo_card": false,
-"shuffle_song_items": false,
+"shuffle_song_items": "song",
 "shuffle_cows": false,
 "shuffle_scrubs": "off",
 "shopsanity": "off",


### PR DESCRIPTION
Songs will only appear at the boss heart contains in major dungeons, or at final reward in minor dungeons. Because this is still short 1 location, the ZL location is added as the final 12th. The idea is for it to pair with the potential option in the future to start with the ZL location.