### PR TITLE
Include song notes in spoiler log

### DIFF
--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -325,6 +325,8 @@ def get_random_song():
 def generate_song_list(world):
     fixed_songs = {name: Song.from_str(notes) for name, notes in world.distribution.configure_songs().items()}
     for name1, song1 in fixed_songs.items():
+        if name1 not in ROM_INDICES:
+            raise ValueError(f'Unknown song: {name1!r}. Please use one of these: {", ".join(ROM_INDICES)}')
         if not song1.activation:
             raise ValueError(f'{name1} is empty')
         if len(song1.activation) > 8:

--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -3,6 +3,24 @@ PLAYBACK_LENGTH = 0xA0
 ACTIVATION_START = 0xB78E5C
 ACTIVATION_LENGTH = 0x09
 
+FORMAT_ACTIVATION = {
+    0: 'A',
+    1: 'v',
+    2: '>',
+    3: '<',
+    4: '^',
+}
+READ_ACTIVATION = { # support both Av><^ and ADRLU
+    'a': 0,
+    'v': 1,
+    'd': 1,
+    '>': 2,
+    'r': 2,
+    '<': 3,
+    'l': 3,
+    '^': 4,
+    'u': 4,
+}
 ACTIVATION_TO_PLAYBACK_NOTE = {
     0: 0x02, # A
     1: 0x05, # Down
@@ -12,7 +30,38 @@ ACTIVATION_TO_PLAYBACK_NOTE = {
     0xFF: 0xFF, # Rest
 }
 
+DIFFICULTY_ORDER = [
+    'Zeldas Lullaby',
+    'Sarias Song',
+    'Eponas Song',
+    'Song of Storms',
+    'Song of Time',
+    'Suns Song',
+    'Prelude of Light',
+    'Minuet of Forest',
+    'Bolero of Fire',
+    'Serenade of Water',
+    'Requiem of Spirit',
+    'Nocturne of Shadow',
+]
+ROM_INDICES = {
+    'Zeldas Lullaby': 8,
+    'Eponas Song': 7,
+    'Sarias Song': 6,
+    'Suns Song': 9,
+    'Song of Time': 10,
+    'Song of Storms': 11,
+    'Minuet of Forest': 0,
+    'Bolero of Fire': 1,
+    'Serenade of Water': 2,
+    'Requiem of Spirit': 3,
+    'Nocturne of Shadow': 4,
+    'Prelude of Light': 5,
+}
+
 import random
+from itertools import chain
+from Fill import ShuffleError
 from Utils import random_choices
 
 # checks if one list is a sublist of the other (in either direction)
@@ -174,7 +223,7 @@ class Song():
         padding = [0] * (PLAYBACK_LENGTH - len(self.playback_data))
         self.playback_data += padding
 
-    def display(self):
+    def __repr__(self):
         activation_string = 'Activation Data:\n\t' + ' '.join( map( "{:02x}".format, self.activation_data) )
         # break playback into groups of 8...
         index = 0
@@ -186,31 +235,39 @@ class Song():
         return activation_string + '\n' + playback_string
 
     # create a song, based on a given scheme
-    def __init__(self, rand_song=True, piece_size=3, extra_position='none', starting_range=range(0,5), activation_transform=identity, playback_transform=identity, activation=None):
+    def __init__(self, rand_song=True, piece_size=3, extra_position='none', starting_range=range(0,5), activation_transform=identity, playback_transform=identity, *, activation=None, playback_fast=False):
         if activation:
             self.length = len(activation)
             self.activation = activation
-            self.playback = fast_playback(self.activation)
-            self.break_repeated_notes(0x03)
-            self.format_playback_data()
-            self.increase_duration_to(45)
-            return
-
-        if rand_song:
+        elif rand_song:
             self.length = random.randint(4, 8)
             self.activation = random_choices(range(0,5), k=self.length)
-            self.playback = random_playback(self.activation)
         else:
             if extra_position != 'none':
                 piece_size = 3
             piece = random_piece(piece_size, starting_range)
             self.two_piece_playback(piece, extra_position, activation_transform, playback_transform)
 
-        self.break_repeated_notes()
+        if playback_fast:
+            self.playback = fast_playback(self.activation)
+            self.break_repeated_notes(0x03)
+        else:
+            if not hasattr(self, 'playback'):
+                self.playback = random_playback(self.activation)
+            self.break_repeated_notes()
+
         self.format_activation_data()
         self.format_playback_data()
 
-    __str__ = __repr__ = display
+        if activation:
+            self.increase_duration_to(45)
+
+    @classmethod
+    def from_str(cls, notes):
+        return cls(activation=[READ_ACTIVATION[note.lower()] for note in notes])
+
+    def __str__(self):
+        return ''.join(FORMAT_ACTIVATION[note] for note in self.activation)
 
 # randomly choose song parameters
 def get_random_song():
@@ -265,77 +322,60 @@ def get_random_song():
 
 
 # create a list of 12 songs, none of which are sub-strings of any other song
-def generate_song_list():
-    songs = []
+def generate_song_list(world):
+    fixed_songs = {name: Song.from_str(notes) for name, notes in world.distribution.configure_songs().items()} #TODO length checks?
+    for name1, song1 in fixed_songs.items():
+        if not song1.activation:
+            raise ValueError(f'{name1} is empty')
+        if len(song1.activation) > 8:
+            raise ValueError(f'{name1} is too long (maximum is 8 notes)')
+        for name2, song2 in fixed_songs.items():
+            if name1 != name2 and subsong(song1, song2):
+                raise ValueError(f'{name2} is unplayable because it contains {name1}')
+    random_songs = []
 
-    for _ in range(12):
-        while True:
+    for _ in range(12 - len(fixed_songs)):
+        for _ in range(1000):
             # generate a completely random song
             song = get_random_song()
             # test the song against all existing songs
             is_good = True
 
-            for other_song in songs:
+            for other_song in chain(fixed_songs.values(), random_songs):
                 if subsong(song, other_song):
                     is_good = False
             if is_good:
-                songs.append(song)
+                random_songs.append(song)
                 break
 
+    if len(fixed_songs) + len(random_songs) < 12:
+        # this can happen if the fixed songs are so short that any random set of songs would have them as subsongs
+        raise ShuffleError('Could not generate random songs')
+
     # sort the songs by length
-    songs.sort(key=lambda s: s.difficulty)
-    return songs
+    random_songs.sort(key=lambda s: s.difficulty)
+    for name in DIFFICULTY_ORDER:
+        if name not in fixed_songs:
+            fixed_songs[name] = random_songs.pop(0)
+    return fixed_songs
 
 
 
 # replace the playback and activation requirements for the ocarina songs
-def replace_songs(rom):
-    songs = generate_song_list()
+def replace_songs(world, rom):
+    songs = generate_song_list(world)
+    world.song_notes = songs
 
-    #print('\n\n'.join(map(str, songs)))
-
-    song_order = [
-        8, # zelda's lullaby
-        6, # saria's song
-        7, # epona's song
-        11, # song of storms
-        10, # song of time
-        9, # sun's song
-        5, # prelude of light
-        0, # minuet of forest
-        1, # bolero of fire
-        2, # serenade of water
-        3, # requiem of spirit
-        4, # nocturne of shadow
-    ]
-
-    for index, song in enumerate(songs):
+    for name, song in songs.items():
 
         # fix the song of time
-        if song_order[index] == 10:
+        if name == 'Song of Time':
             song.increase_duration_to(260)
 
         # write the song to the activation table
-        cur_offset = ACTIVATION_START + song_order[index] * ACTIVATION_LENGTH
+        cur_offset = ACTIVATION_START + ROM_INDICES[name] * ACTIVATION_LENGTH
         rom.write_bytes(cur_offset, song.activation_data)
 
         # write the songs to the playback table
-        song_offset = PLAYBACK_START + song_order[index] * PLAYBACK_LENGTH
+        song_offset = PLAYBACK_START + ROM_INDICES[name] * PLAYBACK_LENGTH
         rom.write_bytes(song_offset, song.playback_data)
-
-
-original_songs = [
-    'LURLUR',
-    'ULRULR',
-    'DRLDRL',
-    'RDURDU',
-    'RADRAD',
-    'ADUADU',
-    'AULRLR',
-    'DADALDLD',
-    'ADRRL',
-    'ADALDA',
-    'LRRALRD',
-    'URURLU'
-]
-

--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -323,7 +323,7 @@ def get_random_song():
 
 # create a list of 12 songs, none of which are sub-strings of any other song
 def generate_song_list(world):
-    fixed_songs = {name: Song.from_str(notes) for name, notes in world.distribution.configure_songs().items()} #TODO length checks?
+    fixed_songs = {name: Song.from_str(notes) for name, notes in world.distribution.configure_songs().items()}
     for name1, song1 in fixed_songs.items():
         if not song1.activation:
             raise ValueError(f'{name1} is empty')

--- a/Patches.py
+++ b/Patches.py
@@ -1747,7 +1747,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_byte(symbol, 0x01)
 
     if world.ocarina_songs:
-        replace_songs(rom)
+        replace_songs(world, rom)
 
     # actually write the save table to rom
     world.distribution.give_items(save_context)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -33,6 +33,7 @@ per_world_keys = (
     'item_pool',
     'dungeons',
     'trials',
+    'songs',
     'entrances',
     'locations',
     ':woth_locations',
@@ -208,6 +209,17 @@ class TrialRecord(SimpleRecord({'active': None})):
         return 'active' if self.active else 'inactive'
 
 
+class SongRecord(SimpleRecord({'notes': None})):
+    def __init__(self, src_dict=None):
+        if src_dict is None or isinstance(src_dict, str):
+            src_dict = {'notes': src_dict}
+        super().__init__(src_dict)
+
+
+    def to_json(self):
+        return self.notes
+
+
 
 class WorldDistribution(object):
     def __init__(self, distribution, id, src_dict={}):
@@ -224,6 +236,7 @@ class WorldDistribution(object):
             'randomized_settings': {name: record for (name, record) in src_dict.get('randomized_settings', {}).items()},
             'dungeons': {name: DungeonRecord(record) for (name, record) in src_dict.get('dungeons', {}).items()},
             'trials': {name: TrialRecord(record) for (name, record) in src_dict.get('trials', {}).items()},
+            'songs': {name: SongRecord(record) for (name, record) in src_dict.get('songs', {}).items()},
             'item_pool': {name: ItemPoolRecord(record) for (name, record) in src_dict.get('item_pool', {}).items()},
             'starting_items': {name: StarterRecord(record) for (name, record) in src_dict.get('starting_items', {}).items()},
             'entrances': {name: EntranceRecord(record) for (name, record) in src_dict.get('entrances', {}).items()},
@@ -255,6 +268,7 @@ class WorldDistribution(object):
             'starting_items': SortedDict({name: record.to_json() for (name, record) in self.starting_items.items()}),
             'dungeons': {name: record.to_json() for (name, record) in self.dungeons.items()},
             'trials': {name: record.to_json() for (name, record) in self.trials.items()},
+            'songs': {name: record.to_json() for (name, record) in self.songs.items()},
             'item_pool': SortedDict({name: record.to_json() for (name, record) in self.item_pool.items()}),
             'entrances': {name: record.to_json() for (name, record) in self.entrances.items()},
             'locations': {name: [rec.to_json() for rec in record] if is_pattern(name) else record.to_json() for (name, record) in self.locations.items()},
@@ -348,6 +362,14 @@ class WorldDistribution(object):
                 if record.active:
                     dist_chosen.append(name)
         return dist_chosen
+
+
+    def configure_songs(self):
+        dist_notes = {}
+        for (name, record) in self.songs.items():
+            if record.notes is not None:
+                dist_notes[name] = record.notes
+        return dist_notes
 
 
     def configure_randomized_settings(self, world):
@@ -1109,6 +1131,8 @@ class Distribution(object):
             world_dist.randomized_settings = {randomized_item: getattr(world, randomized_item) for randomized_item in world.randomized_list}
             world_dist.dungeons = {dung: DungeonRecord({ 'mq': world.dungeon_mq[dung] }) for dung in world.dungeon_mq}
             world_dist.trials = {trial: TrialRecord({ 'active': not world.skipped_trials[trial] }) for trial in world.skipped_trials}
+            if hasattr(world, 'song_notes'):
+                world_dist.songs = {song: SongRecord({ 'notes': str(world.song_notes[song]) }) for song in world.song_notes}
             world_dist.entrances = {ent.name: EntranceRecord.from_entrance(ent) for ent in spoiler.entrances[world.id]}
             world_dist.locations = {loc: LocationRecord.from_item(item) for (loc, item) in spoiler.locations[world.id].items()}
             world_dist.woth_locations = {loc.name: LocationRecord.from_item(loc.item) for loc in spoiler.required_locations[world.id]}


### PR DESCRIPTION
This adds the notes of each song to the spoiler log when the “Randomize Ocarina Song Notes” setting is enabled, since I think it's relevant info that was previously missing.

And of course since every spoiler log needs to be a valid plando file, this also adds support for plandoing song notes. However, since the spoiler log doesn't have info about rests or note duration, the rhythm of the song is still generated randomly. A feature to plando the song rhythm as well could be added in the future if desired.

One issue is that the `songs` entry in the spoiler log is still generated (with a value of `{}`) even if the `ocarina_songs` setting is off. It doesn't look like that's easy to fix, so hopefully it's not a deal-breaker.