### PR TITLE
Add Giants Knife as a Starting Item

### DIFF
--- a/StartingItems.py
+++ b/StartingItems.py
@@ -62,6 +62,7 @@ songs = dict(chain(
 
 equipment = dict(chain(
     _entry('kokiri_sword', 'Kokiri Sword'),
+    _entry('giants_knife', 'Giants Knife'),
     _entry('biggoron_sword', 'Biggoron Sword'),
     _entry('deku_shield', 'Deku Shield'),
     _entry('hylian_shield', 'Hylian Shield'),


### PR DESCRIPTION
Just adds Giants Knife to the GUI. I did test it and made sure Link could break it. Also separately if it was added along with Biggoron's then Biggoron's would override.
I'll understand if you don't want to add this, but someone asked on the discord and it was easy so I thought I'd give it a try.