### PR TITLE
Add King Zora Skip as a logic trick

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -857,6 +857,14 @@ logic_tricks = {
                     To kill it, the logic normally guarantees one of
                     Hookshot, Bow, or Magic.
                     '''},
+    'Skip King Zora as Adult with Nothing': {
+        'name'    : 'logic_king_zora_skip',
+        'tags'    : ("Zora's Domain",),
+        'tooltip' : '''\
+                    With a precise jump as adult, it is possible to
+                    get on the fence next to King Zora from the front
+                    to access Zora's Fountain.
+                    '''},
     'Shadow Temple River Statue with Bombchu': {
         'name'    : 'logic_shadow_statue',
         'tags'    : ("Shadow Temple",),

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1720,7 +1720,8 @@
             "Lake Hylia": "is_child and can_dive",
             "ZD Behind King Zora": "
                 Deliver_Letter or zora_fountain == 'open' or
-                (zora_fountain == 'adult' and is_adult)",
+                (zora_fountain == 'adult' and is_adult) or
+                (logic_king_zora_skip and is_adult)",
             "ZD Shop": "is_child or Blue_Fire",
             "ZD Storms Grotto": "can_open_storm_grotto"
         }

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -741,6 +741,7 @@
       "logic_crater_upper_to_lower",
       "logic_zora_with_hovers",
       "logic_domain_gs",
+      "logic_king_zora_skip",
       "logic_shadow_statue",
       "logic_link_goron_dins",
       "logic_fire_song_of_time",


### PR DESCRIPTION
This adds [King Zora Skip](https://www.youtube.com/watch?v=65EI_McXzUk) as a trick. The requirement is just `is_adult` because according to @Hamsda it's fairly easy to set up without a shield as well.