### PR TITLE
Add missing edge from spirit child before locked door to spirit child

### DIFF
--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -38,6 +38,7 @@
             "Nut Crate": "True"
         },
         "exits": {
+            "Child Spirit Temple": "is_child",
             "Child Spirit Temple Climb": "(Small_Key_Spirit_Temple, 1)"
         }
     },


### PR DESCRIPTION
There is a missing edge leading from the region in child spirit after the crawlspace but before the locked door (containing the nut crate) to the main child spirit region. This doesn't affect logic at all since child can freely savewarp and go back to the child spirit region from the before door region, but the exit should be there for consistency. This edge missing could also potentially have an affect on the area sphere alg.

Thanks to LarsP for pointing this out.