### PR TITLE
Like Like locations

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -858,6 +858,36 @@ def get_pool_core(world):
         if world.dungeon_mq['Jabu Jabus Belly']:
             placed_items['Jabu Jabus Belly MQ Cow'] = 'Milk'
 
+    if False:
+        if world.dungeon_mq['Jabu Jabus Belly']:
+            pool.extend('Hylian Shield')
+        if not world.dungeon_mq['Fire Temple']:
+            pool.extend(['Hylian Shield'] * 2)
+        if not world.dungeon_mq['Water Temple']:
+            pool.extend('Hylian Shield')
+        if not world.dungeon_mq['Spirit Temple']:
+            pool.extend(['Hylian Shield'] * 2)
+        if world.dungeon_mq['Shadow Temple']:
+            pool.extend(['Hylian Shield'] * 2)
+        if not world.dungeon_mq['Ganons Castle']:
+            pool.extend('Hylian Shield')
+    else:
+        if world.dungeon_mq['Jabu Jabus Belly']:
+            placed_items['Jabu Jabus Belly MQ Near Boss Like Likes'] = 'Hylian Shield'
+        if not world.dungeon_mq['Fire Temple']:
+            placed_items['Fire Temple Boss Key Loop Like Like'] = 'Hylian Shield'
+            placed_items['Fire Temple Song of Time Room Like Like'] = 'Hylian Shield'
+        if not world.dungeon_mq['Water Temple']:
+            placed_items['Water Temple Like Like'] = 'Hylian Shield'
+        if not world.dungeon_mq['Spirit Temple']:
+            placed_items['Spirit Temple Early Adult Like Like'] = 'Hylian Shield'
+            placed_items['Spirit Temple First Mirror Like Like'] = 'Hylian Shield'
+        if world.dungeon_mq['Shadow Temple']:
+            placed_items['Shadow Temple MQ Invisible Blades Like Like'] = 'Hylian Shield'
+            placed_items['Shadow Temple MQ Invisible Maze Like Like'] = 'Hylian Shield'
+        if not world.dungeon_mq['Ganons Castle']:
+            placed_items['Ganons Castle Shadow Trial Like Like'] = 'Hylian Shield'
+
     if world.shuffle_beans:
         if world.distribution.get_starting_item('Magic Bean') < 10:
             pool.append('Magic Bean Pack')

--- a/LocationList.py
+++ b/LocationList.py
@@ -457,6 +457,7 @@ location_table = OrderedDict([
     ("Jabu Jabus Belly MQ GS Tailpasaran Room",             ("GS Token",    0x02,  0x04, None,                 ("Jabu Jabu's Belly", "Skulltulas",))),
     ("Jabu Jabus Belly MQ GS Invisible Enemies Room",       ("GS Token",    0x02,  0x08, None,                 ("Jabu Jabu's Belly", "Skulltulas",))),
     ("Jabu Jabus Belly MQ GS Near Boss",                    ("GS Token",    0x02,  0x02, None,                 ("Jabu Jabu's Belly", "Skulltulas",))),
+    ("Jabu Jabus Belly MQ Near Boss Like Likes",            ("LikeLike",    0x02,  0x05, None,                 ("Jabu Jabu's Belly", "Like Like",))),
     # Jabu Jabu's Belly shared
     ("Jabu Jabus Belly Barinade Heart",                     ("BossHeart",   0x13,  0x4F, None,                 ("Jabu Jabu's Belly",))),
 
@@ -549,6 +550,8 @@ location_table = OrderedDict([
     ("Fire Temple GS Boulder Maze",                         ("GS Token",    0x04,  0x04, None,                 ("Fire Temple", "Skulltulas",))),
     ("Fire Temple GS Scarecrow Climb",                      ("GS Token",    0x04,  0x10, None,                 ("Fire Temple", "Skulltulas",))),
     ("Fire Temple GS Scarecrow Top",                        ("GS Token",    0x04,  0x08, None,                 ("Fire Temple", "Skulltulas",))),
+    ("Fire Temple Boss Key Loop Like Like",                 ("LikeLike",    0x04,  0x12, None,                 ("Fire Temple", "Like Like",))),
+    ("Fire Temple Song of Time Room Like Like",             ("LikeLike",    0x04,  0x13, None,                 ("Fire Temple", "Like Like",))),
     # Fire Temple MQ
     ("Fire Temple MQ Map Room Side Chest",                  ("Chest",       0x04,  0x02, None,                 ("Fire Temple",))),
     ("Fire Temple MQ Megaton Hammer Chest",                 ("Chest",       0x04,  0x00, None,                 ("Fire Temple",))),
@@ -586,6 +589,7 @@ location_table = OrderedDict([
     ("Water Temple GS Central Pillar",                      ("GS Token",    0x05,  0x04, None,                 ("Water Temple", "Skulltulas",))),
     ("Water Temple GS Falling Platform Room",               ("GS Token",    0x05,  0x02, None,                 ("Water Temple", "Skulltulas",))),
     ("Water Temple GS River",                               ("GS Token",    0x05,  0x10, None,                 ("Water Temple", "Skulltulas",))),
+    ("Water Temple Like Like",                              ("LikeLike",    0x05,  0x06, None,                 ("Water Temple", "Like Like",))),
     # Water Temple MQ
     ("Water Temple MQ Longshot Chest",                      ("Chest",       0x05,  0x00, None,                 ("Water Temple",))),
     ("Water Temple MQ Map Chest",                           ("Chest",       0x05,  0x02, None,                 ("Water Temple",))),
@@ -650,6 +654,8 @@ location_table = OrderedDict([
     ("Shadow Temple MQ GS After Wind",                      ("GS Token",    0x07,  0x08, None,                 ("Shadow Temple", "Skulltulas",))),
     ("Shadow Temple MQ GS After Ship",                      ("GS Token",    0x07,  0x10, None,                 ("Shadow Temple", "Skulltulas",))),
     ("Shadow Temple MQ GS Near Boss",                       ("GS Token",    0x07,  0x04, None,                 ("Shadow Temple", "Skulltulas",))),
+    ("Shadow Temple MQ Invisible Blades Like Like",         ("LikeLike",    0x07,  0x10, None,                 ("Shadow Temple", "Like Like",))),
+    ("Shadow Temple MQ Invisible Maze Like Like",           ("LikeLike",    0x07,  0x0F, None,                 ("Shadow Temple", "Like Like",))),
     # Shadow Temple shared
     ("Shadow Temple Bongo Bongo Heart",                     ("BossHeart",   0x18,  0x4F, None,                 ("Shadow Temple",))),
 
@@ -707,6 +713,9 @@ location_table = OrderedDict([
     ("Spirit Temple MQ GS Symphony Room",                   ("GS Token",    0x06,  0x08, None,                 ("Spirit Temple", "Skulltulas",))),
     ("Spirit Temple MQ GS Nine Thrones Room West",          ("GS Token",    0x06,  0x04, None,                 ("Spirit Temple", "Skulltulas",))),
     ("Spirit Temple MQ GS Nine Thrones Room North",         ("GS Token",    0x06,  0x10, None,                 ("Spirit Temple", "Skulltulas",))),
+
+    ("Spirit Temple Early Adult Like Like",                 ("LikeLike",    0x06,  0x0C, None,                 ("Spirit Temple", "Like Like",))),
+    ("Spirit Temple First Mirror Like Like",                ("LikeLike",    0x06,  0x0F, None,                 ("Spirit Temple", "Like Like",))),
 
     ("Spirit Temple Twinrova Heart",                        ("BossHeart",   0x17,  0x4F, None,                 ("Spirit Temple",))),
 
@@ -789,6 +798,7 @@ location_table = OrderedDict([
     ("Ganons Castle Deku Scrub Center-Left",                ("NPC",         0x0D,  0x37, None,                 ("Ganon's Castle", "Deku Scrub",))),
     ("Ganons Castle Deku Scrub Center-Right",               ("NPC",         0x0D,  0x33, None,                 ("Ganon's Castle", "Deku Scrub",))),
     ("Ganons Castle Deku Scrub Right",                      ("NPC",         0x0D,  0x39, None,                 ("Ganon's Castle", "Deku Scrub",))),
+    ("Ganons Castle Shadow Trial Like Like",                ("LikeLike",    0x0D,  0x0C, None,                 ("Ganon's Castle", "Like Like",))),
     # Ganon's Castle MQ
     ("Ganons Castle MQ Forest Trial Freestanding Key",      ("Collectable", 0x0D,  0x01, None,                 ("Ganon's Castle",))),
     ("Ganons Castle MQ Forest Trial Eye Switch Chest",      ("Chest",       0x0D,  0x02, None,                 ("Ganon's Castle",))),

--- a/data/Glitched World/Fire Temple.json
+++ b/data/Glitched World/Fire Temple.json
@@ -15,7 +15,9 @@
                 (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer) and 
                 (Boss_Key_Fire_Temple or at('Fire Temple Flame Maze', True))",
             "Fire Temple GS Boss Key Loop": "
-                ((Small_Key_Fire_Temple, 8) or not keysanity)"
+                ((Small_Key_Fire_Temple, 8) or not keysanity)",
+            "Fire Temple Boss Key Loop Like Like": "
+                ((Small_Key_Fire_Temple, 8) or not keysanity) and can_feed_like_like"
         },
         "exits": {
             "Fire Temple Big Lava Room":"(Small_Key_Fire_Temple, 2)"
@@ -27,7 +29,8 @@
         "locations": {
             "Fire Temple Big Lava Room Lower Open Door Chest": "True",
             "Fire Temple Big Lava Room Blocked Door Chest": "has_explosives",
-            "Fire Temple GS Song of Time Room": "is_adult"
+            "Fire Temple GS Song of Time Room": "is_adult",
+            "Fire Temple Song of Time Room Like Like": "is_adult and can_feed_like_like"
         },
         "exits": {
             "Fire Temple Lower":  "True",

--- a/data/Glitched World/Ganons Castle.json
+++ b/data/Glitched World/Ganons Castle.json
@@ -73,6 +73,11 @@
             "Ganons Castle Shadow Trial Golden Gauntlets Chest": "(has_bombchus and can_isg) or 
                 (has_explosives and Hover_Boots and can_shield) or
                 ( (can_use(Longshot) and (Hover_Boots or can_use(Dins_Fire))) 
+                    or can_use(Fire_Arrows) )",
+            "Ganons Castle Shadow Trial Like Like": "
+                can_feed_like_like and (has_bombchus and can_isg) or 
+                (has_explosives and Hover_Boots and can_shield) or
+                ( (can_use(Longshot) and (Hover_Boots or can_use(Dins_Fire))) 
                     or can_use(Fire_Arrows) )"
         }
     },

--- a/data/Glitched World/Jabu Jabus Belly MQ.json
+++ b/data/Glitched World/Jabu Jabus Belly MQ.json
@@ -52,6 +52,7 @@
             "Jabu Jabus Belly MQ Near Boss Chest": "True",
             "Jabu Jabus Belly Barinade Heart": "True",
             "Barinade": "True",
+            "Jabu Jabus Belly MQ Near Boss Like Likes": "can_feed_like_like",
             "Jabu Jabus Belly MQ GS Near Boss": "True"
         },
         "exits": {

--- a/data/Glitched World/Shadow Temple MQ.json
+++ b/data/Glitched World/Shadow Temple MQ.json
@@ -43,6 +43,7 @@
         "locations": {
             "Shadow Temple MQ Invisible Blades Visible Chest": "can_play(Song_of_Time)",
             "Shadow Temple MQ Invisible Blades Invisible Chest": "can_play(Song_of_Time)",
+            "Shadow Temple MQ Invisible Blades Like Like": "can_feed_like_like",
             "Shadow Temple MQ Beamos Silver Rupees Chest": "can_use(Longshot)",
             "Shadow Temple MQ Falling Spikes Lower Chest": "True",
             "Shadow Temple MQ Falling Spikes Upper Chest": "Progressive_Strength_Upgrade",
@@ -93,7 +94,8 @@
             "Shadow Temple MQ Spike Walls Left Chest": "(Small_Key_Shadow_Temple, 6)",
             "Shadow Temple MQ Boss Key Chest": "(Small_Key_Shadow_Temple, 6)",
             "Shadow Temple MQ Bomb Flower Chest": "True",
-            "Shadow Temple MQ Freestanding Key": "True"
+            "Shadow Temple MQ Freestanding Key": "True",
+            "Shadow Temple MQ Invisible Maze Like Like": "can_feed_like_like"
         }
     }
 ]

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -62,8 +62,10 @@
             "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
                 (can_use(Hookshot) or can_hover) and has_projectile(either)",
             "Spirit Temple Early Adult Right Chest": "has_projectile(either)",
+            "Spirit Temple Early Adult Like Like": "has_projectile(either) and can_feed_like_like",
             "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 2)",
             "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 2)",
+            "Spirit Temple First Mirror Like Like": "(Small_Key_Spirit_Temple, 2) and can_feed_like_like",
             "Spirit Temple GS Boulder Room": "has_projectile(either) and
                 (can_play(Song_of_Time) or can_use(Hover_Boots))"
         },

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -122,6 +122,7 @@
         "region_name": "Dark Link Area",
         "dungeon": "Water Temple",
         "locations": {
+            "Water Temple Like Like": "can_use(Hookshot) and can_feed_like_like",
             "Water Temple Longshot Chest": "can_use(Hookshot)",
             "Water Temple GS Falling Platform Room": "can_use(Hookshot)"
         },

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -42,6 +42,7 @@
     "can_child_damage": "is_child and (Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire))",
     "can_cut_shrubs": "is_adult or Sticks or Kokiri_Sword or Boomerang or has_explosives",
     "can_dive": "Progressive_Scale",
+    "can_feed_like_like": "Hylian_Shield and (damage_multiplier != 'ohko' or Fairy)", # IDK if nayru's love works or what kills a like like
     "can_leave_forest": "open_forest != 'closed' or is_adult or is_glitched or Deku_Tree_Clear",
     "can_plant_bugs": "is_child and Bugs",
     "can_ride_epona": "is_adult and Epona and (can_play(Eponas_Song) or (is_glitched and can_hover))",

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -42,7 +42,7 @@
     "can_child_damage": "is_child and (Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire))",
     "can_cut_shrubs": "is_adult or Sticks or Kokiri_Sword or Boomerang or has_explosives",
     "can_dive": "Progressive_Scale",
-    "can_feed_like_like": "Hylian_Shield and (damage_multiplier != 'ohko' or Fairy) and (is_adult or can_child_damage)",
+    "can_feed_like_like": "Hylian_Shield and (can_live_dmg(0.5) or Fairy) and (is_adult or can_child_damage)",
     "can_leave_forest": "open_forest != 'closed' or is_adult or is_glitched or Deku_Tree_Clear",
     "can_plant_bugs": "is_child and Bugs",
     "can_ride_epona": "is_adult and Epona and (can_play(Eponas_Song) or (is_glitched and can_hover))",

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -42,7 +42,7 @@
     "can_child_damage": "is_child and (Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire))",
     "can_cut_shrubs": "is_adult or Sticks or Kokiri_Sword or Boomerang or has_explosives",
     "can_dive": "Progressive_Scale",
-    "can_feed_like_like": "Hylian_Shield and (damage_multiplier != 'ohko' or Fairy)", # IDK if nayru's love works or what kills a like like
+    "can_feed_like_like": "Hylian_Shield and (damage_multiplier != 'ohko' or Fairy) and (is_adult or can_child_damage)",
     "can_leave_forest": "open_forest != 'closed' or is_adult or is_glitched or Deku_Tree_Clear",
     "can_plant_bugs": "is_child and Bugs",
     "can_ride_epona": "is_adult and Epona and (can_play(Eponas_Song) or (is_glitched and can_hover))",

--- a/data/World/Fire Temple.json
+++ b/data/World/Fire Temple.json
@@ -19,6 +19,8 @@
                     at('Fire Temple Upper', can_play(Song_of_Time) or has_explosives))",
             "Fire Temple GS Boss Key Loop": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Megaton_Hammer)",
+            "Fire Temple Boss Key Loop Like Like": "
+                can_feed_like_like and ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Megaton_Hammer)",
             "Fairy Pot": "
                 has_bottle and (can_use(Hover_Boots) or can_use(Hookshot)) and
                 (logic_fewer_tunic_requirements or can_use(Goron_Tunic))"
@@ -37,7 +39,9 @@
             "Fire Temple Big Lava Room Lower Open Door Chest": "True",
             "Fire Temple Big Lava Room Blocked Door Chest": "is_adult and has_explosives",
             "Fire Temple GS Song of Time Room": "
-                is_adult and (can_play(Song_of_Time) or logic_fire_song_of_time)"
+                is_adult and (can_play(Song_of_Time) or logic_fire_song_of_time)",
+            "Fire Temple Song of Time Room Like Like": "
+                can_feed_like_like and is_adult and (can_play(Song_of_Time) or logic_fire_song_of_time)"
         },
         "exits": {
             "Fire Temple Lower":  "True",

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -78,7 +78,10 @@
                 Hover_Boots or can_play(Song_of_Time)",
             "Ganons Castle Shadow Trial Golden Gauntlets Chest": "
                 can_use(Fire_Arrows) or 
-                (can_use(Longshot) and (Hover_Boots or can_use(Dins_Fire)))"
+                (can_use(Longshot) and (Hover_Boots or can_use(Dins_Fire)))",
+            "Ganons Castle Shadow Trial Like Like": "
+                can_feed_like_like and (can_use(Fire_Arrows) or 
+                (can_use(Longshot) and (Hover_Boots or can_use(Dins_Fire))))"
         }
     },
     {

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -57,6 +57,7 @@
             "Jabu Jabus Belly Barinade Heart": "True",
             "Barinade": "True",
             "Jabu Jabus Belly MQ GS Near Boss": "True",
+            "Jabu Jabus Belly MQ Near Boss Like Likes": "can_feed_like_like",
             "Fairy Pot": "has_bottle"
         },
         "exits": {

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -49,7 +49,8 @@
                 (logic_shadow_mq_invisible_blades and damage_multiplier != 'ohko')",
             "Shadow Temple MQ Invisible Blades Invisible Chest": "
                 can_play(Song_of_Time) or
-                (logic_shadow_mq_invisible_blades and damage_multiplier != 'ohko')"
+                (logic_shadow_mq_invisible_blades and damage_multiplier != 'ohko')",
+            "Shadow Temple MQ Invisible Blades Like Like": "can_feed_like_like"
         },
         "exits": {
             "Shadow Temple Lower Huge Pit": "has_fire_source or logic_shadow_mq_huge_pit"
@@ -121,7 +122,8 @@
             "Shadow Temple MQ Boss Key Chest": "
                 can_use(Dins_Fire) and (Small_Key_Shadow_Temple, 6)",
             "Shadow Temple MQ Bomb Flower Chest": "True",
-            "Shadow Temple MQ Freestanding Key": "True"
+            "Shadow Temple MQ Freestanding Key": "True",
+            "Shadow Temple MQ Invisible Maze Like Like": "can_feed_like_like"
         }
     }
 ]

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -83,8 +83,11 @@
             "Spirit Temple Early Adult Right Chest": "
                 Bow or Progressive_Hookshot or has_bombchus or (Bombs and logic_spirit_lower_adult_switch)", 
                 #requires a very specific Bombchu use, Hover Boots can be skipped by jumping on top of the rolling rock.
+            "Spirit Temple Early Adult Like Like": "
+                can_feed_like_like and (Bow or Progressive_Hookshot or has_bombchus or (Bombs and logic_spirit_lower_adult_switch))", 
             "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 3)",
             "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 3)",
+            "Spirit Temple First Mirror Like Like": "(Small_Key_Spirit_Temple, 3) and can_feed_like_like",
             "Spirit Temple GS Boulder Room": "
                 can_play(Song_of_Time) and 
                 (Bow or Progressive_Hookshot or has_bombchus or (Bombs and logic_spirit_lower_adult_switch))"

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -143,6 +143,7 @@
         "region_name": "Water Temple Dark Link Region",
         "dungeon": "Water Temple",
         "locations": {
+            "Water Temple Like Like": "can_feed_like_like",
             "Water Temple Longshot Chest": "True",
             "Water Temple River Chest": "can_play(Song_of_Time) and Bow",
             "Water Temple GS River": "


### PR DESCRIPTION
Adds all respawning Like Likes as locations for a potential Like Like shuffle. Only Like Likes that respawn (and can therefore be killed repeatably) are included. The "Default" values in the `LocationList.py` are the IDs of the rooms the Like Likes are in. It's assumed that the room of Jabu-Jabu's Belly MQ with two Like Likes would have them share a drop. This was originally added to #1176 but split out.