### PR TITLE
Fix Triforce Hunt

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -51,7 +51,7 @@ def set_rules(world):
 
         if world.settings.skip_child_zelda and location.name == 'Song from Impa':
             limit_to_itemset(location, SaveContext.giveable_items)
-            if world.settings.triforce_hunt and world.total_starting_triforce_count >= world.triforce_goal - world.world_count:
+            if world.settings.triforce_hunt and world.total_starting_triforce_count >= world.triforce_goal - world.settings.world_count:
                 # We have enough starting Triforce pieces that putting a piece on every world's Song from Impa would hit the goal count
                 # and render the game unbeatable, so for simplicity's sake we forbid putting pieces on any world's Song from Impa.
                 forbid_item(location, 'Triforce Piece')


### PR DESCRIPTION
Triforce Hunt fails to generate with an invalid reference to the world count setting.