### PR TITLE
Remove 'Random (Custom Only)' music options from web GUI.

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3719,7 +3719,8 @@ setting_infos = [
             'randomize_key': 'randomize_all_sfx',
             'distribution': [
                 ('random', 1),
-            ]
+            ],
+            'web:option_remove': ['random_custom_only'],
         },
     ),
     Combobox(
@@ -3747,7 +3748,8 @@ setting_infos = [
             'randomize_key': 'randomize_all_sfx',
             'distribution': [
                 ('random', 1),
-            ]
+            ],
+            'web:option_remove': ['random_custom_only'],
         },
     ),
     Checkbutton(

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -8,7 +8,7 @@ import copy
 
 tab_keys     = ['text', 'app_type', 'footer']
 section_keys = ['text', 'is_colors', 'is_sfx', 'col_span', 'row_span', 'subheader']
-setting_keys = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function']
+setting_keys = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function', 'option_remove']
 types_with_options = ['Checkbutton', 'Radiobutton', 'Combobox', 'SearchBox']
 
 
@@ -118,6 +118,9 @@ def GetSettingJson(setting, web_version, as_array=False):
         tags_list = []
 
         for option_name in setting_info.choice_list:
+            if option_name in settingJson.get('option_remove', []):
+                continue
+
             if as_array:
                 optionJson = {
                     'name':     option_name,


### PR DESCRIPTION
These are identical to 'Random' in the web version as there is no method of supplying custom music and will likely cause confusion if left in the web GUI. They are still present in the offline GUI where they are actually functional.