### PR TITLE
Remove Gold Skulltula Tokens from WOTH and Goals

### DIFF
--- a/Goals.py
+++ b/Goals.py
@@ -147,7 +147,7 @@ def update_goal_items(spoiler):
     # item_locations: only the ones that should appear as "required"/WotH
     all_locations = [location for world in worlds for location in world.get_filled_locations()]
     # Set to test inclusion against
-    item_locations = {location for location in all_locations if location.item.majoritem and not location.locked and location.item.name != 'Triforce Piece'}
+    item_locations = {location for location in all_locations if location.item.majoritem and not location.locked}
 
     # required_locations[category.name][goal.name][world_id] = [...]
     required_locations = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))

--- a/Hints.py
+++ b/Hints.py
@@ -30,6 +30,8 @@ defaultHintDists = [
     'balanced.json', 'bingo.json', 'ddr.json', 'scrubs.json', 'strong.json', 'tournament.json', 'useless.json', 'very_strong.json'
 ]
 
+unHintableWothItems = ['Triforce Piece', 'Gold Skulltula Token']
+
 class RegionRestriction(Enum):
     NONE = 0,
     DUNGEON = 1,
@@ -335,7 +337,8 @@ def get_woth_hint(spoiler, world, checked):
         and not (world.woth_dungeon >= world.hint_dist_user['dungeons_woth_limit'] and location.parent_region.dungeon)
         and location.name not in world.hint_exclusions
         and location.name not in world.hint_type_overrides['woth']
-        and location.item.name not in world.item_hint_type_overrides['woth'],
+        and location.item.name not in world.item_hint_type_overrides['woth']
+        and location.item.name not in unHintableWothItems,
         locations))
 
     if not locations:
@@ -429,7 +432,8 @@ def get_goal_hint(spoiler, world, checked):
             location[0].name not in checked
             and location[0].name not in world.hint_exclusions
             and location[0].name not in world.hint_type_overrides['goal']
-            and location[0].item.name not in world.item_hint_type_overrides['goal'],
+            and location[0].item.name not in world.item_hint_type_overrides['goal']
+            and location.item.name not in unHintableWothItems,
             goal.required_locations))
 
         if not goal_locations:
@@ -518,9 +522,10 @@ def is_not_checked(location, checked):
 def get_good_item_hint(spoiler, world, checked):
     locations = list(filter(lambda location:
         is_not_checked(location, checked)
-        and (location.item.majoritem
-            or location.name in world.added_hint_types['item']
-            or location.item.name in world.item_added_hint_types['item'])
+        and ((location.item.majoritem
+            and location.item.name not in unHintableWothItems)
+                or location.name in world.added_hint_types['item']
+                or location.item.name in world.item_added_hint_types['item'])
         and not location.locked
         and location.name not in world.hint_exclusions
         and location.name not in world.hint_type_overrides['item']


### PR DESCRIPTION
Previously, tokens were considered hintable for way of the hero/goals if tokens were part of the bridge or Ganon's Boss Key conditions. Tokens could therefore only be hinted woth if there were no spare tokens for bridge, GBK, or one of the skulltula house rewards.

Practically, hinting tokens as WOTH is only useful if a meaningful amount of tokens are hinted. The minimum required skulls would be 10 for the skulltula house reward unless the bridge/gbk condition is less than that (unlikely as most users would not purposely select a trival amount of skulls for the wincon). The problem becomes worse with higher skull counts as the likelihood of an exact skull seed increases with less available spares. This dilutes the woth item list, making it more likely to get a token as woth than a useful item. Knowing it's an exact token seed can be useful from a meta aspect, but my opinion is this information is outweighed by the loss of useful required item hints.

Tokens should still be included in the spoiler as woth if they are, and this PR preserves that. The only change is adding a filter to WOTH, Goal, and Good Item hints to prevent hinting tokens or Triforce Pieces.

Triforce Pieces can now appear in the woth list in preparation for changes to Beatable Only to only guarantee access for the minimum TPs to win the game, not all TPs in the world. If that change is not acceptable I can revert this to only affect tokens.

Changes tested with the plando [test_woth_tokens_unhinted.txt](https://github.com/TestRunnerSRL/OoT-Randomizer/files/7230561/test_woth_tokens_unhinted.txt)