### PR TITLE
Fix error when file extension contains capital Z or N.

### DIFF
--- a/Rom.py
+++ b/Rom.py
@@ -81,7 +81,7 @@ class Rom(BigStream):
         if romCRC not in validCRC:
             # Bad CRC validation
             raise RuntimeError('ROM file %s is not a valid OoT 1.0 US ROM.' % file)
-        elif len(self.buffer) < 0x2000000 or len(self.buffer) > (0x4000000) or file_name[1] not in ['.z64', '.n64']:
+        elif len(self.buffer) < 0x2000000 or len(self.buffer) > (0x4000000) or file_name[1].lower() not in ['.z64', '.n64']:
             # ROM is too big, or too small, or not a bad type
             raise RuntimeError('ROM file %s is not a valid OoT 1.0 US ROM.' % file)
         elif len(self.buffer) == 0x2000000:


### PR DESCRIPTION
When attempting to generate a randomized rom, if the file extension contains a capital Z or N, the program will throw an error saying that the rom is invalid. Adding the .lower() fixes this issue. 
This may be a MacOS/Linux specific issue, since Windows usually does not care about letter cases.