### PR TITLE
Updated chest size for tokens when lacs_tokens is enabled

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1585,7 +1585,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             item = read_rom_item(rom, i)
             item['chest_type'] = 0
             write_rom_item(rom, i, item)
-    if world.bridge == 'tokens':
+    if world.bridge == 'tokens' or world.lacs_condition == 'tokens':
         item = read_rom_item(rom, 0x5B)
         item['chest_type'] = 0
         write_rom_item(rom, 0x5B, item)


### PR DESCRIPTION
Tokens were in small chests with CSMS and LACS tokens, this fixes the problem. Verified broken without fix and that this fixes it. 

I also verified that tokens were considered "major items" when lacs tokens is enabled.