### PR TITLE
Small improvement to the less text shuffle option

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -871,7 +871,9 @@ def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
     def is_exempt(m):
         hint_ids = (
             GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES + LIGHT_ARROW_HINT +
-            list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages
+            list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages +
+            shuffle_messages.scrubs_message_ids +
+            [0x5036, 0x70F5] # Chicken count and poe count respectively
         )
         shuffle_exempt = [
             0x208D,         # "One more lap!" for Cow in House race.

--- a/Patches.py
+++ b/Patches.py
@@ -1549,8 +1549,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         set_deku_salesman_data(rom)
 
     # Update scrub messages.
+    shuffle_messages.scrubs_message_ids = []
     for text_id, message in scrub_message_dict.items():
         update_message_by_id(messages, text_id, message)
+        if world.shuffle_scrubs == 'random':
+            shuffle_messages.scrubs_message_ids.extend([text_id])
 
     if world.shuffle_grotto_entrances:
         # Build the Grotto Load Table based on grotto entrance data

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3556,18 +3556,18 @@ setting_infos = [
         default        = 'none',
         choices        = {
             'none':         'No Text Shuffled',
-            'except_hints': 'Shuffled except Hints and Keys',
+            'except_hints': 'Shuffled except Important Text',
             'complete':     'All Text Shuffled',
         },
         gui_tooltip    = '''\
             Will make things confusing for comedic value.
 
-            'Shuffled except Hints and Keys': Key texts
-            are not shuffled because in keysanity it is
-            inconvenient to figure out which keys are which
-            without the correct text. Similarly, non-shop
-            items sold in shops will also retain standard
-            text for the purpose of accurate price checks.
+            'Shuffled except Important Text': For when
+            you want comedy but don't want to impact
+            gameplay. Text that has an impact on gameplay
+            is not shuffled. This includes all hint text,
+            key text, non-shop items sold in shops, random
+            price scrubs, chicken count and poe count.
         ''',
         shared         = True,
     ),


### PR DESCRIPTION
The text shuffle options are `none`, `except_hints` and `complete`. `except_hints` was expanded to include keys awhile back. I renamed it in the GUI to `Shuffled Except Important Text` from `Shuffled Except Keys and Hints` and added deku salesman text if they are shuffled with random price, the big poe count and chicken count.

With this change, this setting no longer impacts gameplay in a way which keeps the player guessing about what the text box said. 

Note: I left songs untouched although when you pick up a song item you cannot know which song it is without pausing. But its easy to see once you pause so I figured its fine.