### PR TITLE
Implement item-spheres + Last WotH

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -339,7 +339,20 @@ def get_woth_hint(spoiler, world, checked):
     if not locations:
         return None
 
-    location = random.choice(locations)
+    if world.include_last_woth and world.last_woth < 1:
+        # Look for furthest location in coarse_spheres (order might be more accurate than in required_locations)
+        better_locations = [loc for sphere in reversed(spoiler.coarse_spheres.values()) for loc in sphere]
+        better_locations = [loc for loc in better_locations if loc.name in set(loc2.name for loc2 in locations)]
+        if len(better_locations) == 0:
+            return None
+        location = better_locations[0]
+        hint_text = "at the end of"
+        hint_color = "Blue"
+        world.last_woth += 1
+    else:
+        location = random.choice(locations)
+        hint_text = "on"
+        hint_color = "Light Blue"
     checked.add(location.name)
 
     if location.parent_region.dungeon:
@@ -349,9 +362,9 @@ def get_woth_hint(spoiler, world, checked):
         location_text = get_hint_area(location)
 
     if world.triforce_hunt:
-        return (GossipText('#%s# is on the path of gold.' % location_text, ['Light Blue']), location)
+        return (GossipText('#%s# is %s the path of gold.' % (location_text, hint_text), [hint_color]), location)
     else:
-        return (GossipText('#%s# is on the way of the hero.' % location_text, ['Light Blue']), location)
+        return (GossipText('#%s# is %s the way of the hero.' % (location_text, hint_text), [hint_color]), location)
 
 
 def get_barren_hint(spoiler, world, checked):
@@ -692,6 +705,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
     world.barren_dungeon = 0
     world.woth_dungeon = 0
+    world.last_woth = 0
 
     search = Search.max_explore([w.state for w in spoiler.worlds])
     for stone in gossipLocations.values():

--- a/Main.py
+++ b/Main.py
@@ -184,9 +184,12 @@ def make_spoiler(settings, worlds, window=dummy_window()):
         window.update_status('Calculating Spoiler Data')
         logger.info('Calculating playthrough.')
         create_playthrough(spoiler)
-        window.update_progress(50)
+        window.update_progress(45)
     if settings.create_spoiler or settings.hints != 'none':
         window.update_status('Calculating Hint Data')
+        logger.info('Calculating coarse spheres.')
+        compute_coarse_spheres(spoiler)
+        window.update_progress(50)
         logger.info('Calculating hint data.')
         update_required_items(spoiler)
         buildGossipHints(spoiler, worlds)
@@ -553,6 +556,140 @@ def find_light_arrows(spoiler):
         maybe_set_light_arrows(location)
 
 
+def compute_coarse_spheres(spoiler):
+    worlds = spoiler.worlds
+    worlds = copy_worlds(worlds)
+    collection_spheres = []
+    
+    # this function tracks spheres in a simplified way: it increments spheres only when "noteworthy" items are collected
+    # "noteworthy" items are defined as follows
+    def is_noteworthy(item):
+        if item.type == "Song":
+            return True
+        if item.type == "Item" and item.advancement:
+            return item.name not in ["Deliver Letter", "Gerudo Membership Card", "Magic Bean"]
+        return False
+     
+    # to keep a readable and useful spoiler log, we only log certain items:
+    def must_be_logged(item, noteworthy):
+        nonlocal collection_spheres, item_locations, spoiler_locations
+        if noteworthy:
+            if item.location in spoiler_locations:
+                return item.location not in collection_spheres[0]
+        else:
+            if item.type == "DungeonReward":
+                return item.location in spoiler_locations
+        return False
+
+    # get list of all of the progressive items that can appear in hints
+    # all_locations: all progressive items. have to collect from these
+    # item_locations: only the ones that should appear as "required"/WotH
+    all_locations = [location for world in worlds for location in world.get_filled_locations()]
+    item_locations = {location for location in all_locations if location.item.majoritem and not location.locked and location.item.name != 'Triforce Piece'}
+    
+    # if the playthrough was generated, filter the list of locations to the
+    # locations in the playthrough. The required locations is a subset of these
+    # locations. Can't use the locations directly since they are location to the
+    # copied spoiler world, so must compare via name and world id
+    if spoiler.playthrough:
+        translate = lambda loc: worlds[loc.world.id].get_location(loc.name)
+        spoiler_locations = set(map(translate, itertools.chain.from_iterable(spoiler.playthrough.values())))
+        item_locations &= spoiler_locations
+    else:
+        spoiler_locations = all_locations
+    
+    search = Search([world.state for world in worlds])
+
+    # Create "-1" sphere
+    sphere_number = -1
+    collection_spheres.append({})
+    
+    distribution = spoiler.settings.distribution.world_dists[0]
+    for (name, record) in distribution.starting_items.items():
+        item = Item(name, world=worlds[0])
+        search.state_list[0].collect(item)
+
+    item = worlds[0].get_location("Links Pocket").item
+    search.state_list[0].collect(item)
+    collection_spheres[-1][item.location] = item.name
+
+    if spoiler.settings.skip_child_zelda:
+        location = worlds[0].get_location("HC Zeldas Letter")
+        item = location.item
+        search.state_list[0].collect(item)
+        collection_spheres[-1][item.location] = item.name
+        location = worlds[0].get_location("Song from Impa")
+        item = location.item
+        search.state_list[0].collect(item)
+        collection_spheres[-1][item.location] = item.name
+    
+    # Compute next spheres
+    had_reachable_locations = True
+    items_to_delay = []
+    items_to_collect = []
+    increment_sphere = True
+    while had_reachable_locations:
+        child_regions, adult_regions, visited_locations = search.next_sphere()
+        
+        if increment_sphere:
+            sphere_number += 1
+            collection_spheres.append({})
+            had_reachable_locations = False
+
+        location = None
+        for loc in all_locations:
+            if loc in visited_locations:
+                continue
+            # Check adult first; it's the most likely.
+            if (loc.parent_region in adult_regions
+                    and loc.access_rule(search.state_list[loc.world.id], spot=loc, age='adult')):
+                had_reachable_locations = True
+                # Mark it visited for this algorithm
+                visited_locations.add(loc)
+                location = loc
+
+            elif (loc.parent_region in child_regions
+                  and loc.access_rule(search.state_list[loc.world.id], spot=loc, age='child')):
+                had_reachable_locations = True
+                # Mark it visited for this algorithm
+                visited_locations.add(loc)
+                location = loc
+            
+            # If location is reachable, add its item to the right list
+            if location:
+                item = location.item
+                if location in collection_spheres[0]:
+                    # If the location was already in sphere -1, ignore it
+                    pass
+                elif is_noteworthy(item):
+                    items_to_delay.append(location.item)
+                else:
+                    items_to_collect.append(location.item)
+                location = None
+        
+        # If some non-remarkable items have been found, collect them and don't open a new sphere
+        if len(items_to_collect) > 0:
+            for item in items_to_collect:
+                search.state_list[item.world.id].collect(item)
+                if must_be_logged(item, False):
+                    collection_spheres[-1][item.location] = item.name
+            items_to_collect = []
+            increment_sphere = False
+            had_reachable_locations = True
+        # Otherwise collect everything remarkable met in the current sphere and open a new one
+        else:
+            for item in items_to_delay:
+                search.state_list[item.world.id].collect(item)
+                if must_be_logged(item, True):
+                    collection_spheres[-1][item.location] = item.name
+            items_to_delay = []
+            increment_sphere = True
+    
+    # Remove possibly empty spheres at the tail
+    while len(collection_spheres) > 0 and len(collection_spheres[-1]) == 0:
+        del collection_spheres[-1]
+    spoiler.coarse_spheres = OrderedDict((str(i-1), {location: location.item for location in sphere}) for i, sphere in enumerate(collection_spheres))
+    
 def update_required_items(spoiler):
     worlds = spoiler.worlds
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -925,6 +925,7 @@ class Distribution(object):
         # One-time init
         update_dict = {
             'file_hash': (self.src_dict.get('file_hash', []) + [None, None, None, None, None])[0:5],
+            'coarse_spheres': None,
             'playthrough': None,
             'entrance_playthrough': None,
             '_settings': self.src_dict.get('settings', {}),
@@ -1070,6 +1071,14 @@ class Distribution(object):
                         self_dict[k]['World %d' % (id + 1)] = world_dist_dict[k]
             else:
                 self_dict.update({k: world_dist_dicts[0][k] for k in per_world_keys})
+                
+            if self.coarse_spheres is not None:
+                self_dict[':item_spheres'] = AlignedDict({
+                    sphere_nr: SortedDict({
+                        name: record.to_json() for name, record in sphere.items()
+                    })
+                    for (sphere_nr, sphere) in self.coarse_spheres.items()
+                }, depth=2)
 
             if self.playthrough is not None:
                 self_dict[':playthrough'] = AlignedDict({
@@ -1119,6 +1128,19 @@ class Distribution(object):
             world_dist.woth_locations = {loc.name: LocationRecord.from_item(loc.item) for loc in spoiler.required_locations[world.id]}
             world_dist.barren_regions = [*world.empty_areas]
             world_dist.gossip_stones = {gossipLocations[loc].name: GossipRecord(spoiler.hints[world.id][loc].to_json()) for loc in spoiler.hints[world.id]}
+
+
+        self.coarse_spheres = {}
+        for (sphere_nr, sphere) in spoiler.coarse_spheres.items():
+            loc_rec_sphere = {}
+            self.coarse_spheres[sphere_nr] = loc_rec_sphere
+            for location in sphere:
+                if spoiler.settings.world_count > 1:
+                    location_key = '%s [W%d]' % (location.name, location.world.id + 1)
+                else:
+                    location_key = location.name
+
+                loc_rec_sphere[location_key] = LocationRecord.from_item(location.item)
 
         self.playthrough = {}
         for (sphere_nr, sphere) in spoiler.playthrough.items():

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3519,6 +3519,18 @@ setting_infos = [
             '!bingo' : {'settings' : ['bingosync_url']},
         },
     ),
+    Checkbutton(
+        name           = 'include_last_woth',
+        gui_text       = 'Include Last Way of the Hero',
+        gui_tooltip    = '''\
+            Replace the first way of the hero hint generated
+            with a last way of the hero hint. This option
+            does not guarantee the hint if you select a
+            distribution without guaranteed way of the
+            hero hints.
+        ''',
+        shared         = True,
+    ),
     Setting_Info(
         name           = "bingosync_url",
         type           = str,

--- a/Spoiler.py
+++ b/Spoiler.py
@@ -54,6 +54,7 @@ class Spoiler(object):
         self.entrances = []
         self.metadata = {}
         self.required_locations = {}
+        self.coarse_spheres = {}
         self.hints = {world.id: {} for world in worlds}
         self.file_hash = []
 

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -334,6 +334,7 @@
             "clearer_hints",
             "hints",
             "hint_dist",
+            "include_last_woth",
             "bingosync_url",
             "misc_hints",
             "text_shuffle",


### PR DESCRIPTION
This adds a function to compute item-spheres the same way that players would track item-spheres and print them in the spoiler log. These item-spheres are coarser than the ones currently listed in the playthrough but made to be easy to track on player side.

We then use these item-spheres to correct matthewkirby/DGBarca's Last WotH Hint system so that it takes from the furthest location according to these item-spheres rather than the current WotH location list whose order could provide the wrong Last Woth.

Special thanks goes to ArthurOudini for his intensive testing and precious feedback.


