### PR TITLE
Ensure starting age and tod are randomized when specified as random in plando

### DIFF
--- a/World.py
+++ b/World.py
@@ -260,12 +260,15 @@ class World(object):
         if self.settings.big_poe_count_random and 'big_poe_count' not in dist_keys:
             self.settings.big_poe_count = random.randint(1, 10)
             self.randomized_list.append('big_poe_count')
-        if self.settings.starting_tod == 'random' and 'starting_tod' not in dist_keys:
+        # If set to random in GUI, we don't want to randomize if it was specified as non-random in the distribution
+        if (self.settings.starting_tod == 'random' and 
+          ('starting_tod' not in dist_keys or self.distribution.distribution._settings['starting_tod'] == 'random')):
             setting_info = get_setting_info('starting_tod')
             choices = [ch for ch in setting_info.choices if ch not in ['default', 'random']]
             self.settings.starting_tod = random.choice(choices)
             self.randomized_list.append('starting_tod')
-        if self.settings.starting_age == 'random' and 'starting_age' not in dist_keys:
+        if (self.settings.starting_age == 'random' and
+          ('starting_age' not in dist_keys or self.distribution.distribution._settings['starting_age'] == 'random')):
             if self.settings.open_forest == 'closed':
                 # adult is not compatible
                 self.settings.starting_age = 'child'


### PR DESCRIPTION
The checks for randomizing these 2 particular items did not take into account that the same value specifying they should be randomized, was a valid value of the setting itself. When I made it so plando can override randomized settings, I didn't account for setting them to random in the plando. The condition was modified to ensure that they will be randomized if they were specified as random in the distribution.