### PR TITLE
Add MW2 hint distribution

### DIFF
--- a/data/Hints/mw2.json
+++ b/data/Hints/mw2.json
@@ -1,0 +1,137 @@
+{
+    "name": "mw2",
+    "gui_name": "MW Season 2",
+    "description": "Hints used for the multi-world tournament season 2.",
+    "add_locations": [
+        {
+            "location": "Song from Ocarina of Time",
+            "types": [
+                "always"
+            ]
+        },
+        {
+            "location": "Deku Theater Skull Mask",
+            "types": [
+                "always"
+            ]
+        },
+        {
+            "location": "DMC Deku Scrub",
+            "types": [
+                "always"
+            ]
+        }
+    ],
+    "remove_locations": [
+        {
+            "location": "Haunted Wasteland",
+            "types": [
+                "barren"
+            ]
+        },
+        {
+            "location": "Hyrule Castle",
+            "types": [
+                "barren"
+            ]
+        },
+        {
+            "location": "outside Ganon's Castle",
+            "types": [
+                "barren"
+            ]
+        }
+    ],
+    "add_items": [],
+    "remove_items": [
+        {
+            "item": "Zeldas Lullaby",
+            "types": [
+                "woth"
+            ]
+        }
+    ],
+    "dungeons_woth_limit": 3,
+    "dungeons_barren_limit": 1,
+    "named_items_required": true,
+    "distribution": {
+        "trial": {
+            "order": 1,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "always": {
+            "order": 2,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "woth": {
+            "order": 3,
+            "weight": 0.0,
+            "fixed": 7,
+            "copies": 2
+        },
+        "barren": {
+            "order": 4,
+            "weight": 0.0,
+            "fixed": 3,
+            "copies": 2
+        },
+        "entrance": {
+            "order": 5,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "sometimes": {
+            "order": 6,
+            "weight": 0.0,
+            "fixed": 100,
+            "copies": 2
+        },
+        "random": {
+            "order": 7,
+            "weight": 9.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "item": {
+            "order": 0,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "song": {
+            "order": 0,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "overworld": {
+            "order": 0,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "dungeon": {
+            "order": 0,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "junk": {
+            "order": 0,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        },
+        "named-item": {
+            "order": 8,
+            "weight": 0.0,
+            "fixed": 0,
+            "copies": 2
+        }
+    }
+}


### PR DESCRIPTION
Adds a new hint distribution used for the multi-world tournament season 2.

Always hints:
- adds OoT song (in case settings would make it sometimes)
- adds Skull Mask
- adds DMC Scrub
- removes ZL

Foolish hints:
- removes Wasteland
- removes Hyrule Castle
- removes OGC

7 WotH (3 dungeon limit), 3 foolish (1 dungeon limit)