### PR TITLE
Add message in place of tricks list when the list is hidden by logic setting

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.html
+++ b/GUI/src/app/pages/generator/generator.component.html
@@ -62,12 +62,17 @@
                           <mat-slider class="scale" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [min]="setting.min" [max]="setting.max" step="1" [(ngModel)]="global.generator_settingsMap[setting.name]"
                                       (ngModelChange)="afterSettingChange()" tickInterval="1" thumbLabel [nbPopover]="tooltipComponent" [nbPopoverContext]="{tooltip: setting.tooltip}" [nbPopoverTrigger]="setting.tooltip && setting.tooltip.length > 0 ? 'hint' : 'noop'" nbPopoverPlacement="right" nbPopoverAdjustment="counterclockwise"></mat-slider>
                         </ng-container>
-                        <!--Text-->
+                        <!--Text Input-->
                         <ng-container *ngSwitchCase="'Textinput'">
                           <span *ngIf="!setting.size || setting.size == 'small' || setting.size == 'medium'" class="numberTextInputLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name]}">{{setting.text}}:</span>
                           <p *ngIf="setting.size == 'full'" class="numberTextInputLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name]}">{{setting.text}}</p>
                           <input class="numberTextInput" [ngClass]="{numberTextInputSmall: setting.size == 'small', numberTextInputMedium: setting.size == 'medium', numberTextInputFull: setting.size == 'full'}" nbInput [disabled]="!global.generator_settingsVisibilityMap[setting.name]" type="text" [maxlength]="setting.max_length ? setting.max_length : 260" fieldSize="small"
                                  (focus)="inputFocusIn(setting.name)" (focusout)="inputFocusOut(setting.name, false)" [(ngModel)]="global.generator_settingsMap[setting.name]" [nbPopover]="tooltipComponent" [nbPopoverContext]="{tooltip: setting.tooltip}" [nbPopoverTrigger]="setting.tooltip && setting.tooltip.length > 0 ? 'hint' : 'noop'" nbPopoverPlacement="right" nbPopoverAdjustment="counterclockwise">
+                        </ng-container>
+                        <!--Text Box-->
+                        <ng-container *ngSwitchCase="'Textbox'">
+                          <span *ngIf="!setting.size || setting.size == 'small' || setting.size == 'medium'" class="numberTextInputLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name]}">{{setting.text}}</span>
+                          <p *ngIf="setting.size == 'full'" class="numberTextInputLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name]}">{{setting.text}}</p>
                         </ng-container>
                         <!--Number-->
                         <ng-container *ngSwitchCase="'Numberinput'">

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2190,6 +2190,7 @@ setting_infos = [
             considered available. MAY BE IMPOSSIBLE TO BEAT.
         ''',
         disable        = {
+            'glitchless': {'settings' : ['tricks_list_msg']},
             'glitched'  : {'settings' : ['allowed_tricks', 'shuffle_interior_entrances', 'shuffle_grotto_entrances',
                                          'shuffle_dungeon_entrances', 'shuffle_overworld_entrances', 'owl_drops',
                                          'warp_songs', 'spawn_positions', 'mq_dungeons_random', 'mq_dungeons', ]},
@@ -3345,6 +3346,14 @@ setting_infos = [
             
             Tricks are only relevant for Glitchless logic.
         '''
+    ),
+    Setting_Info(
+        name           = 'tricks_list_msg',
+        type           = str,
+        gui_text       = "Your current logic setting does not support the enabling of tricks.",
+        gui_type       = "Textbox",
+        shared         = True,
+        choices        = {},
     ),
     Combobox(
         name           = 'logic_earliest_adult_trade',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -248,7 +248,8 @@
           "text": "Enable Tricks",
           "row_span": [8,10,10],
           "settings": [
-            "allowed_tricks"
+            "allowed_tricks",
+            "tricks_list_msg"
           ]
         }
       ]


### PR DESCRIPTION
Adds some simple text whenever the tricks list is hidden, so it does not simply look like a portion of the page failed to load or something and provides some explanation, [can see what it looks like here.](https://i.imgur.com/SjAtSX7.png)

To do this, added the Textbox GUI element, which I basically made by copying the Text Input element and removing the input part. All this element does is display the text in gui_text.

A textbox can be defined as follows:
```
    Setting_Info(
        name           = 'name',
        type           = str,
        gui_text       = "Text to display",
        gui_type       = "Textbox",
        shared         = True,
        choices        = {},
    ),
```
Although the `type` and `choices` elements are unused in this case, but Setting_Info requires they be defined. In fact it doesn't matter what you put for type, but I figured str makes the most sense.