### PR TITLE
Add Nayru's Love to minimal item pool on high damage

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -10,7 +10,7 @@ from decimal import Decimal, ROUND_HALF_UP
 
 
 #This file sets the item pools for various modes. Timed modes and triforce hunt are enforced first, and then extra items are specified per mode to fill in the remaining space.
-#Some basic items that various modes require are placed here, including stones and medallions. Medallion requirements for the two relevant entrances are also decided.
+#Some basic items that various modes require are placed here, including stones and medallions. 
 
 
 alwaysitems = ([

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -10,7 +10,7 @@ from decimal import Decimal, ROUND_HALF_UP
 
 
 #This file sets the item pools for various modes. Timed modes and triforce hunt are enforced first, and then extra items are specified per mode to fill in the remaining space.
-#Some basic items that various modes require are placed here, including pendants and crystals. Medallion requirements for the two relevant entrances are also decided.
+#Some basic items that various modes require are placed here, including stones and medallions. Medallion requirements for the two relevant entrances are also decided.
 
 
 alwaysitems = ([
@@ -1322,6 +1322,9 @@ def get_pool_core(world):
 
     for item,max in item_difficulty_max[world.item_pool_value].items():
         replace_max_item(pool, item, max)
+
+    if world.damage_multiplier in ['ohko', 'quadruple'] and world.item_pool_value == 'minimal':
+        pending_junk_pool.append ('Nayrus Love')
 
     world.distribution.alter_pool(world, pool)
 


### PR DESCRIPTION
Currently, Nayru's Love is completely removed from the item pool when set to minimal. This is fine on most damage multipliers and suits the nature of minimal item pool quite well, but can be problematic on OHKO and quad damage, something that was noticed during a random settings league match. Also fixing a comment that seems to have been copy pasted from ALTTPR code that I noticed and was bugging me.