### PR TITLE
cli: Allow reading settings from stdin

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -325,19 +325,22 @@ def get_settings_from_command_line_args():
 
     args = parser.parse_args()
 
-    if args.settings is None:
-        settingsFile = local_path('settings.sav')
+    if args.settings == '-':
+        settings = Settings(json.loads(sys.stdin.read()))
     else:
-        settingsFile = local_path(args.settings)
-
-    try:
-        with open(settingsFile) as f:
-            settings = Settings(json.load(f))
-    except Exception as ex:
         if args.settings is None:
-            settings = Settings({})
+            settingsFile = local_path('settings.sav')
         else:
-            raise ex
+            settingsFile = local_path(args.settings)
+
+        try:
+            with open(settingsFile) as f:
+                settings = Settings(json.load(f))
+        except Exception as ex:
+            if args.settings is None:
+                settings = Settings({})
+            else:
+                raise ex
 
     settings.output_settings = args.output_settings
 


### PR DESCRIPTION
This adds the usual “`-` as filename means standard input” functionality to the CLI's `--settings` option.

Having this would be useful for the Random Settings League.