### PR TITLE
Closed Forest with ER and adult start

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -398,10 +398,6 @@ def shuffle_random_entrances(worlds):
 
         if worlds[0].shuffle_dungeon_entrances:
             entrance_pools['Dungeon'] = world.get_shufflable_entrances(type='Dungeon', only_primary=True)
-            # The fill algorithm will already make sure gohma is reachable, however it can end up putting
-            # a forest escape via the hands of spirit on Deku leading to Deku on spirit in logic.
-            if worlds[0].open_forest == 'closed' and worlds[0].starting_age == 'child' and worlds[0].logic_require_gohma:
-                entrance_pools['Dungeon'].remove(world.get_entrance('KF Outside Deku Tree -> Deku Tree Lobby'))
 
         if worlds[0].shuffle_interior_entrances:
             entrance_pools['Interior'] = world.get_shufflable_entrances(type='Interior', only_primary=True)

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -261,7 +261,7 @@ entrance_shuffle_table = [
                         ('Graveyard Dampes Grave -> Graveyard',                             { 'index': 0x0359 })),
 
     ('Overworld',       ('Kokiri Forest -> LW Bridge From Forest',                          { 'index': 0x05E0 }),
-                        ('LW Bridge -> Kokiri Forest',                                      { 'index': 0x020D })),
+                        ('LW Bridge -> Kokiri Forest From Bridge',                          { 'index': 0x020D })),
     ('Overworld',       ('Kokiri Forest -> Lost Woods',                                     { 'index': 0x011E }),
                         ('LW Forest Exit -> Kokiri Forest',                                 { 'index': 0x0286 })),
     ('Overworld',       ('Lost Woods -> GC Woods Warp',                                     { 'index': 0x04E2 }),
@@ -399,9 +399,8 @@ def shuffle_random_entrances(worlds):
         if worlds[0].shuffle_dungeon_entrances:
             entrance_pools['Dungeon'] = world.get_shufflable_entrances(type='Dungeon', only_primary=True)
             # The fill algorithm will already make sure gohma is reachable, however it can end up putting
-            # a forest escape via the hands of spirit on Deku leading to Deku on spirit in logic. This is
-            # not really a closed forest anymore, so specifically remove Deku Tree from closed forest.
-            if worlds[0].open_forest == 'closed':
+            # a forest escape via the hands of spirit on Deku leading to Deku on spirit in logic.
+            if worlds[0].open_forest == 'closed' and worlds[0].starting_age == 'child' and worlds[0].logic_require_gohma:
                 entrance_pools['Dungeon'].remove(world.get_entrance('KF Outside Deku Tree -> Deku Tree Lobby'))
 
         if worlds[0].shuffle_interior_entrances:

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -410,6 +410,14 @@ def shuffle_random_entrances(worlds):
 
         if worlds[0].shuffle_overworld_entrances:
             entrance_pools['Overworld'] = world.get_shufflable_entrances(type='Overworld')
+            if world.logic_rules == 'glitchless' and worlds[0].open_forest == 'closed' and worlds[0].starting_age == 'child' and \
+                worlds[0].logic_require_gohma and not (worlds[0].shuffle_special_interior_entrances or worlds[0].spawn_positions):
+                entrance_pools['Overworld'].remove(world.get_entrance('Kokiri Forest -> Lost Woods'))
+                entrance_pools['Overworld'].remove(world.get_entrance('LW Forest Exit -> Kokiri Forest'))
+                entrance_pools['Overworld'].remove(world.get_entrance('Lost Woods -> GC Woods Warp'))
+                entrance_pools['Overworld'].remove(world.get_entrance('GC Woods Warp -> Lost Woods'))
+                entrance_pools['Overworld'].remove(world.get_entrance('LW Beyond Mido -> SFM Entryway'))
+                entrance_pools['Overworld'].remove(world.get_entrance('SFM Entryway -> LW Beyond Mido'))
 
         # Set shuffled entrances as such
         for entrance in list(chain.from_iterable(one_way_entrance_pools.values())) + list(chain.from_iterable(entrance_pools.values())):
@@ -744,7 +752,8 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
             if impas_front_entrance is not None and impas_back_entrance is not None and not same_hint_area(impas_front_entrance, impas_back_entrance):
                 raise EntranceShuffleError('Kak Impas House entrances are not in the same hint area')
 
-    if (world.shuffle_special_interior_entrances or world.shuffle_overworld_entrances or world.spawn_positions) and \
+    if (world.shuffle_special_interior_entrances or world.spawn_positions or (world.shuffle_overworld_entrances and \
+       not (world.logic_rules == 'glitchless' and world.open_forest == 'closed' and world.starting_age == 'child' and world.logic_require_gohma))) and \
        (entrance_placed == None or entrance_placed.type in ['SpecialInterior', 'Overworld', 'Spawn', 'WarpSong', 'OwlDrop']):
         # At least one valid starting region with all basic refills should be reachable without using any items at the beginning of the seed
         # Note this creates new empty states rather than reuse the worlds' states (which already have starting items)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1198,9 +1198,9 @@ logic_tricks = {
                     A precise jump can be used to skip
                     needing to use the Slingshot to go
                     around B1 of the Deku Tree. If using
-                    "Closed Forest Requires Deku Tree",
-                    a Slingshot will not be guaranteed
-                    to exist somewhere inside the Forest.
+                    "Closed Forest Requires Gohma", a
+                    Slingshot will not be guaranteed to
+                    exist somewhere inside the Forest.
                     This trick applies to both Vanilla
                     and Master Quest.
                     '''},

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2424,11 +2424,14 @@ setting_infos = [
         gui_text       = 'Closed Forest Requires Gohma',
         gui_tooltip    = '''\
             If Closed Forest is enabled, beating Gohma is
-            logically required in order to go outside the forest
-            (Kokiri Forest, Lost Woods, Sacred Forest Meadow,
-            Deku Tree, and any accessible houses and grottos).
-            The Kokiri Sword, Deku Shield, and Slingshot needed
-            for this will be guaranteed within the forest area.
+            logically required for accessing any overworld
+            area outside of Kokiri Forest, Lost Woods, and
+            Sacred Forest Meadow.
+
+            This typically guarantees that the Kokiri Sword, a
+            Deku Shield, and a Slingshot will be in the forest
+            or connected dungeons, interiors, and grottos.
+
             Explosives, Silver Scale, Din's Fire, and warp songs,
             with the exception of Minuet of Forest if warp song
             destinations are not randomized, are not considered

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2439,8 +2439,8 @@ setting_infos = [
             used to escape the forest early.
 
             This will not apply with certain settings:
+            - Glitched logic
             - Starting as Adult
-            - Shuffle Overworld Entrances
             - Shuffle Interior Entrances set to "All Interiors"
             - Randomize Overworld Spawns
         ''',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1197,10 +1197,10 @@ logic_tricks = {
         'tooltip' : '''\
                     A precise jump can be used to skip
                     needing to use the Slingshot to go
-                    around B1 of the Deku Tree. If used
-                    with the "Closed Forest" setting, a
-                    Slingshot will not be guaranteed to
-                    exist somewhere inside the Forest.
+                    around B1 of the Deku Tree. If using
+                    "Closed Forest Requires Deku Tree",
+                    a Slingshot will not be guaranteed
+                    to exist somewhere inside the Forest.
                     This trick applies to both Vanilla
                     and Master Quest.
                     '''},
@@ -1882,31 +1882,28 @@ setting_infos = [
             'closed':      'Closed Forest',
             },
         gui_tooltip    = '''\
-            'Open Forest': Mido no longer blocks the path to the
-            Deku Tree, and the Kokiri boy no longer blocks the path
-            out of the forest.
-            
-            'Closed Deku': The Kokiri boy no longer blocks the path
-            out of the forest, but Mido still blocks the path to the
-            Deku Tree, requiring Kokiri Sword and Deku Shield to access
-            the Deku Tree.
+            In the child era, Mido blocks the path to the Deku Tree,
+            and a Kokiri boy blocks the path out of the forest.
+            Mido requires the Kokiri Sword and a Deku Shield.
+            The Kokiri boy moves after Gohma is defeated.
 
-            'Closed Forest': Beating Deku Tree is logically required
-            to leave the forest area (Kokiri Forest/Lost Woods/Sacred Forest
-            Meadow/Deku Tree), while the Kokiri Sword and a Deku Shield are
-            required to access the Deku Tree. Items needed for this will be
-            guaranteed inside the forest area. This setting is incompatible
-            with starting as adult, and so Starting Age will be locked to Child.
-            With either "Shuffle Interior Entrances" set to "All", "Shuffle 
-            Overworld Entrances" on, "Randomize Warp Song Destinations" on 
-            or "Randomize Overworld Spawns" on, Closed Forest will instead 
-            be treated as Closed Deku with starting age Child and WILL NOT 
-            guarantee that these items are available in the forest area.
+            'Open Forest': Both paths are always open.
+
+            'Closed Deku': The Kokiri boy no longer blocks the path
+            out of the forest, but Mido still guards the Deku Tree.
+
+            'Closed Forest': The paths to the Deku Tree and out of
+            the forest are both blocked. Closed Forest requires
+            AT LEAST ONE of the following settings to apply:
+            - Starting as Child
+            - Open Door of Time
+            - Shuffle Overworld Entrances
+            - Shuffle Interior Entrances set to "All Interiors"
+            - Randomize Overworld Spawns
+            - Logic Rules set to "Glitched" or "No Logic"
+            Otherwise, it will instead be treated as Closed Deku.
         ''',
         shared         = True,
-        disable        = {
-            'closed' : {'settings' : ['starting_age']}
-        },
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution': [
@@ -2021,7 +2018,7 @@ setting_infos = [
         choices        = {
             'open':       'Always Open',
             'vanilla':    'Vanilla Requirements',
-            'stones':	  'Spiritual Stones',
+            'stones':     'Spiritual Stones',
             'medallions': 'Medallions',
             'dungeons':   'Dungeons',
             'tokens':     'Gold Skulltula Tokens'
@@ -2193,7 +2190,8 @@ setting_infos = [
             'glitched'  : {'settings' : ['allowed_tricks', 'shuffle_interior_entrances', 'shuffle_grotto_entrances',
                                          'shuffle_dungeon_entrances', 'shuffle_overworld_entrances', 'owl_drops',
                                          'warp_songs', 'spawn_positions', 'mq_dungeons_random', 'mq_dungeons', ]},
-            'none'      : {'settings' : ['allowed_tricks', 'logic_no_night_tokens_without_suns_song', 'reachable_locations']},
+            'none'      : {'settings' : ['allowed_tricks', 'logic_no_night_tokens_without_suns_song', 'reachable_locations',
+                                         'logic_require_gohma', ]},
         },
         shared         = True,
     ),
@@ -2414,9 +2412,39 @@ setting_infos = [
             Song to collect them. This prevents needing
             to wait until night for some locations.
         ''',
-        gui_params={
+        gui_params     = {
+            'no_line_break' : True,
+            'web:no_line_break' : False,
             "hide_when_disabled": True,
         },
+        shared         = True,
+    ),
+    Checkbutton(
+        name           = 'logic_require_gohma',
+        gui_text       = 'Closed Forest Requires Gohma',
+        gui_tooltip    = '''\
+            If Closed Forest is enabled, beating Gohma is
+            logically required in order to go outside the forest
+            (Kokiri Forest, Lost Woods, Sacred Forest Meadow,
+            Deku Tree, and any accessible houses and grottos).
+            The Kokiri Sword, Deku Shield, and Slingshot needed
+            for this will be guaranteed within the forest area.
+            Explosives, Silver Scale, Din's Fire, and warp songs,
+            with the exception of Minuet of Forest if warp song
+            destinations are not randomized, are not considered
+            in logic until Gohma is beaten because they can be
+            used to escape the forest early.
+
+            This will not apply with certain settings:
+            - Starting as Adult
+            - Shuffle Overworld Entrances
+            - Shuffle Interior Entrances set to "All Interiors"
+            - Randomize Overworld Spawns
+        ''',
+        gui_params     = {
+            "hide_when_disabled": True,
+        },
+        default        = True,
         shared         = True,
     ),
     Checkbutton(
@@ -3733,10 +3761,7 @@ setting_infos = [
             Choose which age Link will start as.
 
             Starting as adult means you start with
-            the master sword in your inventory.
-
-            Only the child option is compatible with
-            Closed Forest.
+            the Master Sword in your inventory.
         ''',
         shared         = True,
         gui_params     = {

--- a/World.py
+++ b/World.py
@@ -58,12 +58,7 @@ class World(object):
         self.entrance_shuffle = self.shuffle_interior_entrances or self.shuffle_grotto_entrances or self.shuffle_dungeon_entrances or \
                                 self.shuffle_overworld_entrances or self.owl_drops or self.warp_songs or self.spawn_positions
 
-        self.ensure_tod_access = self.shuffle_interior_entrances or self.shuffle_overworld_entrances or self.spawn_positions
         self.disable_trade_revert = self.shuffle_interior_entrances or self.shuffle_overworld_entrances
-
-        if self.open_forest == 'closed' and (self.shuffle_special_interior_entrances or self.shuffle_overworld_entrances or 
-                                             self.warp_songs or self.spawn_positions):
-            self.open_forest = 'closed_deku'
 
         self.triforce_goal = self.triforce_goal_per_world * settings.world_count
 
@@ -99,6 +94,15 @@ class World(object):
         }
 
         self.resolve_random_settings()
+
+        if self.open_forest == 'closed' and self.starting_age == 'adult' and self.logic_rules == 'glitchless' and \
+            not (self.open_door_of_time or \
+            self.shuffle_special_interior_entrances or self.settings.shuffle_overworld_entrances or self.settings.spawn_positions):
+                # adult is not compatible with glitchless closed forest without shuffled entrances or open door of time
+                self.open_forest = 'closed_deku'
+
+        self.ensure_tod_access = self.shuffle_special_interior_entrances or self.shuffle_overworld_entrances or self.spawn_positions or \
+                                 (self.open_forest == 'closed' and (self.starting_age == 'adult' or not self.logic_require_gohma))
 
         if len(settings.hint_dist_user) == 0:
             for d in HintDistFiles():
@@ -247,11 +251,7 @@ class World(object):
             self.starting_tod = random.choice(choices)
             self.randomized_list.append('starting_tod')
         if self.starting_age == 'random':
-            if self.settings.open_forest == 'closed':
-                # adult is not compatible
-                self.starting_age = 'child'
-            else:
-                self.starting_age = random.choice(['child', 'adult'])
+            self.starting_age = random.choice(['child', 'adult'])
             self.randomized_list.append('starting_age')
         if self.chicken_count_random:
             self.chicken_count = random.randint(0, 7)

--- a/World.py
+++ b/World.py
@@ -96,8 +96,8 @@ class World(object):
         self.resolve_random_settings()
 
         if self.open_forest == 'closed' and self.starting_age == 'adult' and self.logic_rules == 'glitchless' and \
-            not (self.open_door_of_time or \
-            self.shuffle_special_interior_entrances or self.settings.shuffle_overworld_entrances or self.settings.spawn_positions):
+            not (self.open_door_of_time or ('Ocarina' and 'Song of Time') in self.distribution.starting_items or \
+            self.shuffle_special_interior_entrances or self.shuffle_overworld_entrances or self.spawn_positions):
                 # adult is not compatible with glitchless closed forest without shuffled entrances or open door of time
                 self.open_forest = 'closed_deku'
 

--- a/data/Glitched World/Deku Tree MQ.json
+++ b/data/Glitched World/Deku Tree MQ.json
@@ -31,7 +31,7 @@
         "region_name": "Deku Tree Boss Room",
         "dungeon": "Deku Tree",
         "events": {
-            "Deku Tree Clear": "Buy_Deku_Shield and (Kokiri_Sword or Sticks)"
+            "Defeat Gohma": "Buy_Deku_Shield and (Kokiri_Sword or Sticks)"
         },
         "locations": {
             "Deku Tree MQ Before Spinning Log Chest": "True",
@@ -39,8 +39,8 @@
             "Deku Tree MQ GS Basement Graves Room": "Boomerang and can_play(Song_of_Time)",
             "Deku Tree MQ GS Basement Back Room": "Boomerang",
             "Deku Tree MQ Deku Scrub": "True",
-            "Deku Tree Queen Gohma Heart": "Buy_Deku_Shield and (Kokiri_Sword or Sticks)",
-            "Queen Gohma": "Buy_Deku_Shield and (Kokiri_Sword or Sticks)"
+            "Deku Tree Queen Gohma Heart": "'Defeat Gohma'",
+            "Queen Gohma": "'Defeat Gohma'"
         },
         "exits": {
             "Deku Tree Lobby": "True"

--- a/data/Glitched World/Deku Tree.json
+++ b/data/Glitched World/Deku Tree.json
@@ -41,14 +41,12 @@
         "region_name": "Deku Tree Boss Room",
         "dungeon": "Deku Tree",
         "events": {
-            "Deku Tree Clear": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and
+            "Defeat Gohma": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and
                 ((here(has_shield or can_use(Megaton_Hammer)) and (is_adult or Kokiri_Sword or Sticks)) or is_adult)"
         },
         "locations": {
-            "Deku Tree Queen Gohma Heart": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and 
-                ((here(has_shield or can_use(Megaton_Hammer)) and (is_adult or Kokiri_Sword or Sticks)) or is_adult)",
-            "Queen Gohma": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and
-                ((here(has_shield or can_use(Megaton_Hammer)) and (is_adult or Kokiri_Sword or Sticks)) or is_adult)"
+            "Deku Tree Queen Gohma Heart": "'Defeat Gohma'",
+            "Queen Gohma": "'Defeat Gohma'"
         },
         "exits": {
             "Deku Tree Lobby": "True"

--- a/data/Glitched World/Forest Temple MQ.json
+++ b/data/Glitched World/Forest Temple MQ.json
@@ -64,7 +64,7 @@
         "exits": {
             "Forest Temple NE Outdoors": "
                 can_use(Iron_Boots) or can_use(Longshot) or 
-                (Progressive_Scale, 2) or (logic_forest_well_swim and can_use(Hookshot))",
+                Golden_Scale or (logic_forest_well_swim and can_use(Hookshot))",
             "Forest Temple Outdoors Top Ledges": "can_use(Fire_Arrows)"
         }
     },

--- a/data/Glitched World/Forest Temple.json
+++ b/data/Glitched World/Forest Temple.json
@@ -54,7 +54,7 @@
         "exits": {
             "Forest Temple Outdoors High Balconies": "can_use(Hookshot)",
                 #Longshot can grab some very high up vines to drain the well.
-            "Forest Temple NW Outdoors": "can_use(Iron_Boots) or (Progressive_Scale, 2)",
+            "Forest Temple NW Outdoors": "can_use(Iron_Boots) or Golden_Scale",
             "Forest Temple Lobby": "True",
             "Forest Temple Falling Room": "can_hover or
                 at('Forest Temple Outdoors High Balconies',

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -129,7 +129,7 @@
         "exits": {
             "Kokiri Forest": "True",
             "GC Woods Warp": "True",
-            "Zora River": "(can_dive or can_jumpslash) and can_leave_forest",
+            "Zora River": "(Silver_Scale or can_jumpslash) and can_leave_forest",
             "LW Beyond Mido": "True",
             "LW Near Shortcuts Grotto": "can_blast_or_smash"
             #//Can Exit to Woods bridge with megaflip, but walking through kokiri forest is true anyway
@@ -230,7 +230,7 @@
         },
         "locations": {
             "Pierre": "is_adult and Bonooru and not free_scarecrow",
-            "LH Underwater Item": "is_child and can_dive",
+            "LH Underwater Item": "is_child and Silver_Scale",
             "LH Sun": "
                 is_adult and 
                 (can_use(Distant_Scarecrow) or 'Water Temple Clear' or can_hover) and can_use(Bow)",
@@ -261,7 +261,7 @@
         "region_name": "LH Lab",
         "locations": {
             "LH Lab Dive": "
-                (Progressive_Scale, 2) or
+                Golden_Scale or
                 (Iron_Boots and can_use(Hookshot)) or (has_bottle and can_use(Hover_Boots))",
             "LH GS Lab Crate": "Iron_Boots and can_use(Hookshot)"
         }
@@ -1004,7 +1004,7 @@
             "ZR Front": "True",
             "ZR Open Grotto": "True",
             "ZR Fairy Grotto": "can_blast_or_smash",
-            "Lost Woods": "can_dive or can_use(Iron_Boots) or (is_child and (can_isg or Nuts)) or can_mega",
+            "Lost Woods": "Silver_Scale or can_use(Iron_Boots) or (is_child and (can_isg or Nuts)) or can_mega",
             "ZR Storms Grotto": "can_play(Song_of_Storms) and can_stun_deku",
             "Zoras Domain": "can_play(Zeldas_Lullaby) or can_mega or can_use(Hover_Boots) or is_child"
         }
@@ -1233,7 +1233,7 @@
         "region_name": "HF Tektite Grotto",
         "locations": {
             "HF Tektite Grotto Freestanding PoH": "
-                (Progressive_Scale, 2) or can_use(Iron_Boots)"
+                Golden_Scale or can_use(Iron_Boots)"
         }
     },
     {

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -45,7 +45,7 @@
     "can_child_damage": "is_child and (Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire))",
     "can_cut_shrubs": "is_adult or Sticks or Kokiri_Sword or Boomerang or has_explosives",
     "can_leave_forest": "open_forest != 'closed' or not logic_require_gohma or is_adult or is_glitched or Defeat_Gohma
-            or Time_Travel or shuffle_special_interior_entrances or shuffle_overworld_entrances or spawn_positions",
+            or Time_Travel or shuffle_special_interior_entrances or spawn_positions",
     "can_plant_bugs": "is_child and Bugs",
     "can_ride_epona": "is_adult and Epona and (can_play(Eponas_Song) or (is_glitched and can_hover))",
     "can_stun_deku": "is_adult or (Slingshot or Boomerang or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or Nuts or Deku_Shield)",

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -5,6 +5,8 @@
     # at/here metarules.
     "Hookshot": "Progressive_Hookshot",
     "Longshot": "(Progressive_Hookshot, 2)",
+    "Silver_Scale": "Progressive_Scale and can_leave_forest",
+    "Golden_Scale": "(Progressive_Scale, 2) and can_leave_forest",
     "Silver_Gauntlets": "(Progressive_Strength_Upgrade, 2)",
     "Golden_Gauntlets": "(Progressive_Strength_Upgrade, 3)",
     "Scarecrow": "Progressive_Hookshot and can_play(Scarecrow_Song)",
@@ -14,12 +16,13 @@
     # to avoid infinite recursion.
     "Goron_Tunic": "'Goron Tunic' or Buy_Goron_Tunic",
     "Zora_Tunic": "'Zora Tunic' or Buy_Zora_Tunic",
+    "Dins_Fire": "'Dins Fire' and can_leave_forest",
 
     # Refill aliases. If we start considering Bow etc refills we can enable these aliases
     # without editing all logic files.
     # "Bow": "'Bow'",
     # "Slingshot": "'Slingshot'",
-    "Bombs": "Bomb_Bag",
+    "Bombs": "Bomb_Bag and can_leave_forest",
     "Deku_Shield": "Buy_Deku_Shield",
     "Hylian_Shield": "Buy_Hylian_Shield",
     "Nuts": "Buy_Deku_Nut_5 or Buy_Deku_Nut_10 or Deku_Nut_Drop",
@@ -30,7 +33,7 @@
     "Fairy": "'Fairy' or Buy_Fairys_Spirit",
     # "Big_Poe": "'Big Poe'",
 
-    "has_bombchus": "(Buy_Bombchu_5 or Buy_Bombchu_10 or Buy_Bombchu_20 or Bombchu_Drop) and (bombchus_in_logic or Bomb_Bag)",
+    "has_bombchus": "(Buy_Bombchu_5 or Buy_Bombchu_10 or Buy_Bombchu_20 or Bombchu_Drop) and (bombchus_in_logic or Bomb_Bag) and can_leave_forest",
     "found_bombchus": "(bombchus_in_logic and (Bombchus or Bombchus_5 or Bombchus_10 or Bombchus_20)) or (not bombchus_in_logic and Bomb_Bag)",
     "has_explosives": "Bombs or (bombchus_in_logic and has_bombchus)",
     "is_child": "age == 'child'",
@@ -41,8 +44,8 @@
     "can_child_attack": "is_child and (Slingshot or Boomerang or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire))",
     "can_child_damage": "is_child and (Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire))",
     "can_cut_shrubs": "is_adult or Sticks or Kokiri_Sword or Boomerang or has_explosives",
-    "can_dive": "Progressive_Scale",
-    "can_leave_forest": "open_forest != 'closed' or is_adult or is_glitched or Deku_Tree_Clear",
+    "can_leave_forest": "open_forest != 'closed' or not logic_require_gohma or is_adult or is_glitched or Defeat_Gohma
+            or Time_Travel or shuffle_special_interior_entrances or shuffle_overworld_entrances or spawn_positions",
     "can_plant_bugs": "is_child and Bugs",
     "can_ride_epona": "is_adult and Epona and (can_play(Eponas_Song) or (is_glitched and can_hover))",
     "can_stun_deku": "is_adult or (Slingshot or Boomerang or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or Nuts or Deku_Shield)",

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -87,15 +87,11 @@
         "dungeon": "Deku Tree",
         "locations": {
             "Deku Tree MQ Deku Scrub": "can_stun_deku",
-            "Deku Tree Queen Gohma Heart": "
-                here(has_fire_source_with_torch) and here(has_shield) and
-                (is_adult or Kokiri_Sword or Sticks)",
-            "Queen Gohma": "
-                here(has_fire_source_with_torch) and here(has_shield) and
-                (is_adult or Kokiri_Sword or Sticks)"
+            "Deku Tree Queen Gohma Heart": "'Defeat Gohma'",
+            "Queen Gohma": "'Defeat Gohma'"
         },
         "events": {
-            "Deku Tree Clear": "
+            "Defeat Gohma": "
                 here(has_fire_source_with_torch) and here(has_shield) and
                 (is_adult or Kokiri_Sword or Sticks)"
         },

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -58,14 +58,12 @@
         "region_name": "Deku Tree Boss Room",
         "dungeon": "Deku Tree",
         "events": {
-            "Deku Tree Clear": "
+            "Defeat Gohma": "
                 here(has_shield) and (is_adult or Kokiri_Sword or Sticks)"
         },
         "locations": {
-            "Deku Tree Queen Gohma Heart": "
-                here(has_shield) and (is_adult or Kokiri_Sword or Sticks)",
-            "Queen Gohma": "
-                here(has_shield) and (is_adult or Kokiri_Sword or Sticks)"
+            "Deku Tree Queen Gohma Heart": "'Defeat Gohma'",
+            "Queen Gohma": "'Defeat Gohma'"
         },
         "exits": {
             "Deku Tree Lobby": "True"

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -75,7 +75,7 @@
         "exits": {
             "Forest Temple NE Outdoors": "
                 can_use(Iron_Boots) or can_use(Longshot) or 
-                (Progressive_Scale, 2) or (logic_forest_well_swim and can_use(Hookshot))",
+                Golden_Scale or (logic_forest_well_swim and can_use(Hookshot))",
             "Forest Temple Outdoors Top Ledges": "can_use(Fire_Arrows)"
         }
     },

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -33,7 +33,7 @@
                 has_explosives or Kokiri_Sword or can_use(Dins_Fire)"
         },
         "exits": {
-            "Forest Temple NE Outdoors": "(Progressive_Scale, 2)",
+            "Forest Temple NE Outdoors": "Golden_Scale",
             #Other methods of crossing through the well are not currently relevant.
             "Forest Temple Outdoors High Balconies": "
                 here(is_adult or has_explosives or
@@ -61,7 +61,7 @@
             "Forest Temple Outdoors High Balconies": "
                 can_use(Longshot) or (logic_forest_vines and can_use(Hookshot))",
                 #Longshot can grab some very high up vines to drain the well.
-            "Forest Temple NW Outdoors": "can_use(Iron_Boots) or (Progressive_Scale, 2)",
+            "Forest Temple NW Outdoors": "can_use(Iron_Boots) or Golden_Scale",
             "Forest Temple Lobby": "True"
         }
     },

--- a/data/World/Jabu Jabus Belly.json
+++ b/data/World/Jabu Jabus Belly.json
@@ -16,7 +16,7 @@
             "Jabu Jabus Belly GS Lobby Basement Lower": "can_use(Boomerang) or can_use(Hookshot)",
             "Jabu Jabus Belly GS Lobby Basement Upper": "can_use(Boomerang) or can_use(Hookshot)",
             "Jabu Jabus Belly Deku Scrub": "
-                can_dive or is_child or logic_jabu_scrub_jump_dive or can_use(Iron_Boots)",
+                Silver_Scale or is_child or logic_jabu_scrub_jump_dive or can_use(Iron_Boots)",
             "Fairy Pot": "has_bottle"
         },
         "exits": {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -16,7 +16,7 @@
             "Child Spawn": "is_child",
             "Adult Spawn": "is_adult",
             "Prelude of Light Warp": "can_play(Prelude_of_Light) and can_leave_forest",
-            "Minuet of Forest Warp": "can_play(Minuet_of_Forest)",
+            "Minuet of Forest Warp": "can_play(Minuet_of_Forest) and (not warp_songs or can_leave_forest)",
             "Bolero of Fire Warp": "can_play(Bolero_of_Fire) and can_leave_forest",
             "Serenade of Water Warp": "can_play(Serenade_of_Water) and can_leave_forest",
             "Nocturne of Shadow Warp": "can_play(Nocturne_of_Shadow) and can_leave_forest",
@@ -81,8 +81,8 @@
         "locations": {
             "KF Kokiri Sword Chest": "is_child",
             "KF GS Know It All House": "
-                is_child and can_child_attack and at_night and
-                (had_night_start or can_leave_forest or can_play(Suns_Song))",
+                is_child and can_child_attack and at_night and (ensure_tod_access or
+                open_forest != 'closed' or 'Defeat Gohma' or had_night_start or can_play(Suns_Song))",
             "KF GS Bean Patch": "
                 can_plant_bugs and can_child_attack",
             "KF GS House of Twins": "
@@ -101,8 +101,17 @@
             "KF Kokiri Shop": "True",
             "KF Outside Deku Tree": "is_adult or open_forest == 'open' or 'Showed Mido Sword & Shield'",
             "Lost Woods": "True",
-            "LW Bridge From Forest": "can_leave_forest",
+            "LW Bridge From Forest": "open_forest != 'closed' or is_adult or 'Defeat Gohma'",
             "KF Storms Grotto": "can_open_storm_grotto"
+        }
+    },
+    {
+        "region_name": "Kokiri Forest From Bridge",
+        "scene": "Kokiri Forest",
+        "hint": "Kokiri Forest",
+        "exits": {
+            "Kokiri Forest": "open_forest != 'closed' or is_adult or 'Defeat Gohma'",
+            "LW Bridge From Forest": "open_forest != 'closed' or is_adult or 'Defeat Gohma'"
         }
     },
     {
@@ -224,7 +233,7 @@
                 is_adult and
                 (can_use(Hover_Boots) or can_use(Longshot) or
                     here(can_plant_bean) or logic_lost_woods_bridge)",
-            "Zora River": "can_leave_forest and (can_dive or can_use(Iron_Boots))",
+            "Zora River": "can_leave_forest and (Silver_Scale or can_use(Iron_Boots))",
             "LW Beyond Mido": "is_child or logic_mido_backflip or can_play(Sarias_Song)",
             "LW Near Shortcuts Grotto": "here(can_blast_or_smash)"
         }
@@ -319,7 +328,7 @@
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "exits": {
-            "Kokiri Forest": "True",
+            "Kokiri Forest From Bridge": "True",
             "Hyrule Field": "True",
             "Lost Woods": "can_use(Longshot)"
         }
@@ -363,7 +372,7 @@
         },
         "locations": {
             "Pierre": "is_adult and Bonooru and not free_scarecrow",
-            "LH Underwater Item": "is_child and can_dive",
+            "LH Underwater Item": "is_child and Silver_Scale",
             "LH Sun": "
                 is_adult and 
                 (can_use(Distant_Scarecrow) or 'Water Temple Clear') and can_use(Bow)",
@@ -385,7 +394,7 @@
         },
         "exits": {
             "Hyrule Field": "True",
-            "Zoras Domain": "is_child and can_dive",
+            "Zoras Domain": "is_child and Silver_Scale",
             "LH Owl Flight": "is_child",
             "LH Lab": "True",
             "LH Fishing Island": "
@@ -394,7 +403,7 @@
             "Water Temple Lobby": "
                 can_use(Hookshot) and
                 (can_use(Iron_Boots) or
-                    ((can_use(Longshot) or logic_water_hookshot_entry) and (Progressive_Scale, 2)))",
+                    ((can_use(Longshot) or logic_water_hookshot_entry) and Golden_Scale))",
             "LH Grotto": "True"
         }
     },
@@ -425,7 +434,7 @@
         },
         "locations": {
             "LH Lab Dive": "
-                (Progressive_Scale, 2) or
+                Golden_Scale or
                 (logic_lab_diving and Iron_Boots and can_use(Hookshot))",
             "LH GS Lab Crate": "Iron_Boots and can_use(Hookshot)"
         },
@@ -736,7 +745,9 @@
             "ToT Light Arrows Cutscene": "is_adult and can_trigger_lacs"
         },
         "exits": {
-            "ToT Entrance": "True",
+            "ToT Entrance": "
+                (open_forest != 'closed' or starting_age == 'child' or here(is_child) or
+                shuffle_overworld_entrances or shuffle_special_interior_entrances or spawn_positions)",
             "Beyond Door of Time": "can_play(Song_of_Time) or open_door_of_time"
         }
     },
@@ -746,7 +757,10 @@
         "hint": "Temple of Time",
         "locations": {
             "Master Sword Pedestal": "True",
-            "Sheik at Temple": "Forest_Medallion and is_adult"
+            "Sheik at Temple": "
+                Forest_Medallion and is_adult and
+                (open_forest != 'closed' or starting_age == 'child' or here(is_child) or
+                shuffle_overworld_entrances or shuffle_special_interior_entrances or spawn_positions)"
         },
         "exits": {
             "Temple of Time": "True"
@@ -1665,7 +1679,7 @@
             "ZR Front": "True",
             "ZR Open Grotto": "True",
             "ZR Fairy Grotto": "here(can_blast_or_smash)",
-            "Lost Woods": "can_dive or can_use(Iron_Boots)",
+            "Lost Woods": "Silver_Scale or can_use(Iron_Boots)",
             "ZR Storms Grotto": "can_open_storm_grotto",
             "ZR Behind Waterfall": "
                 can_play(Zeldas_Lullaby) or
@@ -1717,7 +1731,7 @@
         },
         "exits": {
             "ZR Behind Waterfall": "True",
-            "Lake Hylia": "is_child and can_dive",
+            "Lake Hylia": "is_child and Silver_Scale",
             "ZD Behind King Zora": "
                 Deliver_Letter or zora_fountain == 'open' or
                 (zora_fountain == 'adult' and is_adult)",
@@ -1832,7 +1846,9 @@
         "region_name": "LLR Talons House",
         "scene": "LLR Talons House",
         "locations": {
-            "LLR Talons Chickens": "is_child and at_day and Zeldas_Letter"
+            "LLR Talons Chickens": "
+                is_child and Zeldas_Letter and at_day and (ensure_tod_access or
+                open_forest != 'closed' or 'Defeat Gohma' or not had_night_start or can_play(Suns_Song))"
         },
         "exits": {
             "Lon Lon Ranch": "True"
@@ -2083,7 +2099,7 @@
         "scene": "HF Tektite Grotto",
         "locations": {
             "HF Tektite Grotto Freestanding PoH": "
-                (Progressive_Scale, 2) or can_use(Iron_Boots)"
+                Golden_Scale or can_use(Iron_Boots)"
         },
         "exits": {
             "Hyrule Field": "True"

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -97,10 +97,11 @@
                 ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and 
                     (logic_lens_spirit_mq or can_use(Lens_of_Truth)))",
             "Desert Colossus": "
-                ((Small_Key_Spirit_Temple, 7) and
+                can_leave_forest and
+                (((Small_Key_Spirit_Temple, 7) and
                     (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot or is_adult)) or
                 ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and
-                    (logic_lens_spirit_mq or can_use(Lens_of_Truth)) and is_adult)"
+                    (logic_lens_spirit_mq or can_use(Lens_of_Truth)) and is_adult))"
         }
     },
     {

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -152,9 +152,10 @@
         },
         "exits": {
             "Desert Colossus": "
-                (is_child and (Small_Key_Spirit_Temple, 5)) or
+                can_leave_forest and
+                ((is_child and (Small_Key_Spirit_Temple, 5)) or
                 (can_use(Silver_Gauntlets) and
-                    (((Small_Key_Spirit_Temple, 3) and has_explosives) or (Small_Key_Spirit_Temple, 5)))"
+                    (((Small_Key_Spirit_Temple, 3) and has_explosives) or (Small_Key_Spirit_Temple, 5))))"
         }
     },
     {

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -49,7 +49,7 @@
         "locations": {
             "Water Temple MQ Boss Key Chest": "
                 (can_use(Zora_Tunic) or logic_fewer_tunic_requirements) and can_use(Dins_Fire) and
-                (logic_water_dragon_jump_dive or can_dive or can_use(Iron_Boots))",
+                (logic_water_dragon_jump_dive or Silver_Scale or can_use(Iron_Boots))",
             "Water Temple MQ GS River": "True",
             "Fairy Pot": "has_bottle",
             "Nut Pot": "True"

--- a/data/World/Water Temple.json
+++ b/data/World/Water Temple.json
@@ -52,7 +52,7 @@
             "Water Temple GS Behind Gate": "
                 (can_use(Hookshot) or can_use(Hover_Boots)) and 
                 has_explosives and can_play(Zeldas_Lullaby) and
-                (can_use(Iron_Boots) or can_dive)",
+                (can_use(Iron_Boots) or Silver_Scale)",
             "Water Temple GS Central Pillar": "
                 can_play(Zeldas_Lullaby) and
                     (((can_use(Longshot) or (logic_water_central_gs_fw and can_use(Hookshot) and can_use(Farores_Wind))) and 
@@ -79,8 +79,8 @@
             "Water Temple Dragon Statue": "
                 can_play(Zeldas_Lullaby) and Progressive_Strength_Upgrade and
                 ((Iron_Boots and can_use(Hookshot)) or
-                    (logic_water_dragon_adult and (has_bombchus or can_use(Bow) or can_use(Hookshot)) and (can_dive or Iron_Boots)) or
-                    (logic_water_dragon_child and Child_Water_Temple and (has_bombchus or Slingshot or Boomerang) and can_dive))"
+                    (logic_water_dragon_adult and (has_bombchus or can_use(Bow) or can_use(Hookshot)) and (Silver_Scale or Iron_Boots)) or
+                    (logic_water_dragon_child and Child_Water_Temple and (has_bombchus or Slingshot or Boomerang) and Silver_Scale))"
         }
     },
     {

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -44,6 +44,7 @@
     "enhance_map_compass": false,
     "reachable_locations": "all",
     "logic_no_night_tokens_without_suns_song": true,
+    "logic_require_gohma": true,
     "disabled_locations": [
       "Deku Theater Mask of Truth",
       "Kak 40 Gold Skulltula Reward",
@@ -141,6 +142,7 @@
     "enhance_map_compass": false,
     "reachable_locations": "all",
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma": true,
     "disabled_locations": [
       "Deku Theater Mask of Truth"
     ],
@@ -245,6 +247,7 @@
     "enhance_map_compass": false,
     "reachable_locations": "all",
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma": true,
     "disabled_locations": [
       "Deku Theater Mask of Truth"
     ],
@@ -326,6 +329,7 @@
     "complete_mask_quest":                     false,
     "fast_chests":                             true,
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma":                     true,
     "free_scarecrow":                          false,
     "fast_bunny_hood":                         false,
     "start_with_rupees":                       false,
@@ -451,6 +455,7 @@
     "enhance_map_compass": false,
     "reachable_locations": "all",
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma": true,
     "disabled_locations": [
       "Kak 40 Gold Skulltula Reward",
       "Kak 50 Gold Skulltula Reward",
@@ -528,6 +533,7 @@
     "complete_mask_quest":                     false,
     "fast_chests":                             true,
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma":                     true,
     "free_scarecrow":                          true,
     "fast_bunny_hood":                         true,
     "start_with_rupees":                       true,
@@ -618,7 +624,7 @@
     "world_count": 1,
     "randomize_settings": false,
     "logic_rules": "glitchless",
-    "open_forest": "closed_deku",
+    "open_forest": "closed",
     "open_kakariko": "closed",
     "open_door_of_time": false,
     "zora_fountain": "closed",
@@ -656,6 +662,7 @@
     "enhance_map_compass": true,
     "reachable_locations": "beatable",
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma": false,
     "disabled_locations": [],
     "allowed_tricks": [
       "logic_fewer_tunic_requirements",
@@ -860,6 +867,7 @@
     "complete_mask_quest":                     false,
     "fast_chests":                             true,
     "logic_no_night_tokens_without_suns_song": false,
+    "logic_require_gohma":                     true,
     "free_scarecrow":                          false,
     "fast_bunny_hood":                         false,
     "start_with_rupees":                       false,

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -232,7 +232,8 @@
           "row_span": [2,2,2],
           "settings": [
             "reachable_locations",
-            "logic_no_night_tokens_without_suns_song"
+            "logic_no_night_tokens_without_suns_song",
+            "logic_require_gohma"
           ]
         },
         {


### PR DESCRIPTION
Closed Forest is made to work with all forms of ER and with adult start.
Adult start requires either ER or open door of time.
Closed Forest is also changed to only gate the forest exit, and the requirement of defeating Gohma to leave the forest is moved to a separate logical setting.