### PR TITLE
Added a new text file to the data directory that can be used to remove sequences from random music.

### DIFF
--- a/Music.py
+++ b/Music.py
@@ -2,7 +2,7 @@
 
 import random
 import os
-from Utils import compare_version
+from Utils import compare_version, data_path
 
 
 # Format: (Title, Sequence ID)
@@ -135,7 +135,7 @@ def process_sequences(rom, sequences, target_sequences, disabled_source_sequence
 
     # If present, load the file containing custom music to exclude
     try:
-        with open(os.path.join(u'.', u'data', u'custom_music_exclusion.txt')) as excl_in:
+        with open(os.path.join(data_path(), u'custom_music_exclusion.txt')) as excl_in:
             seq_exclusion_list = excl_in.readlines()
         seq_exclusion_list = [seq.rstrip() for seq in seq_exclusion_list if seq[0] != '#']
         seq_exclusion_list = [seq for seq in seq_exclusion_list if seq.endswith('.meta')]

--- a/Music.py
+++ b/Music.py
@@ -133,11 +133,24 @@ def process_sequences(rom, sequences, target_sequences, disabled_source_sequence
         if cosmetic_name not in disabled_target_sequences:
             target_sequences.append(target)
 
+    # If present, load the file containing custom music to exclude
+    try:
+        with open(os.path.join(u'.', u'data', u'custom_music_exclusion.txt')) as excl_in:
+            seq_exclusion_list = excl_in.readlines()
+        seq_exclusion_list = [seq.rstrip() for seq in seq_exclusion_list if seq[0] != '#']
+        seq_exclusion_list = [seq for seq in seq_exclusion_list if seq.endswith('.meta')]
+    except FileNotFoundError:
+        seq_exclusion_list = []
+
     # Process music data in data/Music/
     # Each sequence requires a valid .seq sequence file and a .meta metadata file
     # Current .meta format: Cosmetic Name\nInstrument Set\nPool
     for dirpath, _, filenames in os.walk(u'./data/Music'):
         for fname in filenames:
+            # Skip if included in exclusion file
+            if fname in seq_exclusion_list:
+                continue
+
             # Find meta file and check if corresponding seq file exists
             if fname.endswith('.meta') and os.path.isfile(os.path.join(dirpath, fname.split('.')[0] + '.seq')):
                 # Read meta info

--- a/data/custom_music_exclusion.txt
+++ b/data/custom_music_exclusion.txt
@@ -1,0 +1,3 @@
+# To omit a track from shuffled music, list the filename of its
+# .meta file below. One per line
+# Lines that begin with # are comments and not parsed


### PR DESCRIPTION
I wrote this as a way to enhance user experience when using custom random
music. Putting the files you wish to exclude from custom random music will
ensure they aren’t shuffled in.

While a user can just remove the tracks that they do not want, when
updating the music repository you get everything back. This allows users to
continue excluding tracks through updates to the custom music repo.