### PR TITLE
SCZ: Provide Impa's item to the correct worlds.

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1003,7 +1003,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     if world.skip_child_zelda:
         save_context.give_item('Zeldas Letter')
-        save_context.give_raw_item(world.get_location('Song from Impa').item.name)
+        for w in spoiler.worlds:
+            item = w.get_location('Song from Impa').item
+            if world.id == item.world.id:
+                save_context.give_raw_item(item.name)
         save_context.write_bits(0x0ED7, 0x04) # "Obtained Malon's Item"
         save_context.write_bits(0x0ED7, 0x08) # "Woke Talon in castle"
         save_context.write_bits(0x0ED7, 0x10) # "Talon has fled castle"


### PR DESCRIPTION
Fixes #1210.

Tested with logging (i.e. printf debugging).