### PR TITLE
Remove MQ Forest Trick Hookshot through gap

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -369,14 +369,14 @@ logic_tricks = {
                     or hit the shortcut switch at the top of the
                     room and jump from the glass blocks that spawn.
                     '''},
-    'Forest Temple MQ Twisted Hallway Switch with Hookshot': {
-        'name'    : 'logic_forest_mq_hallway_switch_hookshot',
-        'tags'    : ("Forest Temple",),
-        'tooltip' : '''\
-                    There's a very small gap between the glass block
-                    and the wall. Through that gap you can hookshot
-                    the target on the ceiling.
-                    '''},
+    #'Forest Temple MQ Twisted Hallway Switch with Hookshot': {
+    #    'name'    : 'logic_forest_mq_hallway_switch_hookshot',
+    #    'tags'    : ("Forest Temple",),
+    #    'tooltip' : '''\
+    #                There's a very small gap between the glass block
+    #                and the wall. Through that gap you can hookshot
+    #                the target on the ceiling.
+    #                '''},
     'Death Mountain Trail Chest with Strength': {
         'name'    : 'logic_dmt_bombable',
         'tags'    : ("Death Mountain Trail",),

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -33,8 +33,7 @@
                 is_adult and (Progressive_Strength_Upgrade or
                     (logic_forest_mq_block_puzzle and has_bombchus and can_use(Hookshot)))",
             "Forest Temple Outdoor Ledge": "
-                (logic_forest_mq_hallway_switch_jumpslash and can_use(Hover_Boots)) or
-                (logic_forest_mq_hallway_switch_hookshot and can_use(Hookshot))",
+                (logic_forest_mq_hallway_switch_jumpslash and can_use(Hover_Boots))",
             "Forest Temple Boss Region": "
                 Forest_Temple_Jo_and_Beth and Forest_Temple_Amy_and_Meg"
         }

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -686,7 +686,6 @@
       "logic_forest_first_gs",
       "logic_forest_well_swim",
       "logic_forest_mq_hallway_switch_jumpslash",
-      "logic_forest_mq_hallway_switch_hookshot",
       "logic_dmt_bombable",
       "logic_goron_city_pot_with_strength",
       "logic_adult_kokiri_gs",


### PR DESCRIPTION
This trick was recently calculated to be a clip by the definitions used in the glichless rulesets, which logic is a subset of.  As such, it needs be removed to preserve that.