### PR TITLE
Updating "Random Settings" exceptions text to include scrub information.

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1860,6 +1860,7 @@ setting_infos = [
                          - Variable numbers of Spiritual Stones, Medallions, or Dungeons
                          for Rainbow Bridge and Ganon's Boss Key on LACS 
                          (you will always be required to obtain all the relevant rewards)
+                         - Scrub Shuffle will either be "Off" or "On (Affordable)"
                          ''',
         default        = False,
         disable        = {


### PR DESCRIPTION
"Random Main Rule Settings" provides a list of settings that are not randomized when turned on when you hover over it in the GUI.  These exceptions are missing Shuffle Scrub information.