### PR TITLE
Remove the fake key from water temple logic.

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1294,8 +1294,6 @@ def get_pool_core(world):
 
     if not world.keysanity and not world.dungeon_mq['Fire Temple']:
         world.state.collect(ItemFactory('Small Key (Fire Temple)'))
-    if not world.dungeon_mq['Water Temple']:
-        world.state.collect(ItemFactory('Small Key (Water Temple)'))
 
     if world.triforce_hunt:
         triforce_count = int((TriforceCounts[world.item_pool_value] * world.triforce_goal_per_world).to_integral_value(rounding=ROUND_HALF_UP))

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -8,10 +8,10 @@
             "Boss Area": "can_use(Longshot) or can_hover or (can_use(Hover_Boots) and (can_mega or Megaton_Hammer))",
             "Dark Link Area": "(at('High Alcove', can_play(Zeldas_Lullaby)) or 
                     (can_use(Hover_Boots) and (can_mega or Megaton_Hammer)))
-                and (Small_Key_Water_Temple,5)",
+                and (Small_Key_Water_Temple, 4)",
             "Under Entrance Block": "can_use(Hookshot) and Iron_Boots",
             "Central Pillar from Lobby": "can_use(Hookshot) and Iron_Boots and
-                (Small_Key_Water_Temple,5)",
+                (Small_Key_Water_Temple, 4)",
             "Compass Room": "can_use(Iron_Boots) and can_use(Hookshot)",
             "Ruto Column": "can_use(Iron_Boots) or can_use(Longshot) or can_jumpslash"
         }
@@ -27,7 +27,7 @@
             "Caged Skulltula": "is_adult",
             "Dragon Head Area": "is_adult",
             "Boss Key Area": "is_adult and 
-                (Small_Key_Water_Temple,5)
+                (Small_Key_Water_Temple, 4)
                 and (can_use(Longshot) or can_hover or Hover_Boots)",
             "Boss Area": "can_play(Zeldas_Lullaby) and can_use(Longshot)",
             "Water Temple Lobby": "can_play(Zeldas_Lullaby)"
@@ -68,9 +68,9 @@
         },
         "exits": {
             "Central Pillar": "can_play(Zeldas_Lullaby) and 
-                ((Small_Key_Water_Temple,6)
+                ((Small_Key_Water_Temple, 5)
                 or here(is_child and can_use(Sticks)) or has_fire_source or can_use(Bow))",
-            "Boss Key Area": "(Small_Key_Water_Temple,5) and
+            "Boss Key Area": "(Small_Key_Water_Temple, 4) and
                 (can_use(Longshot) or can_hover or can_use(Hover_Boots)) and can_play(Zeldas_Lullaby)",
             "Dragon Head Area": "Progressive_Strength_Upgrade and (is_adult or can_child_attack) and can_play(Zeldas_Lullaby)",
             "Caged Skulltula": "has_explosives and can_play(Zeldas_Lullaby)",
@@ -112,7 +112,7 @@
         "region_name": "Boss Key Area",
         "dungeon": "Water Temple",
         "locations": {
-            "Water Temple Boss Key Chest": "(Small_Key_Water_Temple,6) and
+            "Water Temple Boss Key Chest": "(Small_Key_Water_Temple, 5) and
                 (is_adult or can_hover)",
             "Water Temple GS Near Boss Key Chest": "(is_adult or can_hover) and
                 (can_use(Hookshot) or can_use(Boomerang) or can_mega)"

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -31,7 +31,7 @@
             "Fairy Pot": "has_bottle and can_use(Longshot)"
         },
         "exits": {
-            "Water Temple Falling Platform Room": "(Small_Key_Water_Temple, 5)"
+            "Water Temple Falling Platform Room": "(Small_Key_Water_Temple, 4)"
         }
     },
     {
@@ -56,12 +56,12 @@
             "Water Temple GS Central Pillar": "
                 can_play(Zeldas_Lullaby) and
                     (((can_use(Longshot) or (logic_water_central_gs_fw and can_use(Hookshot) and can_use(Farores_Wind))) and 
-                        ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))) or
+                        ((Small_Key_Water_Temple, 5) or can_use(Bow) or can_use(Dins_Fire))) or
                     (logic_water_central_gs_irons and can_use(Hookshot) and can_use(Iron_Boots) and
                         (can_use(Bow) or can_use(Dins_Fire))) or
                     (logic_water_central_gs_fw and Child_Water_Temple and Boomerang and can_use(Farores_Wind) and
                         (Sticks or can_use(Dins_Fire) or
-                        ((Small_Key_Water_Temple, 6) and (can_use(Hover_Boots) or can_use(Bow))))))"
+                        ((Small_Key_Water_Temple, 5) and (can_use(Hover_Boots) or can_use(Bow))))))"
         },
         "exits": {
             "Water Temple Cracked Wall": "
@@ -69,11 +69,11 @@
                 (logic_water_cracked_wall_nothing or (logic_water_cracked_wall_hovers and can_use(Hover_Boots)))",
             "Water Temple Middle Water Level": "
                 (Bow or can_use(Dins_Fire) or
-                    ((Small_Key_Water_Temple, 6) and can_use(Hookshot)) or
+                    ((Small_Key_Water_Temple, 5) and can_use(Hookshot)) or
                     (Child_Water_Temple and Sticks)) and
                 can_play(Zeldas_Lullaby)",
             "Water Temple North Basement": "
-                (Small_Key_Water_Temple, 5) and
+                (Small_Key_Water_Temple, 4) and
                 (can_use(Longshot) or (logic_water_boss_key_region and can_use(Hover_Boots))) and
                 (can_use(Iron_Boots) or can_play(Zeldas_Lullaby))",
             "Water Temple Dragon Statue": "
@@ -88,14 +88,14 @@
         "dungeon": "Water Temple",
         "locations": {
             "Water Temple Boss Key Chest": "
-                (Small_Key_Water_Temple, 6) and 
+                (Small_Key_Water_Temple, 5) and 
                 (logic_water_bk_jump_dive or can_use(Iron_Boots)) and
                 (logic_water_north_basement_ledge_jump or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)",
             "Water Temple GS Near Boss Key Chest": "True",
                 # Longshot just reaches without the need to actually go near,
                 # Otherwise you have hovers and just hover over and collect with a jump slash
             "Fairy Pot": "
-                has_bottle and (Small_Key_Water_Temple, 6) and 
+                has_bottle and (Small_Key_Water_Temple, 5) and 
                 (logic_water_bk_jump_dive or can_use(Iron_Boots)) and
                 (logic_water_north_basement_ledge_jump or (has_explosives and Progressive_Strength_Upgrade) or Hover_Boots)"
         }
@@ -120,7 +120,7 @@
         "locations": {
             "Water Temple Central Pillar Chest": "
                 can_use(Iron_Boots) and can_use(Zora_Tunic) and can_use(Hookshot) and 
-                ((Small_Key_Water_Temple, 6) or can_use(Bow) or can_use(Dins_Fire))"
+                ((Small_Key_Water_Temple, 5) or can_use(Bow) or can_use(Dins_Fire))"
         },
         "exits": {
             "Water Temple Cracked Wall": "True"
@@ -136,7 +136,7 @@
                 (logic_water_falling_platform_gs_boomerang and can_use(Boomerang))"
         },
         "exits": {
-            "Water Temple Dark Link Region": "(Small_Key_Water_Temple, 6) and can_use(Hookshot)"
+            "Water Temple Dark Link Region": "(Small_Key_Water_Temple, 5) and can_use(Hookshot)"
         }
     },
     {


### PR DESCRIPTION
This key only exists in logic. It's not real, and doesn't appear anywhere in game.

There's just no real reason to keep it around, since it's functionally *identical* to just having the key counts in water be reduced by one. The fire one is justified because that's actually tied to settings, but the only setting that took this fake key out of logic for water was turning MQ on...which already uses a separate set of logic files, meaning the key count is always the exact same whenever this logic file is being used, meaning this ends up saving _no_ space and simplifies absolutely nothing.

It's also confusing for anyone reading the logic files, since they'll end up assuming you need one more key than rando says you have to, and I don't think anyone wants to keep explaining what a "fake logical key" is.

I fixed this confusion by removing the lines that give you the fake key, and by reducing the key count for each door in water temple by 1 to compensate. This *should* be functionally the exact same as it is on live, and the only noticeable change should be to anyone who's reading the logic files.