### PR TITLE
Wasteland at night requires song of storms or sword

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -170,13 +170,14 @@ logic_tricks = {
                     Can be reached by side-hopping off
                     the watchtower.
                     '''},
-    'Wasteland at Night without Song of Storms or Spin Attack': {
+    'Wasteland at Night without Sword or Song of Storms': {
         'name'    : 'logic_wasteland_night',
         'tags'    : ("Haunted Wasteland",),
         'tooltip' : '''\
                     The poles are difficult to see at night.
-                    Logic normally requires Song of Storms or
-                    spin attack because they improve visibility.
+                    Logic normally requires either a sword,
+                    or Song of Storms, because standard spin
+                    attacks or lightning improve visibility.
                     '''},
     'Dodongo\'s Cavern Staircase with Bow': {
         'name'    : 'logic_dc_staircase',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -170,6 +170,14 @@ logic_tricks = {
                     Can be reached by side-hopping off
                     the watchtower.
                     '''},
+    'Wasteland at Night without Song of Storms': {
+        'name'    : 'logic_wasteland_night',
+        'tags'    : ("Haunted Wasteland",),
+        'tooltip' : '''\
+                    The poles are difficult to see at night.
+                    Logic normally requires Song of Storms because
+                    the lightning makes the poles clearly visible.
+                    '''},
     'Dodongo\'s Cavern Staircase with Bow': {
         'name'    : 'logic_dc_staircase',
         'tags'    : ("Dodongo's Cavern",),
@@ -1615,7 +1623,7 @@ setting_infos = [
         choices        = {
             'open':       'Always Open',
             'vanilla':    'Vanilla Requirements',
-            'stones':	  'All Spiritual Stones',
+            'stones':     'All Spiritual Stones',
             'medallions': 'All Medallions',
             'dungeons':   'All Dungeons',
             'tokens':     'Gold Skulltula Tokens'

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -170,13 +170,13 @@ logic_tricks = {
                     Can be reached by side-hopping off
                     the watchtower.
                     '''},
-    'Wasteland at Night without Song of Storms': {
+    'Wasteland at Night without Song of Storms or Spin Attack': {
         'name'    : 'logic_wasteland_night',
         'tags'    : ("Haunted Wasteland",),
         'tooltip' : '''\
                     The poles are difficult to see at night.
-                    Logic normally requires Song of Storms because
-                    the lightning makes the poles clearly visible.
+                    Logic normally requires Song of Storms or
+                    spin attack because they improve visibility.
                     '''},
     'Dodongo\'s Cavern Staircase with Bow': {
         'name'    : 'logic_dc_staircase',

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -498,18 +498,29 @@
         "scene": "Haunted Wasteland",
         "hint": "Haunted Wasteland",
         "locations": {
-            "Wasteland Chest": "has_fire_source",
             "Wasteland Bombchu Salesman": "
                 Progressive_Wallet and 
-                (is_adult or Sticks or Kokiri_Sword)",
+                (is_adult or Sticks or Kokiri_Sword)"
+        },
+        "exits": {
+            "Wasteland Monument": "at_day or can_play(Song_of_Storms) or logic_wasteland_night",
+            "Wasteland Near Fortress": "
+                logic_wasteland_crossing or can_use(Hover_Boots) or can_use(Longshot)"
+        }
+    },
+	{
+        "region_name": "Wasteland Monument",
+        "scene": "Haunted Wasteland",
+        "hint": "Haunted Wasteland",
+        "locations": {
+            "Wasteland Chest": "has_fire_source",
             "Wasteland GS": "can_use(Hookshot) or can_use(Boomerang)",
             "Fairy Pot": "has_bottle",
             "Nut Pot": "True"
         },
         "exits": {
             "Wasteland Near Colossus": "logic_lens_wasteland or can_use(Lens_of_Truth)",
-            "Wasteland Near Fortress": "
-                logic_wasteland_crossing or can_use(Hover_Boots) or can_use(Longshot)"
+            "Haunted Wasteland": "at_day or can_play(Song_of_Storms) or logic_wasteland_night"
         }
     },
     {
@@ -517,7 +528,7 @@
         "scene": "Haunted Wasteland",
         "exits": {
             "Desert Colossus": "True",
-            "Haunted Wasteland": "logic_reverse_wasteland"
+            "Wasteland Monument": "logic_reverse_wasteland"
         }
     },
     {
@@ -1614,7 +1625,7 @@
     },
     {
         "region_name": "LLR Stables",
-		"locations": {
+        "locations": {
             "LLR Stables Left Cow": "can_play(Eponas_Song)",
             "LLR Stables Right Cow": "can_play(Eponas_Song)"
         },
@@ -1883,7 +1894,7 @@
     },
     {
         "region_name": "DMT Cow Grotto",
-		 "locations": {
+         "locations": {
             "DMT Cow Grotto Cow": "can_play(Eponas_Song)"
         },
         "exits": {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -503,12 +503,14 @@
                 (is_adult or Sticks or Kokiri_Sword)"
         },
         "exits": {
-            "Wasteland Monument": "at_day or can_play(Song_of_Storms) or logic_wasteland_night",
+            "Wasteland Monument": "
+                at_day or ((is_adult or Kokiri_Sword) and Magic_Meter) or
+                can_play(Song_of_Storms) or logic_wasteland_night",
             "Wasteland Near Fortress": "
                 logic_wasteland_crossing or can_use(Hover_Boots) or can_use(Longshot)"
         }
     },
-	{
+    {
         "region_name": "Wasteland Monument",
         "scene": "Haunted Wasteland",
         "hint": "Haunted Wasteland",
@@ -520,7 +522,9 @@
         },
         "exits": {
             "Wasteland Near Colossus": "logic_lens_wasteland or can_use(Lens_of_Truth)",
-            "Haunted Wasteland": "at_day or can_play(Song_of_Storms) or logic_wasteland_night"
+            "Haunted Wasteland": "
+                at_day or ((is_adult or Kokiri_Sword) and Magic_Meter) or
+                can_play(Song_of_Storms) or logic_wasteland_night"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -504,7 +504,7 @@
         },
         "exits": {
             "Wasteland Monument": "
-                at_day or ((is_adult or Kokiri_Sword) and Magic_Meter) or
+                at_day or is_adult or Kokiri_Sword or
                 can_play(Song_of_Storms) or logic_wasteland_night",
             "Wasteland Near Fortress": "
                 logic_wasteland_crossing or can_use(Hover_Boots) or can_use(Longshot)"
@@ -523,7 +523,7 @@
         "exits": {
             "Wasteland Near Colossus": "logic_lens_wasteland or can_use(Lens_of_Truth)",
             "Haunted Wasteland": "
-                at_day or ((is_adult or Kokiri_Sword) and Magic_Meter) or
+                at_day or is_adult or Kokiri_Sword or
                 can_play(Song_of_Storms) or logic_wasteland_night"
         }
     },

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -291,6 +291,7 @@
       "logic_visible_collisions",
       "logic_child_deadhand",
       "logic_man_on_roof",
+      "logic_wasteland_night",
       "logic_dc_staircase",
       "logic_dc_jump",
       "logic_gerudo_kitchen",


### PR DESCRIPTION
The poles in haunted wasteland are very difficult to see at night, but the flashes from song of storms make them visible. So going between the monument and the bombchu salesman area should require daytime, song of storms, or a trick. Only in ER could the player ever be required to cross wasteland at night, but I think it presents a significant accessibility issue in those cases.