### PR TITLE
Update for ice cavern glitch logic

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -704,6 +704,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_byte(0xB6D3D2, 0x00) # Gerudo Training Grounds
     rom.write_byte(0xB6D42A, 0x00) # Inside Ganon's Castle
 
+    #Tell Sheik at Ice Cavern we are always an Adult
+    rom.write_int32(0xC7B9C0, 0x00000000)
+    rom.write_int32(0xC7BAEC, 0x00000000)
+    rom.write_int32(0xc7BCA4, 0x00000000)
+
     # Allow Farore's Wind in dungeons where it's normally forbidden
     rom.write_byte(0xB6D3D3, 0x00) # Gerudo Training Grounds
     rom.write_byte(0xB6D42B, 0x00) # Inside Ganon's Castle
@@ -867,11 +872,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
         #Tell the well water we are always a child.
         rom.write_int32(0xDD5BF4, 0x00000000)
-
-        #Tell Sheik at Ice Cavern we are always an Adult
-        rom.write_int32(0xC7B9C0, 0x00000000)
-        rom.write_int32(0xC7BAEC, 0x00000000)
-        rom.write_int32(0xc7BCA4, 0x00000000)
 
         #Make the Adult well blocking stone dissappear if the well has been drained by
         #checking the well drain event flag instead of links age. This actor doesn't need a

--- a/data/Glitched World/Ice Cavern.json
+++ b/data/Glitched World/Ice Cavern.json
@@ -17,8 +17,8 @@
             "Ice Cavern Freestanding PoH": "(is_adult or (is_child and (can_live_dmg(0.5) or can_use(Nayrus_Love)))) and
                 (Blue_Fire or (is_adult and Bombs and can_shield and (can_live_dmg(0.5) or can_use(Nayrus_Love)))
                 or can_use(Boomerang))",
-            "Ice Cavern Iron Boots Chest": "is_adult and (Blue_Fire or (can_use(Hover_Boots) and can_shield) or can_mega)",
-            "Sheik in Ice Cavern": "is_adult and (Blue_Fire or (can_use(Hover_Boots) and can_shield) or can_mega)",
+            "Ice Cavern Iron Boots Chest": "(can_jumpslash or can_use(Slingshot) or can_use(Dins_Fire)) and (Blue_Fire or (can_use(Hover_Boots) and can_shield) or can_mega)",
+            "Sheik in Ice Cavern": "(can_jumpslash or can_use(Slingshot) or can_use(Dins_Fire)) and (Blue_Fire or (can_use(Hover_Boots) and can_shield) or can_mega)",
             "Ice Cavern GS Spinning Scythe Room": "can_use(Hookshot) or can_use(Boomerang) or
                 (can_use(Hover_Boots) and can_mega)",
             "Ice Cavern GS Heart Piece Room": "(is_adult or (is_child and (can_live_dmg(0.5) or can_use(Nayrus_Love)) )) and


### PR DESCRIPTION
Just a very small portion of the changes for glitch logic I've been working on. This is all I can really propose for main right now, since the rest is all reliant on unfinished stuff, but it's a small start.

One of the commits changes patches.py to make the change that allows child to get Serenade always apply, so that it's applicable in glitchless logic as well (as I really do not want a chest sitting in the open that child _should_ be able to reach easily but will softlock them if they open).

The second PR changes the actual logic for killing the wolfos to match the glitchless methods (Swords, sticks, slingshot, din's). It's *not* the final logic for killing them, as part of that logic would involve stuff that isn't 100% implemented yet, and I haven't 100% reviewed ice cavern yet for my changes, _but_ I feel that the glitchless ways to kill it are close enough to what the final logic for killing it in glitch logic would be.