### PR TITLE
Fixes for guarantee_trade_path

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -607,15 +607,21 @@ logic_tricks = {
         'name'    : 'logic_biggoron_bolero',
         'tags'    : ("Death Mountain Trail",),
         'tooltip' : '''\
-                    If you do not wear the Goron Tunic, the heat timer
-                    inside the crater will override the trade item's timer.
-                    When you exit to Death Mountain Trail you will have
-                    one second to deliver the Eye Drops before the timer
-                    expires. It works best if you play Bolero as quickly as
-                    possible upon receiving the Eye Drops. If you have few
-                    hearts, there is enough time to dip Goron City to
-                    refresh the heat timer as long as you've already
-                    pulled the block.
+                    Playing a warp song normally causes a trade item to
+                    spoil immediately, however, it is possible use Bolero
+                    to reach Biggoron and still deliver the Eye Drops
+                    before they spoil. If you do not wear the Goron Tunic,
+                    the heat timer inside the crater will override the trade
+                    item's timer. When you exit to Death Mountain Trail you
+                    will have one second to show the Eye Drops before they
+                    expire. You can get extra time to show the Eye Drops if
+                    you warp immediately upon receiving them. If you don't
+                    have many hearts, you may have to reset the heat timer
+                    by quickly dipping in and out of Darunia's chamber.
+                    This trick does not apply if "Randomize Warp Song
+                    Destinations" is enabled, or if the settings are such
+                    that trade items do not need to be delivered within a
+                    time limit.
                     '''},
     'Wasteland Crossing without Hover Boots or Longshot': {
         'name'    : 'logic_wasteland_crossing',

--- a/World.py
+++ b/World.py
@@ -59,7 +59,7 @@ class World(object):
                                 self.shuffle_overworld_entrances or self.owl_drops or self.warp_songs or self.spawn_positions
 
         self.ensure_tod_access = self.shuffle_interior_entrances or self.shuffle_overworld_entrances or self.spawn_positions
-        self.disable_trade_revert = self.shuffle_interior_entrances or self.shuffle_overworld_entrances or self.warp_songs
+        self.disable_trade_revert = self.shuffle_interior_entrances or self.shuffle_overworld_entrances
 
         if self.open_forest == 'closed' and (self.shuffle_special_interior_entrances or self.shuffle_overworld_entrances or 
                                              self.warp_songs or self.spawn_positions):

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -76,7 +76,7 @@
     # Biggoron's trade path
     # ER with certain settings disables timers and prevents items from reverting on save warp.
     # Otherwise, to get to Biggoron requires: a trick, clearing boulders on DMT, or Darunia's Chamber
-    "guarantee_trade_path": "disable_trade_revert or logic_biggoron_bolero or can_blast_or_smash or (logic_dmt_climb_hovers and can_use(Hover_Boots)) or 'Stop GC Rolling Goron as Adult'",
+    "guarantee_trade_path": "disable_trade_revert or can_blast_or_smash or 'Stop GC Rolling Goron as Adult' or (logic_dmt_climb_hovers and can_use(Hover_Boots)) or (logic_biggoron_bolero and not warp_songs and can_play(Bolero_of_Fire) and at('DMC Central Local', can_use(Hookshot) or can_use(Hover_Boots) or can_plant_bean))",
     "guarantee_hint": "(hints == 'mask' and Mask_of_Truth) or (hints == 'agony' and Stone_of_Agony) or (hints != 'mask' and hints != 'agony')",
     "has_fire_source": "can_use(Dins_Fire) or can_use(Fire_Arrows)",
     "has_fire_source_with_torch": "has_fire_source or (is_child and Sticks)",

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -76,7 +76,7 @@
     # Biggoron's trade path
     # ER with certain settings disables timers and prevents items from reverting on save warp.
     # Otherwise, to get to Biggoron requires: a trick, clearing boulders on DMT, or Darunia's Chamber
-    "guarantee_trade_path": "disable_trade_revert or logic_biggoron_bolero or can_blast_or_smash or 'Stop GC Rolling Goron as Adult'",
+    "guarantee_trade_path": "disable_trade_revert or logic_biggoron_bolero or can_blast_or_smash or (logic_dmt_climb_hovers and can_use(Hover_Boots)) or 'Stop GC Rolling Goron as Adult'",
     "guarantee_hint": "(hints == 'mask' and Mask_of_Truth) or (hints == 'agony' and Stone_of_Agony) or (hints != 'mask' and hints != 'agony')",
     "has_fire_source": "can_use(Dins_Fire) or can_use(Fire_Arrows)",
     "has_fire_source_with_torch": "has_fire_source or (is_child and Sticks)",


### PR DESCRIPTION
Three fixes involving guarantee_trade_path:

1. When adding the trick to climb DMT with just Hovers, I forgot to add a check to allow that during the trade quest timer.

2. Spawn ER combined with the "deliver eyedrops with bolero of fire" trick used to allow savewarping to reach Biggoron if adult spawned in that area, but of course savewarping would fail the quest. It used to be that the only way you could reach Biggoron that would fail the timer was with Bolero, so the Biggoron trick didn't need additional logic to confirm that you actually came from Bolero. So I added the full logic to use Bolero and reach Biggoron. None of the logichelpers have previously used at(), so hopefully that actually works correctly (some kind of event was needed because of the possibility of planting a bean to traverse the crater).

3. Warp Destination ER used to disable trade items from reverting only because of conflicts with the biggoron bolero trick. One possible solution to the Spawn ER issue was to also make it disable trade timers, but in both cases I didn't think the trick should take precedence in the matter. I removed warp song ER from the list of settings that disable trade items from reverting and prevented the Biggoron trick from activating if warp song ER is enabled. One awkward thing is that, in theory, warps into crater could be compatible with the trick, but it's not worth the trouble to calculate whether any warps could be used. (Is warp_songs the correct thing to check here? That setting hasn't previously been referenced in logic.)

I updated the tooltip for the Biggoron trick, mainly to reflect under what settings it does not apply.