### PR TITLE
Loosen No Logic "logic" requirements

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -650,7 +650,10 @@
             "Colossus Great Fairy Fountain": "has_explosives",
             "Spirit Temple Lobby": "True",
             "Wasteland Near Colossus": "True",
-            "Colossus Grotto": "can_use(Silver_Gauntlets)"
+            "Colossus Grotto": "can_use(Silver_Gauntlets)",
+            # These, and all other false entrances, exist to loosen the ER requirements for no logic.
+            "Silver Gauntlets Hand": "False",
+            "Mirror Shield Hand": "False"
         }
     },
     {
@@ -1087,7 +1090,8 @@
         "scene": "Kak Impas House",
         "exits": {
             "Kakariko Village": "True",
-            "Kak Impas House Near Cow": "True"
+            "Kak Impas House Near Cow": "True",
+            "Kak Impas House Back": "False"
         }
     },
     {
@@ -1209,7 +1213,8 @@
             "Graveyard Heart Piece Grave": "is_adult or at_night",
             "Graveyard Dampes Grave": "is_adult",
             "Graveyard Dampes House": "is_adult or at_dampe_time",
-            "Kakariko Village": "True"
+            "Kakariko Village": "True",
+            "Graveyard Warp Pad Region": "False"
         }
     },
     {


### PR DESCRIPTION
According to a previous conversation, no logic uses the gflitchless logic files for handling all of ER's "Logic", just with all entrances set to "True".

By adding a few "[entrance]": "False" lines to areas where it's possible to pass using glitches, it should make no logic seeds slightly more open without impacting glitchless logic.

In theory this should also be able to be done by simply making no logic use the glitch logic files for entrances instead of the glitchless logic files, but that would require me completing glitch logic 2.0 first which...is a while off.

Drafted because I still want to add to this, and I need to test generation still.