### PR TITLE
Rewrite logic for Deku Backroom GS to be human-readable and change the basement web trick

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ player.
 * Removed tricks
   * `Water Temple Boss Key Chest with Iron Boots`
   * `Water Temple Dragon Statue with Bombchu` - superseded by the new Dragon Statue tricks.
+* Changed Tricks
+  * Burning the two vertical webs in the Deku Tree basement with bow is now default logic. The relevant trick has been renamed to `Deku Tree Basement Web to Gohma with Bow` to reflect this.
 * New "Hint Distribution" customization options
   * Old hardcoded hint distributions are now defined by json files in `data/Hints`.
   * Custom hint distributions can be added to this folder, or defined directly in Plando files.

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -215,12 +215,13 @@ logic_tricks = {
         'name'    : 'logic_deku_b1_webs_with_bow',
         'tags'    : ("Deku Tree", "Entrance",),
         'tooltip' : '''\
-                    All spider web walls in Deku Tree basement can be burnt
-                    by adult using just a bow shooting through torches. Applies
-                    to the circular floor web dropping to Gohma.
+                    All spider web walls in the Deku Tree basement can be burnt
+                    as adult with just a bow by shooting through torches. This
+                    trick only applies to the circular web leading to Gohma,
+                    the two vertical webs are always in logic.
 
                     Backflip onto the chest near the torch at the bottom of
-                    the vine wall. With a precise position you can shoot
+                    the vine wall. With precise positioning you can shoot
                     through the torch to the right edge of the circular web.
 
                     This allows completion of adult Deku Tree with no fire source.

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -211,20 +211,17 @@ logic_tricks = {
         'tooltip' : '''\
                     Can be defeated by doing a precise jump slash.
                     '''},
-    'Deku Tree Basement Webs with Bow': {
+    'Deku Tree Basement Web to Gohma with Bow': {
         'name'    : 'logic_deku_b1_webs_with_bow',
         'tags'    : ("Deku Tree", "Entrance",),
         'tooltip' : '''\
                     All spider web walls in Deku Tree basement can be burnt
                     by adult using just a bow shooting through torches. Applies
-                    to the web obstructing the door to the single scrub room,
-                    the web obstructing the bombable wall in the back room
-                    and the circular floor web dropping to Gohma.
+                    to the circular floor web dropping to Gohma.
 
-                    For the circular web dropping to Gohma, backflip onto the
-                    chest near the torch at the bottom of the vine wall. With a
-                    precise position you can shoot through the torch to the
-                    right edge of the circular web.
+                    Backflip onto the chest near the torch at the bottom of
+                    the vine wall. With a precise position you can shoot
+                    through the torch to the right edge of the circular web.
 
                     This allows completion of adult Deku Tree with no fire source.
                     '''},

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -21,9 +21,9 @@
             "KF Outside Deku Tree": "True",
             "Deku Tree Slingshot Room": "here(has_shield)",
             "Deku Tree Basement Backroom": "
-                (here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow))) and
+                (here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow)) and
                 here(can_use(Slingshot) or can_use(Bow))) or
-                (is_child and logic_deku_b1_skip)",
+                (is_child and (logic_deku_b1_skip or here(is_adult))",
             "Deku Tree Boss Room": "
                 here(has_fire_source_with_torch or
                      (logic_deku_b1_webs_with_bow and can_use(Bow))) and
@@ -45,7 +45,7 @@
         "region_name": "Deku Tree Basement Backroom",
         "dungeon": "Deku Tree",
         "locations": {
-                "Deku Tree GS Basement Back Room": "
+            "Deku Tree GS Basement Back Room": "
                 here(has_fire_source_with_torch or can_use(Bow)) and
                 here(can_blast_or_smash) and
                 (can_use(Boomerang) or can_use(Hookshot))"

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -42,7 +42,7 @@
         }
     },
     {
-        "region_name": "Deku Tree Basement Backroom"
+        "region_name": "Deku Tree Basement Backroom",
         "dungeon": "Deku Tree",
         "locations": {
                 "Deku Tree GS Basement Back Room": "

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -12,15 +12,6 @@
                 can_use_projectile or can_use(Dins_Fire) or
                 (logic_deku_basement_gs and (is_adult or Sticks or Kokiri_Sword))",
             "Deku Tree GS Basement Gate": "is_adult or can_child_attack",
-            "Deku Tree GS Basement Back Room": "
-                (here(has_fire_source_with_torch or
-                      (logic_deku_b1_webs_with_bow and can_use(Bow))) and
-                    here(can_use(Slingshot) or can_use(Bow)) and
-                    here(can_blast_or_smash) and
-                    here(can_use(Hookshot) or can_use(Boomerang))) or
-                ((logic_deku_b1_skip or here(is_adult)) and is_child and
-                    has_explosives and can_use(Boomerang) and
-                    (Sticks or can_use(Dins_Fire)))",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
             "Deku Baba Nuts": "
                 is_adult or Slingshot or Sticks or 
@@ -29,6 +20,8 @@
         "exits": {
             "KF Outside Deku Tree": "True",
             "Deku Tree Slingshot Room": "here(has_shield)",
+			"Deku Tree Basement Backroom": "(here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow))) and here(can_use(Slingshot) or can_use(Bow))) or
+                (is_child and logic_deku_b1_skip)",
             "Deku Tree Boss Room": "
                 here(has_fire_source_with_torch or
                      (logic_deku_b1_webs_with_bow and can_use(Bow))) and
@@ -44,6 +37,16 @@
         },
         "exits": {
             "Deku Tree Lobby": "True"
+        }
+    },
+    {
+        "region_name": "Deku Tree Basement Backroom"
+        "dungeon": "Deku Tree",
+        "locations": {
+                "Deku Tree GS Basement Back Room": "
+                here(has_fire_source_with_torch or can_use(Bow)) and
+                here(can_blast_or_smash) and
+                (can_use(Boomerang) or can_use(Hookshot))"
         }
     },
     {

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -20,7 +20,9 @@
         "exits": {
             "KF Outside Deku Tree": "True",
             "Deku Tree Slingshot Room": "here(has_shield)",
-            "Deku Tree Basement Backroom": "(here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow))) and here(can_use(Slingshot) or can_use(Bow))) or
+            "Deku Tree Basement Backroom": "
+                (here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow))) and
+                here(can_use(Slingshot) or can_use(Bow))) or
                 (is_child and logic_deku_b1_skip)",
             "Deku Tree Boss Room": "
                 here(has_fire_source_with_torch or
@@ -47,6 +49,9 @@
                 here(has_fire_source_with_torch or can_use(Bow)) and
                 here(can_blast_or_smash) and
                 (can_use(Boomerang) or can_use(Hookshot))"
+        },
+        "exits": {
+            "Deku Tree Lobby": "True"
         }
     },
     {

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -20,7 +20,7 @@
         "exits": {
             "KF Outside Deku Tree": "True",
             "Deku Tree Slingshot Room": "here(has_shield)",
-			"Deku Tree Basement Backroom": "(here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow))) and here(can_use(Slingshot) or can_use(Bow))) or
+            "Deku Tree Basement Backroom": "(here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow))) and here(can_use(Slingshot) or can_use(Bow))) or
                 (is_child and logic_deku_b1_skip)",
             "Deku Tree Boss Room": "
                 here(has_fire_source_with_torch or

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -21,7 +21,7 @@
             "KF Outside Deku Tree": "True",
             "Deku Tree Slingshot Room": "here(has_shield)",
             "Deku Tree Basement Backroom": "
-                (here(has_fire_source_with_torch or (can_use(Bow) and logic_deku_b1_webs_with_bow)) and
+                (here(has_fire_source_with_torch or can_use(Bow)) and
                 here(can_use(Slingshot) or can_use(Bow))) or
                 (is_child and (logic_deku_b1_skip or here(is_adult))",
             "Deku Tree Boss Room": "


### PR DESCRIPTION
I rewrote some of the here()s for the to just be a room instead, and sorted it all out to be less of a mess. This should be the same logically, just far more readable and easier to understand.

~~I've drafted it because I'm not sure that the trick for burning the vertical webs is actually really that important. 2/3 fire requirements are absolutely trivial with bow (one is literally the exact same as the intended method for torches room in water temple, and the other is even easier), and the only slightly awkward one is in the main b1 room since you need to stand to the side of the torch.~~

I've now changed it to make the 'Deku Tree Basement Webs with Bow' trick just for Gohma, after consensus from r0b and Rattus that burning the two vertical webs in the basement with bow was easy enough to not be justified as a trick.