### PR TITLE
Fix New Keysanity Options

### DIFF
--- a/DungeonList.py
+++ b/DungeonList.py
@@ -123,6 +123,9 @@ def create_dungeons(world):
             small_keys = ItemFactory(['Small Key (%s)' % name] * dungeon_info['small_key_mq'])           
         dungeon_items = ItemFactory(['Map (%s)' % name, 
                                      'Compass (%s)' % name] * dungeon_info['dungeon_item'])
+        if world.settings.shuffle_mapcompass in ['any_dungeon', 'overworld']:
+            for item in dungeon_items:
+                item.priority = True
 
         world.dungeons.append(Dungeon(world, name, hint, boss_keys, small_keys, dungeon_items))
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2579,7 +2579,7 @@ setting_infos = [
             for a milder Keysanity experience.
         ''',
         disable        = {
-            'dungeons': {'settings': ['one_item_per_dungeon']},
+            'any_dungeon': {'settings': ['one_item_per_dungeon']},
         },
         shared         = True,
         gui_params     = {


### PR DESCRIPTION
Maps/Compasses should be Priorty items if Map/Compasses are shuffled into Any Dungeon or Overworld. Also fixed it so that Small Keys in Any Dungeon should disable the Dungeons Have One Major Item setting as they are incompatible.