### PR TITLE
Fix disabled songs

### DIFF
--- a/Unittest.py
+++ b/Unittest.py
@@ -235,7 +235,8 @@ class TestPlandomizer(unittest.TestCase):
             "plando-num-bottles-fountain-closed-good",
             "plando-num-bottles-fountain-open-good",
             "plando-change-triforce-piece-count",
-            "plando-use-normal-triforce-piece-count"
+            "plando-use-normal-triforce-piece-count",
+            "disabled-song-location",
         ]
         for filename in filenames:
             with self.subTest(filename):

--- a/tests/plando/disabled-song-location.json
+++ b/tests/plando/disabled-song-location.json
@@ -1,0 +1,7 @@
+{
+  "settings": {
+    "disabled_locations": [
+      "Song from Ocarina of Time"
+    ]
+  }
+}


### PR DESCRIPTION
Rework how item groups are handled in plandomizer. Item groups should be directly used with get_item as long as some item in the item_pool is also in the item_group still instead of adding all valid items in the group to the valid_items list individually.

This will fix #Junk song locations pulling a Junk item instead of a JunkSong before the check for switching #Junk to #JunkSong can be made.
