### PR TITLE
Spirit Temple MQ vanilla key layouts in logic

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1269,17 +1269,6 @@ def get_pool_core(world):
                 placed_items[location] = item
             except KeyError:
                 continue
-        # Logic cannot handle vanilla key layout in some dungeons
-        # this is because vanilla expects the dungeon major item to be
-        # locked behind the keys, which is not always true in rando.
-        # We can resolve this by starting with some extra keys
-        if world.dungeon_mq['Spirit Temple']:
-            # Yes somehow you need 3 keys. This dungeon is bonkers
-            world.state.collect(ItemFactory('Small Key (Spirit Temple)'))
-            world.state.collect(ItemFactory('Small Key (Spirit Temple)'))
-            world.state.collect(ItemFactory('Small Key (Spirit Temple)'))
-        #if not world.dungeon_mq['Fire Temple']:
-        #    world.state.collect(ItemFactory('Small Key (Fire Temple)'))
     if world.shuffle_bosskeys == 'vanilla':
         for location, item in vanillaBK.items():
             try:

--- a/Patches.py
+++ b/Patches.py
@@ -1111,10 +1111,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             save_context.addresses['dungeon_items'][dungeon]['compass'].value = True
             save_context.addresses['dungeon_items'][dungeon]['map'].value = True
 
-    if world.shuffle_smallkeys == 'vanilla':
-        if world.dungeon_mq['Spirit Temple']:
-            save_context.addresses['keys']['spirit'].value = 3
-
     if world.start_with_rupees:
         rom.write_byte(rom.sym('MAX_RUPEES'), 0x01)
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2713,9 +2713,7 @@ setting_infos = [
             mode.
 
             'Vanilla': Small Keys will appear in their 
-            vanilla locations. You start with 3 keys in 
-            Spirit Temple MQ because the vanilla key 
-            layout is not beatable in logic.
+            vanilla locations.
 
             'Dungeon': Small Keys can only appear in their
             respective dungeon. If Fire Temple is not a

--- a/data/Glitched World/Spirit Temple MQ.json
+++ b/data/Glitched World/Spirit Temple MQ.json
@@ -21,6 +21,14 @@
     {
         "region_name": "Child Spirit Temple",
         "dungeon": "Spirit Temple",
+        "events": {
+            "Spirit Temple Room 06 Eye Switch": "
+                has_bombchus and Slingshot and 
+                (can_use(Dins_Fire) or 
+                    here(is_adult and can_use(Longshot) and can_use(Silver_Gauntlets) and 
+                          (can_use(Fire_Arrows) or
+                              (logic_spirit_mq_frozen_eye and Bow and can_play(Song_of_Time)))))"
+        },
         "locations": {
             "Spirit Temple MQ Map Room Enemy Chest": "
                 (Sticks or Kokiri_Sword) and 
@@ -28,11 +36,11 @@
             "Spirit Temple MQ Map Chest": "
                 Sticks or Kokiri_Sword or has_explosives",
             "Spirit Temple MQ Silver Block Hallway Chest": "
-                has_bombchus and (Small_Key_Spirit_Temple, 7) and Slingshot and 
-                (can_use(Dins_Fire) or 
-                    here(is_adult and can_use(Longshot) and can_use(Silver_Gauntlets) and 
-                          (can_use(Fire_Arrows) or
-                              (logic_spirit_mq_frozen_eye and Bow and can_play(Song_of_Time)))))"
+                'Spirit Temple Room 06 Eye Switch' and
+                ((Small_Key_Spirit_Temple, 7) or
+                (shuffle_smallkeys == 'vanilla' and at('Adult Spirit Temple', Megaton_Hammer)
+                    and can_play(Zeldas_Lullaby) and can_play(Requiem_of_Spirit)
+                    and (Small_Key_Spirit_Temple, 4)))",
         },
         "exits": {
             "Spirit Temple Shared": "has_bombchus and (Small_Key_Spirit_Temple, 2)"
@@ -43,7 +51,10 @@
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple MQ Child Hammer Switch Chest": "
-                (Small_Key_Spirit_Temple, 7) and Megaton_Hammer and can_play(Requiem_of_Spirit)",
+                Megaton_Hammer and can_play(Requiem_of_Spirit) and
+                ((Small_Key_Spirit_Temple, 7) or
+                (shuffle_smallkeys == 'vanilla' and 'Spirit Temple Room 06 Eye Switch'
+                    and can_play(Zeldas_Lullaby) and (Small_Key_Spirit_Temple, 4)))",
             "Spirit Temple MQ Child Climb South Chest": "(Small_Key_Spirit_Temple, 7)",
             "Spirit Temple MQ Statue Room Lullaby Chest": "can_play(Zeldas_Lullaby)",
             "Spirit Temple MQ Statue Room Invisible Chest": "logic_lens_spirit_mq or can_use(Lens_of_Truth)",

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -21,20 +21,30 @@
     {
         "region_name": "Child Spirit Temple",
         "dungeon": "Spirit Temple",
+        "events": {
+            "Spirit Temple Room 06 Eye Switch": "
+                has_bombchus and Slingshot and 
+                (can_use(Dins_Fire) or
+                 at('Adult Spirit Temple', (can_use(Fire_Arrows) or
+                                           (logic_spirit_mq_frozen_eye and can_use(Bow) and
+                                            can_play(Song_of_Time)))))"
+        },
         "locations": {
             "Spirit Temple MQ Child Hammer Switch Chest": "
-                at('Adult Spirit Temple', (Small_Key_Spirit_Temple, 7) and Megaton_Hammer)",
+                at('Adult Spirit Temple', Megaton_Hammer) and
+                ((Small_Key_Spirit_Temple, 7) or
+                (shuffle_smallkeys == 'vanilla' and 'Spirit Temple Room 06 Eye Switch'
+                    and can_play(Zeldas_Lullaby) and (Small_Key_Spirit_Temple, 4)))",
             "Spirit Temple MQ Map Room Enemy Chest": "
                 (Sticks or Kokiri_Sword) and 
                 has_bombchus and Slingshot and can_use(Dins_Fire)",
             "Spirit Temple MQ Map Chest": "
                 Sticks or Kokiri_Sword or has_explosives",
             "Spirit Temple MQ Silver Block Hallway Chest": "
-                has_bombchus and (Small_Key_Spirit_Temple, 7) and Slingshot and 
-                (can_use(Dins_Fire) or
-                 at('Adult Spirit Temple', (can_use(Fire_Arrows) or
-                                           (logic_spirit_mq_frozen_eye and can_use(Bow) and
-                                            can_play(Song_of_Time)))))",
+                'Spirit Temple Room 06 Eye Switch' and
+                ((Small_Key_Spirit_Temple, 7) or
+                (shuffle_smallkeys == 'vanilla' and at('Adult Spirit Temple', Megaton_Hammer)
+                    and can_play(Zeldas_Lullaby) and (Small_Key_Spirit_Temple, 4)))",
             "Fairy Pot": "
                 has_bottle and (Sticks or Kokiri_Sword) and
                 has_bombchus and Slingshot"


### PR DESCRIPTION
Updated logic for the 2 vanilla key locations that require 7 keys. (The 3rd unobtainable key requires 6)
When keys are set to vanilla locations they each require only 4 keys plus the items required to reach the other 3 offending key locations.
So we no longer have to start with 3 free keys.