### PR TITLE
Fixes for plando shop prices

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -642,7 +642,7 @@ class Shop_Item():
         bytes += int_to_bytes(self.object, 2)
         bytes += int_to_bytes(self.model, 2)
         bytes += int_to_bytes(self.func1, 4)
-        bytes += int_to_bytes(self.price, 2)
+        bytes += int_to_bytes(self.price, 2, signed=True)
         bytes += int_to_bytes(self.pieces, 2)
         bytes += int_to_bytes(self.description_message, 2)
         bytes += int_to_bytes(self.purchase_message, 2)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -772,7 +772,6 @@ class WorldDistribution(object):
             item = self.get_item(ignore_pools, item_pools, location, player_id, record, worlds)
 
             if record.price is not None and item.type != 'Shop':
-                location.price = record.price
                 world.shop_prices[location.name] = record.price
 
             if location.type == 'Song' and item.type != 'Song':

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -771,9 +771,6 @@ class WorldDistribution(object):
 
             item = self.get_item(ignore_pools, item_pools, location, player_id, record, worlds)
 
-            if record.price is not None and item.type != 'Shop':
-                world.shop_prices[location.name] = record.price
-
             if location.type == 'Song' and item.type != 'Song':
                 self.song_as_items = True
             location.world.push_item(location, item, True)

--- a/Rules.py
+++ b/Rules.py
@@ -33,9 +33,12 @@ def set_rules(world):
                 # If price was specified in plando, use it here so access rule is set correctly.
                 if location.name in world.distribution.locations and world.distribution.locations[location.name].price is not None:
                     price = world.distribution.locations[location.name].price
-                    if price > 999 and price < 32768: # Cap positive values above 999 so that they're not impossible
+                    if price > 999: # Cap positive values above 999 so that they're not impossible.
                         world.distribution.locations[location.name].price = 999
                         price = 999
+                    elif price < -32768: # Prices below this will error on patching.
+                        world.distribution.locations[location.name].price = -32768
+                        price = -32768
                     location.price = price
                     world.shop_prices[location.name] = price
                 location.add_rule(create_shop_rule(location))

--- a/Rules.py
+++ b/Rules.py
@@ -68,8 +68,6 @@ def set_rules(world):
 
 def create_shop_rule(location):
     def required_wallets(price):
-        if price > 32767: # Price will be too high and player can get item with any wallet or rupee amount.
-            return 0
         if price > 500:
             return 3
         if price > 200:

--- a/Rules.py
+++ b/Rules.py
@@ -63,6 +63,8 @@ def set_rules(world):
 
 def create_shop_rule(location):
     def required_wallets(price):
+        if price > 32767: # Price will be too high and player can get item with any wallet or rupee amount.
+            return 0
         if price > 500:
             return 3
         if price > 200:

--- a/Rules.py
+++ b/Rules.py
@@ -32,8 +32,12 @@ def set_rules(world):
                 location.price = world.shop_prices[location.name]
                 # If price was specified in plando, use it here so access rule is set correctly.
                 if location.name in world.distribution.locations and world.distribution.locations[location.name].price is not None:
-                    location.price = world.distribution.locations[location.name].price
-                    world.shop_prices[location.name] = world.distribution.locations[location.name].price
+                    price = world.distribution.locations[location.name].price
+                    if price > 999 and price < 32768: # Cap positive values above 999 so that they're not impossible
+                        world.distribution.locations[location.name].price = 999
+                        price = 999
+                    location.price = price
+                    world.shop_prices[location.name] = price
                 location.add_rule(create_shop_rule(location))
             else:
                 add_item_rule(location, lambda location, item: item.type == 'Shop' and item.world.id == location.world.id)

--- a/Rules.py
+++ b/Rules.py
@@ -33,6 +33,7 @@ def set_rules(world):
                 # If price was specified in plando, use it here so access rule is set correctly.
                 if location.name in world.distribution.locations and world.distribution.locations[location.name].price is not None:
                     location.price = world.distribution.locations[location.name].price
+                    world.shop_prices[location.name] = world.distribution.locations[location.name].price
                 location.add_rule(create_shop_rule(location))
             else:
                 add_item_rule(location, lambda location, item: item.type == 'Shop' and item.world.id == location.world.id)

--- a/Rules.py
+++ b/Rules.py
@@ -30,6 +30,9 @@ def set_rules(world):
             if location.name in world.shop_prices:
                 add_item_rule(location, lambda location, item: item.type != 'Shop')
                 location.price = world.shop_prices[location.name]
+                # If price was specified in plando, use it here so access rule is set correctly.
+                if location.name in world.distribution.locations and world.distribution.locations[location.name].price is not None:
+                    location.price = world.distribution.locations[location.name].price
                 location.add_rule(create_shop_rule(location))
             else:
                 add_item_rule(location, lambda location, item: item.type == 'Shop' and item.world.id == location.world.id)


### PR DESCRIPTION
This addresses two issues with plando'd shop prices:

1) **(Much more critical)** When calculating access rules for shop locations, the prices set in the plando were not considered, only the default prices for a given location. This completely broke logic for plando'd shop locations.

2) As dotzo discovered, you can plando in prices up to 0xFFFF (above that and generation will fail) since we represent prices as an unsigned halfword. Because the value is signed in the actual game, prices up to 0x7FFF will work properly (and be impossible to buy if they are above 999). However, prices above 0x7FFF will be considered negative, and thus the player can purchase them with any wallet or rupee amount. Rather than limit the plando to cap prices at a reasonable value like 999, we thought it'd be more fun to allow plando makers to set such high prices and allow the player to get them with no wallet upgrades. So this was added to the rule calculation.

Note: If the number for a price above 0x7FFF is odd (LSB is 1) it will give the player max rupees, if it's even it will take all their rupees, but they will receive the item either way.