### PR TITLE
named-item hint changes for DDR community

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -820,6 +820,9 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
                     place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
                     if not place_ok:
                         raise Exception('Not enough gossip stones for user-provided item hints')
+    
+    # Shuffle named items if named-item hints are not required
+    random.shuffle(world.item_hints)
 
     hint_types = list(hint_types)
     hint_prob  = list(hint_prob)

--- a/Hints.py
+++ b/Hints.py
@@ -455,18 +455,20 @@ def get_specific_item_hint(spoiler, world, checked):
 
     location = random.choice(locations)
     checked.add(location.name)
-
-    if world.hint_dist_user['vague_named_items']:
-        item_text = 'an aid to the hero'
-    else:
-        item_text = getHint(getItemGenericName(location.item), world.clearer_hints).text
-
+    item_text = getHint(getItemGenericName(location.item), world.clearer_hints).text
+    
     if location.parent_region.dungeon:
         location_text = getHint(location.parent_region.dungeon.name, world.clearer_hints).text
-        return (GossipText('#%s# hoards #%s#.' % (location_text, item_text), ['Green', 'Red']), location)
+        if world.hint_dist_user['vague_named_items']:
+            return (GossipText('#%s# may be on the hero\'s path.' % (location_text), ['Green']), location)
+        else:
+            return (GossipText('#%s# hoards #%s#.' % (location_text, item_text), ['Green', 'Red']), location)
     else:
         location_text = get_hint_area(location)
-        return (GossipText('#%s# can be found at #%s#.' % (item_text, location_text), ['Red', 'Green']), location)
+        if world.hint_dist_user['vague_named_items']:
+            return (GossipText('#%s# may be on the hero\'s path.' % (location_text), ['Green']), location)
+        else:
+            return (GossipText('#%s# can be found at #%s#.' % (item_text, location_text), ['Red', 'Green']), location)
 
 
 def get_random_location_hint(spoiler, world, checked):

--- a/Hints.py
+++ b/Hints.py
@@ -431,27 +431,30 @@ def get_good_item_hint(spoiler, world, checked):
 
 
 def get_specific_item_hint(spoiler, world, checked):
-    itemname = world.named_item_pool.pop(0)
-    if itemname == "Bottle" and world.hint_dist == "bingo":
-        locations = [
-            location for location in world.get_filled_locations()
-            if (is_not_checked(location, checked)
-                and location.name not in world.hint_exclusions
-                and location.item.name in bingoBottlesForHints
-                and not location.locked
-                and location.name not in world.hint_type_overrides['named-item'])
-        ]
-    else:
-        locations = [
-            location for location in world.get_filled_locations()
-            if (is_not_checked(location, checked)
-                and location.name not in world.hint_exclusions
-                and location.item.name == itemname
-                and not location.locked
-                and location.name not in world.hint_type_overrides['named-item'])
-        ]
-    if not locations:
-        return None
+    while True:
+        itemname = world.named_item_pool.pop(0)
+        if itemname == "Bottle" and world.hint_dist == "bingo":
+            locations = [
+                location for location in world.get_filled_locations()
+                if (is_not_checked(location, checked)
+                    and location.name not in world.hint_exclusions
+                    and location.item.name in bingoBottlesForHints
+                    and not location.locked
+                    and location.name not in world.hint_type_overrides['named-item'])
+            ]
+        else:
+            locations = [
+                location for location in world.get_filled_locations()
+                if (is_not_checked(location, checked)
+                    and location.name not in world.hint_exclusions
+                    and location.item.name == itemname
+                    and not location.locked
+                    and location.name not in world.hint_type_overrides['named-item'])
+            ]
+        if len(locations) > 0:
+            break
+        if len(world.named_item_pool) == 0:
+            return None
 
     location = random.choice(locations)
     checked.add(location.name)
@@ -459,13 +462,13 @@ def get_specific_item_hint(spoiler, world, checked):
     
     if location.parent_region.dungeon:
         location_text = getHint(location.parent_region.dungeon.name, world.clearer_hints).text
-        if world.hint_dist_user['vague_named_items']:
+        if world.hint_dist_user.get('vague_named_items', False):
             return (GossipText('#%s# may be on the hero\'s path.' % (location_text), ['Green']), location)
         else:
             return (GossipText('#%s# hoards #%s#.' % (location_text, item_text), ['Green', 'Red']), location)
     else:
         location_text = get_hint_area(location)
-        if world.hint_dist_user['vague_named_items']:
+        if world.hint_dist_user.get('vague_named_items', False):
             return (GossipText('#%s# may be on the hero\'s path.' % (location_text), ['Green']), location)
         else:
             return (GossipText('#%s# can be found at #%s#.' % (item_text, location_text), ['Red', 'Green']), location)
@@ -736,7 +739,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
         if world.shopsanity != "off" and "Progressive Wallet" not in world.item_hints:
             world.item_hints.append("Progressive Wallet")
-        world.named_item_pool = world.item_hints
+        world.named_item_pool = list(world.item_hints)
 
 
     # Load hint distro from distribution file or pre-defined settings

--- a/Hints.py
+++ b/Hints.py
@@ -828,7 +828,9 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
                     if not place_ok:
                         raise Exception('Not enough gossip stones for user-provided item hints')
     
-    # Shuffle named items if named-item hints are not required
+    # Shuffle named items hints
+    # When all items are not required to be hinted, this allows for
+    # opportunity-style hints to be drawn at random from the defined list.
     random.shuffle(world.named_item_pool)
 
     hint_types = list(hint_types)

--- a/Main.py
+++ b/Main.py
@@ -105,7 +105,7 @@ def resolve_settings(settings, window=dummy_window()):
         settings.player_num = settings.world_count
 
     # Set to a custom hint distribution if plando is overriding the distro
-    if len(settings.hint_dist_user) == 0:
+    if len(settings.hint_dist_user) != 0:
         settings.hint_dist = 'custom'
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)

--- a/Main.py
+++ b/Main.py
@@ -104,6 +104,10 @@ def resolve_settings(settings, window=dummy_window()):
             raise Exception(f'Player Num is {settings.player_num}; must be between (1, {settings.world_count})')
         settings.player_num = settings.world_count
 
+    # Set to a custom hint distribution if plando is overriding the distro
+    if len(settings.hint_dist_user) == 0:
+        settings.hint_dist = 'custom'
+
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)
     settings.remove_disabled()
     logger.info('(Original) Settings string: %s\n', settings.settings_string)

--- a/World.py
+++ b/World.py
@@ -173,6 +173,8 @@ class World(object):
                     raise Exception('Custom hint text too large for %s', loc['location'])
                 self.hint_text_overrides.update({loc['location']: loc['text']})
 
+        self.named_item_pool = list(self.item_hints)
+
         self.always_hints = [hint.name for hint in getRequiredHints(self)]
         
         self.state = State(self)

--- a/data/Hints/balanced.json
+++ b/data/Hints/balanced.json
@@ -9,6 +9,7 @@
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,
     "named_items_required":  true,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 1},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 1},

--- a/data/Hints/bingo.json
+++ b/data/Hints/bingo.json
@@ -29,6 +29,7 @@
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,
     "named_items_required":  true,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 0},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 0},

--- a/data/Hints/scrubs.json
+++ b/data/Hints/scrubs.json
@@ -11,6 +11,7 @@
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,
     "named_items_required":  true,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 2},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},

--- a/data/Hints/strong.json
+++ b/data/Hints/strong.json
@@ -9,6 +9,7 @@
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,
     "named_items_required":  true,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.00, "fixed":   0, "copies": 1},
         "always":     {"order":  2, "weight": 0.00, "fixed":   0, "copies": 2},

--- a/data/Hints/tournament.json
+++ b/data/Hints/tournament.json
@@ -9,6 +9,7 @@
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,
     "named_items_required":  true,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":          {"order":  1, "weight": 0.0, "fixed":  0, "copies": 1},
         "always":         {"order":  2, "weight": 0.0, "fixed":  0, "copies": 2},

--- a/data/Hints/useless.json
+++ b/data/Hints/useless.json
@@ -9,6 +9,7 @@
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,
     "named_items_required":  false,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 0},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 0},

--- a/data/Hints/very_strong.json
+++ b/data/Hints/very_strong.json
@@ -9,6 +9,7 @@
     "dungeons_woth_limit":   40,
     "dungeons_barren_limit": 40,
     "named_items_required":  true,
+    "vague_named_items":     false,
     "distribution":          {
         "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 1},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},


### PR DESCRIPTION
Currently the named-item hint type draws from the item_hints list in the order provided. This worked fine for bingo hints as all items were meant to hinted. Some community members would like to use this to force hints for certain items from a pool. This is implemented by shuffling the item list after the required hints are generated.

Additionally, a new `vague_named_items` key is added to hint distributions to change named item hints to avoid naming the item. Chosen text is "may be on the hero's path" based on community feedback.

Finally, named item hints currently remove entries from the `item_hints` list to avoid double-hinting named items. This had the unintended side effect of removing the item from the spoiler as well. A copy of the named item list is made on world initialization to prevent this. The `hint_dist` setting is also set to `custom` when a plando hint distribution is used to avoid confusion.

Tested with the below plando for different and identical seeds.

```
{
  "settings":            {
    "item_hints": [
        "Boss Key (Forest Temple)",      
        "Boss Key (Fire Temple)", 
        "Boss Key (Water Temple)",
        "Boss Key (Shadow Temple)",
        "Boss Key (Spirit Temple)",
        "Hover Boots",
        "Progressive Hookshot",
        "Dins Fire",
        "Bomb Bag",
        "Boomerang",
        "Bow",
        "Megaton Hammer",
        "Iron Boots",
        "Magic Meter",
        "Mirror Shield",
        "Fire Arrows",
        "Progressive Strength Upgrade",
        "Kokiri Sword" 
    ],
    "hint_dist_user": {
      "name":                  "custom",
      "gui_name":              "Plando Test Hint Distribution",
      "description":           "for debugging",
      "add_locations":         [],
      "remove_locations":      [],
      "add_items":             [],
      "remove_items":          [],
      "dungeons_woth_limit":   2,
      "dungeons_barren_limit": 1,
      "named_items_required":  false,
      "vague_named_items":  true,
      "distribution":          {
          "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 2},
          "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 0},
          "woth":       {"order":  3, "weight": 0.0, "fixed":   0, "copies": 2},
          "barren":     {"order":  4, "weight": 0.0, "fixed":   0, "copies": 1},
          "entrance":   {"order":  5, "weight": 0.0, "fixed":   0, "copies": 2},
          "sometimes":  {"order":  6, "weight": 0.0, "fixed":   0, "copies": 1},
          "random":     {"order":  7, "weight": 0.0, "fixed":   0, "copies": 2},
          "item":       {"order":  8, "weight": 0.0, "fixed":   0, "copies": 2},
          "song":       {"order":  9, "weight": 0.0, "fixed":   0, "copies": 2},
          "overworld":  {"order": 10, "weight": 0.0, "fixed":   0, "copies": 2},
          "dungeon":    {"order": 11, "weight": 0.0, "fixed":   0, "copies": 2},
          "junk":       {"order": 12, "weight": 0.0, "fixed":   0, "copies": 1},
          "named-item": {"order": 13, "weight": 1.0, "fixed":   0, "copies": 4}
      }
    }
  },
  "randomized_settings": {},
  "starting_items":      {},
  "item_pool":           {},
  "entrances":           {},
  "locations":           {}
}
```
