### PR TITLE
Remove “same hint area” requirements if all hints are off

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -731,7 +731,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
                 if not max_search.visited(location):
                     raise EntranceShuffleError('%s is unreachable' % location.name)
 
-    if world.shuffle_interior_entrances and \
+    if world.shuffle_interior_entrances and (world.misc_hints or world.hints != 'none') and \
        (entrance_placed == None or entrance_placed.type in ['Interior', 'SpecialInterior']):
         # Ensure Kak Potion Shop entrances are in the same hint area so there is no ambiguity as to which entrance is used for hints
         potion_front_entrance = get_entrance_replacing(world.get_region('Kak Potion Shop Front'), 'Kakariko Village -> Kak Potion Shop Front')

--- a/Main.py
+++ b/Main.py
@@ -191,7 +191,7 @@ def make_spoiler(settings, worlds, window=dummy_window()):
         update_required_items(spoiler)
         buildGossipHints(spoiler, worlds)
         window.update_progress(55)
-    else:
+    elif settings.misc_hints:
         # Ganon may still provide the Light Arrows hint
         find_light_arrows(spoiler)
     spoiler.build_file_hash()


### PR DESCRIPTION
This removes the “same hint area” requirements for the potion shop and Impa's house when all hints (including Ganondorf's light arrows hint) are off.

Second attempt at #1248 because GitHub erroneously detected that one as merged.