### PR TITLE
Rom Header Patching Fixes

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -894,7 +894,7 @@ def patch_cosmetics(settings, rom):
     # try to detect the cosmetic patch data format
     versioned_patch_set = None
     cosmetic_context = rom.read_int32(rom.sym('RANDO_CONTEXT') + 4)
-    if cosmetic_context >= 0x80000000:
+    if cosmetic_context >= 0x80000000 and cosmetic_context <= 0x80F7FFFC:
         cosmetic_context = (cosmetic_context - 0x80400000) + 0x3480000 # convert from RAM to ROM address
         cosmetic_version = rom.read_int32(cosmetic_context)
         versioned_patch_set = patch_sets.get(cosmetic_version)

--- a/Rom.py
+++ b/Rom.py
@@ -148,7 +148,7 @@ class Rom(BigStream):
 
     def update_header(self):
         crc = calculate_crc(self)
-        self.write_int32s(0x10, [crc[0], crc[1]])
+        self.write_bytes(0x10, crc)
 
 
     def read_rom(self, file):

--- a/Rom.py
+++ b/Rom.py
@@ -54,6 +54,10 @@ class Rom(BigStream):
         self.buffer.extend(bytearray([0x00] * (0x4000000 - len(self.buffer))))
         self.original = self.copy()
 
+        # Add version number to header.
+        self.write_bytes(0x35, get_version_bytes(__version__))
+        self.force_patch.extend([0x35, 0x36, 0x37])
+
 
     def copy(self):
         new_rom = Rom()
@@ -127,6 +131,8 @@ class Rom(BigStream):
         self.changed_dma = {}
         self.force_patch = []
         self.last_address = None
+        self.write_bytes(0x35, get_version_bytes(__version__))
+        self.force_patch.extend([0x35, 0x36, 0x37])
 
 
     def sym(self, symbol_name):
@@ -141,7 +147,6 @@ class Rom(BigStream):
 
 
     def update_header(self):
-        self.write_bytes(0x35, get_version_bytes(__version__))
         crc = calculate_crc(self)
         self.write_int32s(0x10, [crc[0], crc[1]])
 


### PR DESCRIPTION
A few dumb things I found by doing some dumb things.

First commit moves the patching of the version in the header of the ROM away from `update_header`. Prior to this commit, the version number in the ROM header would be overwritten when applying a patch, making it give false information.

Second commit is a bounds check when reading the cosmetic version from the cosmetic context. This is due to old rando versions having bytes where the cosmetic context address usually is that are out-of-bounds of the ROM when treated as an address.

And the third commit fixes the CRC for uncompressed ROMs. This has seemingly been broken for a long time, since commit `6addbb8bd379897a8cc52b3f5320c51feba831fd` was merged in version 5.0.40. The fact that nobody has noticed this in 14 months is a sad reminder that compress memes are long dead.