### PR TITLE
Adding more validation to plando

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -865,6 +865,9 @@ class WorldDistribution(object):
                 except KeyError:
                     raise RuntimeError(
                         'Too many items were added to world %d, and not enough junk is available to be removed.' % (self.id + 1))
+                except IndexError:
+                    raise RuntimeError(
+                        'Unknown item %s being placed on location %s in world %d.' % (record.item, location, self.id + 1))
             # Update item_pool after item is replaced
             if item.name not in self.item_pool:
                 self.item_pool[item.name] = ItemPoolRecord()

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 import random
+import difflib
 
 from functools import reduce
 from collections import defaultdict
@@ -329,6 +330,24 @@ class WorldDistribution(object):
             else:
                 return lambda s: invert != (s == pattern)
 
+    # When a string isn't found in the source list, attempt to get closest match from the list
+    # ex. Given "Recovery Hart" returns "Did you mean 'Recovery Heart'?"
+    def build_close_match(self, name, type, entrance_pools=None):
+        source = []
+        if type == 'item':
+            source = item_table.keys()
+        elif type == 'location':
+            source = location_table.keys()
+        elif type == 'entrance':
+            for pool in entrance_pools.values():
+                for entrance in pool:
+                    source.append(entrance.name)
+        elif type == 'stone':
+            source = [x.name for x in gossipLocations.values()]
+        close_match = difflib.get_close_matches(name, source, 1)
+        if len(close_match) > 0:
+            return "Did you mean %s?" % (repr(close_match[0]))
+        return "" # No matches
 
     # adds the location entry only if there is no record for that location already
     def add_location(self, new_location, new_item):
@@ -425,11 +444,11 @@ class WorldDistribution(object):
                 if item.name not in self.item_pool or self.item_pool[item.name].count != 0
             ]  # Only allow items to be candidates if they haven't been set to 0
             if len(candidates) == 0:
-                raise RuntimeError("Unknown item, or item set to 0 in the item pool could not be added: " + item_name)
+                raise RuntimeError("Unknown item, or item set to 0 in the item pool could not be added: " + repr(item_name) + ". " + self.build_close_match(item_name, 'item'))
             added_items = random_choices(candidates, k=count)
         else:
             if not IsItem(item_name):
-                raise RuntimeError("Unknown item could not be added: " + item_name)
+                raise RuntimeError("Unknown item could not be added: " + repr(item_name) + ". " + self.build_close_match(item_name, 'item'))
             added_items = [item_name] * count
 
         for item in added_items:
@@ -549,8 +568,11 @@ class WorldDistribution(object):
         for (name, record) in self.entrances.items():
             if record.region is None:
                 continue
-            if not worlds[self.id].get_entrance(name):
-                raise RuntimeError('Unknown entrance in world %d: %s' % (self.id + 1, name))
+            try:
+                if not worlds[self.id].get_entrance(name):
+                    raise RuntimeError('Unknown entrance in world %d: %s. %s' % (self.id + 1, name, self.build_close_match(name, 'entrance', entrance_pools)))
+            except KeyError:
+                raise RuntimeError('Unknown entrance in world %d: %s. %s' % (self.id + 1, name, self.build_close_match(name, 'entrance', entrance_pools)))
 
             entrance_found = False
             for pool_type, entrance_pool in entrance_pools.items():
@@ -687,7 +709,7 @@ class WorldDistribution(object):
                 try:
                     location = LocationFactory(name)
                 except KeyError:
-                    raise RuntimeError('Unknown location in world %d: %s' % (world.id + 1, name))
+                    raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(name), self.build_close_match(name, 'location')))
                 if location.type == 'Boss':
                     raise RuntimeError('Boss or already placed in world %d: %s' % (world.id + 1, name))
                 else:
@@ -767,7 +789,7 @@ class WorldDistribution(object):
                 try:
                     location = LocationFactory(location_name)
                 except KeyError:
-                    raise RuntimeError('Unknown location in world %d: %s' % (world.id + 1, location_name))
+                    raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(location_name), self.build_close_match(location_name, 'location')))
                 if location.type == 'Boss':
                     continue
                 elif location.name in world.settings.disabled_locations:
@@ -867,7 +889,7 @@ class WorldDistribution(object):
                         'Too many items were added to world %d, and not enough junk is available to be removed.' % (self.id + 1))
                 except IndexError:
                     raise RuntimeError(
-                        'Unknown item %s being placed on location %s in world %d.' % (record.item, location, self.id + 1))
+                        'Unknown item %s being placed on location %s in world %d. %s' % (repr(record.item), location, self.id + 1, self.build_close_match(record.item, 'item')))
             # Update item_pool after item is replaced
             if item.name not in self.item_pool:
                 self.item_pool[item.name] = ItemPoolRecord()
@@ -875,7 +897,7 @@ class WorldDistribution(object):
                 self.item_pool[item.name].count += 1
         except IndexError:
             raise RuntimeError(
-                'Unknown item %s being placed on location %s in world %d.' % (record.item, location, self.id + 1))
+                'Unknown item %s being placed on location %s in world %d. %s' % (repr(record.item), location, self.id + 1, self.build_close_match(record.item, 'item')))
         # Ensure pool copy is persisted to real pool
         for i, new_pool in enumerate(pool):
             if new_pool:
@@ -893,7 +915,7 @@ class WorldDistribution(object):
             try:
                 location = LocationFactory(name)
             except KeyError:
-                raise RuntimeError('Unknown location in world %d: %s' % (world.id + 1, name))
+                raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(name), self.build_close_match(name, 'location')))
             if location.type == 'Boss':
                 continue
 
@@ -912,7 +934,7 @@ class WorldDistribution(object):
             matcher = self.pattern_matcher(name)
             stoneID = pull_random_element([stoneIDs], lambda id: matcher(gossipLocations[id].name))
             if stoneID is None:
-                raise RuntimeError('Gossip stone unknown or already assigned in world %d: %s' % (self.id + 1, name))
+                raise RuntimeError('Gossip stone unknown or already assigned in world %d: %s. %s' % (self.id + 1, repr(name), self.build_close_match(name, 'stone')))
             spoiler.hints[self.id][stoneID] = GossipText(text=record.text, colors=record.colors, prefix='')
 
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -22,7 +22,7 @@ from version import __version__
 from Utils import random_choices
 from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
 import StartingItems
-from SettingsList import get_setting_info, is_mapped
+from SettingsList import get_setting_info, is_mapped, get_all_settings
 
 
 class InvalidFileException(Exception):
@@ -330,25 +330,6 @@ class WorldDistribution(object):
             else:
                 return lambda s: invert != (s == pattern)
 
-    # When a string isn't found in the source list, attempt to get closest match from the list
-    # ex. Given "Recovery Hart" returns "Did you mean 'Recovery Heart'?"
-    def build_close_match(self, name, type, entrance_pools=None):
-        source = []
-        if type == 'item':
-            source = item_table.keys()
-        elif type == 'location':
-            source = location_table.keys()
-        elif type == 'entrance':
-            for pool in entrance_pools.values():
-                for entrance in pool:
-                    source.append(entrance.name)
-        elif type == 'stone':
-            source = [x.name for x in gossipLocations.values()]
-        close_match = difflib.get_close_matches(name, source, 1)
-        if len(close_match) > 0:
-            return "Did you mean %s?" % (repr(close_match[0]))
-        return "" # No matches
-
     # adds the location entry only if there is no record for that location already
     def add_location(self, new_location, new_item):
         for (location, record) in self.locations.items():
@@ -444,11 +425,11 @@ class WorldDistribution(object):
                 if item.name not in self.item_pool or self.item_pool[item.name].count != 0
             ]  # Only allow items to be candidates if they haven't been set to 0
             if len(candidates) == 0:
-                raise RuntimeError("Unknown item, or item set to 0 in the item pool could not be added: " + repr(item_name) + ". " + self.build_close_match(item_name, 'item'))
+                raise RuntimeError("Unknown item, or item set to 0 in the item pool could not be added: " + repr(item_name) + ". " + build_close_match(item_name, 'item'))
             added_items = random_choices(candidates, k=count)
         else:
             if not IsItem(item_name):
-                raise RuntimeError("Unknown item could not be added: " + repr(item_name) + ". " + self.build_close_match(item_name, 'item'))
+                raise RuntimeError("Unknown item could not be added: " + repr(item_name) + ". " + build_close_match(item_name, 'item'))
             added_items = [item_name] * count
 
         for item in added_items:
@@ -570,9 +551,9 @@ class WorldDistribution(object):
                 continue
             try:
                 if not worlds[self.id].get_entrance(name):
-                    raise RuntimeError('Unknown entrance in world %d: %s. %s' % (self.id + 1, name, self.build_close_match(name, 'entrance', entrance_pools)))
+                    raise RuntimeError('Unknown entrance in world %d: %s. %s' % (self.id + 1, name, build_close_match(name, 'entrance', entrance_pools)))
             except KeyError:
-                raise RuntimeError('Unknown entrance in world %d: %s. %s' % (self.id + 1, name, self.build_close_match(name, 'entrance', entrance_pools)))
+                raise RuntimeError('Unknown entrance in world %d: %s. %s' % (self.id + 1, name, build_close_match(name, 'entrance', entrance_pools)))
 
             entrance_found = False
             for pool_type, entrance_pool in entrance_pools.items():
@@ -709,7 +690,7 @@ class WorldDistribution(object):
                 try:
                     location = LocationFactory(name)
                 except KeyError:
-                    raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(name), self.build_close_match(name, 'location')))
+                    raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(name), build_close_match(name, 'location')))
                 if location.type == 'Boss':
                     raise RuntimeError('Boss or already placed in world %d: %s' % (world.id + 1, name))
                 else:
@@ -789,7 +770,7 @@ class WorldDistribution(object):
                 try:
                     location = LocationFactory(location_name)
                 except KeyError:
-                    raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(location_name), self.build_close_match(location_name, 'location')))
+                    raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(location_name), build_close_match(location_name, 'location')))
                 if location.type == 'Boss':
                     continue
                 elif location.name in world.settings.disabled_locations:
@@ -889,7 +870,7 @@ class WorldDistribution(object):
                         'Too many items were added to world %d, and not enough junk is available to be removed.' % (self.id + 1))
                 except IndexError:
                     raise RuntimeError(
-                        'Unknown item %s being placed on location %s in world %d. %s' % (repr(record.item), location, self.id + 1, self.build_close_match(record.item, 'item')))
+                        'Unknown item %s being placed on location %s in world %d. %s' % (repr(record.item), location, self.id + 1, build_close_match(record.item, 'item')))
             # Update item_pool after item is replaced
             if item.name not in self.item_pool:
                 self.item_pool[item.name] = ItemPoolRecord()
@@ -897,7 +878,7 @@ class WorldDistribution(object):
                 self.item_pool[item.name].count += 1
         except IndexError:
             raise RuntimeError(
-                'Unknown item %s being placed on location %s in world %d. %s' % (repr(record.item), location, self.id + 1, self.build_close_match(record.item, 'item')))
+                'Unknown item %s being placed on location %s in world %d. %s' % (repr(record.item), location, self.id + 1, build_close_match(record.item, 'item')))
         # Ensure pool copy is persisted to real pool
         for i, new_pool in enumerate(pool):
             if new_pool:
@@ -915,7 +896,7 @@ class WorldDistribution(object):
             try:
                 location = LocationFactory(name)
             except KeyError:
-                raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(name), self.build_close_match(name, 'location')))
+                raise RuntimeError('Unknown location in world %d: %s. %s' % (world.id + 1, repr(name), build_close_match(name, 'location')))
             if location.type == 'Boss':
                 continue
 
@@ -934,7 +915,7 @@ class WorldDistribution(object):
             matcher = self.pattern_matcher(name)
             stoneID = pull_random_element([stoneIDs], lambda id: matcher(gossipLocations[id].name))
             if stoneID is None:
-                raise RuntimeError('Gossip stone unknown or already assigned in world %d: %s. %s' % (self.id + 1, repr(name), self.build_close_match(name, 'stone')))
+                raise RuntimeError('Gossip stone unknown or already assigned in world %d: %s. %s' % (self.id + 1, repr(name), build_close_match(name, 'stone')))
             spoiler.hints[self.id][stoneID] = GossipText(text=record.text, colors=record.colors, prefix='')
 
 
@@ -990,19 +971,19 @@ class Distribution(object):
         if 'settings' in self.src_dict:
             for setting, choice in self.src_dict['settings'].items():
                 if not is_mapped(setting):
-                    raise TypeError('%s is not a valid setting.' % (repr(setting)))
+                    raise TypeError('%s is not a valid setting. %s' % (repr(setting), build_close_match(setting, 'setting')))
                 info = get_setting_info(setting)
                 if type(choice) != info.type:
                     raise TypeError('Supplied choice %s for setting %s is of type %s, expecting %s' % (repr(choice), repr(setting), repr(type(choice).__name__), repr(info.type.__name__)))
                 if not isinstance(choice, list) and choice not in info.choice_list:
                     if setting == 'compress_rom' and choice == 'Temp':
                         continue
-                    raise ValueError('%s is not a valid choice for setting %s' % (repr(choice), repr(setting)))
+                    raise ValueError('%s is not a valid choice for setting %s. %s' % (repr(choice), repr(setting), build_close_match(choice, 'choice', info.choice_list)))
                 # If setting is a list, must check each element
                 elif isinstance(choice, list):
                     for element in choice:
                         if element not in info.choice_list:
-                            raise ValueError('%s is not a valid choice for setting %s' % (repr(element), repr(setting)))
+                            raise ValueError('%s is not a valid choice for setting %s. %s' % (repr(element), repr(setting), build_close_match(choice, 'choice', info.choice_list)))
             self.src_dict['_settings'] = self.src_dict['settings']
             del self.src_dict['settings']
 
@@ -1299,3 +1280,26 @@ def pull_all_elements(pools, predicate=lambda k:True, remove=True):
     if len(elements) == 0:
         return None
     return elements
+
+# When a string isn't found in the source list, attempt to get closest match from the list
+# ex. Given "Recovery Hart" returns "Did you mean 'Recovery Heart'?"
+def build_close_match(name, type, list=None):
+    source = []
+    if type == 'item':
+        source = item_table.keys()
+    elif type == 'location':
+        source = location_table.keys()
+    elif type == 'entrance':
+        for pool in list.values():
+            for entrance in pool:
+                source.append(entrance.name)
+    elif type == 'stone':
+        source = [x.name for x in gossipLocations.values()]
+    elif type == 'setting':
+        source = get_all_settings()
+    elif type == 'choice':
+        source = list
+    close_match = difflib.get_close_matches(name, source, 1)
+    if len(close_match) > 0:
+        return "Did you mean %s?" % (repr(close_match[0]))
+    return "" # No matches

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -970,6 +970,8 @@ class Distribution(object):
                 if type(choice) != info.type:
                     raise TypeError('Supplied choice %s for setting %s is of type %s, expecting %s' % (repr(choice), repr(setting), repr(type(choice).__name__), repr(info.type.__name__)))
                 if not isinstance(choice, list) and choice not in info.choice_list:
+                    if setting == 'compress_rom' and choice == 'Temp':
+                        continue
                     raise ValueError('%s is not a valid choice for setting %s' % (repr(choice), repr(setting)))
                 # If setting is a list, must check each element
                 elif isinstance(choice, list):

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -22,7 +22,7 @@ from version import __version__
 from Utils import random_choices
 from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
 import StartingItems
-from SettingsList import get_setting_info, is_mapped, get_all_settings
+from SettingsList import get_setting_info, is_mapped, setting_infos
 
 
 class InvalidFileException(Exception):
@@ -1283,22 +1283,22 @@ def pull_all_elements(pools, predicate=lambda k:True, remove=True):
 
 # When a string isn't found in the source list, attempt to get closest match from the list
 # ex. Given "Recovery Hart" returns "Did you mean 'Recovery Heart'?"
-def build_close_match(name, type, list=None):
+def build_close_match(name, value_type, source_list=None):
     source = []
-    if type == 'item':
+    if value_type == 'item':
         source = item_table.keys()
-    elif type == 'location':
+    elif value_type == 'location':
         source = location_table.keys()
-    elif type == 'entrance':
-        for pool in list.values():
+    elif value_type == 'entrance':
+        for pool in source_list.values():
             for entrance in pool:
                 source.append(entrance.name)
-    elif type == 'stone':
+    elif value_type == 'stone':
         source = [x.name for x in gossipLocations.values()]
-    elif type == 'setting':
-        source = get_all_settings()
-    elif type == 'choice':
-        source = list
+    elif value_type == 'setting':
+        source = [x.name for x in setting_infos]
+    elif value_type == 'choice':
+        source = source_list
     close_match = difflib.get_close_matches(name, source, 1)
     if len(close_match) > 0:
         return "Did you mean %s?" % (repr(close_match[0]))

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -21,6 +21,7 @@ from version import __version__
 from Utils import random_choices
 from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
 import StartingItems
+from SettingsList import get_setting_info, is_mapped
 
 
 class InvalidFileException(Exception):
@@ -962,6 +963,19 @@ class Distribution(object):
 
         self.settings.__dict__.update(update_dict['_settings'])
         if 'settings' in self.src_dict:
+            for setting, choice in self.src_dict['settings'].items():
+                if not is_mapped(setting):
+                    raise TypeError('%s is not a valid setting.' % (repr(setting)))
+                info = get_setting_info(setting)
+                if type(choice) != info.type:
+                    raise TypeError('Supplied choice %s for setting %s is of type %s, expecting %s' % (repr(choice), repr(setting), repr(type(choice).__name__), repr(info.type.__name__)))
+                if not isinstance(choice, list) and choice not in info.choice_list:
+                    raise ValueError('%s is not a valid choice for setting %s' % (repr(choice), repr(setting)))
+                # If setting is a list, must check each element
+                elif isinstance(choice, list):
+                    for element in choice:
+                        if element not in info.choice_list:
+                            raise ValueError('%s is not a valid choice for setting %s' % (repr(element), repr(setting)))
             self.src_dict['_settings'] = self.src_dict['settings']
             del self.src_dict['settings']
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4735,6 +4735,13 @@ def get_settings_from_tab(tab_name):
                     yield setting
             return
 
+def get_all_settings():
+    for tab in setting_map['Tabs']:
+        for section in tab['sections']:
+            for setting in section['settings']:
+                yield setting
+    return
+
 
 def is_mapped(setting_name):
     for tab in setting_map['Tabs']:

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4735,14 +4735,6 @@ def get_settings_from_tab(tab_name):
                     yield setting
             return
 
-def get_all_settings():
-    for tab in setting_map['Tabs']:
-        for section in tab['sections']:
-            for setting in section['settings']:
-                yield setting
-    return
-
-
 def is_mapped(setting_name):
     for tab in setting_map['Tabs']:
         for section in tab['sections']:

--- a/tests/plando/plando-placed-and-added-ice-traps.json
+++ b/tests/plando/plando-placed-and-added-ice-traps.json
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "shopsanity": 4,
+    "shopsanity": "4",
     "shuffle_weird_egg": true,
     "junk_ice_traps": "on"
   },


### PR DESCRIPTION
Adds validation for the following cases to plandomizer:

* User specifies a setting which does not exist
* User specified choice for a setting is not of the right type
* User specified choice for a setting is not a valid choice
* Item name specified in location does not exist (already threw an error but with an unhelpful message)
    * An IndexError handler and message already existed for this case but was not in the correct location. I left the other one since I assume it's still reachable somehow.

For list settings (trick, disabled locations etc.) each element of the supplied list is validated individually.

There's a gross special case for "Temp" value of compress_rom since that's not in its setting list but appears to be a valid option, albeit plando-only.

Also adds to error messages for unknown values (items, locations etc.) so that it will attempt to guess what the user intended using difflib. If no match is found then there is no additional string in the error.

All unit tests passed.