### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2674,7 +2674,7 @@ setting_infos = [
             'remove':      'Remove',
             'startwith':   'Start With',
             'vanilla':     'Vanilla Locations',
-            'dungeon':     'Dungeon Only',
+            'dungeon':     'Own Dungeon',
             'overworld':   'Overworld Only',
             'any_dungeon': 'Any Dungeon',
             'keysanity':   'Anywhere',
@@ -2691,7 +2691,7 @@ setting_infos = [
             'Vanilla': Maps and Compasses will appear in
             their vanilla locations.
 
-            'Dungeon': Maps and Compasses can only appear
+            'Own Dungeon': Maps and Compasses can only appear
             in their respective dungeon.
             
             'Overworld Only': Maps and Compasses can only appear
@@ -2720,7 +2720,7 @@ setting_infos = [
         choices        = {
             'remove':      'Remove (Keysy)',
             'vanilla':     'Vanilla Locations',
-            'dungeon':     'Dungeon Only',
+            'dungeon':     'Own Dungeon',
             'overworld':   'Overworld Only',
             'any_dungeon': 'Any Dungeon',
             'keysanity':   'Anywhere (Keysanity)',
@@ -2735,7 +2735,7 @@ setting_infos = [
             Spirit Temple MQ because the vanilla key 
             layout is not beatable in logic.
 
-            'Dungeon': Small Keys can only appear in their
+            'Own Dungeon': Small Keys can only appear in their
             respective dungeon. If Fire Temple is not a
             Master Quest dungeon, the door to the Boss Key
             chest will be unlocked.
@@ -2805,7 +2805,7 @@ setting_infos = [
         choices        = {
             'remove':      'Remove (Keysy)',
             'vanilla':     'Vanilla Locations',
-            'dungeon':     'Dungeon Only',
+            'dungeon':     'Own Dungeon',
             'overworld':   'Overworld Only',
             'any_dungeon': 'Any Dungeon',
             'keysanity':   'Anywhere (Keysanity)',
@@ -2818,7 +2818,7 @@ setting_infos = [
             'Vanilla': Boss Keys will appear in their 
             vanilla locations.
 
-            'Dungeon': Boss Keys can only appear in their
+            'Own Dungeon': Boss Keys can only appear in their
             respective dungeon.
             
             'Overworld Only': Boss Keys can only appear outside
@@ -2854,7 +2854,7 @@ setting_infos = [
         choices        = {
             'remove':          "Remove (Keysy)",
             'vanilla':         "Vanilla Location",
-            'dungeon':         "Dungeon Only",
+            'dungeon':         "Own Dungeon",
             'overworld':       "Overworld Only",
             'any_dungeon':     "Any Dungeon",
             'keysanity':       "Anywhere (Keysanity)",
@@ -2868,7 +2868,7 @@ setting_infos = [
             'Remove': Ganon's Castle Boss Key is removed
             and the boss door in Ganon's Tower starts unlocked.
 
-            'Dungeon': Ganon's Castle Boss Key can only appear
+            'Own Dungeon': Ganon's Castle Boss Key can only appear
             inside Ganon's Castle.
 
             'Vanilla': Ganon's Castle Boss Key will appear in 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1857,7 +1857,9 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
+            "randomize_key": "randomize_settings",
             "hide_when_disabled": True,
+            'distribution': [(6, 1)],
         },
     ),
     Scale(
@@ -1872,7 +1874,9 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
+            "randomize_key": "randomize_settings",
             "hide_when_disabled": True,
+            'distribution': [(3, 1)],
         },
     ),
     Scale(
@@ -1888,7 +1892,9 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
+            "randomize_key": "randomize_settings",
             "hide_when_disabled": True,
+            'distribution': [(9, 1)],
         },
     ),
     Scale(
@@ -2933,7 +2939,9 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
+            "randomize_key": "randomize_settings",
             "hide_when_disabled": True,
+            'distribution': [(6, 1)],
         },
     ),
     Scale(
@@ -2948,7 +2956,9 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
+            "randomize_key": "randomize_settings",
             "hide_when_disabled": True,
+            'distribution': [(3, 1)],
         },
     ),
     Scale(
@@ -2964,7 +2974,9 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
+            "randomize_key": "randomize_settings",
             "hide_when_disabled": True,
+            'distribution': [(9, 1)],
         },
     ),
     Scale(

--- a/World.py
+++ b/World.py
@@ -236,6 +236,16 @@ class World(object):
             self.randomized_list.extend(setting_info.disable[True]['settings'])
             for section in setting_info.disable[True]['sections']:
                 self.randomized_list.extend(get_settings_from_section(section))
+            for setting in list(self.randomized_list):
+                if (setting == 'bridge_medallions' and self.bridge != 'medallions') \
+                        or (setting == 'bridge_stones' and self.bridge != 'stones') \
+                        or (setting == 'bridge_rewards' and self.bridge != 'dungeons') \
+                        or (setting == 'bridge_tokens' and self.bridge != 'tokens') \
+                        or (setting == 'lacs_medallions' and self.lacs_condition != 'medallions') \
+                        or (setting == 'lacs_stones' and self.lacs_condition != 'stones') \
+                        or (setting == 'lacs_rewards' and self.lacs_condition != 'dungeons') \
+                        or (setting == 'lacs_tokens' and self.lacs_condition != 'tokens'):
+                    self.randomized_list.remove(setting)
         if self.big_poe_count_random:
             self.big_poe_count = random.randint(1, 10)
             self.randomized_list.append('big_poe_count')


### PR DESCRIPTION
### Change 'Dungeon Only' to 'Own Dungeon' for key shuffle settings.
Provides some clarity with the 'Any Dungeon' option now existing.

###  Use friendly names for SFX choices in cosmetics log.
Previously, even in the old .txt log, it used the key for each sound effect instead of the displayed name in the GUI. This changes it to use the GUI name instead.

###  Handle variable rewards for Bridge/LACS in Randomize Main Rule Settings.
Sets the distribution for variable bridge and LACS settings to force 'randomize' them to their default. Also cleans the unused settings out of randomized_settings in the spoiler log.