### PR TITLE
Change exit() to sys.exit()

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -7,7 +7,7 @@ for i,v in enumerate(min_python_version):
     if sys.version_info[i] < v:
         print("Randomizer requires at least version 3.6 and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
         raw_input("Press enter to exit...")
-        exit(1)
+        sys.exit(1)
     if sys.version_info[i] > v:
         break
 


### PR DESCRIPTION
`exit()` is created by the `site` module and [is intended for use in the REPL only](https://docs.python.org/3.8/library/constants.html#constants-added-by-the-site-module), and the other two comparable calls (in `OoTRandomizer.py` and `Settings.py`) already use `sys.exit()`. This is mostly a style/consistency change, but it also ensures correct behavior when the script is run with the `-S` flag.