### PR TITLE
Bump node-sass from 4.12.0 to 4.14.1

### DIFF
--- a/GUI/package.json
+++ b/GUI/package.json
@@ -133,7 +133,7 @@
     "karma-jasmine-html-reporter": "0.2.2",
     "nebular-icons": "1.1.0",
     "ngx-color-picker": "https://github.com/dragonbane0/ngx-color-picker/tarball/7471e8595e5bf508813c5f6b1964e53ac9902448",
-    "node-sass": "4.12.0",
+    "node-sass": "4.14.0",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "popper.js": "1.15.0",

--- a/GUI/package.json
+++ b/GUI/package.json
@@ -89,7 +89,7 @@
     "tree-kill": "1.2.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.13.9",
+    "@angular-devkit/build-angular": "0.13.10",
     "@angular/animations": "7.2.15",
     "@angular/cdk": "7.3.7",
     "@angular/cli": "7.3.9",
@@ -133,7 +133,7 @@
     "karma-jasmine-html-reporter": "0.2.2",
     "nebular-icons": "1.1.0",
     "ngx-color-picker": "https://github.com/dragonbane0/ngx-color-picker/tarball/7471e8595e5bf508813c5f6b1964e53ac9902448",
-    "node-sass": "4.14.0",
+    "node-sass": "4.14.1",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "popper.js": "1.15.0",

--- a/GUI/package_release.json
+++ b/GUI/package_release.json
@@ -135,7 +135,7 @@
     "karma-jasmine-html-reporter": "0.2.2",
     "nebular-icons": "1.1.0",
     "ngx-color-picker": "https://github.com/dragonbane0/ngx-color-picker/tarball/7471e8595e5bf508813c5f6b1964e53ac9902448",
-    "node-sass": "4.12.0",
+    "node-sass": "4.14.0",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "popper.js": "1.15.0",

--- a/GUI/package_release.json
+++ b/GUI/package_release.json
@@ -90,7 +90,7 @@
     "tree-kill": "1.2.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.13.9",
+    "@angular-devkit/build-angular": "0.13.10",
     "@angular/animations": "7.2.15",
     "@angular/cdk": "7.3.7",
     "@angular/cli": "7.3.9",
@@ -135,7 +135,7 @@
     "karma-jasmine-html-reporter": "0.2.2",
     "nebular-icons": "1.1.0",
     "ngx-color-picker": "https://github.com/dragonbane0/ngx-color-picker/tarball/7471e8595e5bf508813c5f6b1964e53ac9902448",
-    "node-sass": "4.14.0",
+    "node-sass": "4.14.1",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "popper.js": "1.15.0",


### PR DESCRIPTION
~~I still get a warning that the node-sass@4.12.0 postinstall script failed for some reason, but regardless continues to work.~~ This is probably due to angular having 4.12 in it's dependencies, but everything seems to work fine so should be irrelevant.

![screenshot of Ocarina of Time Randomizer having finished creating a seed while showing that node v14.15.0 is being used](https://user-images.githubusercontent.com/634079/99586291-8741fc00-29b5-11eb-95a0-802b164b1cc0.png)

and it still works for node 12.18.3

![image](https://user-images.githubusercontent.com/634079/99586430-bce6e500-29b5-11eb-8ba5-c2cd8d13e1a5.png)
