### PR TITLE
Fix encoding error on warp song message when destination is Dampé's house

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -424,6 +424,9 @@ def encode_text_string(text):
             for _ in range(CONTROL_CODES[n][1]):
                 result.append(ord(next(it)))
             continue
+        if n in CHARACTER_MAP.values(): # Character has already been translated
+            result.append(n)
+            continue
         raise ValueError(f"While encoding {text!r}: Unable to translate unicode character {ch!r} ({n}).  (Already decoded: {result!r})")
     return result
 


### PR DESCRIPTION
The function encode_text_string added in #1320 didn't account for the case where a special character has already been encoded, which can occur when processing the custom message for a warp song destination at Dampé's house. I checked that this didn't break any previously working plando'd hint text or Dampé hint text names. Fix can be tested with this plando:

```json
{
  "entrances": {
    "Bolero of Fire Warp -> DMC Central Local": {
      "region": "Graveyard Dampes House",
      "from": "Graveyard"
    }
  },
  "starting_items": {
    "Bolero of Fire": 1,
    "Ocarina": 1
  }
}
```