### PR TITLE
Add "Free Zelda" timesaver setting

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -817,7 +817,9 @@ def get_pool_core(world):
     elif world.item_pool_value == 'plentiful':
         ruto_bottles += 1
 
-    if world.shuffle_weird_egg:
+    if world.free_zelda:
+        placed_items['HC Malon Egg'] = 'Recovery Heart'
+    elif world.shuffle_weird_egg:
         pool.append('Weird Egg')
     else:
         placed_items['HC Malon Egg'] = 'Weird Egg'

--- a/Patches.py
+++ b/Patches.py
@@ -1009,15 +1009,27 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # Make the Kakariko Gate not open with the MS
     if world.open_kakariko != 'open':
         rom.write_int32(0xDD3538, 0x34190000) # li t9, 0
-    if world.open_kakariko == 'closed':
-        rom.write_byte(rom.sym('OPEN_KAKARIKO'), 0)
-    else:
+    if world.open_kakariko != 'closed':
         rom.write_byte(rom.sym('OPEN_KAKARIKO'), 1)
 
     if world.complete_mask_quest:
         rom.write_byte(rom.sym('COMPLETE_MASK_QUEST'), 1)
-    else:
-        rom.write_byte(rom.sym('COMPLETE_MASK_QUEST'), 0)
+
+    if world.free_zelda:
+        save_context.give_item('Zeldas Letter')
+        save_context.give_item(world.get_location('Song from Impa').item.name)
+        save_context.write_bits(0x0ED7, 0x04) # "Obtained Malon's Item"
+        save_context.write_bits(0x0ED7, 0x08) # "Woke Talon in castle"
+        save_context.write_bits(0x0ED7, 0x10) # "Talon has fled castle"
+        save_context.write_bits(0x0EDD, 0x01) # "Obtained Zelda's Letter"
+        save_context.write_bits(0x0EDE, 0x02) # "Learned Zelda's Lullaby"
+        save_context.write_bits(0x00D4 + 0x5F * 0x1C + 0x04 + 0x3, 0x10) # "Moved crates to access the courtyard"
+        if world.open_kakariko != 'closed':
+            save_context.write_bits(0x0F07, 0x40) # "Spoke to Gate Guard About Mask Shop"
+        if world.complete_mask_quest:
+            save_context.write_bits(0x0F07, 0x80) # "Soldier Wears Keaton Mask"
+            save_context.write_bits(0x0EF6, 0x8F) # "Sold Masks & Unlocked Masks" / "Obtained Mask of Truth"
+            save_context.write_bits(0x0EE4, 0xF0) # "Paid Back Mask Fees"
 
     if world.zora_fountain == 'open':
         save_context.write_bits(0x0EDB, 0x08) # "Moved King Zora"

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -846,6 +846,7 @@ class SaveContext():
         "Claim Check"    : {'item_slot.adult_trade'     : 'claim_check'},
         "Weird Egg"      : {'item_slot.child_trade'     : 'weird_egg'},
         "Chicken"        : {'item_slot.child_trade'     : 'chicken'},
+        "Zeldas Letter"  : {'item_slot.child_trade'     : 'zeldas_letter'},
         "Goron Tunic"    : {'equip_items.goron_tunic'   : True},
         "Zora Tunic"     : {'equip_items.zora_tunic'    : True},
         "Iron Boots"     : {'equip_items.iron_boots'    : True},

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1990,6 +1990,7 @@ setting_infos = [
         gui_tooltip    = '''\
             Start having already met Zelda and obtained
             Zelda's Letter along with the song from Impa.
+            This is incompatble with songs shuffled anywhere.
         ''',
         shared         = True,
     ),
@@ -2261,6 +2262,7 @@ setting_infos = [
             - Gerudo Training Ground's Ice Arrow Location
 
             'Anywhere': Songs can appear in any location.
+            This is incompatible with "Free Zelda".
         ''',
         gui_params     = {
             'randomize_key': 'randomize_settings',
@@ -2269,6 +2271,9 @@ setting_infos = [
                 ('dungeon', 1),
                 ('any', 1),
             ],
+        },
+        disable        = {
+            'any' : {'settings' : ['free_zelda']}
         },
         shared         = True,
     ),

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1985,6 +1985,15 @@ setting_infos = [
         disabled_default = 0,
     ),
     Checkbutton(
+        name           = 'free_zelda',
+        gui_text       = 'Free Zelda',
+        gui_tooltip    = '''\
+            Start having already met Zelda and obtained
+            Zelda's Letter along with the song from Impa.
+        ''',
+        shared         = True,
+    ),
+    Checkbutton(
         name           = 'no_escape_sequence',
         gui_text       = 'Skip Tower Escape Sequence',
         gui_tooltip    = '''\

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -6,7 +6,8 @@
             "Links Pocket": "True"
         },
         "exits": {
-            "Root Exits": "is_starting_age or Time_Travel"
+            "Root Exits": "is_starting_age or Time_Travel",
+            "HC Garden Locations": "free_zelda"
         }
     },
     {
@@ -440,7 +441,7 @@
         "exits": {
             "Market": "True",
             #// garden will logically need weird-egg as letter first can screw over the mask quest
-            "HC Garden": "Weird_Egg or (not shuffle_weird_egg)",
+            "HC Garden": "Weird_Egg or free_zelda or (not shuffle_weird_egg)",
             "HC Great Fairy Fountain": "True",
             "HC Storms Grotto": "can_play(Song_of_Storms)"
         }
@@ -448,12 +449,18 @@
     {
         "region_name": "HC Garden",
         "hint": "Hyrule Castle",
+        "exits": {
+            "HC Garden Locations": "True",
+            "Hyrule Castle Grounds": "True"
+        }
+    },
+    {
+        # Directly reachable from Root in "Free Zelda"
+        "region_name": "HC Garden Locations",
+        "hint": "Hyrule Castle",
         "locations": {
             "HC Zeldas Letter": "True",
             "Song from Impa": "True"
-        },
-        "exits": {
-            "Hyrule Castle Grounds": "True"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -6,7 +6,8 @@
             "Links Pocket": "True"
         },
         "exits": {
-            "Root Exits": "is_starting_age or Time_Travel"
+            "Root Exits": "is_starting_age or Time_Travel",
+            "HC Garden Locations": "free_zelda"
         }
     },
     {
@@ -646,7 +647,7 @@
         },
         "exits": {
             "Castle Grounds": "True",
-            "HC Garden": "Weird_Egg or (not shuffle_weird_egg)",
+            "HC Garden": "Weird_Egg or free_zelda or (not shuffle_weird_egg)",
             "HC Great Fairy Fountain": "has_explosives",
             "HC Storms Grotto": "can_open_storm_grotto"
         }
@@ -655,12 +656,19 @@
         "region_name": "HC Garden",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
+        "exits": {
+            "HC Garden Locations": "True",
+            "Hyrule Castle Grounds": "True"
+        }
+    },
+    {
+        # Directly reachable from Root in "Free Zelda"
+        "region_name": "HC Garden Locations",
+        "scene": "Castle Grounds",
+        "hint": "Hyrule Castle",
         "locations": {
             "HC Zeldas Letter": "True",
             "Song from Impa": "True"
-        },
-        "exits": {
-            "Hyrule Castle Grounds": "True"
         }
     },
     {

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -287,6 +287,7 @@
           "text": "Timesavers",
           "row_span": [1,1,1],
           "settings": [
+            "free_zelda",
             "no_escape_sequence",
             "no_guard_stealth",
             "no_epona_race",


### PR DESCRIPTION
This new setting essentially acts as if you already met Zelda as child when loading up the save, which means you start with Zelda's Letter, all relevant flags and whichever song Impa would have taught you. The way it's currently implemented mimics Link's Pocket behavior (the stone/medallion you start with), which means the "Song from Impa" location still exist in the spoiler and playthrough, and that can affect hints, or some internal checks (mostly ER related).

The setting is also currently incompatible with songsanity, so that'll disable the option entirely when you select it, but we can probably try to work on that in the future. It also makes Weird Egg shuffle meaningless ofc, tho I don't know if they should disable each other so I haven't done it yet. I guess they should, but I would like to hear what others think.

When it comes to the GUI, the setting is currently named "Free Zelda" and sitting at the top of the timesaver section, but that's open to changes, especially when it comes to the name. I don't have any ideas myself, so feel free to make suggestions or changes in that regard.