### PR TITLE
Restore Original Cosmetic Model/Icon Colors

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -43,6 +43,12 @@ def patch_music(rom, settings, log, symbols):
 def patch_model_colors(rom, color, model_addresses):
     main_addresses, dark_addresses = model_addresses
 
+    if color is None:
+        for address in main_addresses + dark_addresses:
+            original = rom.original.read_bytes(address, 3)
+            rom.write_bytes(address, original)
+        return
+
     for address in main_addresses:
         rom.write_bytes(address, color)
 
@@ -59,7 +65,10 @@ def patch_tunic_icon(rom, tunic, color):
         'Zora Tunic': 0x00800000,
     }
 
-    tunic_icon = icon.generate_tunic_icon(color)
+    if color is not None:
+        tunic_icon = icon.generate_tunic_icon(color)
+    else:
+        tunic_icon = rom.original.read_bytes(icon_locations[tunic], 0x1000)
 
     rom.write_bytes(icon_locations[tunic], tunic_icon)
 
@@ -101,6 +110,8 @@ def patch_tunic_colors(rom, settings, log, symbols):
         # patch the tunic icon
         if [tunic, tunic_option] not in [['Kokiri Tunic', 'Kokiri Green'], ['Goron Tunic', 'Goron Red'], ['Zora Tunic', 'Zora Blue']]:
             patch_tunic_icon(rom, tunic, color)
+        else:
+            patch_tunic_icon(rom, tunic, None)
 
         log.equipment_colors[tunic] = CollapseDict({
             ':option': tunic_option,
@@ -451,6 +462,8 @@ def patch_gauntlet_colors(rom, settings, log, symbols):
         rom.write_bytes(address, color)
         if settings.correct_model_colors:
             patch_model_colors(rom, color, model_addresses)
+        else:
+            patch_model_colors(rom, None, model_addresses)
         log.equipment_colors[gauntlet] = CollapseDict({
             ':option': gauntlet_option,
             'color': color_to_hex(color),
@@ -489,6 +502,8 @@ def patch_shield_frame_colors(rom, settings, log, symbols):
             rom.write_bytes(address, color)
         if settings.correct_model_colors and shield_frame_option != 'Red':
             patch_model_colors(rom, color, model_addresses)
+        else:
+            patch_model_colors(rom, None, model_addresses)
 
         log.equipment_colors[shield_frame] = CollapseDict({
             ':option': shield_frame_option,
@@ -530,9 +545,15 @@ def patch_heart_colors(rom, settings, log, symbols):
         rom.write_int16s(file_select_address, color) # file select normal hearts
         if heart_option != 'Red':
             rom.write_int16s(file_select_address + 6, color) # file select DD hearts
-            if settings.correct_model_colors:
-                patch_model_colors(rom, color, model_addresses) # heart model colors
-                icon.patch_overworld_icon(rom, color, 0xF43D80) # Overworld Heart Icon
+        else:
+            original_dd_color = rom.original.read_bytes(file_select_address + 6, 6)
+            rom.write_bytes(file_select_address + 6, original_dd_color)
+        if settings.correct_model_colors and heart_option != 'Red':
+            patch_model_colors(rom, color, model_addresses) # heart model colors
+            icon.patch_overworld_icon(rom, color, 0xF43D80) # Overworld Heart Icon
+        else:
+            patch_model_colors(rom, None, model_addresses)
+            icon.patch_overworld_icon(rom, None, 0xF43D80)
         log.ui_colors[heart] = CollapseDict({
             ':option': heart_option,
             'color': color_to_hex(color),
@@ -568,6 +589,10 @@ def patch_magic_colors(rom, settings, log, symbols):
             patch_model_colors(rom, color, model_addresses)
             icon.patch_overworld_icon(rom, color, 0xF45650, data_path('icons/magicSmallExtras.raw')) # Overworld Small Pot
             icon.patch_overworld_icon(rom, color, 0xF47650, data_path('icons/magicLargeExtras.raw')) # Overworld Big Pot
+        else:
+            patch_model_colors(rom, None, model_addresses)
+            icon.patch_overworld_icon(rom, None, 0xF45650)
+            icon.patch_overworld_icon(rom, None, 0xF47650)
         log.ui_colors[magic_color] = CollapseDict({
             ':option': magic_option,
             'color': color_to_hex(color),

--- a/IconManip.py
+++ b/IconManip.py
@@ -98,12 +98,13 @@ def rgbToRGB5a1(rgbValues):
 
 # Patch overworld icons
 def patch_overworld_icon(rom, color, address, fileName = None):
+    original = rom.original.read_bytes(address, 0x800)
+
     if color is None:
-        original = rom.original.read_bytes(address, 0x800)
         rom.write_bytes(address, original)
         return
 
-    rgbBytes = rgb5a1ToRGB(rom.read_bytes(address, 0x800))
+    rgbBytes = rgb5a1ToRGB(original)
     greyscaled = greyscaleRGB(rgbBytes)
     rgbBytes = addHueToRGB(greyscaled, color)
     if fileName != None:

--- a/IconManip.py
+++ b/IconManip.py
@@ -98,6 +98,11 @@ def rgbToRGB5a1(rgbValues):
 
 # Patch overworld icons
 def patch_overworld_icon(rom, color, address, fileName = None):
+    if color is None:
+        original = rom.original.read_bytes(address, 0x800)
+        rom.write_bytes(address, original)
+        return
+
     rgbBytes = rgb5a1ToRGB(rom.read_bytes(address, 0x800))
     greyscaled = greyscaleRGB(rgbBytes)
     rgbBytes = addHueToRGB(greyscaled, color)


### PR DESCRIPTION
Currently, if a patch file was generated with a non-default heart color, non-default tunic colors, or with "Item Model Color Matches Cosmetics", the models and icons of these cosmetic changes are not overwritten back to the default when patching with cosmetics that use default heart/magic/tunic colors or without "Item Colors Match Cosmetics" enabled. This commit should restore the original colors from the base ROM in those cases.

Fixes #1075.