### PR TITLE
Fix the logic issue with Crater Upper to Central in ER

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1506,7 +1506,7 @@
             "DMC Central Nearby": "
                 can_use(Goron_Tunic) and can_use(Longshot) and 
                 ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or 
-                    (Fairy and not shuffle_dungeon_entrances) or can_use(Nayrus_Love))"
+                    (Fairy and not entrance_shuffle) or can_use(Nayrus_Love))"
         }
     },
     {


### PR DESCRIPTION
Any ER setting will now disable the fairy use here (which is only relevant in quad dmg or OHKO). This is more restricted than it has to be, but I don't think it's worth taking the risk to have a more "accurate" condition which will have to be constantly updated.

Fixes #1177 