### PR TITLE
Removed biggoron sword from the scarce item pool

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -95,6 +95,7 @@ item_difficulty_max = {
         'Bombchus (10)': 2,
         'Bombchus (20)': 0,
         'Magic Meter': 1, 
+        'Biggoron Sword': 0,
         'Double Defense': 0, 
         'Deku Stick Capacity': 1, 
         'Deku Nut Capacity': 1, 


### PR DESCRIPTION
I was looking for some way to increase enemies defence, but thought a nice compromise might just be to remove the Biggoron Sword from the Scarce item pool.

Just finished a play-thru on this (also: tokensanity, shopsanity, hero mode, double-damage) and it was very rewarding. I legit struggled during the final battle.

Couldn't find any previous discussion about whether Biggoron Sword belongs in the Scarce pool, but I did find this semi-related ticket. https://github.com/TestRunnerSRL/OoT-Randomizer/issues/103

Won't be upset if you decide against merging it :)

Love your work!