### PR TITLE
Split on last dot in Patch filename for output files

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -361,7 +361,7 @@ def from_patch_file(settings, window=dummy_window()):
 
     logger.info('Patching ROM.')
 
-    filename_split = os.path.basename(settings.patch_file).split('.')
+    filename_split = os.path.basename(settings.patch_file).rpartition('.')
 
     if settings.output_file:
         outfilebase = settings.output_file
@@ -455,7 +455,7 @@ def cosmetic_patch(settings, window=dummy_window()):
 
     logger.info('Patching ROM.')
 
-    filename_split = os.path.basename(settings.patch_file).split('.')
+    filename_split = os.path.basename(settings.patch_file).rpartition('.')
 
     if settings.output_file:
         outfilebase = settings.output_file


### PR DESCRIPTION
Fixes #1314

Note that filename_split[1] is now the separator instead of the separator being lost on split. It isn't currently used so doesn't change the way any of the code works. Index 0 is still the filename before the extension, Index -1 is the extension, but this way the filenames don't get truncated if the user decides to use `.` in their file names as separators for reasons other than an extension.