### PR TITLE
Remove starting_items redundancy in plando/spoiler (part 1)

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -967,18 +967,11 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     #Removes items from item_hints list if they are included in starting gear.
     #This method ensures that the right number of copies are removed, e.g.
     #if you start with one strength and hints call for two, you still get
-    #one hint for strength
-    for item in itertools.chain(world.settings.starting_items, world.settings.starting_equipment, world.settings.starting_songs):
-        itemname = everything[item].itemname
-        if itemname in world.item_hints:
-            world.item_hints.remove(itemname)
-
-    #Skip_child_zelda can cause the same problem, but needs to be handled separately since
-    #it doesn't update the starting gear lists
-    if world.settings.skip_child_zelda:
-        itemname = world.get_location('Song from Impa').item.name 
-        if itemname in world.item_hints:
-            world.item_hints.remove(itemname)
+    #one hint for strength. This also handles items from Skip Child Zelda.
+    for itemname, record in world.distribution.effective_starting_items.items():
+        for _ in range(record.count):
+            if itemname in world.item_hints:
+                world.item_hints.remove(itemname)
 
     world.named_item_pool = list(world.item_hints)
 

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1370,7 +1370,6 @@ def get_pool_core(world):
             pool.remove(junk_item)
             pool.append(pending_item)
 
-    world.distribution.configure_starting_items_settings(world)
     world.distribution.collect_starters(world.state)
 
     return (pool, placed_items)

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -643,6 +643,12 @@ vanillaSK = {
     'Water Temple MQ Freestanding Key': 'Small Key (Water Temple)',    
 }
 
+
+# a useless placeholder item placed at some skipped and inaccessible locations
+# (e.g. HC Malon Egg with Skip Child Zelda, or the carpenters with Open Gerudo Fortress)
+IGNORE_LOCATION = 'Recovery Heart'
+
+
 junk_pool_base = [
     ('Bombs (5)',       8),
     ('Bombs (10)',      2),
@@ -829,7 +835,7 @@ def get_pool_core(world):
         pending_junk_pool.append('Rutos Letter')
 
     if world.settings.skip_child_zelda:
-        placed_items['HC Malon Egg'] = 'Recovery Heart'
+        placed_items['HC Malon Egg'] = IGNORE_LOCATION
     elif world.settings.shuffle_weird_egg:
         pool.append('Weird Egg')
     else:
@@ -1060,16 +1066,16 @@ def get_pool_core(world):
         pool.extend(['Ice Trap'] * 4)
 
     if world.settings.gerudo_fortress == 'open':
-        placed_items['Hideout Jail Guard (1 Torch)'] = 'Recovery Heart'
-        placed_items['Hideout Jail Guard (2 Torches)'] = 'Recovery Heart'
-        placed_items['Hideout Jail Guard (3 Torches)'] = 'Recovery Heart'
-        placed_items['Hideout Jail Guard (4 Torches)'] = 'Recovery Heart'
+        placed_items['Hideout Jail Guard (1 Torch)'] = IGNORE_LOCATION
+        placed_items['Hideout Jail Guard (2 Torches)'] = IGNORE_LOCATION
+        placed_items['Hideout Jail Guard (3 Torches)'] = IGNORE_LOCATION
+        placed_items['Hideout Jail Guard (4 Torches)'] = IGNORE_LOCATION
     elif world.settings.shuffle_hideoutkeys in ['any_dungeon', 'overworld', 'keysanity']:
         if world.settings.gerudo_fortress == 'fast':
             pool.append('Small Key (Thieves Hideout)')
-            placed_items['Hideout Jail Guard (2 Torches)'] = 'Recovery Heart'
-            placed_items['Hideout Jail Guard (3 Torches)'] = 'Recovery Heart'
-            placed_items['Hideout Jail Guard (4 Torches)'] = 'Recovery Heart'
+            placed_items['Hideout Jail Guard (2 Torches)'] = IGNORE_LOCATION
+            placed_items['Hideout Jail Guard (3 Torches)'] = IGNORE_LOCATION
+            placed_items['Hideout Jail Guard (4 Torches)'] = IGNORE_LOCATION
         else:
             pool.extend(['Small Key (Thieves Hideout)'] * 4)
         if world.settings.item_pool_value == 'plentiful':
@@ -1077,9 +1083,9 @@ def get_pool_core(world):
     else:
         if world.settings.gerudo_fortress == 'fast':
             placed_items['Hideout Jail Guard (1 Torch)'] = 'Small Key (Thieves Hideout)'
-            placed_items['Hideout Jail Guard (2 Torches)'] = 'Recovery Heart'
-            placed_items['Hideout Jail Guard (3 Torches)'] = 'Recovery Heart'
-            placed_items['Hideout Jail Guard (4 Torches)'] = 'Recovery Heart'
+            placed_items['Hideout Jail Guard (2 Torches)'] = IGNORE_LOCATION
+            placed_items['Hideout Jail Guard (3 Torches)'] = IGNORE_LOCATION
+            placed_items['Hideout Jail Guard (4 Torches)'] = IGNORE_LOCATION
         else:
             placed_items['Hideout Jail Guard (1 Torch)'] = 'Small Key (Thieves Hideout)'
             placed_items['Hideout Jail Guard (2 Torches)'] = 'Small Key (Thieves Hideout)'
@@ -1090,7 +1096,7 @@ def get_pool_core(world):
         pool.append('Gerudo Membership Card')
     elif world.settings.shuffle_gerudo_card:
         pending_junk_pool.append('Gerudo Membership Card')
-        placed_items['Hideout Gerudo Membership Card'] = 'Ice Trap'
+        placed_items['Hideout Gerudo Membership Card'] = IGNORE_LOCATION
     else:
         placed_items['Hideout Gerudo Membership Card'] = 'Gerudo Membership Card'
     if world.settings.shuffle_gerudo_card and world.settings.item_pool_value == 'plentiful':
@@ -1322,7 +1328,7 @@ def get_pool_core(world):
         placed_items['Gift from Sages'] = 'Boss Key (Ganons Castle)'
         pool.extend(get_junk_item())
     else:
-        placed_items['Gift from Sages'] = 'Ice Trap'
+        placed_items['Gift from Sages'] = IGNORE_LOCATION
 
     if world.settings.item_pool_value == 'plentiful':
         pool.extend(easy_items)

--- a/Main.py
+++ b/Main.py
@@ -123,6 +123,8 @@ def resolve_settings(settings, window=dummy_window()):
 def generate(settings, window=dummy_window()):
     worlds = build_world_graphs(settings, window=window)
     place_items(settings, worlds, window=window)
+    for world in worlds:
+        world.distribution.configure_effective_starting_items(worlds, world)
     if worlds[0].enable_goal_hints:
         replace_goal_names(worlds)
     return make_spoiler(settings, worlds, window=window)

--- a/Patches.py
+++ b/Patches.py
@@ -1095,11 +1095,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_byte(rom.sym('COMPLETE_MASK_QUEST'), 1)
 
     if world.settings.skip_child_zelda:
-        save_context.give_item('Zeldas Letter')
-        for w in spoiler.worlds:
-            item = w.get_location('Song from Impa').item
-            if world.id == item.world.id:
-                save_context.give_raw_item(item.name)
         save_context.write_bits(0x0ED7, 0x04) # "Obtained Malon's Item"
         save_context.write_bits(0x0ED7, 0x08) # "Woke Talon in castle"
         save_context.write_bits(0x0ED7, 0x10) # "Talon has fled castle"
@@ -1521,20 +1516,17 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
                 rom.write_byte(0x2000FED, special['text_id']) #Fix text box
             elif location.name == 'Sheik at Colossus':
                 rom.write_byte(0x218C589, special['text_id']) #Fix text box
-        elif location.type == 'Boss':
-            if location.name == 'Links Pocket':
-                save_context.give_item(item.name)
-            else:
-                rom.write_byte(locationaddress, special['item_id'])
-                rom.write_byte(secondaryaddress, special['addr2_data'])
-                bit_mask_hi = special['bit_mask'] >> 16
-                bit_mask_lo = special['bit_mask'] & 0xFFFF
-                if location.name == 'Bongo Bongo':
-                    rom.write_int16(0xCA3F32, bit_mask_hi)
-                    rom.write_int16(0xCA3F36, bit_mask_lo)
-                elif location.name == 'Twinrova':
-                    rom.write_int16(0xCA3EA2, bit_mask_hi)
-                    rom.write_int16(0xCA3EA6, bit_mask_lo)
+        elif location.type == 'Boss' and location.name != 'Links Pocket':
+            rom.write_byte(locationaddress, special['item_id'])
+            rom.write_byte(secondaryaddress, special['addr2_data'])
+            bit_mask_hi = special['bit_mask'] >> 16
+            bit_mask_lo = special['bit_mask'] & 0xFFFF
+            if location.name == 'Bongo Bongo':
+                rom.write_int16(0xCA3F32, bit_mask_hi)
+                rom.write_int16(0xCA3F36, bit_mask_lo)
+            elif location.name == 'Twinrova':
+                rom.write_int16(0xCA3EA2, bit_mask_hi)
+                rom.write_int16(0xCA3EA6, bit_mask_lo)
 
     # add a cheaper bombchu pack to the bombchu shop
     # describe

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -30,7 +30,7 @@ class InvalidFileException(Exception):
 
 per_world_keys = (
     'randomized_settings',
-    'starting_items',
+    ':effective_starting_items',
     'item_pool',
     'dungeons',
     'trials',
@@ -184,6 +184,10 @@ class StarterRecord(SimpleRecord({'count': 1})):
         super().__init__(src_dict)
 
 
+    def copy(self):
+        return StarterRecord(self.count)
+
+
     def to_json(self):
         return self.count
 
@@ -221,6 +225,7 @@ class WorldDistribution(object):
     def __init__(self, distribution, id, src_dict={}):
         self.distribution = distribution
         self.id = id
+        self.world = None # populated in World.__init__
         self.base_pool = []
         self.major_group = []
         self.song_as_items = False
@@ -234,7 +239,6 @@ class WorldDistribution(object):
             'trials': {name: TrialRecord(record) for (name, record) in src_dict.get('trials', {}).items()},
             'songs': {name: SongRecord(record) for (name, record) in src_dict.get('songs', {}).items()},
             'item_pool': {name: ItemPoolRecord(record) for (name, record) in src_dict.get('item_pool', {}).items()},
-            'starting_items': {name: StarterRecord(record) for (name, record) in src_dict.get('starting_items', {}).items()},
             'entrances': {name: EntranceRecord(record) for (name, record) in src_dict.get('entrances', {}).items()},
             'locations': {name: [LocationRecord(rec) for rec in record] if is_pattern(name) else LocationRecord(record) for (name, record) in src_dict.get('locations', {}).items() if not is_output_only(name)},
             'woth_locations': None,
@@ -261,8 +265,8 @@ class WorldDistribution(object):
 
     def to_json(self):
         return {
-            'randomized_settings': self.randomized_settings,      
-            'starting_items': SortedDict({name: record.to_json() for (name, record) in self.starting_items.items()}),
+            'randomized_settings': self.randomized_settings,
+            ':effective_starting_items': SortedDict({name: record.to_json() for (name, record) in self.effective_starting_items.items()}),
             'dungeons': {name: record.to_json() for (name, record) in self.dungeons.items()},
             'trials': {name: record.to_json() for (name, record) in self.trials.items()},
             'songs': {name: record.to_json() for (name, record) in self.songs.items()},
@@ -380,14 +384,6 @@ class WorldDistribution(object):
             setattr(world, name, record)
             if name not in world.randomized_list:
                 world.randomized_list.append(name)
-
-
-    def configure_starting_items_settings(self, world):
-        if world.settings.start_with_rupees:
-            self.give_item('Rupees', 999)
-        if world.settings.start_with_consumables:
-            self.give_item('Deku Sticks', 99)
-            self.give_item('Deku Nuts', 99)
 
 
     def pool_remove_item(self, pools, item_name, count, world_id=None, use_base_pool=True):
@@ -925,25 +921,52 @@ class WorldDistribution(object):
             spoiler.hints[self.id][stoneID] = GossipText(text=record.text, colors=record.colors, prefix='')
 
 
-    def give_item(self, item, count=1):
-        if item in self.starting_items:
-            self.starting_items[item].count += count
-        else:
-            self.starting_items[item] = StarterRecord(count)
-
-
     def give_items(self, save_context):
-        for (name, record) in self.starting_items.items():
+        for (name, record) in self.effective_starting_items.items():
             if record.count == 0:
                 continue
             save_context.give_item(name, record.count)
 
 
     def get_starting_item(self, item):
-        if item in self.starting_items:
-            return self.starting_items[item].count
+        items = self.effective_starting_items
+        if item in items:
+            return items[item].count
         else:
             return 0
+
+    @property
+    def starting_items(self):
+        return self.distribution.starting_items_from_settings()
+
+    @property
+    def effective_starting_items(self):
+        items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
+
+        def add_item(item, count=1):
+            if item in items:
+                items[item].count += count
+            else:
+                items[item] = StarterRecord(count)
+
+        if self.world is not None:
+            if self.world.start_with_rupees:
+                add_item('Rupees', 999)
+            if self.world.start_with_consumables:
+                add_item('Deku Sticks', 99)
+                add_item('Deku Nuts', 99)
+            skipped_locations = ['Links Pocket']
+            if self.world.skip_child_zelda:
+                add_item('Zeldas Letter')
+                skipped_locations.append('Song from Impa')
+            for w in self.distribution.worlds():
+                for location in skipped_locations:
+                    item = w.get_location(location).item
+                    if item is not None and self.world.id == item.world.id:
+                        add_item(item.name)
+
+        return items
+
 
 
 class Distribution(object):
@@ -1034,9 +1057,6 @@ class Distribution(object):
         for world in self.world_dists:
             world.update({}, update_all=True)
 
-        if 'starting_items' not in self.src_dict:
-            self.populate_starting_items_from_settings()
-
         world_names = ['World %d' % (i + 1) for i in range(len(self.world_dists))]
 
         for k in per_world_keys:
@@ -1059,45 +1079,52 @@ class Distribution(object):
                         world.update({k: self.src_dict[k]})
 
 
-    def populate_starting_items_from_settings(self):
-        starting_items = list(itertools.chain(self.settings.starting_equipment, self.settings.starting_items, self.settings.starting_songs))
-        data = defaultdict(int)
-        for itemsetting in starting_items:
-            if itemsetting in StartingItems.everything:
-                item = StartingItems.everything[itemsetting]
-                if not item.special:
-                    data[item.itemname] += 1
-                else:
-                    if item.itemname == 'Rutos Letter' and self.settings.zora_fountain != 'open':
-                        data['Rutos Letter'] = 1
-                    elif item.itemname in ['Bottle', 'Rutos Letter']:
-                        data['Bottle'] += 1
+    def starting_items_from_settings(self):
+        data = defaultdict(lambda: StarterRecord(0))
+        if isinstance(self.settings.starting_items, dict):
+            if self.settings.starting_equipment:
+                raise ValueError('Incompatible starting item settings. Either move starting_equipment into starting_items or make starting_items a list')
+            if self.settings.starting_songs:
+                raise ValueError('Incompatible starting item settings. Either move starting_songs into starting_items or make starting_items a list')
+            data.update((item_name, StarterRecord(count)) for item_name, count in self.settings.starting_items.items())
+        else:
+            starting_items = list(itertools.chain(self.settings.starting_equipment, self.settings.starting_items, self.settings.starting_songs))
+            for itemsetting in starting_items:
+                if itemsetting in StartingItems.everything:
+                    item = StartingItems.everything[itemsetting]
+                    if not item.special:
+                        data[item.itemname].count += 1
                     else:
-                        raise KeyError("invalid special item: {}".format(item.itemname))
-            else:
-                raise KeyError("invalid starting item: {}".format(itemsetting))
+                        if item.itemname == 'Rutos Letter' and self.settings.zora_fountain != 'open':
+                            data['Rutos Letter'].count += 1
+                        elif item.itemname in ['Bottle', 'Rutos Letter']:
+                            data['Bottle'].count += 1
+                        else:
+                            raise KeyError("invalid special item: {}".format(item.itemname))
+                else:
+                    raise KeyError("invalid starting item: {}".format(itemsetting))
 
-        # add ammo
-        for item in list(data.keys()):
-            match = [x for x in StartingItems.inventory.values() if x.itemname == item]
-            if match and match[0].ammo:
-                for ammo,qty in match[0].ammo.items():
-                    data[ammo] += qty[data[item]-1]
+            # add ammo
+            for item in list(data.keys()):
+                match = [x for x in StartingItems.inventory.values() if x.itemname == item]
+                if match and match[0].ammo:
+                    for ammo,qty in match[0].ammo.items():
+                        data[ammo].count += qty[data[item].count - 1]
 
         # add hearts
         if self.settings.starting_hearts > 3:
-            data['Piece of Heart (Treasure Chest Game)'] = 1
-            data['Piece of Heart'] -= 1
+            if not data['Piece of Heart (Treasure Chest Game)'].count:
+                data['Piece of Heart (Treasure Chest Game)'].count += 1
+                data['Piece of Heart'].count -= 1
             num_hearts_to_collect = self.settings.starting_hearts - 3
             if num_hearts_to_collect % 2 == 1:
-                data['Piece of Heart'] += 4
+                data['Piece of Heart'].count += 4
                 num_hearts_to_collect -= 1
             for i in range(0, num_hearts_to_collect, 2):
-                data['Piece of Heart'] += 4
-                data['Heart Container'] += 1
+                data['Piece of Heart'].count += 4
+                data['Heart Container'].count += 1
 
-        for world in self.world_dists:
-            world.update({'starting_items': data})
+        return data
 
 
     def to_json(self, include_output=True, spoiler=True):
@@ -1214,6 +1241,11 @@ class Distribution(object):
                         entrance_key = entrance.name
 
                     ent_rec_sphere[entrance_key] = EntranceRecord.from_entrance(entrance)
+
+
+    def worlds(self):
+        for world_dist in self.world_dists:
+            yield world_dist.world
 
 
     @staticmethod

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -234,6 +234,9 @@ class WorldDistribution(object):
 
 
     def update(self, src_dict, update_all=False):
+        if 'starting_items' in src_dict:
+            raise ValueError('"starting_items" at the top level is no longer supported, please move it into "settings"')
+
         update_dict = {
             'randomized_settings': {name: record for (name, record) in src_dict.get('randomized_settings', {}).items()},
             'dungeons': {name: DungeonRecord(record) for (name, record) in src_dict.get('dungeons', {}).items()},

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -942,21 +942,21 @@ class WorldDistribution(object):
     def configure_effective_starting_items(self, worlds, world):
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
 
-        if world is not None:
-            if world.start_with_rupees:
-                add_starting_item_with_ammo(items, 'Rupees', 999)
-            if world.start_with_consumables:
-                add_starting_item_with_ammo(items, 'Deku Sticks', 99)
-                add_starting_item_with_ammo(items, 'Deku Nuts', 99)
-            skipped_locations = ['Links Pocket']
-            if world.skip_child_zelda:
-                add_starting_item_with_ammo(items, 'Zeldas Letter')
-                skipped_locations.append('Song from Impa')
-            for iter_world in worlds:
-                for location in skipped_locations:
-                    item = iter_world.get_location(location).item
-                    if item is not None and world.id == item.world.id:
-                        add_starting_item_with_ammo(items, item.name)
+        if world.start_with_rupees:
+            add_starting_item_with_ammo(items, 'Rupees', 999)
+        if world.start_with_consumables:
+            add_starting_item_with_ammo(items, 'Deku Sticks', 99)
+            add_starting_item_with_ammo(items, 'Deku Nuts', 99)
+
+        skipped_locations = ['Links Pocket']
+        if world.skip_child_zelda:
+            add_starting_item_with_ammo(items, 'Zeldas Letter')
+            skipped_locations.append('Song from Impa')
+        for iter_world in worlds:
+            for location in skipped_locations:
+                item = iter_world.get_location(location).item
+                if item is not None and world.id == item.world.id:
+                    add_starting_item_with_ammo(items, item.name)
 
         self.effective_starting_items = items
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -951,7 +951,7 @@ class WorldDistribution(object):
 
         skipped_locations = ['Links Pocket']
         if world.settings.skip_child_zelda:
-            skipped_locations += ['HC Zeldas Letter', 'Song from Impa']
+            skipped_locations += ['HC Malon Egg', 'HC Zeldas Letter', 'Song from Impa']
         for iter_world in worlds:
             for location in skipped_locations:
                 loc = iter_world.get_location(location)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -942,14 +942,14 @@ class WorldDistribution(object):
     def configure_effective_starting_items(self, worlds, world):
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
 
-        if world.start_with_rupees:
+        if world.settings.start_with_rupees:
             add_starting_item_with_ammo(items, 'Rupees', 999)
-        if world.start_with_consumables:
+        if world.settings.start_with_consumables:
             add_starting_item_with_ammo(items, 'Deku Sticks', 99)
             add_starting_item_with_ammo(items, 'Deku Nuts', 99)
 
         skipped_locations = ['Links Pocket']
-        if world.skip_child_zelda:
+        if world.settings.skip_child_zelda:
             add_starting_item_with_ammo(items, 'Zeldas Letter')
             skipped_locations.append('Song from Impa')
         for iter_world in worlds:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -984,13 +984,6 @@ class Distribution(object):
             '_settings': self.src_dict.get('settings', {}),
         }
 
-        # If starting items specified in plando, remove starting items from settings.
-        # These aren't considered in logic either way, but this prevents them showing up in the spoiler.
-        if 'starting_items' in self.src_dict:
-            self.settings.starting_items = []
-            self.settings.starting_equipment = []
-            self.settings.starting_songs = []
-
         self.settings.__dict__.update(update_dict['_settings'])
         if 'settings' in self.src_dict:
             validate_settings(self.src_dict['settings'])

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -265,6 +265,8 @@ class SaveContext():
             self.give_health(count)
         elif item == "Bombchu Item":
             self.give_bombchu_item()
+        elif item == "Recovery Heart": # ItemPool.IGNORE_LOCATION
+            pass # used to disable some skipped and inaccessible locations
         elif item in SaveContext.save_writes_table:
             for address, value in SaveContext.save_writes_table[item].items():
                 if value is None:
@@ -952,7 +954,7 @@ class SaveContext():
     }
 
     giveable_items = set(chain(save_writes_table.keys(), bottle_types.keys(),
-        ["Piece of Heart", "Piece of Heart (Treasure Chest Game)", "Heart Container", "Rupee (1)"]))
+        ["Piece of Heart", "Piece of Heart (Treasure Chest Game)", "Heart Container", "Rupee (1)", "Recovery Heart"]))
 
 
     equipable_items = {

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -250,15 +250,13 @@ class SaveContext():
         self.addresses['quest']['heart_pieces'].value = int((health % 1) * 4)
 
 
-    def give_raw_item(self, item):
-        if item.endswith(')'):
-            item_base, count = item[:-1].split(' (', 1)
-            if count.isdigit():
-                return self.give_item(item_base, count=int(count))
-        return self.give_item(item)
-
-
     def give_item(self, item, count=1):
+        if item.endswith(')'):
+            item_base, implicit_count = item[:-1].split(' (', 1)
+            if implicit_count.isdigit():
+                item = item_base
+                count *= int(implicit_count)
+
         if item in SaveContext.bottle_types:
             self.give_bottle(item, count)
         elif item in ["Piece of Heart", "Piece of Heart (Treasure Chest Game)"]:

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -5070,7 +5070,8 @@ def validate_settings(settings_dict):
         info = get_setting_info(setting)
         # Ensure the type of the supplied choice is correct
         if type(choice) != info.type:
-            raise TypeError('Supplied choice %r for setting %r is of type %r, expecting %r' % (choice, setting, type(choice).__name__, info.type.__name__))
+            if setting != 'starting_items' or type(choice) != dict: # allow dict (plando syntax) for starting items in addition to the list syntax used by the GUI
+                raise TypeError('Supplied choice %r for setting %r is of type %r, expecting %r' % (choice, setting, type(choice).__name__, info.type.__name__))
         # If setting is a list, must check each element
         if isinstance(choice, list):
             for element in choice:

--- a/World.py
+++ b/World.py
@@ -50,6 +50,7 @@ class World(object):
         # this gives the world an attribute for every setting listed in Settings.py
         self.settings = settings
         self.distribution = settings.distribution.world_dists[id]
+        self.distribution.world = self
 
         # rename a few attributes...
         self.keysanity = settings.shuffle_smallkeys in ['keysanity', 'remove', 'any_dungeon', 'overworld']

--- a/World.py
+++ b/World.py
@@ -50,7 +50,6 @@ class World(object):
         # this gives the world an attribute for every setting listed in Settings.py
         self.settings = settings
         self.distribution = settings.distribution.world_dists[id]
-        self.distribution.world = self
 
         # rename a few attributes...
         self.keysanity = settings.shuffle_smallkeys in ['keysanity', 'remove', 'any_dungeon', 'overworld']


### PR DESCRIPTION
This addresses the first 2 steps of #1349:

* Allow the `starting_items` setting to be plando'd with the syntax currently used by the top-level `starting_items` entry
    * This will be in addition to the current syntax for the setting, which will continue to be used by the GUI for now
    * Checks are in place to prevent using the dict-style syntax for `starting_items` while also having `starting_equipment` and/or `starting_songs` present (even if the former is plando'd and the latter comes from the GUI), which doesn't make much sense since dict-style `starting_items` includes equipment and songs.
* Remove the top-level entry, replacing it with an informative (i.e. ignored in plando) `:skipped_locations` entry

I have tested to make sure the new syntax works as expected, and the GUI still works as it did before. This also fixes #1353, as well as the bug where a Triforce piece on free Song from Impa would overwrite plando'd starting pieces instead of being added.