### PR TITLE
Fix character encoding and allows for control codes in plando'd hint texts

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -62,8 +62,8 @@ CHARACTER_MAP = {
     '⯆': 0xA6,
     '⯇': 0xA7,
     '⯈': 0xA8,
-    chr(0xA9): 0xA9,  # Down arrow -- not sure what best supports this
-    chr(0xAA): 0xAA,  # C-stick    -- not sure what best supports this
+    chr(0xA9): 0xA9,  # Down arrow   -- not sure what best supports this
+    chr(0xAA): 0xAA,  # Analog stick -- not sure what best supports this
 }
 # Support other ways of directly specifying controller inputs in OOTR's character set.
 # (This is backwards-compatibility support for ShadowShine57's previous patch.)

--- a/Messages.py
+++ b/Messages.py
@@ -618,7 +618,8 @@ class Message:
 
     @classmethod
     def from_string(cls, text, id=0, opts=0x00):
-        return cls(text + "\x02", 0, id, opts, 0, len(bytes) + 1)
+        bytes = text + "\x02"
+        return cls(bytes, 0, id, opts, 0, len(bytes) + 1)
 
     @classmethod
     def from_bytearray(cls, bytearray, id=0, opts=0x00):

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1152,7 +1152,7 @@ class Distribution(object):
             raise InvalidFileException("Your Ocarina of Time ROM doesn't belong in the plandomizer setting. If you don't know what plandomizer is, or don't plan to use it, leave that setting blank and try again.")
 
         try:
-            with open(filename) as infile:
+            with open(filename, encoding='utf-8') as infile:
                 src_dict = json.load(infile)
         except json.decoder.JSONDecodeError as e:
             raise InvalidFileException(f"Invalid Plandomizer File. Make sure the file is a valid JSON file. Failure reason: {str(e)}") from None

--- a/Settings.py
+++ b/Settings.py
@@ -333,7 +333,7 @@ def get_settings_from_command_line_args():
                 for fn in os.listdir(data_path('Presets'))
                 if fn.endswith('.json'))
         for fn in presetsFiles:
-            with open(fn) as f:
+            with open(fn, encoding='utf-8') as f:
                 presets = json.load(f)
                 if args.settings_preset in presets:
                     settings_base.update(presets[args.settings_preset])
@@ -348,7 +348,7 @@ def get_settings_from_command_line_args():
         settingsFile = local_path(args.settings or 'settings.sav')
 
         try:
-            with open(settingsFile) as f:
+            with open(settingsFile, encoding='utf-8') as f:
                 settings_base.update(json.load(f))
         except Exception as ex:
             if args.settings is not None:

--- a/TextBox.py
+++ b/TextBox.py
@@ -18,21 +18,19 @@ CONTROL_CHARS = {
     'NAME':         ['@', '\x0F'],
     'COLOR':        ['#', '\x05\x00'],
 }
-TEXT_END   = '\x02'
+TEXT_END = '\x02'
 
 
 def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, replace_control_chars=True):
     # Replace stand-in characters with their actual control code.
     if replace_control_chars:
         def replace_bytes(matchobj):
-            return bytes.fromhex(matchobj[1].decode('utf-8'))
+            return ''.join(chr(x) for x in bytes.fromhex(matchobj[1]))
 
         for char in CONTROL_CHARS.values():
             text = text.replace(char[0], char[1])
 
-        text = bytearray(
-            re.sub(br"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", replace_bytes, text.encode('utf-8'), flags=re.IGNORECASE)
-        )
+        text = re.sub(r"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", replace_bytes, text, flags=re.IGNORECASE)
 
     # Parse the text into a list of control codes.
     text_codes = Messages.parse_control_codes(text)

--- a/TextBox.py
+++ b/TextBox.py
@@ -1,4 +1,5 @@
 import Messages
+import re
 
 # Least common multiple of all possible character widths. A line wrap must occur when the combined widths of all of the
 # characters on a line reach this value.
@@ -23,8 +24,15 @@ TEXT_END   = '\x02'
 def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, replace_control_chars=True):
     # Replace stand-in characters with their actual control code.
     if replace_control_chars:
+        def replace_bytes(matchobj):
+            return bytes.fromhex(matchobj[1].decode('utf-8'))
+
         for char in CONTROL_CHARS.values():
             text = text.replace(char[0], char[1])
+
+        text = bytearray(
+            re.sub(br"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", replace_bytes, text.encode('utf-8'), flags=re.IGNORECASE)
+        )
 
     # Parse the text into a list of control codes.
     text_codes = Messages.parse_control_codes(text)


### PR DESCRIPTION
This commit overhauls the way UTF-8-to-ROM texts are translated, solving
encoding issues that can arise when using control characters followed by
byte values greater than 0x80.

It also allows plando'd hint texts to include arbitrary control codes,
which can be used for trickery like including sound effects.  Plando
authors should be aware this can cause instability if misused and should test any
produced ROMs accordingly.

Arbitrary control code syntax: `${hex}`.  Example:
`"${12 28 df}The cow goes moo."`

Loosely tested.  Someone more familiar with actually playing the game should probably give this a closer look.