### PR TITLE
Mark mirror_shield_frame_color as cosmetic

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4486,6 +4486,7 @@ setting_infos = [
         gui_text       = 'Mirror Shield Frame Color',
         gui_type       = "Combobox",
         shared         = False,
+        cosmetic       = True,
         choices        = get_shield_frame_color_options(),
         default        = 'Red',
         gui_tooltip    = '''\


### PR DESCRIPTION
Same as #1394 but for a different setting. I checked the settings list and this should be the last one with this error.