### PR TITLE
'Randomized settings' tooltip clarification

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1662,6 +1662,10 @@ setting_infos = [
                          - Logic Rules
                          - (Random) Number of MQ Dungeons
                          - Rainbow Bridge Requirement: Gold Skulltula Tokens
+                         - Ganon's Boss Key On LACS: Gold Skulltula Tokens
+                         - Variable numbers of Spiritual Stones, Medallions or Dungeons
+                         for Rainbow Bridge and Ganon's Boss Key on LACS 
+                         (you will always be required to obtain all the relevant rewards)
                          ''',
         default        = False,
         disable        = {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1657,7 +1657,11 @@ setting_infos = [
         name           = 'randomize_settings',
         gui_text       = 'Randomize Main Rule Settings',
         gui_tooltip    = '''\
-                         Randomizes most Main Rules.
+                         Randomizes all settings on the 'Main Rules' tab, except:
+
+                         - Logic Rules
+                         - (Random) Number of MQ Dungeons
+                         - Rainbow Bridge Requirement: Gold Skulltula Tokens
                          ''',
         default        = False,
         disable        = {


### PR DESCRIPTION
It now tells the user what's randomized.

![random_settings](https://user-images.githubusercontent.com/63906538/97757137-701d9600-1afc-11eb-838d-e5921274df4e.png)
