### PR TITLE
Rework of Path of Gold and some Triforce Hunt changes

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -313,6 +313,7 @@ def get_hint_area(spot):
 
 
 def get_woth_hint(spoiler, world, checked):
+    hint_suffix = "is on the way of the hero."
     locations = spoiler.required_locations[world.id]
     locations = list(filter(lambda location:
         location.name not in checked
@@ -321,6 +322,22 @@ def get_woth_hint(spoiler, world, checked):
         and location.name not in world.hint_type_overrides['woth']
         and location.item.name not in world.item_hint_type_overrides['woth'],
         locations))
+
+    # Choose a opportunity hint instead if either there are no woth remaining or randomly if there aren't many woth remaining
+    if not locations or (len(locations) < 3 and random.random() > 0.5):
+        opportunity_locations = spoiler.opportunity_locations[world.id]
+        opportunity_locations = list(filter(lambda location:
+            location.name not in checked
+            and not (world.woth_dungeon >= world.hint_dist_user['dungeons_woth_limit'] and location.parent_region.dungeon)
+            and location.name not in world.hint_exclusions
+            and location.name not in world.hint_type_overrides['woth']
+            and location.item.name not in world.item_hint_type_overrides['woth'],
+            opportunity_locations))
+
+        # only select an from the opportunity locations if there are any
+        if opportunity_locations:
+            hint_suffix = "contains an opportunity."
+            locations = opportunity_locations
 
     if not locations:
         return None
@@ -334,7 +351,7 @@ def get_woth_hint(spoiler, world, checked):
     else:
         location_text = get_hint_area(location)
 
-    return (GossipText('#%s# is on the way of the hero.' % location_text, ['Light Blue']), location)
+    return (GossipText(f'#{location_text}# {hint_suffix}', ['Light Blue']), location)
 
 
 def get_barren_hint(spoiler, world, checked):

--- a/Hints.py
+++ b/Hints.py
@@ -334,10 +334,7 @@ def get_woth_hint(spoiler, world, checked):
     else:
         location_text = get_hint_area(location)
 
-    if world.triforce_hunt:
-        return (GossipText('#%s# is on the path of gold.' % location_text, ['Light Blue']), location)
-    else:
-        return (GossipText('#%s# is on the way of the hero.' % location_text, ['Light Blue']), location)
+    return (GossipText('#%s# is on the way of the hero.' % location_text, ['Light Blue']), location)
 
 
 def get_barren_hint(spoiler, world, checked):

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -121,13 +121,6 @@ item_difficulty_max = {
     },
 }
 
-TriforceCounts = {
-    'plentiful': Decimal(2.00),
-    'balanced':  Decimal(1.50),
-    'scarce':    Decimal(1.25),
-    'minimal':   Decimal(1.00),
-}
-
 DT_vanilla = (
     ['Recovery Heart'] * 2)
 
@@ -1298,8 +1291,7 @@ def get_pool_core(world):
         world.state.collect(ItemFactory('Small Key (Water Temple)'))
 
     if world.triforce_hunt:
-        triforce_count = int((TriforceCounts[world.item_pool_value] * world.triforce_goal_per_world).to_integral_value(rounding=ROUND_HALF_UP))
-        pending_junk_pool.extend(['Triforce Piece'] * triforce_count)
+        pending_junk_pool.extend(['Triforce Piece'] * world.triforce_count_per_world)
 
     if world.shuffle_ganon_bosskey in ['lacs_vanilla', 'lacs_medallions', 'lacs_stones', 'lacs_dungeons', 'lacs_tokens']:
         placed_items['ToT Light Arrows Cutscene'] = 'Boss Key (Ganons Castle)'

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -35,6 +35,7 @@ per_world_keys = (
     'entrances',
     'locations',
     ':woth_locations',
+    ':opportunity_locations',
     ':barren_regions',
     'gossip_stones',
 )
@@ -227,6 +228,7 @@ class WorldDistribution(object):
             'entrances': {name: EntranceRecord(record) for (name, record) in src_dict.get('entrances', {}).items()},
             'locations': {name: [LocationRecord(rec) for rec in record] if is_pattern(name) else LocationRecord(record) for (name, record) in src_dict.get('locations', {}).items() if not is_output_only(name)},
             'woth_locations': None,
+            'opportunity_locations': None,
             'barren_regions': None,
             'gossip_stones': {name: [GossipRecord(rec) for rec in record] if is_pattern(name) else GossipRecord(record) for (name, record) in src_dict.get('gossip_stones', {}).items()},
         }
@@ -257,6 +259,7 @@ class WorldDistribution(object):
             'entrances': {name: record.to_json() for (name, record) in self.entrances.items()},
             'locations': {name: [rec.to_json() for rec in record] if is_pattern(name) else record.to_json() for (name, record) in self.locations.items()},
             ':woth_locations': None if self.woth_locations is None else {name: record.to_json() for (name, record) in self.woth_locations.items()},
+            ':opportunity_locations': None if self.opportunity_locations is None else {name: record.to_json() for (name, record) in self.opportunity_locations.items()},
             ':barren_regions': self.barren_regions,
             'gossip_stones': SortedDict({name: [rec.to_json() for rec in record] if is_pattern(name) else record.to_json() for (name, record) in self.gossip_stones.items()}),
         }
@@ -985,6 +988,7 @@ class Distribution(object):
             world_dist.entrances = {ent.name: EntranceRecord.from_entrance(ent) for ent in spoiler.entrances[world.id]}
             world_dist.locations = {loc: LocationRecord.from_item(item) for (loc, item) in spoiler.locations[world.id].items()}
             world_dist.woth_locations = {loc.name: LocationRecord.from_item(loc.item) for loc in spoiler.required_locations[world.id]}
+            world_dist.opportunity_locations = {loc.name: LocationRecord.from_item(loc.item) for loc in spoiler.opportunity_locations[world.id]}
             world_dist.barren_regions = [*world.empty_areas]
             world_dist.gossip_stones = {gossipLocations[loc].name: GossipRecord(spoiler.hints[world.id][loc].to_json()) for loc in spoiler.hints[world.id]}
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ do that.
   * Many locations that did not previously have item hints now have hints, in case a custom hint distribution makes use of them.
   * Using the hint distribution "Bingo" allows setting a "Bingosync URL" to build hints for the specific OoTR Bingo board. Otherwise it's a generic hint distribution for OoTR Bingo.
 * Hint distributions can configure groups of stones to all have the same hint, and can also disable stones from receiving useful hints (give them junk hints instead).
+* New hint subtype: Opportunity
+  * These are weaker versions of Way of the Hero hints that appear if there are optional goals and there are not enough Way of the Hero locations.
+  * Optional goals are settings that have the requirements be less than the available, such as medallions, stones, triforce pieces.
+  * These hints are like Way of the Hero, but they are items needed to complete all optional objectives.
+  * This replaces the previous Path of Gold hints.
+* Triforce Hunt changes
+  * When playing beatable only, there is no longer a guarantee that all triforces are reachable (the minimum is still guaranteed).
+  * Path of Gold is replaced with Opportunity hints, and Way of the Hero hints are now able to be generated.
 * Tournament hint distribution changes <!-- keep updated if there are changes later -->
   * Temple of Time stones all provide the same hint.
   * Grotto stones are disabled and only provide junk hints.
@@ -223,6 +231,7 @@ do that.
   * Deku Theater Skull Mask is an "always" hint.
   * Only "always" and "WotH" hints have duplicates now.
   * Number of unique hints of each type are now (not counting seed-dependent hint types like 'always' and 'trial'): 4 WotH, 0 barren, 4(remainder) sometimes.
+  * See Opportunity hint subtype above for when settings contain optional goals.
 * Added options to `Background Music` and `Fanfares` for randomly selecting only from [custom music](https://wiki.ootrandomizer.com/index.php?title=Readme#Custom_Music_and_Fanfares).
 * Tricks can be filtered in the GUI using a new dropdown.
 * Various Quality of Life improvements

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1860,7 +1860,7 @@ setting_infos = [
                 'sections' : ['open_section', 'shuffle_section', 'shuffle_dungeon_section'],
                 'settings': ['starting_age', 'shuffle_interior_entrances', 'shuffle_grotto_entrances', 'shuffle_dungeon_entrances',
                              'shuffle_overworld_entrances', 'owl_drops', 'warp_songs', 'spawn_positions',
-                             'triforce_hunt', 'triforce_goal_per_world', 'bombchus_in_logic', 'one_item_per_dungeon'],
+                             'triforce_hunt', 'triforce_count_per_world', 'triforce_goal_per_world', 'bombchus_in_logic', 'one_item_per_dungeon'],
             }
         },
         shared         = True,
@@ -2129,7 +2129,22 @@ setting_infos = [
         },
         disable        = {
             True  : {'settings' : ['shuffle_ganon_bosskey']},
-            False : {'settings' : ['triforce_goal_per_world']}
+            False : {'settings' : ['triforce_count_per_world', 'triforce_goal_per_world']}
+        },
+    ),
+    Scale(
+        name           = 'triforce_count_per_world',
+        gui_text       = 'Triforces Per World',
+        default        = 30,
+        min            = 1,
+        max            = 200,
+        shared         = True,
+        gui_tooltip    = '''\
+            Select the amount of Triforce Pieces placed in each world.
+            Each world will have the same number of triforces.
+        ''',
+        gui_params     = {
+            "hide_when_disabled": True,
         },
     ),
     Scale(
@@ -2142,16 +2157,9 @@ setting_infos = [
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces required to beat the game.
 
-            In multiworld, each world will have the same number of triforces 
-            in them. The required amount will be per world collectively. 
+            In multiworld, the required amount will be per world collectively. 
             For example, if this is set to 20 in a 2 player multiworld, players 
             need 40 total, but one player could obtain 30 and the other 10. 
-
-            Extra pieces are determined by the the Item Pool setting:
-            'Plentiful': 100% Extra
-            'Balanced': 50% Extra
-            'Scarce': 25% Extra
-            'Minimal: No Extra
         ''',
         gui_params     = {
             "hide_when_disabled": True,

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2137,7 +2137,7 @@ setting_infos = [
         gui_text       = 'Triforces Per World',
         default        = 30,
         min            = 1,
-        max            = 200,
+        max            = 100,
         shared         = True,
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces placed in each world.

--- a/Spoiler.py
+++ b/Spoiler.py
@@ -52,6 +52,7 @@ class Spoiler(object):
         self.entrances = []
         self.metadata = {}
         self.required_locations = {}
+        self.opportunity_locations = {}
         self.hints = {world.id: {} for world in worlds}
         self.file_hash = []
 

--- a/State.py
+++ b/State.py
@@ -41,7 +41,7 @@ class State(object):
 
 
     def won_triforce_hunt(self):
-        return self.has('Triforce Piece', self.world.triforce_count)
+        return self.has('Triforce Piece', self.world.triforce_goal)
 
 
     def won_normal(self):

--- a/State.py
+++ b/State.py
@@ -98,6 +98,28 @@ class State(object):
         return (self.count_of(ItemInfo.medallions) + self.count_of(ItemInfo.stones)) >= count
 
 
+    def get_opportunity_progress(self):
+        progress = {}
+
+        if self.world.triforce_hunt and self.world.triforce_goal < self.world.triforce_count and self.world.triforce_goal > 0:
+            progress['Triforce Piece'] = self.item_count('Triforce Piece')
+
+        if ((self.world.bridge == 'stones' and self.world.bridge_stones < 3 and self.world.bridge_stones > 0) or 
+           (self.world.lacs_condition == 'stones' and self.world.lacs_stones < 3 and self.world.lacs_stones > 0)):
+                progress['Stones'] = self.count_of(ItemInfo.stones)
+        if ((self.world.bridge == 'medallions' and self.world.bridge_medallions < 6 and self.world.bridge_medallions > 0) or 
+           (self.world.lacs_condition == 'medallions' and self.world.lacs_medallions < 6 and self.world.lacs_medallions > 0)):
+                progress['Medallions'] = self.count_of(ItemInfo.medallions)
+        if ((self.world.bridge == 'dungeons' and self.world.bridge_rewards < 9 and self.world.bridge_rewards > 0) or 
+           (self.world.lacs_condition == 'dungeons' and self.world.lacs_rewards < 9 and self.world.lacs_rewards > 0)):
+                progress['Dungeons'] = self.count_of(ItemInfo.stones) + self.count_of(ItemInfo.medallions)
+        if ((self.world.bridge == 'tokens' and self.world.bridge_tokens < 100 and self.world.bridge_tokens > 0) or 
+           (self.world.lacs_condition == 'tokens' and self.world.lacs_tokens < 100 and self.world.lacs_tokens > 0)):
+                progress['Gold Skulltula Token'] = self.count_of('Gold Skulltula Token')
+        
+        return progress
+
+
     def had_night_start(self):
         stod = self.world.starting_tod
         # These are all not between 6:30 and 18:00

--- a/World.py
+++ b/World.py
@@ -32,6 +32,7 @@ class World(object):
         self._region_cache = {}
         self._location_cache = {}
         self.required_locations = []
+        self.opportunity_locations = []
         self.shop_prices = {}
         self.scrub_prices = {}
         self.maximum_wallets = 0

--- a/World.py
+++ b/World.py
@@ -65,6 +65,8 @@ class World(object):
                                              self.warp_songs or self.spawn_positions):
             self.open_forest = 'closed_deku'
 
+        if self.triforce_goal_per_world > self.triforce_count_per_world:
+            raise ValueError("Triforces required cannot be more than the triforce count.")
         self.triforce_goal = self.triforce_goal_per_world * settings.world_count
 
         if self.triforce_hunt:

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -175,6 +175,7 @@
             "warp_songs",
             "spawn_positions",
             "triforce_hunt",
+            "triforce_count_per_world",
             "triforce_goal_per_world",
             "bombchus_in_logic",
             "one_item_per_dungeon",


### PR DESCRIPTION
Path of Gold is now replaced with "Opportunity" hints. Opportunity hints are weaker woth hints that are placed when there are optional goals and there are not enough woth locations. Optional goals refers to settings that set the required goals to be less than the available (such as medallion, stone, triforce hunt etc). These Opportunity hints are like woth, except that instead of being items required to beat the game, they are items required to complete all the reachable optional goals (such as collect all Triforces).

With this change, Triforce Hunt now only logically requires the minimum number of Triforces. This means that the Way of the Hero can now be generated for Triforce Hunt. The previous Path of Gold will now be Opportunity hints when there are not enough Way of the Hero. A consequence of this is that in Beatable-Only, some optional triforces may not be reachable.

Another change is that the number of triforces places is a setting along with the required pieces, instead of using the item distribution to determine the count. When the setting is randomized, it will default to 30 pieces, 20 required.