### PR TITLE
Improve grammar for light arrow hint in multiworld

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -757,10 +757,11 @@ def buildGanonText(world, messages):
     elif world.light_arrow_location:
         text = get_raw_text(getHint('Light Arrow Location', world.clearer_hints).text)
         location = world.light_arrow_location
-        location_hint = get_hint_area(location).replace('Ganon\'s Castle', 'my castle')
+        location_hint = get_hint_area(location)
         if world.id != location.world.id:
             text += "\x05\x42Player %d's\x05\x40 %s" % (location.world.id +1, get_raw_text(location_hint))
         else:
+            location_hint = location_hint.replace('Ganon\'s Castle', 'my castle')
             text += get_raw_text(location_hint)
     else:
         text = get_raw_text(getHint('Validation Line', world.clearer_hints).text)


### PR DESCRIPTION
Instead of “Player n's my castle”, Ganon will now say “Player n's Ganon's Castle”.