### PR TITLE
Remove non-repeatable trick

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -456,16 +456,6 @@ logic_tricks = {
                     Allow the Boomerang to return to you through
                     the Song of Time block to grab the token.
                     '''},
-    'Bottom of the Well Like Like GS without Boomerang': {
-        'name'    : 'logic_botw_cage_gs',
-        'tags'    : ("Bottom of the Well", "Skulltulas",),
-        'tooltip' : '''\
-                    After killing the Skulltula, the Like Like
-                    can be used to boost you into the token.
-                    It is possible to do this in such a way
-                    that you collect the token prior to taking
-                    damage from the Like Like.
-                    '''},
     'Bottom of the Well MQ Dead Hand Freestanding Key with Boomerang': {
         'name'    : 'logic_botw_mq_dead_hand_key',
         'tags'    : ("Bottom of the Well",),

--- a/data/World/Bottom of the Well.json
+++ b/data/World/Bottom of the Well.json
@@ -41,8 +41,8 @@
                 Boomerang and (logic_lens_botw or can_use(Lens_of_Truth)) and 
                 (Small_Key_Bottom_of_the_Well, 3)",
             "Bottom of the Well GS Like Like Cage": "
-                (Small_Key_Bottom_of_the_Well, 3) and (logic_lens_botw or can_use(Lens_of_Truth)) and
-                (Boomerang or (logic_botw_cage_gs and can_child_attack))",
+                Boomerang and (logic_lens_botw or can_use(Lens_of_Truth)) and
+                (Small_Key_Bottom_of_the_Well, 3)",
             "Stick Pot": "True",
             "Nut Pot": "True"
         },


### PR DESCRIPTION
If you defeat all of the enemies in the main room of Bottom of the Well, it's a permanent flag, and they stay dead. It likely wasn't an intentional thing from the OoT devs, but it exists, and so the Like Like Boost to the token will not be repeatable if all of the enemies in the room are defeated.