### PR TITLE
Avoid starting with too many Triforce pieces in Skip Child Zelda

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -972,6 +972,8 @@ class Distribution(object):
             if 'Triforce Piece' in world.distribution.starting_items:
                 world.triforce_count += world.distribution.starting_items['Triforce Piece'].count
                 total_starting_count += world.distribution.starting_items['Triforce Piece'].count
+            if world.skip_child_zelda and 'Song from Impa' in world.distribution.locations and world.distribution.locations['Song from Impa'].item == 'Triforce Piece':
+                total_starting_count += 1
             total_count += world.triforce_count
 
         if total_count < worlds[0].triforce_goal:
@@ -979,6 +981,9 @@ class Distribution(object):
 
         if total_starting_count >= worlds[0].triforce_goal:
             raise RuntimeError('Too many Triforce Pieces in starting items. There should be at most %d and there are %d.' % (worlds[0].triforce_goal - 1, total_starting_count))
+
+        for world in worlds:
+            world.total_starting_triforce_count = total_starting_count # used later in Rules.py
 
 
     def reset(self):

--- a/Rules.py
+++ b/Rules.py
@@ -51,6 +51,10 @@ def set_rules(world):
 
         if world.skip_child_zelda and location.name == 'Song from Impa':
             limit_to_itemset(location, SaveContext.giveable_items)
+            if world.triforce_hunt and world.total_starting_triforce_count >= world.triforce_goal - world.world_count:
+                # We have enough starting Triforce pieces that putting a piece on every world's Song from Impa would hit the goal count
+                # and render the game unbeatable, so for simplicity's sake we forbid putting pieces on any world's Song from Impa.
+                forbid_item(location, 'Triforce Piece')
 
         if location.name == 'Forest Temple MQ First Room Chest' and world.shuffle_bosskeys == 'dungeon' and world.shuffle_smallkeys == 'dungeon' and world.tokensanity == 'off':
             # This location needs to be a small key. Make sure the boss key isn't placed here.

--- a/World.py
+++ b/World.py
@@ -37,6 +37,7 @@ class World(object):
         self.maximum_wallets = 0
         self.light_arrow_location = None
         self.triforce_count = 0
+        self.total_starting_triforce_count = 0
         self.bingosync_url = None
 
         self.parser = Rule_AST_Transformer(self)
@@ -197,6 +198,7 @@ class World(object):
         new_world.shop_prices = copy.copy(self.shop_prices)
         new_world.triforce_goal = self.triforce_goal
         new_world.triforce_count = self.triforce_count
+        new_world.total_starting_triforce_count = self.total_starting_triforce_count
         new_world.maximum_wallets = self.maximum_wallets
         new_world.distribution = self.distribution
 


### PR DESCRIPTION
Fixes #1331 by disallowing Triforce pieces on the Song from Impa location if it would cause the game to start with starting pieces ≥ goal pieces. The issue is addressed both with and without plandoing the piece.

For the sake of simplicity, multiworld seeds disallow placing a piece on _any_ world's song from Impa if placing pieces on _all_ worlds' songs from Impa would trigger the bug.