### PR TITLE
Update Tournament Hints

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -136,7 +136,6 @@ def tokens_required_by_settings(world):
 # Hints required under certain settings
 conditional_always = {
     'Market 10 Big Poes':           lambda world: world.big_poe_count > 3,
-    'Deku Theater Skull Mask':      lambda world: world.hint_dist == 'tournament' and not world.complete_mask_quest,
     'Deku Theater Mask of Truth':   lambda world: not world.complete_mask_quest,
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
     'HF Ocarina of Time Item':      lambda world: stones_required_by_settings(world) < 2,

--- a/README.md
+++ b/README.md
@@ -216,13 +216,13 @@ do that.
   * Many locations that did not previously have item hints now have hints, in case a custom hint distribution makes use of them.
   * Using the hint distribution "Bingo" allows setting a "Bingosync URL" to build hints for the specific OoTR Bingo board. Otherwise it's a generic hint distribution for OoTR Bingo.
 * Hint distributions can configure groups of stones to all have the same hint, and can also disable stones from receiving useful hints (give them junk hints instead).
-* Tournament hint distribution changes <!-- keep updated if there are changes later -->
-  * Temple of Time stones all provide the same hint.
+* Tournament hint distribution changes
   * Grotto stones are disabled and only provide junk hints.
   * Zelda's Lullaby is never considered for Way of the Hero hints.
-  * Deku Theater Skull Mask is an "always" hint.
-  * Only "always" and "WotH" hints have duplicates now.
-  * Number of unique hints of each type are now (not counting seed-dependent hint types like 'always' and 'trial'): 4 WotH, 0 barren, 4(remainder) sometimes.
+  * Only "always", "Barren", and "WotH" hints have duplicates now.
+  * One "Barren" hint will point to a dungeon if the seed has barren dungeons.
+  * Number of unique hints of each type are now (not counting seed-dependent hint types like 'always' and 'trial'): 4 WotH, 2 barren, 5(remainder) sometimes.
+* The previous Tournament hint distribution has been renamed "Scrubs Tournament"
 * Added options to `Background Music` and `Fanfares` for randomly selecting only from [custom music](https://wiki.ootrandomizer.com/index.php?title=Readme#Custom_Music_and_Fanfares).
 * Tricks can be filtered in the GUI using a new dropdown.
 * Various Quality of Life improvements

--- a/data/Hints/tournament.json
+++ b/data/Hints/tournament.json
@@ -1,7 +1,7 @@
 {
     "name":                  "tournament",
     "gui_name":              "Tournament",
-    "description":           "Fixed number of hints for each type, contains duplicates, and only useful hints.",
+    "description":           "Tournament hints used for OoTR Season 4. Gossip stones in grottos are disabled. 4 WotH, 2 Barren, remainder filled with Sometimes. Always, WotH, and Barren hints duplicated.",
     "add_locations":         [],
     "remove_locations":      [],
     "add_items":             [],
@@ -10,23 +10,22 @@
     "dungeons_barren_limit": 1,
     "named_items_required":  true,
     "distribution":          {
-        "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 1},
-        "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},
-        "woth":       {"order":  3, "weight": 0.0, "fixed":   4, "copies": 2},
-        "barren":     {"order":  4, "weight": 0.0, "fixed":   0, "copies": 1},
-        "entrance":   {"order":  5, "weight": 0.0, "fixed":   4, "copies": 1},
-        "sometimes":  {"order":  6, "weight": 0.0, "fixed": 100, "copies": 1},
-        "random":     {"order":  7, "weight": 9.0, "fixed":   0, "copies": 1},
-        "item":       {"order":  0, "weight": 0.0, "fixed":   0, "copies": 1},
-        "song":       {"order":  0, "weight": 0.0, "fixed":   0, "copies": 1},
-        "overworld":  {"order":  0, "weight": 0.0, "fixed":   0, "copies": 1},
-        "dungeon":    {"order":  0, "weight": 0.0, "fixed":   0, "copies": 1},
-        "junk":       {"order":  0, "weight": 0.0, "fixed":   0, "copies": 1},
-        "named-item": {"order":  8, "weight": 0.0, "fixed":   0, "copies": 1}
+        "trial":          {"order":  1, "weight": 0.0, "fixed":  0, "copies": 1},
+        "always":         {"order":  2, "weight": 0.0, "fixed":  0, "copies": 2},
+        "woth":           {"order":  3, "weight": 0.0, "fixed":  4, "copies": 2},
+        "barren_dungeon": {"order":  4, "weight": 0.0, "fixed":  1, "copies": 2},
+        "barren":         {"order":  5, "weight": 0.0, "fixed":  1, "copies": 2},
+        "entrance":       {"order":  6, "weight": 0.0, "fixed":  4, "copies": 1},
+        "sometimes":      {"order":  7, "weight": 0.0, "fixed": 99, "copies": 1},
+        "random":         {"order":  8, "weight": 9.0, "fixed":  0, "copies": 1},
+        "item":           {"order":  0, "weight": 0.0, "fixed":  0, "copies": 1},
+        "song":           {"order":  0, "weight": 0.0, "fixed":  0, "copies": 1},
+        "overworld":      {"order":  0, "weight": 0.0, "fixed":  0, "copies": 1},
+        "dungeon":        {"order":  0, "weight": 0.0, "fixed":  0, "copies": 1},
+        "junk":           {"order":  0, "weight": 0.0, "fixed":  0, "copies": 1},
+        "named-item":     {"order":  9, "weight": 0.0, "fixed":  0, "copies": 1}
     },
-    "groups": [
-        ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)"]
-    ],
+    "groups": [],
     "disabled": [
         "HC (Storms Grotto)", "HF (Cow Grotto)", "HF (Near Market Grotto)", "HF (Southeast Grotto)", "HF (Open Grotto)", "Kak (Open Grotto)", "ZR (Open Grotto)", "KF (Storms Grotto)", "LW (Near Shortcuts Grotto)", "DMT (Storms Grotto)", "DMC (Upper Grotto)"
     ]


### PR DESCRIPTION
### Add new '_dungeon' and '_overworld' variants of WotH and Barren hints.

Adds 'woth_dungeon', 'woth_overworld', 'barren_dungeon', and 'barren_overworld' as hint types. These are the same as their base types but restrict the location/area to a dungeon or an overworld region respectively. In the event that the dungeon hints run out of dungeons for one reason or another, those will fall back to allowing an overworld location. The overworld variants do not have a fallback if there are no valid overworld locations, and that hint would be skipped instead.

### Update Tournament hint distribution.

Removed Skull Mask from ever being considered an always hint without the hint distribution specifically requesting it. Tournament hints no longer group the Temple of Time gossip stones into a single hint and now include one barren dungeon hint (falls back to an overworld region if none are available) and a generic barren hint (which would be an overworld region as the barren dungeon limit is 1). Updated the tooltip of the Tournament hint distribution to be accurate.