### PR TITLE
Mark bombchu_trail_color_inner as cosmetic

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4268,6 +4268,7 @@ setting_infos = [
         gui_text       = 'Bombchu Trail Inner',
         gui_type       = "Combobox",
         shared         = False,
+        cosmetic       = True,
         choices        = get_bombchu_trail_color_options(),
         default        = 'Red',
         gui_tooltip    = '''\


### PR DESCRIPTION
This is clearly a cosmetic setting but wasn't marked as such, probably by mistake.