### PR TITLE
Make both 2h swords conditionally foolish

### DIFF
--- a/World.py
+++ b/World.py
@@ -655,7 +655,6 @@ class World(object):
         exclude_item_list = [
             'Double Defense',
             'Ice Arrows',
-            'Biggoron Sword',
         ]
         if (self.damage_multiplier != 'ohko' and self.damage_multiplier != 'quadruple' and 
             self.shuffle_scrubs == 'off' and not self.shuffle_grotto_entrances):
@@ -668,6 +667,10 @@ class World(object):
             # Serenade and Prelude are never required unless one of those settings is enabled
             exclude_item_list.append('Serenade of Water')
             exclude_item_list.append('Prelude of Light')
+        if self.logic_rules == 'glitchless':
+            # Both two-handed swords can be required in glitch logic, so only consider them foolish in glitchless
+            exclude_item_list.append('Biggoron Sword')
+            exclude_item_list.append('Giants Knife')
 
         for i in self.item_hint_type_overrides['barren']:
             if i in exclude_item_list:


### PR DESCRIPTION
Fixes #1311.

Currently, GK cannot be foolish, despite BGS being allowed to be foolish. This PR changes both to be allowed to be foolish in glitchless logic only.

Both 2-handed swords are logically useful in both iterations of glitch logic (although they're technically useless in 1.0, since their only logical use is able to be done with MS and a glitchless trick...or just a pot), so we don't really want them to be foolish there.