### PR TITLE
Fix logic bug with Impa's Rooftop

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -311,7 +311,7 @@ entrance_shuffle_table = [
                         ('Zoras Fountain -> ZD Behind King Zora',                           { 'index': 0x01A1 })),
 
     ('OwlDrop',         ('LH Owl Flight -> Hyrule Field',                                   { 'index': 0x027E, 'addresses': [0xAC9F26] })),
-    ('OwlDrop',         ('DMT Owl Flight -> Kak Impas Ledge',                               { 'index': 0x0554, 'addresses': [0xAC9EF2] })),
+    ('OwlDrop',         ('DMT Owl Flight -> Kak Impas Rooftop',                             { 'index': 0x0554, 'addresses': [0xAC9EF2] })),
 
     ('Spawn',           ('Child Spawn -> KF Links House',                                   { 'index': 0x00BB, 'addresses': [0xB06342] })),
     ('Spawn',           ('Adult Spawn -> Temple of Time',                                   { 'index': 0x05F4, 'addresses': [0xB06332] })),

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -987,8 +987,6 @@
                 is_child and (Slingshot or has_bombchus or 
                     (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword) and
                     (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))) and at_night",
-            "Kak GS Above Impas House": "
-                (can_use(Hookshot) or (logic_kakariko_rooftop_gs and can_use(Hover_Boots))) and at_night",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -1004,7 +1002,9 @@
             "Kak Potion Shop Front": "is_child or at_day",
             "Kak Redead Grotto": "can_open_bomb_grotto",
             "Kak Impas Ledge": "
-                (is_child and at_day) or (is_adult and logic_visible_collisions) or can_use(Hookshot)",
+                (is_child and at_day) or (is_adult and logic_visible_collisions)",
+            "Kak Impas Rooftop": "
+                can_use(Hookshot) or (logic_kakariko_rooftop_gs and can_use(Hover_Boots))",
             "Kak Odd Medicine Rooftop": "
                 can_use(Hookshot) or 
                 (logic_man_on_roof and 
@@ -1022,6 +1022,18 @@
         "hint": "Kakariko Village",
         "exits": {
             "Kak Impas House Back": "True",
+            "Kakariko Village": "True"
+        }
+    },
+    {
+        "region_name": "Kak Impas Rooftop",
+        "scene": "Kakariko Village",
+        "hint": "Kakariko Village",
+        "locations": {
+            "Kak GS Above Impas House": "is_adult and at_night"
+        },
+        "exits": {
+            "Kak Impas Ledge": "True",
             "Kakariko Village": "True"
         }
     },
@@ -1356,7 +1368,7 @@
         "region_name": "DMT Owl Flight",
         "scene": "Death Mountain",
         "exits": {
-            "Kak Impas Ledge": "True"
+            "Kak Impas Rooftop": "True"
         }
     },
     {


### PR DESCRIPTION
1. The rooftop Skulltula should have been accessible if a warp or spawn drops adult onto the roof.

2. The new hover boots trick to get onto the roof should have been allowed access to Impa's house back when the visible one-way collision trick is off. (Not worth documenting this in the trick's tooltip, imo.)