### PR TITLE
Add support for custom item groups

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -919,8 +919,7 @@ class Distribution(object):
             **item_groups,
         } 
         if self.src_dict and 'custom_groups' in self.src_dict:
-            for custom_group in self.src_dict['custom_groups']:
-                self.search_groups[custom_group] = self.src_dict['custom_groups'][custom_group]
+            self.search_groups.update(self.src_dict['custom_groups'])
         
         self.world_dists = [WorldDistribution(self, id) for id in range(settings.world_count)]
         # One-time init

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -41,12 +41,6 @@ per_world_keys = (
 )
 
 
-search_groups = {
-    **location_groups,
-    **item_groups,
-}
-
-
 def SimpleRecord(props):
     class Record(object):
         def __init__(self, src_dict=None):
@@ -279,7 +273,7 @@ class WorldDistribution(object):
         if invert:
             pattern = pattern[1:]
         if pattern.startswith('#'):   
-            group = search_groups[pattern[1:]]
+            group = self.distribution.search_groups[pattern[1:]]
             if pattern == '#MajorItem':
                 if not self.major_group: # If necessary to compute major_group, do so only once
                     self.major_group = [item for item in group if item in self.base_pool]
@@ -920,6 +914,14 @@ class Distribution(object):
     def __init__(self, settings, src_dict=None):
         self.src_dict = src_dict or {}
         self.settings = settings
+        self.search_groups = {
+            **location_groups,
+            **item_groups,
+        } 
+        if self.src_dict and 'custom_groups' in self.src_dict:
+            for custom_group in self.src_dict['custom_groups']:
+                self.search_groups[custom_group] = self.src_dict['custom_groups'][custom_group]
+        
         self.world_dists = [WorldDistribution(self, id) for id in range(settings.world_count)]
         # One-time init
         update_dict = {


### PR DESCRIPTION
Adds support for custom item groups within plando. For example, here is a now valid plando file:

```json
{
  "custom_groups": {
    "CustomList1": [ "Kokiri Sword", "Biggoron Sword", "Giants Knife" ],
    "CustomList2": [ "Small Key (Water Temple)", "Small Key (Shadow Temple)" ]
  },
  "locations": {
    "KF Midos Top Left Chest": "#CustomList1",
    "KF Midos Top Right Chest": "#CustomList2"
  }
}
```

And in the spoiler:

```json
"KF Midos Top Left Chest":                               "Biggoron Sword",
"KF Midos Top Right Chest":                              "Small Key (Water Temple)",
```

custom_groups will be read in and each group in the list will be added to search_groups. To accomodate this, search_groups was made a property of the Distribution class.

Note that we assume the plando maker knows what they're doing so we allow them to "break" their settings, for example, even if keys are set to dungeon only we'll allow them to place keys outside their dungeon if listed within an item group, the same way they can place a specific key outside its dungeon.