### PR TITLE
Logic 2

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1221,16 +1221,18 @@ logic_tricks = {
                     courtyard without Hover Boots. Applies
                     to both Vanilla and Master Quest.
                     '''},
-    'Forest Temple Scarecrow Route': {
-        'name'    : 'logic_forest_scarecrow',
+    'Forest Temple East Courtyard Door Frame with Hover Boots': {
+        'name'    : 'logic_forest_door_frame',
         'tags'    : ("Forest Temple",),
         'tooltip' : '''\
-                    From on top of the door frame in the NE
-                    courtyard, you can summon Pierre. You
-                    can get there with a precise Hover Boots
-                    movement. You will take fall damage.
-                    This allows you to reach the falling
-                    ceiling room early.
+                    A precise Hover Boots movement from the upper
+                    balconies in this courtyard can be used to get on
+                    top of the door frame. Applies to both Vanilla and
+                    Master Quest. In Vanilla, from on top the door
+                    frame you can summon Pierre, allowing you to access
+                    the falling ceiling room early. In Master Quest,
+                    this allows you to obtain the GS on the door frame
+                    as adult without Hookshot or Song of Time.
                     '''},
     'Dodongo\'s Cavern MQ Early Bomb Bag Area as Child': {
         'name'    : 'logic_dc_mq_child_bombs',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1282,7 +1282,7 @@ logic_tricks = {
                     fire wall, and by defeating Armos to detonate bomb
                     flowers (among other methods). While these techniques
                     themselves are relatively simple, they're not
-                    relevant unless "Dodongo\'s Cavern MQ Light the Eyes
+                    relevant unless "Dodongo's Cavern MQ Light the Eyes
                     with Strength" is enabled, which is a trick which
                     that is particularly difficult for child to perform.
                     '''},

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -227,6 +227,14 @@ logic_tricks = {
 
                     This allows completion of adult Deku Tree with no fire source.
                     '''},
+    'Deku Tree MQ Roll Under the Spiked Log': {
+        'name'    : 'logic_deku_mq_log',
+        'tags'    : ("Deku Tree",),
+        'tooltip' : '''\
+                    You can get past the spiked log by rolling
+                    to briefly shrink your hitbox. As adult,
+                    the timing is a bit more precise.
+                    '''},
     'Hammer Rusted Switches Through Walls': {
         'name'    : 'logic_rusted_switches',
         'tags'    : ("Fire Temple", "Ganon's Castle",),
@@ -243,6 +251,17 @@ logic_tricks = {
                     The chest in the basement can be reached with
                     strength by doing a jump slash with a lit
                     stick to access the bomb flowers.
+                    '''},
+    'Bottom of the Well MQ Jump Over the Pits': {
+        'name'    : 'logic_botw_mq_pits',
+        'tags'    : ("Bottom of the Well",),
+        'tooltip' : '''\
+                    While the pits in Bottom of the Well don't allow you to
+                    jump just by running straight at them, you can still get
+                    over them by side-hopping or backflipping across. With
+                    explosives, this allows you to access the central areas
+                    without Zelda's Lullaby. With Zelda's Lullaby, it allows
+                    you to access the west inner room without explosives.
                     '''},
     'Skip Forest Temple MQ Block Puzzle with Bombchu': {
         'name'    : 'logic_forest_mq_block_puzzle',
@@ -279,6 +298,19 @@ logic_tricks = {
                     Can fly behind the waterfall with
                     a cucco as child.
                     '''},
+    'Water Temple MQ Central Pillar with Fire Arrows': {
+        'name'    : 'logic_water_mq_central_pillar',
+        'tags'    : ("Water Temple",),
+        'tooltip' : '''\
+                    Slanted torches have misleading hitboxes. Whenever
+                    you see a slanted torch jutting out of the wall,
+                    you can expect most or all of its hitbox is actually
+                    on the other side that wall. This can make slanted
+                    torches very finicky to light when using arrows. The
+                    torches in the central pillar of MQ Water Temple are
+                    a partcularly egregious example. Logic normally
+                    expects Din's Fire and Song of Time.
+                    '''},
     'Gerudo Training Grounds MQ Left Side Silver Rupees with Hookshot': {
         'name'    : 'logic_gtg_mq_with_hookshot',
         'tags'    : ("Gerudo Training Grounds",),
@@ -307,7 +339,7 @@ logic_tricks = {
         'tags'    : ("Forest Temple", "Entrance", "Skulltulas",),
         'tooltip' : '''\
                     Allows killing this Skulltula with Sword or Sticks by
-                    jumpslashing it as you let go from the vines. You will
+                    jump slashing it as you let go from the vines. You will
                     take fall damage.
                     Also allows killing it as Child with a Bomb throw. It's
                     much more difficult to use a Bomb as child due to
@@ -323,8 +355,18 @@ logic_tricks = {
                     required if Forest Temple is in its Master Quest
                     form.
                     '''},
-    'Reach Forest Temple MQ Twisted Hallway Switch with Hookshot': {
-        'name'    : 'logic_forest_mq_hallway_switch',
+    'Forest Temple MQ Twisted Hallway Switch with Jump Slash': {
+        'name'    : 'logic_forest_mq_hallway_switch_jumpslash',
+        'tags'    : ("Forest Temple",),
+        'tooltip' : '''\
+                    The switch to twist the hallway can be hit with
+                    a jump slash through the glass block. To get in
+                    front of the switch, either use the Hover Boots
+                    or hit the shortcut switch at the top of the
+                    room and jump from the glass blocks that spawn.
+                    '''},
+    'Forest Temple MQ Twisted Hallway Switch with Hookshot': {
+        'name'    : 'logic_forest_mq_hallway_switch_hookshot',
         'tags'    : ("Forest Temple",),
         'tooltip' : '''\
                     There's a very small gap between the glass block
@@ -446,8 +488,11 @@ logic_tricks = {
                     If you move quickly you can sneak past the edge of
                     a flame wall before it can rise up to block you.
                     To do it without taking damage is more precise.
-                    Allows you to reach a GS without needing either
-                    Song of Time or Hover Boots.
+                    Allows you to reach the side room GS without needing
+                    Song of Time or Hover Boots. If either of "Fire Temple
+                    MQ Lower to Upper Lizalfos Maze with Hover Boots" or
+                    "with Precise Jump" are enabled, this also allows you
+                    to progress deeper into the dungeon without Hookshot.
                     '''},
     'Fire Temple MQ Climb without Fire Source': {
         'name'    : 'logic_fire_mq_climb',
@@ -457,6 +502,14 @@ logic_tricks = {
                     the climbable wall, skipping the need to use a
                     fire source and spawn a Hookshot target.
                     '''},
+    'Fire Temple MQ Lower to Upper Lizalfos Maze with Hover Boots': {
+        'name'    : 'logic_fire_mq_maze_hovers',
+        'tags'    : ("Fire Temple",),
+        'tooltip' : '''\
+                    Use the Hover Boots off of a crate to
+                    climb to the upper maze without needing
+                    to spawn and use the Hookshot targets.
+                    '''},
     'Fire Temple MQ Chest Near Boss without Breaking Crate': {
         'name'    : 'logic_fire_mq_near_boss',
         'tags'    : ("Fire Temple",),
@@ -465,23 +518,35 @@ logic_tricks = {
                     Shoot a flaming arrow at the side of the crate to light the
                     torch without needing to get over there and break the crate.
                     '''},
-    'Fire Temple MQ Boulder Maze Side Room without Box': {
+    'Fire Temple MQ Lizalfos Maze Side Room without Box': {
         'name'    : 'logic_fire_mq_maze_side_room',
         'tags'    : ("Fire Temple",),
         'tooltip' : '''\
                     You can walk from the blue switch to the door and
                     quickly open the door before the bars reclose. This
-                    skips needing the Hookshot in order to reach a box
-                    to place on the switch.
+                    skips needing to reach the upper sections of the
+                    maze to get a box to place on the switch.
                     '''},
     'Fire Temple MQ Boss Key Chest without Bow': {
         'name'    : 'logic_fire_mq_bk_chest',
         'tags'    : ("Fire Temple",),
         'tooltip' : '''\
-                    Din\'s alone can be used to unbar the door to
-                    the boss key chest's room thanks to an
+                    It is possible to light both of the timed torches
+                    to unbar the door to the boss key chest's room
+                    with just Din's Fire if you move very quickly
+                    between the two torches. It is also possible to
+                    unbar the door with just Din's by abusing an
                     oversight in the way the game counts how many
                     torches have been lit.
+                    '''},
+    'Fire Temple MQ Above Flame Wall Maze GS from Below with Longshot': {
+        'name'    : 'logic_fire_mq_above_maze_gs',
+        'tags'    : ("Fire Temple", "Skulltulas",),
+        'tooltip' : '''\
+                    The floor of the room that contains this Skulltula
+                    is only solid from above. From the maze below, the
+                    Longshot can be shot through the ceiling to obtain 
+                    the token with two fewer small keys than normal.
                     '''},
     'Zora\'s River Lower Freestanding PoH as Adult with Nothing': {
         'name'    : 'logic_zora_river_lower',
@@ -504,6 +569,15 @@ logic_tricks = {
         'tooltip' : '''\
                     Release the Bombchu with good timing so that
                     it explodes near the bottom of the pot.
+                    '''},
+    'Shadow Temple MQ Invisible Blades Silver Rupees without Song of Time': {
+        'name'    : 'logic_shadow_mq_invisible_blades',
+        'tags'    : ("Shadow Temple",),
+        'tooltip' : '''\
+                    The Like Like can be used to boost you into the
+                    silver rupee that normally requires Song of Time.
+                    This cannot be performed on OHKO since the Like
+                    Like does not boost you high enough if you die.
                     '''},
     'Shadow Temple MQ Lower Huge Pit without Fire Source': {
         'name'    : 'logic_shadow_mq_huge_pit',
@@ -585,6 +659,15 @@ logic_tricks = {
                     jump slash immediately. You will take fall
                     damage.
                     '''},
+    'Deku Tree MQ Compass Room GS Boulders with Just Hammer': {
+        'name'    : 'logic_deku_mq_compass_gs',
+        'tags'    : ("Deku Tree", "Skulltulas",),
+        'tooltip' : '''\
+                    Climb to the top of the vines, then let go
+                    and jump slash immediately to destroy the
+                    boulders using the Hammer, without needing
+                    to spawn a Song of Time block.
+                    '''},
     'Lake Hylia Lab Wall GS with Jump Slash': {
         'name'    : 'logic_lab_wall_gs',
         'tags'    : ("Lake Hylia", "Skulltulas",),
@@ -619,6 +702,18 @@ logic_tricks = {
                     on the torches is quite short so you must move
                     quickly in order to light all three.
                     '''},
+    'Spirit Temple MQ Sun Block Room as Child without Song of Time': {
+        'name'    : 'logic_spirit_mq_sun_block_sot',
+        'tags'    : ("Spirit Temple",),
+        'tooltip' : '''\
+                    While adult can easily jump directly to the switch that
+                    unbans the door to the sun block room, child Link cannot
+                    make the jump without spawning a Song of Time block to
+                    jump from. You can skip this by throwing the crate down
+                    onto the switch from above, which does unbar the door,
+                    however the crate immediately breaks, so you must move
+                    quickly to get through the door before it closes back up.
+                    '''},
     'Shadow Trial MQ Torch with Bow': {
         'name'    : 'logic_shadow_trial_mq',
         'tags'    : ("Ganon's Castle",),
@@ -650,6 +745,18 @@ logic_tricks = {
                     damage from the spikes. The Gold Skulltula Token
                     in the following room can also be obtained with
                     just the Hover Boots.
+                    '''},
+    'Water Temple MQ North Basement GS without Small Key': {
+        'name'    : 'logic_water_mq_locked_gs',
+        'tags'    : ("Water Temple", "Skulltulas",),
+        'tooltip' : '''\
+                    There is an invisible Hookshot target that can be used
+                    to get over the gate that blocks you from going to this
+                    Skulltula early. This avoids going through some rooms
+                    that normally require a Small Key to access. If "Water
+                    Temple North Basement Ledge with Precise Jump" is not
+                    enabled, this also skips needing Hover Boots or
+                    Scarecrow's Song to reach the locked door.
                     '''},
     'Water Temple Falling Platform Room GS with Hookshot': {
         'name'    : 'logic_water_falling_platform_gs_hookshot',
@@ -708,6 +815,16 @@ logic_tricks = {
                     out of the rock without needing to destroy it, by
                     using the Hookshot in the correct way.
                     '''},
+    'Death Mountain Trail Lower Red Rock GS with Hover Boots': {
+        'name'    : 'logic_trail_gs_lower_hovers',
+        'tags'    : ("Death Mountain Trail", "Skulltulas",),
+        'tooltip' : '''\
+                    After killing the Skulltula, the token can be
+                    collected without needing to destroy the rock by
+                    backflipping down onto it with the Hover Boots.
+                    First use the Hover Boots to stand on a nearby
+                    fence, and go for the Skulltula Token from there.
+                    '''},
     'Death Mountain Trail Lower Red Rock GS with Magic Bean': {
         'name'    : 'logic_trail_gs_lower_bean',
         'tags'    : ("Death Mountain Trail", "Skulltulas",),
@@ -721,7 +838,7 @@ logic_tricks = {
         'name'    : 'logic_crater_upper_to_lower',
         'tags'    : ("Death Mountain Crater",),
         'tooltip' : '''\
-                    With the Hammer, you can jumpslash the rock twice
+                    With the Hammer, you can jump slash the rock twice
                     in the same jump in order to destroy it before you
                     fall into the lava.
                     '''},
@@ -735,7 +852,7 @@ logic_tricks = {
         'name'    : 'logic_domain_gs',
         'tags'    : ("Zora's Domain", "Skulltulas",),
         'tooltip' : '''\
-                    A precise jumpslash can kill the Skulltula and
+                    A precise jump slash can kill the Skulltula and
                     recoil back onto the top of the frozen waterfall.
                     To kill it, the logic normally guarantees one of
                     Hookshot, Bow, or Magic.
@@ -769,14 +886,25 @@ logic_tricks = {
                     pushing the block.
                     '''},
     'Fire Temple MQ Big Lava Room Blocked Door without Hookshot': {
-        'name'    : 'logic_fire_mq_bombable_chest',
+        'name'    : 'logic_fire_mq_blocked_chest',
         'tags'    : ("Fire Temple",),
         'tooltip' : '''\
-                    A precisely-angled jump can get over the wall
-                    of fire in this room. It's expected that you
-                    will take damage as you do this. As it may
-                    take multiple attempts, you won't be expected
-                    to use a fairy to survive.
+                    There is a gap between the hitboxes of the flame
+                    wall in the big lava room. If you know where this
+                    gap is located, you can jump through it and skip
+                    needing to use the Hookshot. To do this without
+                    taking damage is more precise.
+                    '''},
+    'Fire Temple MQ Lower to Upper Lizalfos Maze with Precise Jump': {
+        'name'    : 'logic_fire_mq_maze_jump',
+        'tags'    : ("Fire Temple",),
+        'tooltip' : '''\
+                    A precise jump off of a crate can be used to
+                    climb to the upper maze without needing to spawn
+                    and use the Hookshot targets. This trick
+                    supersedes both "Fire Temple MQ Lower to Upper
+                    Lizalfos Maze with Hover Boots" and "Fire Temple
+                    MQ Lizalfos Maze Side Room without Box."
                     '''},
     'Light Trial MQ without Hookshot': {
         'name'    : 'logic_light_trial_mq',
@@ -784,8 +912,8 @@ logic_tricks = {
         'tooltip' : '''\
                     If you move quickly you can sneak past the edge of
                     a flame wall before it can rise up to block you.
-                    In this case it doesn't seem possible to do it
-                    without taking damage.
+                    In this case to do it without taking damage is
+                    especially precise.
                     '''},
     'Ice Cavern MQ Scarecrow GS with No Additional Items': {
         'name'    : 'logic_ice_mq_scarecrow',
@@ -793,12 +921,20 @@ logic_tricks = {
         'tooltip' : '''\
                     A precise jump can be used to reach this alcove.
                     '''},
+    'Ice Cavern MQ Red Ice GS without Song of Time': {
+        'name'    : 'logic_ice_mq_red_ice_gs',
+        'tags'    : ("Ice Cavern", "Skulltulas",),
+        'tooltip' : '''\
+                    If you side-hop into the perfect position, you
+                    can briefly stand on the platform with the red
+                    ice just long enough to dump some blue fire.
+                    '''},
     'Ice Cavern Block Room GS with Hover Boots': {
         'name'    : 'logic_ice_block_gs',
         'tags'    : ("Ice Cavern", "Skulltulas",),
         'tooltip' : '''\
                     The Hover Boots can be used to get in front of the
-                    Skulltula to kill it with a jumpslash. Then, the
+                    Skulltula to kill it with a jump slash. Then, the
                     Hover Boots can again be used to obtain the Token,
                     all without Hookshot or Boomerang.
                     '''},
@@ -809,9 +945,9 @@ logic_tricks = {
                     By memorizing the path, you can travel through the
                     Wasteland in reverse.
                     Note that jumping to the carpet merchant as child
-                    requires a fairly precise jumpslash.
+                    typically requires a fairly precise jump slash.
                     The equivalent trick for going forward through the
-                    Wasteland is "Lensless Wasteland".
+                    Wasteland is "Lensless Wasteland."
                     To cross the river of sand with no additional items,
                     be sure to also enable "Wasteland Crossing without
                     Hover Boots or Longshot."
@@ -830,7 +966,7 @@ logic_tricks = {
         'name'    : 'logic_shadow_mq_gap',
         'tags'    : ("Shadow Temple",),
         'tooltip' : '''\
-                    You can Longshot a torch and jumpslash-recoil onto
+                    You can Longshot a torch and jump-slash recoil onto
                     the tongue. It works best if you Longshot the right
                     torch from the left side of the room.
                     '''},
@@ -854,6 +990,18 @@ logic_tricks = {
                     switch pressed. One way is to quickly roll
                     from the switch and open the door before it
                     closes.
+                    '''},
+    'Kakariko Rooftop GS with Hover Boots': {
+        'name'    : 'logic_kakariko_rooftop_gs',
+        'tags'    : ("Kakariko Village", "Skulltulas",),
+        'tooltip' : '''\
+                    Take the Hover Boots from the entrance to Impa's
+                    House over to the rooftop of Skulltula House. From
+                    there, a precise Hover Boots backwalk with backflip
+                    can be used to get onto a hill above the side of
+                    the village. And then from there you can Hover onto
+                    Impa's rooftop to kill the Skulltula and backflip
+                    into the token.
                     '''},
     'Graveyard Freestanding PoH with Boomerang': {
         'name'    : 'logic_graveyard_poh',
@@ -905,9 +1053,9 @@ logic_tricks = {
                     after the Wallmaster has begun its attempt to grab you.
                     Also included with this trick is that fact that the switch
                     that unbars the door to the final chest of GTG can be hit
-                    without a projectile, using a precise jumpslash.
+                    without a projectile, using a precise jump slash.
                     This trick supersedes "Gerudo Training Grounds MQ Left Side
-                    Silver Rupees with Hookshot".
+                    Silver Rupees with Hookshot."
                     '''},
     'Reach Gerudo Training Grounds Fake Wall Ledge with Hover Boots': {
         'name'    : 'logic_gtg_fake_wall',
@@ -924,11 +1072,11 @@ logic_tricks = {
         'name'    : 'logic_water_cracked_wall_nothing',
         'tags'    : ("Water Temple",),
         'tooltip' : '''\
-                    A precise jumpslash (among other methods) will
+                    A precise jump slash (among other methods) will
                     get you to the cracked wall without needing the
                     Hover Boots or to raise the water to the middle
                     level. This trick supersedes "Water Temple
-                    Cracked Wall with Hover Boots".
+                    Cracked Wall with Hover Boots."
                     '''},
     'Water Temple North Basement Ledge with Precise Jump': {
         'name'    : 'logic_water_north_basement_ledge_jump',
@@ -952,6 +1100,15 @@ logic_tricks = {
                     The majority of the tricks that allow you to skip Iron Boots
                     in the Water Temple are not going to be relevant unless this
                     trick is first enabled.
+                    '''},
+    'Water Temple Central Pillar GS with Farore\'s Wind': {
+        'name'    : 'logic_water_central_gs_fw',
+        'tags'    : ("Water Temple", "Skulltulas",),
+        'tooltip' : '''\
+                    If you set Farore's Wind inside the central pillar
+                    and then return to that warp point after raising
+                    the water to the highest level, you can obtain this
+                    Skulltula Token with Hookshot or Boomerang.
                     '''},
     'Water Temple Central Pillar GS with Iron Boots': {
         'name'    : 'logic_water_central_gs_irons',
@@ -983,9 +1140,10 @@ logic_tricks = {
                     If you come into the dragon statue room from the
                     serpent river, you can jump down from above and get
                     into the tunnel without needing either Iron Boots
-                    or a Scale. You must shoot the switch from above
-                    with the Bow, and then quickly get through the
-                    tunnel before the gate closes.
+                    or a Scale. This trick applies to both Vanilla and
+                    Master Quest. In Vanilla, you must shoot the switch
+                    from above with the Bow, and then quickly get
+                    through the tunnel before the gate closes.
                     '''},
     'Water Temple Dragon Statue Switch from Above the Water as Adult': {
         'name'    : 'logic_water_dragon_adult',
@@ -999,8 +1157,7 @@ logic_tricks = {
                     just using the Iron Boots, a well-timed dive with at least
                     the Silver Scale could be used swim through the tunnel. If
                     coming from the serpent river, a jump dive can also be used
-                    to get into the tunnel, so this trick supersedes "Water
-                    Temple Dragon Statue Jump Dive".
+                    to get into the tunnel.
                     '''},
     'Water Temple Dragon Statue Switch from Above the Water as Child': {
         'name'    : 'logic_water_dragon_child',
@@ -1055,13 +1212,14 @@ logic_tricks = {
                     but it must be thrown from a particular distance
                     away and with precise timing.
                     '''},
-    'Forest Temple Outside Backdoor without Hover Boots': {
+    'Forest Temple Outside Backdoor with Jump Slash': {
         'name'    : 'logic_forest_outside_backdoor',
         'tags'    : ("Forest Temple",),
         'tooltip' : '''\
-                    With a precise jumpslash from above, you
-                    can reach the backdoor to the west
-                    courtyard without Hover Boots.
+                    With a precise jump slash from above,
+                    you can reach the backdoor to the west
+                    courtyard without Hover Boots. Applies
+                    to both Vanilla and Master Quest.
                     '''},
     'Forest Temple Scarecrow Route': {
         'name'    : 'logic_forest_scarecrow',
@@ -1078,7 +1236,7 @@ logic_tricks = {
         'name'    : 'logic_dc_mq_child_bombs',
         'tags'    : ("Dodongo's Cavern",),
         'tooltip' : '''\
-                    With a precise jumpslash from above, you
+                    With a precise jump slash from above, you
                     can reach the Bomb Bag area as only child
                     without needing a Slingshot. You will
                     take fall damage.
@@ -1102,6 +1260,32 @@ logic_tricks = {
                     you also enable the Adult variant: "Dodongo's
                     Cavern Spike Trap Room Jump without Hover Boots."
                     '''},
+    'Dodongo\'s Cavern MQ Light the Eyes with Strength': {
+        'name'    : 'logic_dc_mq_eyes',
+        'tags'    : ("Dodongo's Cavern",),
+        'tooltip' : '''\
+                    If you move very quickly, it is possible to use
+                    the bomb flower at the top of the room to light
+                    the eyes. To perform this trick as child is
+                    significantly more diffult, but child will never
+                    be expected to do so unless "Dodongo's Cavern MQ
+                    Back Areas as Child without Explosives" is enabled.
+                    Also, the bombable floor before King Dodongo can be
+                    destroyed with Hammer if hit in the very center.
+                    '''},
+    'Dodongo\'s Cavern MQ Back Areas as Child without Explosives': {
+        'name'    : 'logic_dc_mq_child_back',
+        'tags'    : ("Dodongo's Cavern",),
+        'tooltip' : '''\
+                    Child can progress through the back areas without
+                    explosives by throwing a pot at a switch to lower a
+                    fire wall, and by defeating Armos to detonate bomb
+                    flowers (among other methods). While these techniques
+                    themselves are relatively simple, they're not
+                    relevant unless "Dodongo\'s Cavern MQ Light the Eyes
+                    with Strength" is enabled, which is a trick which
+                    that is particularly difficult for child to perform.
+                    '''},
     'Rolling Goron (Hot Rodder Goron) as Child with Strength': {
         'name'    : 'logic_child_rolling_with_strength',
         'tags'    : ("Goron City",),
@@ -1122,7 +1306,7 @@ logic_tricks = {
         'tags'    : ("Gerudo Valley",),
         'tooltip' : '''\
                     From the far side of Gerudo Valley, a precise
-                    Hover Boots movement and jumpslash recoil can
+                    Hover Boots movement and jump-slash recoil can
                     allow adult to reach the ledge with the crate
                     PoH without needing Longshot. You will take 
                     fall damage.
@@ -1163,7 +1347,7 @@ logic_tricks = {
                     be used to obtain the token without needing the Hookshot.
                     Applies to both Vanilla and Master Quest. For obtaining
                     the chests in this room with just Hover Boots, be sure to
-                    enable "Shadow Temple Stone Umbrella Skip".
+                    enable "Shadow Temple Stone Umbrella Skip."
                     '''},
     'Water Temple Central Bow Target without Longshot or Hover Boots': {
         'name'    : 'logic_water_central_bow',
@@ -1185,6 +1369,16 @@ logic_tricks = {
                     itself, allowing you to skip needing to spawn the
                     scarecrow.
                     '''},
+    'Fire Trial MQ with Hookshot': {
+        'name'    : 'logic_fire_trial_mq',
+        'tags'    : ("Ganon's Castle",),
+        'tooltip' : '''\
+                    It's possible to hook the target at the end of
+                    fire trial with just Hookshot, but it requires
+                    precise aim and perfect positioning. The main
+                    difficulty comes from getting on the very corner
+                    of the obelisk without falling into the lava.
+                    '''},
     'Shadow Temple Entry with Fire Arrows': {
         'name'    : 'logic_shadow_fire_arrow_entry',
         'tags'    : ("Shadow Temple",),
@@ -1202,7 +1396,7 @@ logic_tricks = {
                     Wasteland without using the Lens of Truth to see
                     the Poe.
                     The equivalent trick for going in reverse through
-                    the Wasteland is "Reverse Wasteland".
+                    the Wasteland is "Reverse Wasteland."
                     '''},
     'Bottom of the Well without Lens of Truth': {
         'name'    : 'logic_lens_botw',

--- a/data/World/Bottom of the Well MQ.json
+++ b/data/World/Bottom of the Well MQ.json
@@ -4,35 +4,41 @@
         "dungeon": "Bottom of the Well",
         "exits": {
             "Kakariko Village": "True",
-            "Bottom of the Well Main Area" : "is_child"
+            "Bottom of the Well Perimeter": "is_child"
         }
     },
     {
-        "region_name": "Bottom of the Well Main Area",
+        "region_name": "Bottom of the Well Perimeter",
         "dungeon": "Bottom of the Well",
         "locations": {
             "Bottom of the Well MQ Compass Chest": "
                 Kokiri_Sword or (Sticks and logic_child_deadhand)",
-            "Bottom of the Well MQ Map Chest": "
-                can_play(Zeldas_Lullaby) or has_explosives",
-            "Bottom of the Well MQ Lens of Truth Chest": "
-                has_explosives and 
-                (Small_Key_Bottom_of_the_Well, 2)",
             "Bottom of the Well MQ Dead Hand Freestanding Key": "
                 has_explosives or (logic_botw_mq_dead_hand_key and Boomerang)",
-            "Bottom of the Well MQ East Inner Room Freestanding Key": "
-                can_play(Zeldas_Lullaby) or has_explosives",
             "Bottom of the Well MQ GS Basement": "can_child_attack",
-            "Bottom of the Well MQ GS West Inner Room": "
-                can_child_attack and 
-                (can_play(Zeldas_Lullaby) or has_explosives)",
             "Bottom of the Well MQ GS Coffin Room": "
-                can_child_attack and 
-                (Small_Key_Bottom_of_the_Well, 2)",
-            "Fairy Pot": "has_bottle and has_explosives and Slingshot"
+                can_child_attack and (Small_Key_Bottom_of_the_Well, 2)",
+            "Wall Fairy": "has_bottle and Slingshot" # The fairy pot is obsolete
         },
         "exits": {
-            "Bottom of the Well" : "True"
+            "Bottom of the Well": "True",
+            "Bottom of the Well Middle": "
+                can_play(Zeldas_Lullaby) or (logic_botw_mq_pits and has_explosives)"
+        }
+    },
+    {
+        "region_name": "Bottom of the Well Middle",
+        "dungeon": "Bottom of the Well",
+        "locations": {
+            "Bottom of the Well MQ Map Chest": "True",
+            "Bottom of the Well MQ Lens of Truth Chest": "
+                has_explosives and (Small_Key_Bottom_of_the_Well, 2)",
+            "Bottom of the Well MQ East Inner Room Freestanding Key": "True",
+            "Bottom of the Well MQ GS West Inner Room": "
+                can_child_attack and (logic_botw_mq_pits or has_explosives)"
+        },
+        "exits": {
+            "Bottom of the Well Perimeter": "True"
         }
     }
 ]

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -18,7 +18,7 @@
             "Deku Tree Compass Room": "
                 here(can_use(Slingshot) or can_use(Bow)) and
                 here(has_fire_source_with_torch or can_use(Bow))",
-            "Deku Tree Basement Water Room": "
+            "Deku Tree Basement Water Room Front": "
                 here(can_use(Slingshot) or can_use(Bow)) and here(has_fire_source_with_torch)",
             "Deku Tree Basement Ledge": "logic_deku_b1_skip or here(is_adult)"
         }
@@ -30,24 +30,39 @@
             "Deku Tree MQ Compass Chest": "True",
             "Deku Tree MQ GS Compass Room": "
                 (can_use(Hookshot) or can_use(Boomerang)) and
-                (has_bombchus or (Bombs and (here(is_adult) or can_play(Song_of_Time))))"
+                here(has_bombchus or
+                    (Bombs and (can_play(Song_of_Time) or is_adult)) or
+                    (can_use(Hammer) and (can_play(Song_of_Time) or logic_deku_mq_compass_gs)))"
         },
         "exits": {
             "Deku Tree Lobby": "True"
         }
     },
     {
-        "region_name": "Deku Tree Basement Water Room",
+        "region_name": "Deku Tree Basement Water Room Front",
         "dungeon": "Deku Tree",
         "locations": {
-            "Deku Tree MQ Before Spinning Log Chest": "True",
+            "Deku Tree MQ Before Spinning Log Chest": "True"
+        },
+        "exits": {
+            "Deku Tree Basement Water Room Back": "
+                logic_deku_mq_log or (is_child and (Deku_Shield or Hylian_Shield)) or
+                can_use(Longshot) or (can_use(Hookshot) and can_use(Iron_Boots))",
+            "Deku Tree Lobby": "True"
+        }
+    },
+    {
+        "region_name": "Deku Tree Basement Water Room Back",
+        "dungeon": "Deku Tree",
+        "locations": {
             "Deku Tree MQ After Spinning Log Chest": "can_play(Song_of_Time)"
         },
         "exits": {
-            #Whatever fire source you used to get in in here is used again, Whatever projectile you
-            #used for the eye shoot takes out the room of scrubs/larva/bats.
-            "Deku Tree Basement Back Room": "True",
-            "Deku Tree Lobby": "True"
+            "Deku Tree Basement Back Room": "
+                (here(can_use(Sticks) or can_use(Dins_Fire)) or
+                    at('Deku Tree Basement Water Room Front', can_use(Fire_Arrows))) and
+                here(is_adult or Kokiri_Sword or can_use_projectile or (Nuts and Sticks))",
+            "Deku Tree Basement Water Room Front": "True"
         }
     },
     {
@@ -63,7 +78,7 @@
         },
         "exits": {
             "Deku Tree Basement Ledge": "is_child",
-            "Deku Tree Basement Water Room": "
+            "Deku Tree Basement Water Room Back": "
                 can_use(Kokiri_Sword) or can_use_projectile or (Nuts and can_use(Sticks))"
         }
     }, 

--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -38,7 +38,12 @@
                 is_adult or (here(is_adult) and has_explosives) or
                 (logic_dc_mq_child_bombs and (Kokiri_Sword or Sticks) and
                     (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))",
-            "Dodongos Cavern Boss Area": "has_explosives"
+            "Dodongos Cavern Boss Area": "
+                has_explosives or
+                (logic_dc_mq_eyes and Progressive_Strength_Upgrade and
+                    (is_adult or logic_dc_mq_child_back) and
+                    (here(can_use(Sticks)) or can_use(Dins_Fire) or
+                        (is_adult and (logic_dc_jump or Hammer or Hover_Boots or Hookshot))))"
         }
     },
     {
@@ -49,9 +54,9 @@
         },
         "exits": {
             "Dodongos Cavern Bomb Bag Area": "
-                (here(is_adult and can_use(Bow)) or Progressive_Strength_Upgrade or
+                (here(can_use(Bow)) or Progressive_Strength_Upgrade or
                  can_use(Dins_Fire) or has_explosives) and
-                (can_use(Slingshot))"
+                can_use(Slingshot)"
         }
     },
     {
@@ -60,7 +65,7 @@
         "locations": {
             "Dodongos Cavern MQ Bomb Bag Chest": "True",
             "Dodongos Cavern MQ GS Scrub Room": "
-                (here(is_adult and can_use(Bow)) or Progressive_Strength_Upgrade or
+                (here(can_use(Bow)) or Progressive_Strength_Upgrade or
                  can_use(Dins_Fire) or has_explosives) and
                 (can_use(Hookshot) or can_use(Boomerang))"
         },
@@ -75,10 +80,10 @@
             "Dodongos Cavern MQ Under Grave Chest": "True",
             "Dodongos Cavern Boss Room Chest": "True",
             "Dodongos Cavern King Dodongo Heart": "
-                (Bombs or Progressive_Strength_Upgrade) and 
+                can_blast_or_smash and (Bombs or Progressive_Strength_Upgrade) and 
                 (is_adult or Sticks or Kokiri_Sword)",
             "King Dodongo": "
-                (Bombs or Progressive_Strength_Upgrade) and 
+                can_blast_or_smash and (Bombs or Progressive_Strength_Upgrade) and 
                 (is_adult or Sticks or Kokiri_Sword)",
             "Dodongos Cavern MQ GS Back Area": "True",
             "Fairy Pot": "has_bottle"

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -73,8 +73,13 @@
         "locations": {
             "Fire Temple MQ Lizalfos Maze Upper Chest": "True",
             "Fire Temple MQ Compass Chest": "has_explosives",
-            "Fire Temple MQ GS Skull On Fire": "(can_play(Song_of_Time) and can_use(Hookshot)) or can_use(Longshot)",
-            "Wall Fairy": "has_bottle and ((can_play(Song_of_Time) and can_use(Hookshot)) or can_use(Longshot))",
+            "Fire Temple MQ GS Skull On Fire": "
+                (can_play(Song_of_Time) and can_use(Hookshot) and (has_explosives or logic_rusted_switches)) or
+                can_use(Longshot)",
+            "Wall Fairy": "
+                has_bottle and
+                ((can_play(Song_of_Time) and can_use(Hookshot) and (has_explosives or logic_rusted_switches)) or
+                    can_use(Longshot))",
             "Fairy Pot": "has_bottle and (Small_Key_Fire_Temple, 3)"
         },
         "exits": {

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -4,24 +4,21 @@
         "dungeon": "Fire Temple",
         "locations": {
             "Fire Temple MQ Map Room Side Chest": "
-                is_adult or Kokiri_Sword or can_use(Sticks) or can_use(Slingshot)",
+                is_adult or Kokiri_Sword or Sticks or Slingshot or Bombs or can_use(Dins_Fire)",
             "Fire Temple MQ Near Boss Chest": "
-                (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and (
-                    ((can_use(Hover_Boots) or (logic_fire_mq_near_boss and can_use(Bow))) and has_fire_source) or 
-                    (can_use(Hookshot) and (can_use(Fire_Arrows) or 
+                (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and
+                (((can_use(Hover_Boots) or (logic_fire_mq_near_boss and can_use(Bow))) and has_fire_source) or 
+                    (can_use(Hookshot) and (can_use(Fire_Arrows) or
                         (can_use(Dins_Fire) and 
-                        ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or can_use(Goron_Tunic) or 
-                            can_use(Bow) or (Progressive_Hookshot, 2))))))",
-            "Fairy Pot": "has_bottle and (Small_Key_Fire_Temple, 5)"
+                            ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or
+                                can_use(Goron_Tunic) or can_use(Bow) or can_use(Longshot))))))"
         },
         "exits": {
             "Fire Temple Entrance": "True",
             "Fire Boss Room": "
                 can_use(Goron_Tunic) and can_use(Megaton_Hammer) and Boss_Key_Fire_Temple and
                 ((has_fire_source and (logic_fire_boss_door_jump or Hover_Boots)) or at('Fire Temple Upper', True))",
-            "Fire Lower Locked Door": "
-                (Small_Key_Fire_Temple, 5) and 
-                (has_explosives or can_use(Megaton_Hammer) or can_use(Hookshot))",
+            "Fire Lower Locked Door": "(Small_Key_Fire_Temple, 5) and (is_adult or Kokiri_Sword)",
             "Fire Big Lava Room": "
                 (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and can_use(Megaton_Hammer)"
         }
@@ -30,8 +27,9 @@
         "region_name": "Fire Lower Locked Door",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple MQ Megaton Hammer Chest": "is_adult",
-            "Fire Temple MQ Map Chest": "can_use(Megaton_Hammer)"
+            "Fire Temple MQ Megaton Hammer Chest": "is_adult and (has_explosives or Megaton_Hammer or Hookshot)",
+            "Fire Temple MQ Map Chest": "can_use(Megaton_Hammer)",
+            "Fairy Pot": "has_bottle"
         }
     },
     {
@@ -39,16 +37,14 @@
         "dungeon": "Fire Temple",
         "locations": {
             "Fire Temple MQ Boss Key Chest": "
-                has_fire_source and (Bow or logic_fire_mq_bk_chest) and 
-                Progressive_Hookshot",
+                has_fire_source and (Bow or logic_fire_mq_bk_chest) and can_use(Hookshot)",
             "Fire Temple MQ Big Lava Room Blocked Door Chest": "
                 has_fire_source and has_explosives and
-                (Progressive_Hookshot or
-                    (logic_fire_mq_bombable_chest and (damage_multiplier != 'ohko' or can_use(Nayrus_Love))))",
+                (can_use(Hookshot) or logic_fire_mq_blocked_chest)",
             "Fire Temple MQ GS Big Lava Room Open Door": "True",
             "Fairy Pot": "
                 has_bottle and has_fire_source and (Bow or logic_fire_mq_bk_chest) and
-                (Progressive_Hookshot or logic_fire_song_of_time)"
+                (can_use(Hookshot) or logic_fire_song_of_time)"
 
         },
         "exits": {
@@ -63,11 +59,12 @@
         "locations": {
             "Fire Temple MQ Lizalfos Maze Lower Chest": "True",
             "Fire Temple MQ Lizalfos Maze Side Room Chest": "
-                has_explosives and (logic_fire_mq_maze_side_room or can_use(Hookshot))"
+                has_explosives and (logic_fire_mq_maze_side_room or at('Fire Upper Maze', True))"
         },
         "exits": {
             "Fire Upper Maze": "
-                (has_explosives or logic_rusted_switches) and can_use(Hookshot)"
+                ((has_explosives or logic_rusted_switches) and can_use(Hookshot)) or
+                (logic_fire_mq_maze_hovers and can_use(Hover_Boots)) or logic_fire_mq_maze_jump"
         }
     },
     {
@@ -76,26 +73,29 @@
         "locations": {
             "Fire Temple MQ Lizalfos Maze Upper Chest": "True",
             "Fire Temple MQ Compass Chest": "has_explosives",
-            "Fire Temple MQ GS Skull On Fire": "
-                can_play(Song_of_Time) or can_use(Longshot)",
-            "Wall Fairy": "
-                has_bottle and (can_play(Song_of_Time) or can_use(Longshot))"
+            "Fire Temple MQ GS Skull On Fire": "(can_play(Song_of_Time) and can_use(Hookshot)) or can_use(Longshot)",
+            "Wall Fairy": "has_bottle and ((can_play(Song_of_Time) and can_use(Hookshot)) or can_use(Longshot))",
+            "Fairy Pot": "has_bottle and (Small_Key_Fire_Temple, 3)"
         },
         "exits": {
-            "Fire Temple Upper": "(Small_Key_Fire_Temple, 3) and Bow"
+            "Fire Temple Upper": "
+                (Small_Key_Fire_Temple, 3) and
+                ((can_use(Bow) and can_use(Hookshot)) or can_use(Fire_Arrows))"
         }
     },
     {
         "region_name": "Fire Temple Upper",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple MQ Freestanding Key": "True",
-            "Fire Temple MQ Chest On Fire": "(Small_Key_Fire_Temple, 4)",
+            "Fire Temple MQ Freestanding Key": "can_use(Hookshot) or logic_fire_mq_flame_maze",
+            "Fire Temple MQ Chest On Fire": "
+                (can_use(Hookshot) or logic_fire_mq_flame_maze) and (Small_Key_Fire_Temple, 4)",
             "Fire Temple MQ GS Fire Wall Maze Side Room": "
                 can_play(Song_of_Time) or Hover_Boots or logic_fire_mq_flame_maze",
             "Fire Temple MQ GS Fire Wall Maze Center": "has_explosives",
-            "Fire Temple MQ GS Above Fire Wall Maze": "(Small_Key_Fire_Temple, 5)",
-            "Fairy Pot": "has_bottle"
+            "Fire Temple MQ GS Above Fire Wall Maze": "
+                (can_use(Hookshot) and (Small_Key_Fire_Temple, 5)) or
+                (logic_fire_mq_above_maze_gs and can_use(Longshot))"
         }
     },
     {

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -84,7 +84,10 @@
         "dungeon": "Forest Temple",
         "locations": {
             "Forest Temple MQ Well Chest": "can_use(Bow) or can_use(Slingshot)",
-            "Forest Temple MQ GS Raised Island Courtyard": "can_use(Hookshot) or can_use(Boomerang)",
+            "Forest Temple MQ GS Raised Island Courtyard": "
+                can_use(Hookshot) or can_use(Boomerang) or
+                (can_use(Fire_Arrows) and
+                    (can_play(Song_of_Time) or (can_use(Hover_Boots) and logic_forest_door_frame)))",
             "Forest Temple MQ GS Well": "
                 (can_use(Iron_Boots) and can_use(Hookshot)) or can_use(Bow) or can_use(Slingshot)",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -19,24 +19,22 @@
         "dungeon": "Forest Temple",
         "locations": {
             "Forest Temple MQ Wolfos Chest": "
-                    (can_play(Song_of_Time) or is_child) and
-                    (is_adult or can_use(Dins_Fire) or
-                     can_use(Sticks) or can_use(Slingshot) or Kokiri_Sword)",
+                (can_play(Song_of_Time) or is_child) and
+                (is_adult or can_use(Dins_Fire) or
+                    can_use(Sticks) or can_use(Slingshot) or Kokiri_Sword)",
             "Forest Temple MQ GS Block Push Room": "is_adult or Kokiri_Sword",
             "Fairy Pot": "has_bottle and (can_play(Song_of_Time) or is_child)"
         },
         "exits": {
             "Forest Temple NW Outdoors": "can_use(Bow) or can_use(Slingshot)",
             "Forest Temple NE Outdoors": "can_use(Bow) or can_use(Slingshot)",
-            #End of the road for child
+            # End of the road for child
             "Forest Temple After Block Puzzle": "
-                (is_adult and Progressive_Strength_Upgrade) or
-                (has_bombchus and logic_forest_mq_block_puzzle and can_use(Hookshot))",
+                is_adult and (Progressive_Strength_Upgrade or
+                    (logic_forest_mq_block_puzzle and has_bombchus and can_use(Hookshot)))",
             "Forest Temple Outdoor Ledge": "
-                can_use(Hover_Boots) or
-                (can_use(Hookshot) and 
-                 (Progressive_Strength_Upgrade or logic_forest_mq_hallway_switch or
-                  (has_bombchus and logic_forest_mq_block_puzzle)))",
+                (logic_forest_mq_hallway_switch_jumpslash and can_use(Hover_Boots)) or
+                (logic_forest_mq_hallway_switch_hookshot and can_use(Hookshot))",
             "Forest Temple Boss Region": "
                 Forest_Temple_Jo_and_Beth and Forest_Temple_Amy_and_Meg"
         }
@@ -49,7 +47,13 @@
         },
         "exits": {
             "Forest Temple Bow Region": "(Small_Key_Forest_Temple, 4)",
-            "Forest Temple Outdoor Ledge": "(Small_Key_Forest_Temple, 3)"
+            "Forest Temple Outdoor Ledge": "
+                (Small_Key_Forest_Temple, 3) or
+                (logic_forest_mq_hallway_switch_jumpslash and
+                    (can_use(Hookshot) or logic_forest_outside_backdoor))",
+            "Forest Temple NW Outdoors": "(Small_Key_Forest_Temple, 2)"
+            # Only 2 keys because you must have had access to falling ceiling room to have wasted a key there
+            # and access to falling ceiling room means you must also have had to access to the lower area of this courtyard
         }
     },
     {
@@ -92,7 +96,7 @@
             "Forest Temple Outdoors Top Ledges": "
                 can_use(Hookshot) and 
                 (can_use(Longshot) or can_use(Hover_Boots) or can_play(Song_of_Time) or 
-                 logic_forest_vines)",
+                    logic_forest_vines)",
             "Forest Temple NE Outdoors Ledge": "can_use(Longshot)"
         }
     },
@@ -131,8 +135,8 @@
         },
         "exits": {
             "Forest Temple Falling Room": "
-                (Small_Key_Forest_Temple, 5) and 
-                (can_use(Bow) or can_use(Dins_Fire))" # Only 5 keys because the door you could waste your key on is the door you're trying to use keys to get to.
+                (Small_Key_Forest_Temple, 5) and (can_use(Bow) or can_use(Dins_Fire))"
+            # Only 5 keys because you must have had access to falling ceiling room to have wasted a key there
         }
     },
     {

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -76,7 +76,7 @@
             "Forest Temple NW Outdoors": "True",
             "Forest Temple NE Outdoors": "True",
             "Forest Temple Falling Room": "
-                logic_forest_scarecrow and can_use(Hover_Boots) and can_use(Scarecrow)"
+                logic_forest_door_frame and can_use(Hover_Boots) and can_use(Scarecrow)"
         }
     },
     {

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -49,8 +49,8 @@
         "dungeon": "Ganons Castle",
         "events": {
             "Fire Trial Clear": "
-                can_use(Goron_Tunic) and can_use(Golden_Gauntlets) and 
-                can_use(Light_Arrows) and (can_use(Longshot) or Hover_Boots)"
+                can_use(Goron_Tunic) and can_use(Golden_Gauntlets) and can_use(Light_Arrows) and
+                (can_use(Longshot) or Hover_Boots or (logic_fire_trial_mq and can_use(Hookshot)))"
         }
     },
     {
@@ -119,9 +119,9 @@
         "dungeon": "Ganons Castle",
         "events": {
             "Light Trial Clear": "
-                can_use(Light_Arrows) and (Small_Key_Ganons_Castle, 3) and (logic_lens_castle_mq or can_use(Lens_of_Truth)) and
-                (Progressive_Hookshot or
-                    (logic_light_trial_mq and (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love))))"
+                can_use(Light_Arrows) and (Small_Key_Ganons_Castle, 3) and
+                (logic_lens_castle_mq or can_use(Lens_of_Truth)) and
+                (Progressive_Hookshot or logic_light_trial_mq)"
         },
         "locations": {
             "Ganons Castle MQ Light Trial Lullaby Chest": "can_play(Zeldas_Lullaby)"

--- a/data/World/Ice Cavern MQ.json
+++ b/data/World/Ice Cavern MQ.json
@@ -21,7 +21,7 @@
             "Ice Cavern MQ Map Chest": "
                 Blue_Fire and
                 (is_adult or can_use(Sticks) or Kokiri_Sword or can_use_projectile)",
-            "Blue Fire": "is_adult and has_bottle"
+            "Blue Fire": "has_bottle"
         }
     },
     {
@@ -42,7 +42,7 @@
         "locations": {
             "Ice Cavern MQ Compass Chest": "True",
             "Ice Cavern MQ Freestanding PoH": "has_explosives",
-            "Ice Cavern MQ GS Red Ice": "can_play(Song_of_Time)"
+            "Ice Cavern MQ GS Red Ice": "can_play(Song_of_Time) or logic_ice_mq_red_ice_gs"
         }
     }
 ]

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -41,7 +41,7 @@
             "Jabu Jabus Belly MQ GS Tailpasaran Room": "Sticks or can_use(Dins_Fire)",
             "Jabu Jabus Belly MQ GS Invisible Enemies Room": "
                 (logic_lens_jabu_mq or can_use(Lens_of_Truth)) or
-                at('Jabu Jabus Belly Main', can_use(Hover_Boots))"
+                at('Jabu Jabus Belly Main', can_use(Hover_Boots) and can_use(Hookshot))"
         },
         "exits": {
             "Jabu Jabus Belly Main": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -836,7 +836,8 @@
                 is_child and (Slingshot or has_bombchus or 
                     (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword) and
                     (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))) and at_night",
-            "Kak GS Above Impas House": "can_use(Hookshot) and at_night",
+            "Kak GS Above Impas House": "
+                (can_use(Hookshot) or (logic_kakariko_rooftop_gs and can_use(Hover_Boots))) and at_night",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -1139,7 +1140,9 @@
             "DMT GS Near Kak": "can_blast_or_smash",
             "DMT GS Above Dodongos Cavern": "
                 is_adult and at_night and
-                (can_use(Megaton_Hammer) or (logic_trail_gs_lower_hookshot and can_use(Hookshot)) or
+                (can_use(Megaton_Hammer) or
+                    (logic_trail_gs_lower_hookshot and can_use(Hookshot)) or
+                    (logic_trail_gs_lower_hovers and can_use(Hover_Boots)) or
                     (logic_trail_gs_lower_bean and here(can_plant_bean and (has_explosives or Progressive_Strength_Upgrade))))",
             "Bean Plant Fairy": "
                 can_plant_bean and can_play(Song_of_Storms) and has_bottle and

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -44,8 +44,12 @@
         "region_name": "Shadow Temple Upper Huge Pit",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple MQ Invisible Blades Visible Chest": "can_play(Song_of_Time)",
-            "Shadow Temple MQ Invisible Blades Invisible Chest": "can_play(Song_of_Time)"
+            "Shadow Temple MQ Invisible Blades Visible Chest": "
+                can_play(Song_of_Time) or
+                (logic_shadow_mq_invisible_blades and damage_multiplier != 'ohko')",
+            "Shadow Temple MQ Invisible Blades Invisible Chest": "
+                can_play(Song_of_Time) or
+                (logic_shadow_mq_invisible_blades and damage_multiplier != 'ohko')"
         },
         "exits": {
             "Shadow Temple Lower Huge Pit": "has_fire_source or logic_shadow_mq_huge_pit"
@@ -97,11 +101,9 @@
         "dungeon": "Shadow Temple",
         "locations": {
             "Shadow Temple Bongo Bongo Heart": "
-                (Bow or (logic_shadow_statue and has_bombchus)) and
-                Boss_Key_Shadow_Temple",
+                (Bow or (logic_shadow_statue and has_bombchus)) and Boss_Key_Shadow_Temple",
             "Bongo Bongo": "
-                (Bow or (logic_shadow_statue and has_bombchus)) and
-                Boss_Key_Shadow_Temple",
+                (Bow or (logic_shadow_statue and has_bombchus)) and Boss_Key_Shadow_Temple",
             "Shadow Temple MQ GS After Ship": "True",
             "Shadow Temple MQ GS Near Boss": "Bow or (logic_shadow_statue and has_bombchus)"
         },

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -27,14 +27,12 @@
             "Spirit Temple MQ Map Room Enemy Chest": "
                 (Sticks or Kokiri_Sword) and 
                 has_bombchus and Slingshot and can_use(Dins_Fire)",
-            "Spirit Temple MQ Map Chest": "
-                Sticks or Kokiri_Sword or has_explosives",
+            "Spirit Temple MQ Map Chest": "Sticks or Kokiri_Sword or Bombs",
             "Spirit Temple MQ Silver Block Hallway Chest": "
                 has_bombchus and (Small_Key_Spirit_Temple, 7) and Slingshot and 
                 (can_use(Dins_Fire) or
-                 at('Adult Spirit Temple', (can_use(Fire_Arrows) or
-                                           (logic_spirit_mq_frozen_eye and can_use(Bow) and
-                                            can_play(Song_of_Time)))))",
+                    at('Adult Spirit Temple', (can_use(Fire_Arrows) or
+                        (logic_spirit_mq_frozen_eye and can_use(Bow) and can_play(Song_of_Time)))))",
             "Fairy Pot": "
                 has_bottle and (Sticks or Kokiri_Sword) and
                 has_bombchus and Slingshot"
@@ -49,7 +47,8 @@
         "locations": {
             "Spirit Temple MQ Child Climb South Chest": "(Small_Key_Spirit_Temple, 7)",
             "Spirit Temple MQ Statue Room Lullaby Chest": "can_play(Zeldas_Lullaby)",
-            "Spirit Temple MQ Statue Room Invisible Chest": "logic_lens_spirit_mq or can_use(Lens_of_Truth)",
+            "Spirit Temple MQ Statue Room Invisible Chest": "
+                logic_lens_spirit_mq or can_use(Lens_of_Truth)",
             "Spirit Temple MQ Beamos Room Chest": "(Small_Key_Spirit_Temple, 5)",
             "Spirit Temple MQ Chest Switch Chest": "
                 (Small_Key_Spirit_Temple, 5) and can_play(Song_of_Time)",
@@ -60,13 +59,14 @@
         },
         "exits": {
             "Lower Adult Spirit Temple": "
-                (can_use(Fire_Arrows) or
-                    (logic_spirit_mq_lower_adult and can_use(Dins_Fire) and Bow)) and Mirror_Shield",
+                Mirror_Shield and (can_use(Fire_Arrows) or
+                    (logic_spirit_mq_lower_adult and can_use(Dins_Fire) and Bow))",
             "Spirit Temple Shared": "True",
             "Spirit Temple Boss Area": "
                 (Small_Key_Spirit_Temple, 6) and can_play(Zeldas_Lullaby) and Megaton_Hammer",
             "Mirror Shield Hand": "
-                (Small_Key_Spirit_Temple, 5) and can_play(Song_of_Time) and (logic_lens_spirit_mq or can_use(Lens_of_Truth))"
+                (Small_Key_Spirit_Temple, 5) and can_play(Song_of_Time) and
+                (logic_lens_spirit_mq or can_use(Lens_of_Truth))"
         }
     },
     {
@@ -82,20 +82,25 @@
                 (can_use(Slingshot) and (Small_Key_Spirit_Temple, 7)) or
                 can_use(Bow) or
                 (Bow and Slingshot)",
-            "Spirit Temple MQ Sun Block Room Chest": " can_play(Song_of_Time) or is_adult",
+            "Spirit Temple MQ Sun Block Room Chest": "
+                can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot or
+                is_adult",
             "Spirit Temple MQ GS Sun Block Room": "
-                (logic_spirit_mq_sun_block_gs and can_play(Song_of_Time) and Boomerang) or
+                (logic_spirit_mq_sun_block_gs and Boomerang and
+                    (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot)) or
                 is_adult"
         },
         "exits": {
             "Silver Gauntlets Hand": "
-                ((Small_Key_Spirit_Temple, 7) and (can_play(Song_of_Time) or is_adult)) or 
+                ((Small_Key_Spirit_Temple, 7) and
+                    (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot or is_adult)) or 
                 ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and 
-                 (logic_lens_spirit_mq or can_use(Lens_of_Truth)))",
+                    (logic_lens_spirit_mq or can_use(Lens_of_Truth)))",
             "Desert Colossus": "
-                ((Small_Key_Spirit_Temple, 7) and (can_play(Song_of_Time) or is_adult)) or
+                ((Small_Key_Spirit_Temple, 7) and
+                    (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot or is_adult)) or
                 ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and
-                 (logic_lens_spirit_mq or can_use(Lens_of_Truth)) and is_adult)"
+                    (logic_lens_spirit_mq or can_use(Lens_of_Truth)) and is_adult)"
         }
     },
     {
@@ -119,7 +124,8 @@
         "region_name": "Spirit Temple Boss Area",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple MQ Mirror Puzzle Invisible Chest": "logic_lens_spirit_mq or can_use(Lens_of_Truth)",
+            "Spirit Temple MQ Mirror Puzzle Invisible Chest": "
+                logic_lens_spirit_mq or can_use(Lens_of_Truth)",
             "Spirit Temple Twinrova Heart": "Mirror_Shield and Boss_Key_Spirit_Temple",
             "Twinrova": "Mirror_Shield and Boss_Key_Spirit_Temple"
         }

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -24,7 +24,8 @@
             "Water Temple MQ Map Chest": "has_fire_source and can_use(Hookshot)",
             "Water Temple MQ Central Pillar Chest": "
                 can_use(Zora_Tunic) and can_use(Hookshot) and
-                (can_use(Fire_Arrows) or (can_use(Dins_Fire) and can_play(Song_of_Time)))"
+                ((logic_water_mq_central_pillar and can_use(Fire_Arrows)) or
+                    (can_use(Dins_Fire) and can_play(Song_of_Time)))"
         },
         "exits": {
             "Water Temple Lowered Water Levels": "can_play(Zeldas_Lullaby)"
@@ -46,7 +47,9 @@
         "region_name": "Water Temple Dark Link Region",
         "dungeon": "Water Temple",
         "locations": {
-            "Water Temple MQ Boss Key Chest": "can_use(Dins_Fire)",
+            "Water Temple MQ Boss Key Chest": "
+                (can_use(Zora_Tunic) or logic_fewer_tunic_requirements) and can_use(Dins_Fire) and
+                (logic_water_dragon_jump_dive or can_dive or can_use(Iron_Boots))",
             "Water Temple MQ GS River": "True",
             "Fairy Pot": "has_bottle",
             "Nut Pot": "True"
@@ -66,8 +69,8 @@
             "Water Temple MQ GS Triple Wall Torch": "
                 can_use(Fire_Arrows) and (Hover_Boots or can_use(Scarecrow))",
             "Water Temple MQ GS Freestanding Key Area": "
-                (Small_Key_Water_Temple, 2) and
-                (Hover_Boots or can_use(Scarecrow) or logic_water_north_basement_ledge_jump)"
+                logic_water_mq_locked_gs or ((Small_Key_Water_Temple, 2) and
+                    (Hover_Boots or can_use(Scarecrow) or logic_water_north_basement_ledge_jump))"
         }
     }
 ]

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -7,8 +7,7 @@
                 # Child can access only the falling platform room as the sole entrant into Water Temple.
                 # Use Child_Water_Temple for cases where child assists after the water is lowered.
             "Raise Water Level": "
-                ((is_adult or (not shuffle_overworld_entrances and not shuffle_special_indoor_entrances)) and
-                    (Hookshot or Hover_Boots or Bow)) or
+                (is_adult and (Hookshot or Hover_Boots or Bow)) or
                 (has_fire_source_with_torch and can_use_projectile)"
                 # Ensure that the water level can be raised if it were to be lowered.
         },
@@ -56,11 +55,11 @@
                 (can_use(Iron_Boots) or can_dive)",
             "Water Temple GS Central Pillar": "
                 can_play(Zeldas_Lullaby) and
-                    (((can_use(Longshot) or (can_use(Hookshot) and can_use(Farores_Wind))) and 
+                    (((can_use(Longshot) or (logic_water_central_gs_fw and can_use(Hookshot) and can_use(Farores_Wind))) and 
                         ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))) or
                     (logic_water_central_gs_irons and can_use(Hookshot) and can_use(Iron_Boots) and
                         (can_use(Bow) or can_use(Dins_Fire))) or
-                    (Child_Water_Temple and Boomerang and can_use(Farores_Wind) and
+                    (logic_water_central_gs_fw and Child_Water_Temple and Boomerang and can_use(Farores_Wind) and
                         (Sticks or can_use(Dins_Fire) or
                         ((Small_Key_Water_Temple, 6) and (can_use(Hover_Boots) or can_use(Bow))))))"
         },
@@ -148,15 +147,16 @@
             "Water Temple River Chest": "can_play(Song_of_Time) and Bow",
             "Water Temple GS River": "
                 can_play(Song_of_Time) and 
-                (Iron_Boots or (logic_water_river_gs and can_use(Longshot) and (Bow or has_bombchus)))",
+                ((Iron_Boots and (can_use(Zora_Tunic) or logic_fewer_tunic_requirements)) or
+                    (logic_water_river_gs and can_use(Longshot) and (Bow or has_bombchus)))",
             "Fairy Pot": 
                 "has_bottle and can_play(Song_of_Time)"
         },
         "exits": {
             "Water Temple Dragon Statue": "
+                (can_use(Zora_Tunic) or logic_fewer_tunic_requirements) and
                 can_play(Song_of_Time) and Bow and
-                ((Iron_Boots and (can_use(Zora_Tunic) or logic_fewer_tunic_requirements)) or
-                    logic_water_dragon_jump_dive or logic_water_dragon_adult)"
+                (Iron_Boots or logic_water_dragon_jump_dive or logic_water_dragon_adult)"
         }
     }
 ]


### PR DESCRIPTION
Changes

1) I removed FW to obtain the central pillar skulltula in Water Temple from default logic. It's now the trick "Water Temple Central Pillar GS with Farore's Wind". I felt this solution was just too obscure for players to figure out. If we're being honest, the Iron Boots method is probably just as tricky to figure and yet that took us years before we finally realized. This is a change that affects standard races. I didn't add the trick to the standard settings preset; you should talk about whether that should be done and add it if necessary.

2) I removed rolling under the spiked log in MQ Deku from default logic. It's now the trick "Deku Tree MQ Roll Under the Spiked Log". The logic now expects a usable shield as child, or longshot or hookshot & iron boots as adult. Technically, hookshot alone is enough to reach the torches, but the timing for that is a bit precise. There are actually a lot of ways to get past this log that can't be in logic -- any cutscene item will allow you to phase through as you use it. You can also use damage invincibility, but that is not really more straight-forward than rolling under. (I rather unnecessarily decided to be fully accurate about the logic to access basement back room from basement water room back. In theory I could have just said here(has_fire_source_with_torch) that would have worked the same. The main reason I wrote it all out is so that I wouldn't have to explain why it would have been fine.)

3) In MQ Deku, you could destroy the boulders blocking the Compass room GS with the Hammer. It's very easily done after spawning the Song of Time blocks, but a trick can be used to destroy them with just the Hammer.

4) In MQ Jabu there's a route to skip a lens requirement to kill some invisible enemies by using the Hover Boots as adult to get over there without needing to raise the hookshot target. This was only checking for Hover Boots but actually the token spawns too high, and so Hookshot is also required.

5) I removed sidehopping over the pits in MQ BotW from default logic. It's now the trick "Bottom of the Well MQ Jump Over the Pits". I decided to implement this in regions. This bit of logic trips people up I guess. It's really strange the game doesn't allow you to just jump over them. It made more sense in vanilla where you couldn't always see the pits.

6) There are Wall Fairies in MQ BotW, which require slingshot. They obsolete the Fairy Pot, which required explosives and slingshot. Actually, a Deku Stick jumpslash through the side wall can be used to break the pot, but it's not worth adding a trick just for a fairy, lol. I added a comment that says the fairy pot is obsolete just so that nobody forgets that its there. The walls actually drop 4 items at random, but it's actually the same 4 items just in a different order every time, and between the eight items there are 3 fairies in the pool.

7) I just want to quickly note that, in the process of doing this and the next two changes here, I ended up reorganizing a lot of the logic involving the block puzzle room in MQ Forest Temple. First, I don't know why I didn't realize before that "Forest Temple Outside Backdoor without Hover Boots" was relevant in MQ. If you use Strength to solve the block puzzle, but don't have the Hookshot, you can jumpslash the hallway switch through the glass blocks from the glass blocks that spawn after hitting the shortcut switch at the top, then climb back up and do the precise jumpslash to get up on the ledge with the switch. I renamed the trick to "with Jump Slash" because you can do it "without Hover Boots" in MQ just by hookshotting the target on the ceiling. I worried a bit that people who only know the jumpslash recoil method (uses momentary antigravity and so banned in glitchless-restricted but allowed in standard) would think that there might be something special about the precise jumpslash method and that they could not enable this trick, but since both methods involve a jumpslash, I hope that there won't be any confusion. In the tooltip, I opted not to explain what other settings must be enabled for that trick to matter in MQ (the next section here details a new trick that must be enabled), and I also opted not to give it the entrance tag (since you'd have to not have hookshot in MQ for it to matter). It's very much primarily a vanilla trick, so I didn't want to give MQ undue weight in the tooltip.

8) I removed jumpslashing the hallway switch through the blocks in MQ Forest from default logic. It's now the trick "Forest Temple MQ Twisted Hallway Switch with Jump Slash". You can also bombchu the hallway switch here, and it's not that bad, but neither was jumpslashing the switch, so I decided against having bombchus be in default logic. I also decided against making bombchus a trick since they're obsoleted by the combination of this and hookshot variation of the hallway switch trick. Anyway, jumpslashing the switch with the glass blocks gone is still considered to be in default logic and could be required in order to untwist the hallway and regain access to that courtyard ledge. With the blocks not there, it's more obvious that this jumpslash is a thing that can be done, but also, it's easier because it's less likely that players will jumpslash too early and recoil off without hitting the switch. This trick not being in default logic greatly restricts what can be done logically in MQ Forest without a bow under "standard" settings. (As standard as they can be with your Forest Temple apparently being MQ, that is.) There will be one chest in the entrance that must be a key, one chest behind the lobby that's locked by song of time, and that's it. Regardless of whether or not that 2nd chest is a key, the rest of the dungeon will be logically locked behind a bow. This is due to worst-case key-usage -- there's a locked door at the end of the falling ceiling room that is technically reachable that you could waste a key on, and there are no chests not locked by a bow that you could use to find another key to open things up. I felt that this was a bit of a shame and so I searched for at least a partial solution...

9) I expanded the logical ways of accessing Forest MQ's NW Outdoors. I have done this so that, if the chest locked by Song of Time is a key, then at least the courtyards of MQ Forest could open up to potentially having additional items or keys that could be or lock a logical bow. I feel a change like this was necessary if jumpslashing the switch through the block is not going to be in default logic. What I did is I added a route to NW courtyard that involves solving the block puzzle and falling down from the BK chest room, but does so on 1 fewer key than that route would normally require. (Any route to a check that requires the door after the block puzzle to actually be unlocked however will still require the additional key.) To lock yourself out of the door after the block puzzle you must waste a key on the door at the end of the falling ceiling room. To access that room "early" requires you to first access the NE courtyard, and any means of accessing that courtyard also would give you access to the NW courtyard. (If you accessed NE courtyard through the well, you did so by traveling through NW courtyard. Otherwise, you used the bow to open the door to NE courtyard in the lobby, in which case you can use the Bow to open the door to NW courtyard as well.) To recap: regardless of where you use your key, if you can use a key right now, it either allows you to access to NW courtyard or means that you were able to access the NW courtyard previously. So it should be fine to include this route in logic as long as access to the NW courtyard, however you might have done it previously, is repeatable. Both using the bow in the main room, or falling down from after the block puzzle, should have no issues with repeatability, but one last possibility is that you accessed NW courtyard through the connection with the hallway switch in the block room. In order to reach falling ceiling room you must have one of Hover Boots or Longshot, and both of those can be used, one way or another, to hit the hallway switch while the glass blocks are still there, and in general it's considered okay to force players to perform an out-of-logic trick if they've proven that they can do it by having performed it already. (One such case of this exists already in MQ Forest, with the key logic to access the falling ceiling room.) But there is one slightly problematic little thing: it's possible that you could have used bombchus to hit the hallway switch and have since run out of bombchus. In that case you might not actually know how to perform the necessary trick to hit the switch while the glass blocks are still there, and so you could be forced to learn a new trick to rectify the situation. Since there must be some in-logic way to solve the block room for the courtyard access to matter by this new route, you'll be able to spawn the shortcut glass blocks, and so at worst the trick that you might have to learn is... jumpslashing the switch through the glass block from those glass blocks, which is one aspect of the trick that I just removed from default logic a paragraph ago. Please keep in mind that you have to go very far out of your way to actually lock yourself into this situation. You'd have to bombchu the switch to get into the courtyard, hit the switch again for some unknown reason to respawn the glass blocks, go all the way to the falling ceiling room, unlock the door in there, all without opening any chests that have small keys along the way, and then run completely out of bombchus. If it's seriously a problem that this jumpslash could still need to be learned in this extreme case, then we could check for repeatable bombchu access (which I believe is: has_bombchus or (bombchus_in_logic and not shuffle_dungeon_entrances)), but I don't believe that that's worth doing (nobody wants WotH explosives just for this). What I have done here is a very suspect and tricky piece of logic, and I would appreciate anybody who has an idea of what's happening here to think carefully about whether there are problematic scenarios that I haven't thought of that could cause this expanded logic to be untenable.

10) Expanded the logical ways of killing the Like Like in MQ Fire as child to include Bombs and Din's Fire. Rattus left explosives out here intentionally (Din's was likely an oversight), but I think normal bombs is pretty reasonable. Even bombchus isn't too bad but maybe it's a small step too far.

11) The fairy pots on the opening loop of MQ Fire come after a Stalfos fight, so it needs to check for a sword. I decided to reorganize the region access here in order to move those fairies into the correct area.

12) I added the fairy pot in the middle floor of the east tower in MQ Fire. This obsoletes the pot that's deeper into the dungeon, so I removed that. (There's a wall fairy also that I missed, but I didn't add it since it needs hookshot and the pot doesn't.)

13) I found out that "Fire Temple MQ Big Lava Room Blocked Door without Hookshot" can actually be done without taking damage, so I removed the ohko logic from this section. I also reworded the tooltip now that I have a better understanding of how it works. Full disclosure here, I want to point out that these early rooms of MQ Fire temple, especially with tricks enabled on OHKO and fewer tunic requirements no hearts no Goron Tunic... It can get really dicey. I've tested that everything is possible, but not all of it is especially reasonable, if we're being honest. Some of it has only frames to spare before the time runs out and you die. You have to enable a really nasty combination of settings, though, to actually get yourself into these kinds of situations. So on a related note I felt the need to reword the tooltip for "Fire Temple MQ Boss Key Chest without Bow" to give more emphasis to the method which quickly lights the two timed torches, because in some scenarios only this method can be performed quickly enough to beat the heat timer.

14) I've removed using Fire Arrows to light the torches in the central pillar of MQ Water from default logic. It's now the trick "Water Temple MQ Central Pillar with Fire Arrows". I did some experimenting with the various hitboxes in this dungeon. The torches that have to be lit with Fire Arrows because Din's doesn't reach? The hitbox for those is actually entirely out of bounds. Luckily, arrows go through walls a bit. In central pillar actually, a small sliver of the hitbox is in bounds, but it's still harder than all of the other slanted torches in here because of the way the room is shaped near the torches. The walls next to the torches prevent arrows from going far enough out of bounds to light the them unless the arrow is fired somewhat precisely into the corner of the room. Getting one torch lit is fine, but getting all 4 within the time limit can be troublesome, and then you run out of magic with no good way to refill. I've decided not to include the torches at the top of the side tower as part of this trick. Despite those hitboxes being completely out of bounds, the corners of this room jut inward, creating a much larger area where the arrow will go far enough out of bounds to light the torches. This trick is intended as a bandaid fix until such time that the hitboxes of slanted torches can be adjusted to better match where the torches appear to be. Once the hitboxes have been adjusted, this trick should be removed.

15) In MQ Water, in the dragon statue room, you have to go through the tunnel and light some torches. This tunnel did not used to check for irons or scale. I had previously wondered whether this was an oversight but I noticed that there were some crates in the tunnel that you could easily longshot to, so it seemed fine, but then later on I noticed a problem: Whether or not you can longshot that crate depends on where in the room you decide to try it from. There are invisible walls in the whirlpool that will block your hookshot if you try to hookshot against the current. Left side of the room? Blocked. Right side? No problem. So you could imagine some people would try to hookshot the crate and assume it's impossible, while others would get it no problem and be very confused to find out that they broke logic. I went back and forth on whether or not to change this but in the end I just did not intend for players to have to contend with those janky invisible walls, so I decided to remove it from default logic. I tied getting into this tunnel with no additional items to the equivalent jump dive trick from vanilla, but note that the jump dive is much easier on MQ as there is no precise-ish bow shot to hit a switch, there's no timed gate to get under, and there is a hookshot target that can use to get back up and try the jump dive as many times as you like. "Water Temple Dragon Statue Switch from Above the Water as Adult" used to say it superseded this jump dive trick. I didn't know how best to explain the interaction with these tricks so I just removed any note about that interaction and hopefully the existing tooltip there is clear that it also covers the jump dive method.

16) While making the previous change I wasn't sure what to do about the Zora Tunic for that tunnel. Normally if you use Iron Boots in Water Temple, it checks for Tunic or FTR. Looking at vanilla Water though there's a moment where even without using Irons it checks Tunic/FTR. Zora Tunic general is a pretty useless item, so I wasn't sure what to do with it. What I decided was that any moment inside Fire or Water where you're required to do something where could potentially die from an environment timer if you were too slow (and it doesn't matter how slow you might have to be) would require Tunic or FTR. The overworld and other dungeons can delve a bit more into what's reasonable without a Tunic and what isn't, but for Water and Fire, the tunics are supposed to be a promise. So I put Tunic/FTR on three moments in the two Water Temples that didn't previously have it attached. (Swimming through the well in both Forest Temples takes a decent amount of time and is by far the longest thing that doesn't currently require a Zora Tunic. Lower to Upper Crater as adult in DMC is currently the tightest timer overall that has no tunic logic attached.)

17) I decided to remove bombchus as a logical way of killing the Torch Slugs as child in MQ Spirit. Both these guys and that Like Like in fire can be really annoying because they don't explode chus automatically, so you have to time the explosions all while dodging enemies that can easily take your shield. But with bombs it's not too bad to just throw them in from a safe distance. Maybe try out killing the Like Like and the slugs with explosives and see what you think of it?

18) For some reason blue fire access in MQ Ice was requiring you to be adult, while the fire can be easily accessed as child.

19) I've since learned that Light Trial MQ's Hookshot skip can be done without taking damage (though it is very precise), so I removed the ohko logic.

20) -NEW- I realized that Forest Temple Scarecrow Route applied in Master Quest as well, so I renamed it to "Forest Temple East Courtyard Door Frame with Hover Boots" and rewrote the tooltip to reflect this. (The tooltip used to say that you take fall damage (the logic didn't check for that though) but that's actually only true if you fail it, whoops.) In MQ, you have to be in Forest Temple with Fire Arrows, but no Hookshot, and then you can climb up to the upper balconies Hovers down onto this doorframe and get the Skulltula that's on it. In the process of looking into this I realized there is a variant of this that should be in default logic. You can easily jump from the upper balconies onto a Song of Time block, and then with Song of Time you can ride those blocks over onto the doorframe. You could intentionally despawn all of the blocks, but they're temporary flags and will reset if you leave the dungeon, so you can't screw yourself. A crouch stab from on the doorframe doesn't actually kill this Skulltula, but you need a bow (to use Fire Arrows on a web) for this route to matter, and so rather than at(upper ledges) and check for weapons to kill it or whatever, I just went ahead and checked for Fire Arrows directly.


New Tricks

5) Removed from default logic: "Water Temple Central Pillar GS with Farore's Wind", "Deku Tree MQ Roll Under the Spiked Log", "Bottom of the Well MQ Jump Over the Pits", "Forest Temple MQ Twisted Hallway Switch with Jump Slash" and "Water Temple MQ Central Pillar with Fire Arrows".

6) Kakariko Rooftop GS with Hover Boots - Tricky Hover Boots movement around the rooftops of Kakariko.

7) Death Mountain Trail Lower Red Rock GS with Hover Boots - This skulltula already has two tricks for obtaining, so have a third! In general I kind of regret adding any tricks having to do with abusing wonky boulder collision, but on the other hand the backflip into the upper trial GS I feel is too well-known to not include. And so here we are.

8) Deku Tree MQ Compass Room GS Boulders with Just Hammer - Let go of the vines and mash Hammer to jumpslash immediately and destroy the boulders.

9) Dodongo's Cavern MQ Light the Eyes with Strength - Quickly carry a bomb flower over and throw it down onto the eyes. I decided to including hammering the floor down to King Dodongo as part of this trick. (I would guess that hammering that floor would not be in default logic if it were normally possible to get there without explosives, but it's close enough that I didn't think it needed its own trick when you must perform a much more difficult trick to even get into a situation where it could be relevant.)

10) Dodongo's Cavern MQ Back Areas as Child without Explosives - The previous trick is pretty tough as adult, but almost impossible as child. But after performing that trick as child, it's not entirely obvious how you should proceed. I decided to use this fact to create what is essentially a toggle on whether you might need to perform the previous trick as child. So how do you proceed? You can always throw a pot at the switch to lower the flame walls. After, you can use sticks to defeat an Armos and use its death explosion to detonate some bomb flowers, or you can Din's Fire the bomb flowers directly. In order for being back here as child without explosives to be relevant, you have to somehow reach the bomb flower to light the eyes in a child-only way, and to do that already requires sticks or Din's.

11) Fire Temple MQ Lower to Upper Lizalfos Maze with Hover Boots - Using one of the crates are a starting point you can very easily climb up from the lower maze to the upper maze using the Hover Boots. MQ Fire here on out used to assume that Hookshot was required, so I had to go through and Hookshot-proof the rest of the dungeon. One awkward moment occurred when dealing with the flame wall maze skips. The reason there were separate tricks here for vanilla and MQ is because the MQ variant requires a lot more precision. It used to be that the flame wall skip in MQ was only relevant for reaching a GS without Hovers or Song of Time, but now without Hookshot, another flame wall skip can be used from there to progress deeper into the dungeon. This 2nd flame wall skip can be done identically to the easier one from vanilla. So in theory the 2nd flame wall skip in MQ should probably be the same trick as in vanilla, and the MQ trick should be just for that more difficult first wall. Instead I felt that explaining which flame walls those tricks would apply to and how they interact with each other would be too difficult to do in a way that would not be confusing. I hope that players who are aware of flame wall skips in MQ Fire Temple will be able to figure out a way to perform both skips. UPDATE: I had a bug here that I fixed. To go for the "Pierre" skulltula without Longshot, using Hookshot and Song of Time, requires that you jump from the Hookshot targets that spawn, so I had to add a check for that.

12) Fire Temple MQ Lower to Upper Lizalfos Maze with Precise Jump - I decided to make two separate tricks for this maneuver after discovering that doing it with Hover Boots is absurdly easy as long as you can realize it's a thing that's possible. To do it with a precise jump, however, requires a pretty tricky series of inputs. (I'm not sure if the words "precise jump" really accurately describe what you actually do here. It's an ESS shuffle thing where you jump while having your facing angle in a different direction from the direction you're moving.)

13) Fire Temple MQ Above Flame Wall Maze GS from Below with Longshot - The floor of the room with this Skulltula is only solid from above, so you can kill it from below using the Longshot. This allows you to skip two fire temple keys. I had previously considered this trick and decided not to include it. I guess a similar thing coming up in vanilla Dodongo's Cavern changed my mind. The only real difference in DC is that the vines that you longshot through are not totally opaque.

14) Water Temple MQ North Basement GS without Small Key - Hookshot an invisible target on the ceiling to get over a gate, skipping some rooms that normally need a small key to access.

15) Shadow Temple MQ Invisible Blades Silver Rupees without Song of Time - A Like Like boost into a silver rupee.

16) Spirit Temple MQ Sun Block Room as Child without Song of Time - Throw the crate onto the switch from above to temporarily unbar the door as the crate breaks.

17) Ice Cavern MQ Red Ice GS without Song of Time - You can stand next to the red ice for like a frame if you sidehop into the perfect position, and you can use blue fire at that time.

18) Fire Trial MQ with Hookshot - Mainly a trick about getting onto the very corner of a platform without slipping into lava.


Some other things I looked into:

1) It's apparently possible to reach the carpet guy as child without a jumpslash? I heard it was really precise. It wasn't worth accounting for, but the existing reverse wasteland tooltip says it "requires" a jumpslash, which isn't entirely correct, so my "fix" was to add the word "typically" in front of that part.

2) In MQ DC, it's possible to get the skullula in the upper lizalfos fight without destroying the boulders. I tried again to get a conclusive ruling on whether this is allowed in glitchless or standard and didn't really get anywhere with it. Regardless, it's glitch-adjacent enough that I guess we can leave it alone for now. (Also I tried for a bit but couldn't get it to work, lol.)

3) In MQ Jabu, you can shoot a cow through the boulders just by shooting up from under the collision in a certain way, but there are some controversies with boulder collision tricks that I didn't want to wade further into. I am all set to implement this. I'm able to perform the trick consistently and I know what the logical implications are. There's a skulltula in a later room inside a boulder that you might have to fish out with the boomerang, and you can't kill the tail that blocks access to the invisible enemies and preboss rooms.

4) In MQ Fire, the upper maze chest you can hit the switch guarding that from below with Bow, and then hookshot up there using a crate. It's incredibly easy but unfortunately not super obvious that it should work, so I decided it couldn't be in default logic. Hammer rusted switches through walls obsoletes it, which most players familiar with tricks already enable, so it'd be useless to have it as a trick.

5) In the entrance of MQ Spirit there is a water jet that you can force yourself through as adult if you have the Hover Boots. For two reasons I decided not to include this as a trick. First, it's somewhat glitch-adjacent in how it crushes you if you fail or if you attempt a similar thing as child it "works" but really you've clipped through the ceiling. And 2nd, this would allow earlier access to a locked door, which would require the key logic on child climb to be increased only in the event that this trick is enabled. There's no precedent for enabling a trick actually increasing the requirements like that. You might be able to argue that we should already be taking this locked door into account, but 'crazy dance' in vanilla Spirit Temple is already precedence for not restricting the key logic just b/c some obscure technique exists.

6) The chest in MQ Water Trial can be opened with the ice still there. There isn't any place where you can stand still and have it say "open", but merely pressing forward into it is enough to have it be say that. (It's actually pretty absurd how easily this thing can be opened without a bottle.) I think there are other red ice skips along these lines that can be done by more proactively abusing their collision, like using a bomb's collision to push yourself more into the ice? And that's just a whole can of worms that I didn't want to delve into, so I left it alone for now.