### PR TITLE
Fix item_hint duplication

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -708,6 +708,10 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     # rebuild hint exclusion list
     hintExclusions(world, clear_cache=True)
 
+    #rebuild named item pool
+    world.settings.item_hints += world.item_added_hint_types["named-item"]
+
+
     world.barren_dungeon = 0
     world.woth_dungeon = 0
 

--- a/World.py
+++ b/World.py
@@ -161,8 +161,6 @@ class World(object):
                     raise Exception('Custom hint text too large for %s', loc['location'])
                 self.hint_text_overrides.update({loc['location']: loc['text']})
 
-        self.settings.item_hints = settings.item_hints + self.item_added_hint_types["named-item"]
-        self.named_item_pool = list(self.settings.item_hints)
 
         self.always_hints = [hint.name for hint in getRequiredHints(self)]
         


### PR DESCRIPTION
- Moved the adding of the user-supplied named-item hints to buildWorldGossipHints in Hints.py instead of in World.py
- world.named_item_pool is rebuilt later on in buildWorldGossipHints anyway, and so has been removed from the start