### PR TITLE
Fix removing always hints and removing items from hints

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -57,17 +57,10 @@ def getHintGroup(group, world):
             hint.type = 'always'
 
         # Hint inclusion override from distribution
-        if group in world.added_hint_types:
+        if group in world.added_hint_types or group in world.item_added_hint_types:
             if hint.name in world.added_hint_types[group]:
                 hint.type = group
-            location_check = False
-            if isinstance(hint.type, list):
-                for htype in hint.type:
-                    if htype in ['sometimes', 'song', 'overworld', 'dungeon', 'always'] and (name not in hintExclusions(world)):
-                        location_check = True
-            elif hint.type in ['sometimes', 'song', 'overworld', 'dungeon', 'always'] and (name not in hintExclusions(world)):
-                location_check = True
-            if location_check:
+            if nameIsLocation(name, hint.type, world):
                 location = world.get_location(name)
                 for i in world.item_added_hint_types[group]:
                     if i == location.item.name:
@@ -79,6 +72,11 @@ def getHintGroup(group, world):
         if group in world.hint_type_overrides:
             if name in world.hint_type_overrides[group]:
                 type_override = True
+        if group in world.item_hint_type_overrides:
+            if nameIsLocation(name, hint.type, world):
+                location = world.get_location(name)
+                if location.item.name in world.item_hint_type_overrides[group]:
+                    type_override = True
 
         if group in hint.type and (name not in hintExclusions(world)) and not type_override:
             ret.append(hint)
@@ -1277,5 +1275,14 @@ def hintExclusions(world, clear_cache=False):
 
     return hintExclusions.exclusions
 
+def nameIsLocation(name, hint_type, world):
+    location_check = False
+    if isinstance(hint_type, list):
+        for htype in hint_type:
+            if htype in ['sometimes', 'song', 'overworld', 'dungeon', 'always'] and (name not in hintExclusions(world)):
+                location_check = True
+    elif hint_type in ['sometimes', 'song', 'overworld', 'dungeon', 'always'] and (name not in hintExclusions(world)):
+        location_check = True
+    return location_check
 
 hintExclusions.exclusions = None

--- a/Hints.py
+++ b/Hints.py
@@ -399,7 +399,8 @@ def get_specific_item_hint(spoiler, world, checked):
             if (is_not_checked(location, checked)
                 and location.name not in world.hint_exclusions
                 and location.item.name in bingoBottlesForHints
-                and not location.locked)
+                and not location.locked
+                and location.name not in world.hint_type_overrides['named-item'])
         ]
     else:
         locations = [
@@ -407,7 +408,8 @@ def get_specific_item_hint(spoiler, world, checked):
             if (is_not_checked(location, checked)
                 and location.name not in world.hint_exclusions
                 and location.item.name == itemname
-                and not location.locked)
+                and not location.locked
+                and location.name not in world.hint_type_overrides['named-item'])
         ]
     if not locations:
         return None
@@ -681,10 +683,8 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             logger = logging.getLogger('')
             logger.info("Got Bingosync URL. Building board-specific goals.")
             world.item_hints = buildBingoHintList(world.bingosync_url)
-            world.hint_dist_user = bingoDefaults['settings']['hint_dist_user']
         else:
             world.item_hints = bingoDefaults['settings']['item_hints']
-            world.hint_dist_user=bingoDefaults['settings']['hint_dist_user']
 
         if world.tokensanity in ("overworld", "all") and "Suns Song" not in world.item_hints:
             world.item_hints.append("Suns Song")
@@ -714,55 +714,67 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
         raise Exception("There are gaps in the custom hint orders. Please revise your plando file to remove them.")
     for i in range(1, type_count):
         hint_type = sorted_dist[i]
-        hint_dist[hint_type] = (world.hint_dist_user['distribution'][hint_type]['weight'], world.hint_dist_user['distribution'][hint_type]['copies'])
+        if world.hint_dist_user['distribution'][hint_type]['copies'] > 0:
+            fixed_num = world.hint_dist_user['distribution'][hint_type]['fixed']
+            hint_weight = world.hint_dist_user['distribution'][hint_type]['weight']
+        else:
+            logging.getLogger('').warning("Hint copies is zero for type %s. Assuming this hint type should be disabled.", hint_type)
+            fixed_num = 0
+            hint_weight = 0
+        hint_dist[hint_type] = (hint_weight, world.hint_dist_user['distribution'][hint_type]['copies'])
         hint_dist.move_to_end(hint_type)
-        fixed_hint_types.extend([hint_type] * int(world.hint_dist_user['distribution'][hint_type]['fixed']))
+        fixed_hint_types.extend([hint_type] * int(fixed_num))
 
     hint_types, hint_prob = zip(*hint_dist.items())
     hint_prob, _ = zip(*hint_prob)
 
-    # Add required location hints
-    alwaysLocations = getHintGroup('always', world)
-    for hint in alwaysLocations:
-        location = world.get_location(hint.name)
-        checkedLocations.add(hint.name)
+    # Add required location hints, only if hint copies > 0
+    if hint_dist['always'][1] > 0:
+        alwaysLocations = getHintGroup('always', world)
+        for hint in alwaysLocations:
+            location = world.get_location(hint.name)
+            checkedLocations.add(hint.name)
 
-        if location.name in world.hint_text_overrides:
-            location_text = world.hint_text_overrides[location.name]
-        else:
-            location_text = getHint(location.name, world.clearer_hints).text
-        if '#' not in location_text:
-            location_text = '#%s#' % location_text
-        item_text = getHint(getItemGenericName(location.item), world.clearer_hints).text
-        add_hint(spoiler, world, stoneGroups, GossipText('%s #%s#.' % (location_text, item_text), ['Green', 'Red']), hint_dist['always'][1], location, force_reachable=True)
-        logging.getLogger('').debug('Placed always hint for %s.', location.name)
+            if location.name in world.hint_text_overrides:
+                location_text = world.hint_text_overrides[location.name]
+            else:
+                location_text = getHint(location.name, world.clearer_hints).text
+            if '#' not in location_text:
+                location_text = '#%s#' % location_text
+            item_text = getHint(getItemGenericName(location.item), world.clearer_hints).text
+            add_hint(spoiler, world, stoneGroups, GossipText('%s #%s#.' % (location_text, item_text), ['Green', 'Red']), hint_dist['always'][1], location, force_reachable=True)
+            logging.getLogger('').debug('Placed always hint for %s.', location.name)
 
-    # Add trial hints
-    if world.trials_random and world.trials == 6:
-        add_hint(spoiler, world, stoneGroups, GossipText("#Ganon's Tower# is protected by a powerful barrier.", ['Pink']), hint_dist['trial'][1], force_reachable=True)
-    elif world.trials_random and world.trials == 0:
-        add_hint(spoiler, world, stoneGroups, GossipText("Sheik dispelled the barrier around #Ganon's Tower#.", ['Yellow']), hint_dist['trial'][1], force_reachable=True)
-    elif world.trials < 6 and world.trials > 3:
-        for trial,skipped in world.skipped_trials.items():
-            if skipped:
-                add_hint(spoiler, world, stoneGroups,GossipText("the #%s Trial# was dispelled by Sheik." % trial, ['Yellow']), hint_dist['trial'][1], force_reachable=True)
-    elif world.trials <= 3 and world.trials > 0:
-        for trial,skipped in world.skipped_trials.items():
-            if not skipped:
-                add_hint(spoiler, world, stoneGroups, GossipText("the #%s Trial# protects Ganon's Tower." % trial, ['Pink']), hint_dist['trial'][1], force_reachable=True)
+    # Add trial hints, only if hint copies > 0
+    if hint_dist['trial'][1] > 0:
+        if world.trials_random and world.trials == 6:
+            add_hint(spoiler, world, stoneGroups, GossipText("#Ganon's Tower# is protected by a powerful barrier.", ['Pink']), hint_dist['trial'][1], force_reachable=True)
+        elif world.trials_random and world.trials == 0:
+            add_hint(spoiler, world, stoneGroups, GossipText("Sheik dispelled the barrier around #Ganon's Tower#.", ['Yellow']), hint_dist['trial'][1], force_reachable=True)
+        elif world.trials < 6 and world.trials > 3:
+            for trial,skipped in world.skipped_trials.items():
+                if skipped:
+                    add_hint(spoiler, world, stoneGroups,GossipText("the #%s Trial# was dispelled by Sheik." % trial, ['Yellow']), hint_dist['trial'][1], force_reachable=True)
+        elif world.trials <= 3 and world.trials > 0:
+            for trial,skipped in world.skipped_trials.items():
+                if not skipped:
+                    add_hint(spoiler, world, stoneGroups, GossipText("the #%s Trial# protects Ganon's Tower." % trial, ['Pink']), hint_dist['trial'][1], force_reachable=True)
 
     # Add user-specified hinted item locations if using a built-in hint distribution
-    # Assume 2 stones/hint
+    # Raise error if hint copies is zero
     if len(world.item_hints) > 0 and world.hint_dist_user['named_items_required']:
-        for i in range(0, len(world.item_hints)):
-            hint = get_specific_item_hint(spoiler, world, checkedLocations)
-            if hint == None:
-                raise Exception('No valid hints for user-provided item')
-            else:
-                gossip_text, location = hint
-                place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
-                if not place_ok:
-                    raise Exception('Not enough gossip stones for user-provided item hints')
+        if hint_dist['named-item'][1] == 0:
+            raise Exception('User-provided item hints were requested, but gossip stones per named-item hint is zero')
+        else:
+            for i in range(0, len(world.item_hints)):
+                hint = get_specific_item_hint(spoiler, world, checkedLocations)
+                if hint == None:
+                    raise Exception('No valid hints for user-provided item')
+                else:
+                    gossip_text, location = hint
+                    place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
+                    if not place_ok:
+                        raise Exception('Not enough gossip stones for user-provided item hints')
 
     hint_types = list(hint_types)
     hint_prob  = list(hint_prob)


### PR DESCRIPTION
Fix two problems with hint generation:

1) When setting hint copies to 0, the hint is not placed in the world, but the hint still generates and adds a location to the checked list. This prevents other hint types from using the location.
2) `remove_item` key in the hint distribution does not work for always or sometimes-style hints, though it did work for woth, foolish, random, and good item types. This is because those hint types used dedicated location filters.

New behavior with copies = 0 is to skip hint generation for that hint type entirely. Weights and fixed hint count are set to 0 and a warning is generated if copies = 0. This also serves as a shortcut to disable always and trials hints without using the `remove_locations` key.

`remove_item` logic in `getHintGroups` is added to handle always and sometimes types.

I also deleted a couple redundant bingo-related lines that override the distro in the data/Hints/ folder inadvertently. I added it here as I was using bingo hints to test the changes. Dobby already has this change in his branch for other bingo-related fixes.