### PR TITLE
Allow plando settings to override randomized settings

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -346,6 +346,7 @@ class WorldDistribution(object):
 
 
     def configure_randomized_settings(self, world):
+        # Add randomized_settings defined in distribution to world's randomized settings list
         for name, record in self.randomized_settings.items():
             setattr(world, name, record)
             if name not in world.randomized_list:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -345,8 +345,8 @@ class WorldDistribution(object):
         return dist_chosen
 
 
+    # Add randomized_settings defined in distribution to world's randomized settings list
     def configure_randomized_settings(self, world):
-        # Add randomized_settings defined in distribution to world's randomized settings list
         for name, record in self.randomized_settings.items():
             setattr(world, name, record)
             if name not in world.randomized_list:

--- a/Settings.py
+++ b/Settings.py
@@ -225,7 +225,7 @@ class Settings:
     def get_dependency(self, setting_name, check_random=True):
         info = get_setting_info(setting_name)
         not_in_dist = not '_settings' in self.distribution.src_dict or info.name not in self.distribution.src_dict['_settings'].keys()
-        if check_random and 'randomize_key' in info.gui_params and self.__dict__[info.gui_params['randomize_key']] and plando_randomized_check:
+        if check_random and 'randomize_key' in info.gui_params and self.__dict__[info.gui_params['randomize_key']] and not_in_dist:
             return info.disabled_default
         elif info.dependency != None:
             return info.disabled_default if info.dependency(self) and not_in_dist else None

--- a/Settings.py
+++ b/Settings.py
@@ -264,7 +264,10 @@ class Settings:
             if randomize_key is not None and info.gui_params['randomize_key'] != randomize_key:
                 continue
 
-            if self.__dict__[info.gui_params['randomize_key']]:
+            # Make sure setting is meant to be randomized and not specified in distribution
+            # We check it's not specified in the distribution so that plando can override "Randomize Main Rule Settings"
+            has_settings = '_settings' in self.distribution.src_dict 
+            if self.__dict__[info.gui_params['randomize_key']] and (not has_settings or info.name not in self.distribution.src_dict['_settings'].keys()):
                 randomize_keys_enabled.add(info.gui_params['randomize_key'])
                 choices, weights = zip(*info.gui_params['distribution'])
                 self.__dict__[info.name] = random_choices(choices, weights=weights)[0]
@@ -304,7 +307,9 @@ class Settings:
 
     def to_json(self):
         return {setting.name: self.__dict__[setting.name] for setting in setting_infos
-                if setting.shared and setting.name not in self._disabled}
+                if setting.shared and (setting.name not in self._disabled or
+                # We want to still include settings disabled by "Randomize Main Rule Settings" specified in distribution
+                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))}
 
 
     def to_json_cosmetics(self):

--- a/Settings.py
+++ b/Settings.py
@@ -224,11 +224,11 @@ class Settings:
 
     def get_dependency(self, setting_name, check_random=True):
         info = get_setting_info(setting_name)
-        plando_randomized_check = not '_settings' in self.distribution.src_dict or info.name not in self.distribution.src_dict['_settings'].keys()
+        not_in_dist = not '_settings' in self.distribution.src_dict or info.name not in self.distribution.src_dict['_settings'].keys()
         if check_random and 'randomize_key' in info.gui_params and self.__dict__[info.gui_params['randomize_key']] and plando_randomized_check:
             return info.disabled_default
         elif info.dependency != None:
-            return info.disabled_default if info.dependency(self) and plando_randomized_check else None
+            return info.disabled_default if info.dependency(self) and not_in_dist else None
         else:
             return None
 
@@ -265,10 +265,10 @@ class Settings:
             if randomize_key is not None and info.gui_params['randomize_key'] != randomize_key:
                 continue
 
-            # Make sure setting is meant to be randomized and not specified in distribution
-            # We check it's not specified in the distribution so that plando can override "Randomize Main Rule Settings"
-            has_settings = '_settings' in self.distribution.src_dict 
-            if self.__dict__[info.gui_params['randomize_key']] and (not has_settings or info.name not in self.distribution.src_dict['_settings'].keys()):
+            # Make sure the setting is meant to be randomized and not specified in distribution
+            # We that check it's not specified in the distribution so that plando can override randomized settings
+            not_in_dist = not '_settings' in self.distribution.src_dict or info.name not in self.distribution.src_dict['_settings'].keys()
+            if self.__dict__[info.gui_params['randomize_key']] and not_in_dist:
                 randomize_keys_enabled.add(info.gui_params['randomize_key'])
                 choices, weights = zip(*info.gui_params['distribution'])
                 self.__dict__[info.name] = random_choices(choices, weights=weights)[0]
@@ -309,7 +309,7 @@ class Settings:
     def to_json(self):
         return {setting.name: self.__dict__[setting.name] for setting in setting_infos
                 if setting.shared and (setting.name not in self._disabled or
-                # We want to still include settings disabled by "Randomize Main Rule Settings" specified in distribution
+                # We want to still include settings disabled by randomized settings options if they're specified in distribution
                 ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))}
 
 

--- a/Settings.py
+++ b/Settings.py
@@ -224,10 +224,11 @@ class Settings:
 
     def get_dependency(self, setting_name, check_random=True):
         info = get_setting_info(setting_name)
-        if check_random and 'randomize_key' in info.gui_params and self.__dict__[info.gui_params['randomize_key']]:
+        plando_randomized_check = not '_settings' in self.distribution.src_dict or info.name not in self.distribution.src_dict['_settings'].keys()
+        if check_random and 'randomize_key' in info.gui_params and self.__dict__[info.gui_params['randomize_key']] and plando_randomized_check:
             return info.disabled_default
         elif info.dependency != None:
-            return info.disabled_default if info.dependency(self) else None
+            return info.disabled_default if info.dependency(self) and plando_randomized_check else None
         else:
             return None
 

--- a/World.py
+++ b/World.py
@@ -243,22 +243,22 @@ class World(object):
                         or (setting == 'lacs_rewards' and self.lacs_condition != 'dungeons') \
                         or (setting == 'lacs_tokens' and self.lacs_condition != 'tokens'):
                     self.randomized_list.remove(setting)
-        if self.big_poe_count_random:
+        if self.big_poe_count_random and 'big_poe_count' not in dist_keys:
             self.big_poe_count = random.randint(1, 10)
             self.randomized_list.append('big_poe_count')
-        if self.starting_tod == 'random':
+        if self.starting_tod == 'random' and 'starting_tod' not in dist_keys:
             setting_info = get_setting_info('starting_tod')
             choices = [ch for ch in setting_info.choices if ch not in ['default', 'random']]
             self.starting_tod = random.choice(choices)
             self.randomized_list.append('starting_tod')
-        if self.starting_age == 'random':
+        if self.starting_age == 'random' and 'starting_age' not in dist_keys:
             if self.settings.open_forest == 'closed':
                 # adult is not compatible
                 self.starting_age = 'child'
             else:
                 self.starting_age = random.choice(['child', 'adult'])
             self.randomized_list.append('starting_age')
-        if self.chicken_count_random:
+        if self.chicken_count_random and 'chicken_count' not in dist_keys:
             self.chicken_count = random.randint(0, 7)
             self.randomized_list.append('chicken_count')
 
@@ -267,7 +267,7 @@ class World(object):
         dist_chosen = self.distribution.configure_trials(trial_pool)
         dist_num_chosen = len(dist_chosen)
 
-        if self.trials_random:
+        if self.trials_random and 'trials' not in dist_keys:
             self.trials = dist_num_chosen + random.randint(0, len(trial_pool))
             self.randomized_list.append('trials')
         num_trials = int(self.trials)
@@ -280,7 +280,7 @@ class World(object):
         dungeon_pool = list(self.dungeon_mq)
         dist_num_mq = self.distribution.configure_dungeons(self, dungeon_pool)
 
-        if self.mq_dungeons_random:
+        if self.mq_dungeons_random and 'mq_dungeons' not in dist_keys:
             for dungeon in dungeon_pool:
                 self.dungeon_mq[dungeon] = random.choice([True, False])
             self.mq_dungeons = list(self.dungeon_mq.values()).count(True)

--- a/World.py
+++ b/World.py
@@ -228,6 +228,9 @@ class World(object):
             self.randomized_list.extend(setting_info.disable[True]['settings'])
             for section in setting_info.disable[True]['sections']:
                 self.randomized_list.extend(get_settings_from_section(section))
+            if '_settings' in self.distribution.distribution.src_dict:
+                # Remove settings specified in the distribution
+                self.randomized_list = [x for x in self.randomized_list if x not in self.distribution.distribution.src_dict['_settings'].keys()]
             for setting in list(self.randomized_list):
                 if (setting == 'bridge_medallions' and self.bridge != 'medallions') \
                         or (setting == 'bridge_stones' and self.bridge != 'stones') \

--- a/World.py
+++ b/World.py
@@ -223,14 +223,16 @@ class World(object):
     def resolve_random_settings(self):
         # evaluate settings (important for logic, nice for spoiler)
         self.randomized_list = []
+        dist_keys = []
+        if '_settings' in self.distribution.distribution.src_dict:
+            dist_keys = self.distribution.distribution.src_dict['_settings'].keys()
         if self.randomize_settings:
             setting_info = get_setting_info('randomize_settings')
             self.randomized_list.extend(setting_info.disable[True]['settings'])
             for section in setting_info.disable[True]['sections']:
                 self.randomized_list.extend(get_settings_from_section(section))
-            if '_settings' in self.distribution.distribution.src_dict:
                 # Remove settings specified in the distribution
-                self.randomized_list = [x for x in self.randomized_list if x not in self.distribution.distribution.src_dict['_settings'].keys()]
+                self.randomized_list = [x for x in self.randomized_list if x not in dist_keys]
             for setting in list(self.randomized_list):
                 if (setting == 'bridge_medallions' and self.bridge != 'medallions') \
                         or (setting == 'bridge_stones' and self.bridge != 'stones') \


### PR DESCRIPTION
These changes allow settings to be set in plando, even if they are randomized. For example, if a user wants to randomize main rules but still make sure door of time is open, they can specify DoT to be open in plando and the code to randomize settings will simply ignore DoT. This will display `open_door_of_time` to `true` in the `settings` section of the spoiler, excluding it from the `randomized_settings` section.

It also overrides individually randomized settings. This one is less utility and more convenience, so the user doesn't have to remember to uncheck, for example, random MQ count if they want to specify in their plando to have 0 MQ dungeons but don't specify `mq_dungeons_random` to false.

Extensive testing was done to ensure that the plando-specified settings printed in the spoiler were indeed the actual settings in-game.