### PR TITLE
Fix pending junk items when junk ice traps off

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1334,7 +1334,7 @@ def get_pool_core(world):
                     pending_junk_pool.remove(item)
                 # Remove pending junk already added to the pool by alter_pool from the pending_junk_pool
                 if item in pool:
-                    count = pool.count(item)
+                    count = min(pool.count(item), pending_junk_pool.count(item))
                     for _ in range(count):
                         pending_junk_pool.remove(item)
 

--- a/Unittest.py
+++ b/Unittest.py
@@ -235,7 +235,8 @@ class TestPlandomizer(unittest.TestCase):
             "plando-num-bottles-fountain-closed-good",
             "plando-num-bottles-fountain-open-good",
             "plando-change-triforce-piece-count",
-            "plando-use-normal-triforce-piece-count"
+            "plando-use-normal-triforce-piece-count",
+            "no-ice-trap-pending-junk",
         ]
         for filename in filenames:
             with self.subTest(filename):
@@ -259,6 +260,7 @@ class TestPlandomizer(unittest.TestCase):
             "plando-item-pool-matches-items-placed-after-starting-items-replaced",
             "plando-change-triforce-piece-count",
             "plando-use-normal-triforce-piece-count",
+            "no-ice-trap-pending-junk",
         ]
         for filename in filenames:
             with self.subTest(filename + " pool accuracy"):

--- a/tests/plando/no-ice-trap-pending-junk.json
+++ b/tests/plando/no-ice-trap-pending-junk.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "triforce_hunt": true,
+    "triforce_goal_per_world": 5,
+    "junk_ice_traps": "off"
+  },
+  "item_pool": {
+    "Triforce Piece": 10
+  }
+}


### PR DESCRIPTION
Pending junk items are used to fill in the holes that turning off junk_ice_traps creates. This causes a discrepancy for Triforce Hunt plandos with a certain number of Triforce Pieces.

This seems to happen because the pending_junk_pool normally expects only 1 or maybe at maximum 2 of an item to exist within itself. Removing Ice Traps will cause those items to disappear from pending_junk_pool entirely so no count mismatch occurs. With Triforce Pieces, many get added to the pending_junk_pool, then some of them can get removed from there by removing ice traps.

Now some of the pending_junk_pool has been used. If the number of pieces in the junk_item_pool is more than the item_pool plando value, they are pruned from pending_junk_pool to match making the two values equivalent. This is extremely common because extra Triforce Pieces are normally added. However, if the item_pool value is significantly higher than the required per world setting this is skipped and the number of Triforce Pieces in the pending_junk_pool and in the item pool are now mismatched. This causes an error when trying to remove pool.count(item) Triforce Pieces from pending_junk_pool as you now try to remove an item from a list that does not contain that item.

This fix simply uses the minimum of pool.count(item) and pending_junk_pool.count(item) to remove from the pending_junk_pool. Alternatively you could filter the list since python does not have an equivalent of a removeAll from what I know, but I feel this is easier to understand.

I don't believe this should ever interfere with normal generation, and I don't think it should have any ill effects on plando generations.