### PR TITLE
Increasing bingo hints compatibility 

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -663,7 +663,10 @@ def buildBingoHintList(boardURL):
     for key, value in hintsToAdd.items():
         for _ in range(value):
             hints.append(key)
-     
+
+    #Since there's no way to verify if the Bingosync URL is actually for OoTR, this exception catches that case
+    if len(hints)==0:
+        raise Exception('No item hints found for goals on Bingosync card. Verify Bingosync URL is correct, or leave field blank for generic bingo hints.')
     return hints
 
 

--- a/Hints.py
+++ b/Hints.py
@@ -753,13 +753,18 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
         if world.shopsanity != "off" and "Progressive Wallet" not in world.item_hints:
             world.item_hints.append("Progressive Wallet")
                 
-        world.named_item_pool = list(world.item_hints)
 
+    #Removes items from item_hints list if they are included in starting gear.
+    #This method ensures that the right number of copies are removed, e.g.
+    #if you start with one strength and hints call for two, you still get
+    #one hint for strength
     for item in [*world.starting_items, *world.starting_equipment, *world.starting_songs]:
         itemname=everything[item].itemname
         if itemname in world.item_hints:
             world.item_hints.remove(itemname)
 
+    #Skip_child_zelda can cause the same problem, but needs to be handled separatly since
+    #it doesn't update the starting gear lists
     if world.skip_child_zelda:
         itemname=str(world.get_location('Song from Impa').item)
         if itemname in world.item_hints:

--- a/Hints.py
+++ b/Hints.py
@@ -665,7 +665,7 @@ def buildBingoHintList(boardURL):
             hints.append(key)
 
     #Since there's no way to verify if the Bingosync URL is actually for OoTR, this exception catches that case
-    if len(hints)==0:
+    if len(hints) == 0:
         raise Exception('No item hints found for goals on Bingosync card. Verify Bingosync URL is correct, or leave field blank for generic bingo hints.')
     return hints
 
@@ -762,14 +762,14 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     #if you start with one strength and hints call for two, you still get
     #one hint for strength
     for item in [*world.starting_items, *world.starting_equipment, *world.starting_songs]:
-        itemname=everything[item].itemname
+        itemname = everything[item].itemname
         if itemname in world.item_hints:
             world.item_hints.remove(itemname)
 
     #Skip_child_zelda can cause the same problem, but needs to be handled separately since
     #it doesn't update the starting gear lists
     if world.skip_child_zelda:
-        itemname=str(world.get_location('Song from Impa').item)
+        itemname = str(world.get_location('Song from Impa').item)
         if itemname in world.item_hints:
             world.item_hints.remove(itemname)
 
@@ -778,9 +778,9 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     #Make sure the total number of hints won't pass 40. If so, we limit the always and trial hints
     if world.hint_dist == "bingo":
         numTrialHints=[0,1,2,3,2,1,0]
-        if (2*len(world.item_hints)+2*len(getHintGroup('always', world))+2*numTrialHints[world.trials]>40) and (world.hint_dist_user['named_items_required']):
-            world.hint_dist_user['distribution']['always']['copies']=1
-            world.hint_dist_user['distribution']['trial']['copies']=1
+        if (2*len(world.item_hints) + 2*len(getHintGroup('always', world)) + 2*numTrialHints[world.trials] > 40) and (world.hint_dist_user['named_items_required']):
+            world.hint_dist_user['distribution']['always']['copies'] = 1
+            world.hint_dist_user['distribution']['trial']['copies'] = 1
 
             
     # Load hint distro from distribution file or pre-defined settings

--- a/Hints.py
+++ b/Hints.py
@@ -9,6 +9,7 @@ import urllib.request
 from urllib.error import URLError, HTTPError
 import json
 from enum import Enum
+import itertools
 
 from HintList import getHint, getHintGroup, Hint, hintExclusions
 from Item import MakeEventItem
@@ -761,7 +762,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     #This method ensures that the right number of copies are removed, e.g.
     #if you start with one strength and hints call for two, you still get
     #one hint for strength
-    for item in [*world.starting_items, *world.starting_equipment, *world.starting_songs]:
+    for item in itertools.chain(world.starting_items, world.starting_equipment, world.starting_songs):
         itemname = everything[item].itemname
         if itemname in world.item_hints:
             world.item_hints.remove(itemname)
@@ -769,7 +770,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     #Skip_child_zelda can cause the same problem, but needs to be handled separately since
     #it doesn't update the starting gear lists
     if world.skip_child_zelda:
-        itemname = str(world.get_location('Song from Impa').item)
+        itemname = world.get_location('Song from Impa').item.name 
         if itemname in world.item_hints:
             world.item_hints.remove(itemname)
 
@@ -777,7 +778,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
     #Make sure the total number of hints won't pass 40. If so, we limit the always and trial hints
     if world.hint_dist == "bingo":
-        numTrialHints=[0,1,2,3,2,1,0]
+        numTrialHints = [0,1,2,3,2,1,0]
         if (2*len(world.item_hints) + 2*len(getHintGroup('always', world)) + 2*numTrialHints[world.trials] > 40) and (world.hint_dist_user['named_items_required']):
             world.hint_dist_user['distribution']['always']['copies'] = 1
             world.hint_dist_user['distribution']['trial']['copies'] = 1

--- a/Hints.py
+++ b/Hints.py
@@ -766,7 +766,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
         if itemname in world.item_hints:
             world.item_hints.remove(itemname)
 
-    #Skip_child_zelda can cause the same problem, but needs to be handled separatly since
+    #Skip_child_zelda can cause the same problem, but needs to be handled separately since
     #it doesn't update the starting gear lists
     if world.skip_child_zelda:
         itemname=str(world.get_location('Song from Impa').item)
@@ -775,6 +775,14 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
     world.named_item_pool = list(world.item_hints)
 
+    #Make sure the total number of hints won't pass 40. If so, we limit the always and trial hints
+    if world.hint_dist == "bingo":
+        numTrialHints=[0,1,2,3,2,1,0]
+        if (2*len(world.item_hints)+2*len(getHintGroup('always', world))+2*numTrialHints[world.trials]>40) and (world.hint_dist_user['named_items_required']):
+            world.hint_dist_user['distribution']['always']['copies']=1
+            world.hint_dist_user['distribution']['trial']['copies']=1
+
+            
     # Load hint distro from distribution file or pre-defined settings
     #
     # 'fixed' key is used to mimic the tournament distribution, creating a list of fixed hint types to fill

--- a/Hints.py
+++ b/Hints.py
@@ -14,6 +14,7 @@ from HintList import getHint, getHintGroup, Hint, hintExclusions
 from Item import MakeEventItem
 from Messages import update_message_by_id
 from Search import Search
+from StartingItems import everything
 from TextBox import line_wrap
 from Utils import random_choices, data_path, read_json
 
@@ -662,6 +663,7 @@ def buildBingoHintList(boardURL):
     for key, value in hintsToAdd.items():
         for _ in range(value):
             hints.append(key)
+     
     return hints
 
 
@@ -750,8 +752,20 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
         if world.shopsanity != "off" and "Progressive Wallet" not in world.item_hints:
             world.item_hints.append("Progressive Wallet")
+                
         world.named_item_pool = list(world.item_hints)
 
+    for item in [*world.starting_items, *world.starting_equipment, *world.starting_songs]:
+        itemname=everything[item].itemname
+        if itemname in world.item_hints:
+            world.item_hints.remove(itemname)
+
+    if world.skip_child_zelda:
+        itemname=str(world.get_location('Song from Impa').item)
+        if itemname in world.item_hints:
+            world.item_hints.remove(itemname)
+
+    world.named_item_pool = list(world.item_hints)
 
     # Load hint distro from distribution file or pre-defined settings
     #

--- a/data/Hints/bingo.json
+++ b/data/Hints/bingo.json
@@ -11,7 +11,7 @@
     "named_items_required":  true,
     "vague_named_items":     false,
     "distribution":          {
-        "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 0},
+        "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 2},
         "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},
         "woth":       {"order":  3, "weight": 0.0, "fixed":   0, "copies": 0},
         "barren":     {"order":  4, "weight": 0.0, "fixed":   0, "copies": 0},


### PR DESCRIPTION
Made fixes to the bingo hints which allow it to be combined with more settings (useful for RSL, or people playing bingo with non-default options).

- Remove starting gear from the items to be hinted, which fixes a crash if the generator tries to find an item not in the world (allows the bingo hints to work with starting items, equipment, and songs, as well as skip_child_zelda)
- Include trial hints (still will not pop up in default bingo settings, since those have trials set to 6)
- Verify that the total number of hints does not exceed 40 (including item hints, always hints, and possibly trial hint). If that is the case, limit trial and always hints to one copy each. (allows for always hints to exceed 7, and avoid issues with trial hints)
- Return an error if the board-specific generator returns an empty list of items. Most likely scenario there is the user copied the wrong Bingosync URL, and the board was not for OoTR.