### PR TITLE
Minor fix for DC lobby wall

### DIFF
--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -5,7 +5,7 @@
         "exits": {
             "Death Mountain": "True",
             "Dodongos Cavern Lobby": "
-                here(can_blast_or_smash) or Progressive_Strength_Upgrade"
+                here(can_blast_or_smash or Progressive_Strength_Upgrade)"
         }
     },
     {


### PR DESCRIPTION
This is logically equivalent, but more closely matches what's happening in the game: There's an event (breaking the wall in front of the lobby) which can be done with explosives or hammer (`can_blast_or_smash`) or with the bomb flowers (`Progressive_Strength_Upgrade`). MQ already has the rule like this.