### PR TITLE
Allow randomized settings in MW to be different

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -126,8 +126,9 @@ def generate(settings, window=dummy_window()):
 def build_world_graphs(settings, window=dummy_window()):
     logger = logging.getLogger('')
     worlds = []
-    for i in range(0, settings.world_count):
-        worlds.append(World(i, settings))
+    for i in range(1, settings.world_count):
+        worlds.append(World(i, copy.copy(settings)))
+    worlds.insert(0, World(0, settings))
 
     window.update_status('Creating the Worlds')
     for id, world in enumerate(worlds):

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3272,7 +3272,6 @@ setting_infos = [
             '!tokens':  {'settings': ['lacs_tokens']},
         },
         gui_params     = {
-            'randomize_key': 'randomize_settings',
             'optional': True,
             'distribution': [
                 ('vanilla',    1),
@@ -3294,7 +3293,6 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
-            "randomize_key": "randomize_settings",
             'optional': True,
             "hide_when_disabled": True,
             'distribution': [(6, 1)],
@@ -3312,7 +3310,6 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
-            "randomize_key": "randomize_settings",
             'optional': True,
             "hide_when_disabled": True,
             'distribution': [(3, 1)],
@@ -3331,7 +3328,6 @@ setting_infos = [
         shared         = True,
         disabled_default = 0,
         gui_params     = {
-            "randomize_key": "randomize_settings",
             'optional': True,
             "hide_when_disabled": True,
             'distribution': [(9, 1)],

--- a/World.py
+++ b/World.py
@@ -253,7 +253,11 @@ class World(object):
                         or (setting == 'lacs_medallions' and self.settings.lacs_condition != 'medallions') \
                         or (setting == 'lacs_stones' and self.settings.lacs_condition != 'stones') \
                         or (setting == 'lacs_rewards' and self.settings.lacs_condition != 'dungeons') \
-                        or (setting == 'lacs_tokens' and self.settings.lacs_condition != 'tokens'):
+                        or (setting == 'lacs_tokens' and self.settings.lacs_condition != 'tokens') \
+                        or (setting == 'ganon_bosskey_medallions' and self.settings.shuffle_ganon_bosskey != 'medallions') \
+                        or (setting == 'ganon_bosskey_stones' and self.settings.shuffle_ganon_bosskey != 'stones') \
+                        or (setting == 'ganon_bosskey_rewards' and self.settings.shuffle_ganon_bosskey != 'dungeons') \
+                        or (setting == 'ganon_bosskey_tokens' and self.settings.shuffle_ganon_bosskey != 'tokens'):
                     self.randomized_list.remove(setting)
         if self.settings.big_poe_count_random and 'big_poe_count' not in dist_keys:
             self.settings.big_poe_count = random.randint(1, 10)


### PR DESCRIPTION
Resolves #1387, also linking #1335 as it's relevant

Previously the `settings` object was copied by reference to each World object, which combined with #1276 made it so settings could not be different between worlds. However, some places in the code (such as the spoiler) expect the `settings` object to be modified on the `world` object. To allow for both, the `settings` object is copied by reference on the first world object, but by value on the others.

With this, settings that have a "Random" choice (and are thus randomized in World's `resolve_random_settings` function) can be different between MW worlds. Settings randomized by checking Randomize Main Rules are randomized in Setting's `resolve_random_settings` function, which is run in `main` before generation/world creation even starts, so they cannot be different. This matches behavior on 6.0 stable. I made a halfhearted attempt to move Setting's `resolve_random_settings` into World's but it caused errors, however some more work could be done to allow all settings to be different between worlds.

Also resolved a couple other minor issues:
1) lacs_condition was still randomized with the rest of main rules, which is probably not desired when it's now effectively a secret setting.
2) Randomized Ganon BK didn't remove irrelevant info from randomized_list (ex. ganon bk medallion count when ganon bk is not medallions) 