### PR TITLE
Refactor taking damage into a logic helper

### DIFF
--- a/World.py
+++ b/World.py
@@ -110,8 +110,6 @@ class World(object):
             'Ganons Castle': False
         }
 
-        self.can_take_damage = True
-
         self.resolve_random_settings()
 
         if len(settings.hint_dist_user) == 0:
@@ -203,7 +201,6 @@ class World(object):
         new_world.big_poe_count = copy.copy(self.big_poe_count)
         new_world.starting_tod = self.starting_tod
         new_world.starting_age = self.starting_age
-        new_world.can_take_damage = self.can_take_damage
         new_world.shop_prices = copy.copy(self.shop_prices)
         new_world.triforce_goal = self.triforce_goal
         new_world.triforce_count = self.triforce_count

--- a/data/Glitched World/Dodongos Cavern MQ.json
+++ b/data/Glitched World/Dodongos Cavern MQ.json
@@ -21,8 +21,7 @@
                 is_adult or 
                 (Slingshot and 
                     (has_explosives or 
-                        ((Sticks or can_use(Dins_Fire)) and 
-                            (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))))",
+                        ((Sticks or can_use(Dins_Fire)) and can_take_damage)))",
             "Dodongos Cavern MQ GS Song of Time Block Room": "
                 can_play(Song_of_Time) and (can_child_attack or is_adult)",
             "Dodongos Cavern MQ GS Larvae Room": "can_use(Sticks) or has_fire_source",
@@ -33,7 +32,7 @@
                         (Megaton_Hammer or 
                             ((Sticks or can_use(Dins_Fire) or 
                                 (can_become_adult and (logic_dc_jump or Hover_Boots))) and 
-                            (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love))))))) or 
+                            can_take_damage))))) or 
                 (can_use(Hookshot) and (has_explosives or Progressive_Strength_Upgrade or 
                     Bow or can_use(Dins_Fire)))",
             "Dodongos Cavern MQ Deku Scrub Lobby Rear": "can_stun_deku",
@@ -41,8 +40,7 @@
             "Dodongos Cavern MQ Deku Scrub Staircase": "can_stun_deku",
             "Dodongos Cavern MQ Deku Scrub Side Room Near Lower Lizalfos": "
                 is_adult or has_explosives or 
-                ((Sticks or can_use(Dins_Fire)) and 
-                    (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))",
+                ((Sticks or can_use(Dins_Fire)) and can_take_damage)",
             "Dodongos Cavern Gossip Stone": "True"
         },
         "exits": {

--- a/data/Glitched World/Gerudo Training Grounds MQ.json
+++ b/data/Glitched World/Gerudo Training Grounds MQ.json
@@ -24,7 +24,7 @@
             "Gerudo Training Grounds MQ Underwater Silver Rupee Chest": "
                 (Hover_Boots or at('Gerudo Training Grounds Central Maze Right', can_use(Longshot) or Bow)) and 
                 has_fire_source and Iron_Boots and (logic_fewer_tunic_requirements or can_use(Zora_Tunic)) and 
-                (damage_multiplier != 'ohko' or (Fairy or can_use(Nayrus_Love)))",
+                can_take_damage",
             "Wall Fairy": "has_bottle and can_use(Bow)" #in the Dinalfos room shoot the Gerudo symbol above the door to the lava room.
         }
     },

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -48,6 +48,7 @@
     "can_stun_deku": "is_adult or (Slingshot or Boomerang or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or Nuts or Deku_Shield)",
     "can_summon_gossip_fairy": "Ocarina and (Zeldas_Lullaby or Eponas_Song or Song_of_Time or Suns_Song)",
     "can_summon_gossip_fairy_without_suns": "Ocarina and (Zeldas_Lullaby or Eponas_Song or Song_of_Time)",
+    "can_take_damage": "damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)",
     "can_plant_bean": "is_child and (Magic_Bean or Magic_Bean_Pack)",
     "can_play(song)": "Ocarina and song",
     "can_open_bomb_grotto": "can_blast_or_smash and (Stone_of_Agony or logic_grottos_without_agony)",

--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -32,12 +32,10 @@
         "exits": {
             "Dodongos Cavern Lower Right Side": "
                 here(can_blast_or_smash or
-                      ((can_use(Sticks) or can_use(Dins_Fire)) and
-                       (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love))))",
+                      ((can_use(Sticks) or can_use(Dins_Fire)) and can_take_damage))",
             "Dodongos Cavern Bomb Bag Area": "
                 is_adult or (here(is_adult) and has_explosives) or
-                (logic_dc_mq_child_bombs and (Kokiri_Sword or Sticks) and
-                    (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))",
+                (logic_dc_mq_child_bombs and (Kokiri_Sword or Sticks) and can_take_damage)",
             "Dodongos Cavern Boss Area": "
                 has_explosives or
                 (logic_dc_mq_eyes and Progressive_Strength_Upgrade and

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -8,7 +8,7 @@
             "Forest Temple GS First Room": "
                 (is_adult and (Hookshot or Bow or Bombs)) or (is_child and (Boomerang or Slingshot)) or
                 has_bombchus or can_use(Dins_Fire) or (logic_forest_first_gs and (Bombs or
-                    (can_jumpslash and (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))))",
+                    (can_jumpslash and can_take_damage)))",
             "Forest Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang)",
             "Fairy Pot": "has_bottle and (is_adult or can_child_attack or Nuts)"
         },

--- a/data/World/Gerudo Training Grounds MQ.json
+++ b/data/World/Gerudo Training Grounds MQ.json
@@ -35,8 +35,7 @@
         "locations": {
             "Gerudo Training Grounds MQ Underwater Silver Rupee Chest": "
                 has_fire_source and can_use(Iron_Boots) and
-                (logic_fewer_tunic_requirements or can_use(Zora_Tunic)) and 
-                (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love))"
+                (logic_fewer_tunic_requirements or can_use(Zora_Tunic)) and can_take_damage"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -529,8 +529,7 @@
             "Gerudo Fortress": "True",
             "GV Upper Stream": "True",
             "GV Crate Ledge": "
-                logic_valley_crate_hovers and can_use(Hover_Boots) and
-                (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love))",
+                logic_valley_crate_hovers and can_use(Hover_Boots) and can_take_damage",
             "Gerudo Valley": "
                 is_child or can_ride_epona or can_use(Longshot) or
                 gerudo_fortress == 'open' or 'Carpenter Rescue'",
@@ -986,7 +985,7 @@
             "Kak GS Watchtower": "
                 is_child and (Slingshot or has_bombchus or 
                     (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword) and
-                    (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))) and at_night",
+                    can_take_damage)) and at_night",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -1009,8 +1008,7 @@
                 can_use(Hookshot) or 
                 (logic_man_on_roof and 
                     (is_adult or at_day or Slingshot or has_bombchus or 
-                        (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword) and
-                            (damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)))))",
+                        (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword) and can_take_damage)))",
             "Kak Backyard": "is_adult or at_day",
             "Graveyard": "True",
             "Kak Behind Gate": "is_adult or 'Kakariko Village Gate Open'"
@@ -1307,7 +1305,7 @@
                 can_blast_or_smash or 
                 (logic_dmt_bombable and is_child and Progressive_Strength_Upgrade)",
             "DMT Freestanding PoH": "
-                (damage_multiplier != 'ohko') or can_use(Nayrus_Love) or Fairy or can_use(Hover_Boots) or
+                can_take_damage or can_use(Hover_Boots) or
                 (is_adult and here(can_plant_bean and (has_explosives or Progressive_Strength_Upgrade)))",
             "DMT GS Bean Patch": "
                 can_plant_bugs and can_child_attack and

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -61,15 +61,13 @@
                     has_projectile(child))",
             "Spirit Temple GS Sun on Floor Room": "
                 has_projectile(both) or can_use(Dins_Fire) or 
-                ((damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)) and 
-                    (Sticks or Kokiri_Sword or has_projectile(child))) or 
+                (can_take_damage and (Sticks or Kokiri_Sword or has_projectile(child))) or 
                 (is_child and 
                     (Small_Key_Spirit_Temple, 5) and has_projectile(child)) or 
                 (((Small_Key_Spirit_Temple, 3) or 
                     ((Small_Key_Spirit_Temple, 2) and bombchus_in_logic and not entrance_shuffle)) and 
                 can_use(Silver_Gauntlets) and
-                (has_projectile(adult) or damage_multiplier != 'ohko' or 
-                    Fairy or can_use(Nayrus_Love)))"
+                (has_projectile(adult) or can_take_damage))"
         },
         "exits": {
             "Spirit Temple Central Chamber": "has_explosives",


### PR DESCRIPTION
This moves the rule `damage_multiplier != 'ohko' or Fairy or can_use(Nayrus_Love)`, which is repeated a few times across the logic files, into a new logic helper `can_take_damage`. Some variants are left as-is, so this shouldn't change any logic.