### PR TITLE
Adding "Random" as a possible selection for "Rainbow Bridge Requirement"

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2024,7 +2024,8 @@ setting_infos = [
             'stones':	  'Spiritual Stones',
             'medallions': 'Medallions',
             'dungeons':   'Dungeons',
-            'tokens':     'Gold Skulltula Tokens'
+            'tokens':     'Gold Skulltula Tokens',
+            'random':     'Random'
         },
         gui_tooltip    = '''\
             'Always Open': Rainbow Bridge is always present.
@@ -2033,6 +2034,7 @@ setting_infos = [
             'Medallions': A configurable amount of Medallions.
             'Dungeons': A configurable amount of Dungeon Rewards.
             'Gold Skulltula Tokens': A configurable amount of Gold Skulltula Tokens.
+            'Random': Chooses a random win condition excluding Gold Skulltula Tokens.
         ''',
         shared         = True,
         disable={
@@ -2042,6 +2044,7 @@ setting_infos = [
             'medallions': {'settings': ['bridge_stones', 'bridge_rewards', 'bridge_tokens']},
             'dungeons':   {'settings': ['bridge_medallions', 'bridge_stones', 'bridge_tokens']},
             'tokens':     {'settings': ['bridge_medallions', 'bridge_stones', 'bridge_rewards']},
+            'random':     {'settings': ['bridge_medallions', 'bridge_stones', 'bridge_rewards', 'bridge_tokens']}
         },
         gui_params     = {
             'randomize_key': 'randomize_settings',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2034,7 +2034,7 @@ setting_infos = [
             'Medallions': A configurable amount of Medallions.
             'Dungeons': A configurable amount of Dungeon Rewards.
             'Gold Skulltula Tokens': A configurable amount of Gold Skulltula Tokens.
-            'Random': Chooses a random win condition excluding Gold Skulltula Tokens.
+            'Random': A random Rainbow Bridge requirement excluding Gold Skulltula Tokens.
         ''',
         shared         = True,
         disable={

--- a/World.py
+++ b/World.py
@@ -220,7 +220,7 @@ class World(object):
         return new_world
 
 
-    def setRandomSymbolCount(self):
+    def set_random_bridge_values(self):
         if self.bridge == 'medallions':
             self.bridge_medallions = random.randrange(1, 6)
             self.randomized_list.append('bridge_medallions')
@@ -273,7 +273,7 @@ class World(object):
         if self.bridge == 'random':
             possible_bridge_requirements = ["open", "medallions", "dungeons", "stones", "vanilla"]
             self.bridge = random.choice(possible_bridge_requirements)
-            self.setRandomSymbolCount()
+            self.set_random_bridge_values()
             self.randomized_list.append('bridge')
 
         # Determine Ganon Trials

--- a/World.py
+++ b/World.py
@@ -220,6 +220,18 @@ class World(object):
         return new_world
 
 
+    def setRandomSymbolCount(self):
+        if self.bridge == 'medallions':
+            self.bridge_medallions = random.randrange(1, 6)
+            self.randomized_list.append('bridge_medallions')
+        if self.bridge == 'dungeons':
+            self.bridge_rewards = random.randrange(1, 9)
+            self.randomized_list.append('bridge_rewards')
+        if self.bridge == 'stones':
+            self.bridge_stones = random.randrange(1, 3)
+            self.randomized_list.append('bridge_stones')
+
+
     def resolve_random_settings(self):
         # evaluate settings (important for logic, nice for spoiler)
         self.randomized_list = []
@@ -256,6 +268,13 @@ class World(object):
         if self.chicken_count_random:
             self.chicken_count = random.randint(0, 7)
             self.randomized_list.append('chicken_count')
+
+        # Handle random Rainbow Bridge condition
+        if self.bridge == 'random':
+            possible_bridge_requirements = ["open", "medallions", "dungeons", "stones", "vanilla"]
+            self.bridge = random.choice(possible_bridge_requirements)
+            self.setRandomSymbolCount()
+            self.randomized_list.append('bridge')
 
         # Determine Ganon Trials
         trial_pool = list(self.skipped_trials)

--- a/World.py
+++ b/World.py
@@ -222,13 +222,13 @@ class World(object):
 
     def set_random_bridge_values(self):
         if self.bridge == 'medallions':
-            self.bridge_medallions = random.randrange(1, 6)
+            self.bridge_medallions = 6
             self.randomized_list.append('bridge_medallions')
         if self.bridge == 'dungeons':
-            self.bridge_rewards = random.randrange(1, 9)
+            self.bridge_rewards = 9
             self.randomized_list.append('bridge_rewards')
         if self.bridge == 'stones':
-            self.bridge_stones = random.randrange(1, 3)
+            self.bridge_stones = 3
             self.randomized_list.append('bridge_stones')
 
 


### PR DESCRIPTION
You can select "Random" as an option for "Rainbow Bridge Requirement".  Doing so will randomize Rainbow Bridge Requirement the same way "Randomize Main Rule Settings" does.  This means "tokens" is not a possible option.