### PR TITLE
Triforce count setting

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1298,7 +1298,7 @@ def get_pool_core(world):
     if not world.keysanity and not world.dungeon_mq['Fire Temple']:
         world.state.collect(ItemFactory('Small Key (Fire Temple)'))
 
-    if world.triforce_hunt:
+    if world.settings.triforce_hunt:
         pending_junk_pool.extend(['Triforce Piece'] * world.settings.triforce_count_per_world)
 
     if world.settings.shuffle_ganon_bosskey == 'on_lacs':

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -119,13 +119,6 @@ item_difficulty_max = {
     },
 }
 
-TriforceCounts = {
-    'plentiful': Decimal(2.00),
-    'balanced':  Decimal(1.50),
-    'scarce':    Decimal(1.25),
-    'minimal':   Decimal(1.00),
-}
-
 DT_vanilla = (
     ['Recovery Heart'] * 2)
 
@@ -1305,9 +1298,8 @@ def get_pool_core(world):
     if not world.keysanity and not world.dungeon_mq['Fire Temple']:
         world.state.collect(ItemFactory('Small Key (Fire Temple)'))
 
-    if world.settings.triforce_hunt:
-        triforce_count = int((TriforceCounts[world.settings.item_pool_value] * world.settings.triforce_goal_per_world).to_integral_value(rounding=ROUND_HALF_UP))
-        pending_junk_pool.extend(['Triforce Piece'] * triforce_count)
+    if world.triforce_hunt:
+        pending_junk_pool.extend(['Triforce Piece'] * world.settings.triforce_count_per_world)
 
     if world.settings.shuffle_ganon_bosskey == 'on_lacs':
         placed_items['ToT Light Arrows Cutscene'] = 'Boss Key (Ganons Castle)'

--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ do that.
   * Many locations that did not previously have item hints now have hints, in case a custom hint distribution makes use of them.
   * Using the hint distribution "Bingo" allows setting a "Bingosync URL" to build hints for the specific OoTR Bingo board. Otherwise it's a generic hint distribution for OoTR Bingo.
 * Hint distributions can configure groups of stones to all have the same hint, and can also disable stones from receiving useful hints (give them junk hints instead).
+* Triforce Hunt changes
+  * The number of Triforce pieces available per world, which was previously tied to the item pool setting, is now a separate setting.
 * Tournament hint distribution changes
   * Grotto stones are disabled and only provide junk hints.
   * Zelda's Lullaby is never considered for Way of the Hero hints.

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1882,7 +1882,7 @@ setting_infos = [
                 'sections' : ['open_section', 'shuffle_section', 'shuffle_dungeon_section'],
                 'settings': ['starting_age', 'shuffle_interior_entrances', 'shuffle_grotto_entrances', 'shuffle_dungeon_entrances',
                              'shuffle_overworld_entrances', 'owl_drops', 'warp_songs', 'spawn_positions',
-                             'triforce_hunt', 'triforce_goal_per_world', 'bombchus_in_logic', 'one_item_per_dungeon'],
+                             'triforce_hunt', 'triforce_count_per_world', 'triforce_goal_per_world', 'bombchus_in_logic', 'one_item_per_dungeon'],
             }
         },
         shared         = True,
@@ -2157,7 +2157,22 @@ setting_infos = [
         },
         disable        = {
             True  : {'settings' : ['shuffle_ganon_bosskey', 'ganon_bosskey_stones', 'ganon_bosskey_medallions', 'ganon_bosskey_rewards', 'ganon_bosskey_tokens']},
-            False : {'settings' : ['triforce_goal_per_world']}
+            False : {'settings' : ['triforce_count_per_world', 'triforce_goal_per_world']}
+        },
+    ),
+    Scale(
+        name           = 'triforce_count_per_world',
+        gui_text       = 'Triforces Per World',
+        default        = 30,
+        min            = 1,
+        max            = 200,
+        shared         = True,
+        gui_tooltip    = '''\
+            Select the amount of Triforce Pieces placed in each world.
+            Each world will have the same number of triforces.
+        ''',
+        gui_params     = {
+            "hide_when_disabled": True,
         },
     ),
     Scale(
@@ -2170,16 +2185,9 @@ setting_infos = [
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces required to beat the game.
 
-            In multiworld, each world will have the same number of triforces 
-            in them. The required amount will be per world collectively. 
+            In multiworld, the required amount will be per world collectively. 
             For example, if this is set to 20 in a 2 player multiworld, players 
             need 40 total, but one player could obtain 30 and the other 10. 
-
-            Extra pieces are determined by the the Item Pool setting:
-            'Plentiful': 100% Extra
-            'Balanced': 50% Extra
-            'Scarce': 25% Extra
-            'Minimal: No Extra
         ''',
         gui_params     = {
             "hide_when_disabled": True,

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2170,6 +2170,12 @@ setting_infos = [
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces placed in each world.
             Each world will have the same number of triforces.
+
+            A good number to choose is 1.5 times the amount of
+            Triforce Pieces required per world, for example 30
+            Triforces placed with a goal of 20. Higher ratios will
+            result in easier and shorter seeds, while a ratio closer
+            to 1 will generally be longer and more difficult.
         ''',
         gui_params     = {
             "hide_when_disabled": True,

--- a/World.py
+++ b/World.py
@@ -68,6 +68,8 @@ class World(object):
                                              settings.warp_songs or settings.spawn_positions):
             self.settings.open_forest = 'closed_deku'
 
+        if settings.triforce_goal_per_world > settings.triforce_count_per_world:
+            raise ValueError("Triforces required cannot be more than the triforce count.")
         self.triforce_goal = settings.triforce_goal_per_world * settings.world_count
 
         if settings.triforce_hunt:

--- a/World.py
+++ b/World.py
@@ -12,7 +12,6 @@ from HintList import getRequiredHints
 from Hints import get_hint_area, hint_dist_keys, HintDistFiles
 from Item import Item, ItemFactory, MakeEventItem
 from ItemList import item_table
-from ItemPool import TriforceCounts
 from Location import Location, LocationFactory
 from LocationList import business_scrubs
 from Plandomizer import InvalidFileException
@@ -592,7 +591,6 @@ class World(object):
         trial_goal = Goal(self, 'the Tower', 'path to the Tower', 'White', items=[], create_empty=True)
 
         if self.settings.triforce_hunt and self.settings.triforce_goal_per_world > 0:
-            triforce_count = int((TriforceCounts[self.settings.item_pool_value] * self.settings.triforce_goal_per_world).to_integral_value(rounding=ROUND_HALF_UP))
             # "Hintable" value of False means the goal items themselves cannot
             # be hinted directly. This is used for Triforce Hunt and Skull
             # conditions to restrict hints to useful items instead of the win
@@ -603,7 +601,7 @@ class World(object):
             # Key, which makes these items directly hintable in their respective goals
             # assuming they do not get hinted by another hint type (always, woth with
             # an earlier order in the hint distro, etc).
-            th.add_goal(Goal(self, 'gold', 'path of gold', 'Yellow', items=[{'name': 'Triforce Piece', 'quantity': triforce_count, 'minimum': self.settings.triforce_goal_per_world, 'hintable': False}]))
+            th.add_goal(Goal(self, 'gold', 'path of gold', 'Yellow', items=[{'name': 'Triforce Piece', 'quantity': self.settings.triforce_count_per_world, 'minimum': self.settings.triforce_goal_per_world, 'hintable': False}]))
             self.goal_categories[th.name] = th
         # Category goals are defined for each possible setting for each category.
         # Bridge can be Stones, Medallions, Dungeons, Skulls, or Vanilla.

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -175,6 +175,7 @@
             "warp_songs",
             "spawn_positions",
             "triforce_hunt",
+            "triforce_count_per_world",
             "triforce_goal_per_world",
             "bombchus_in_logic",
             "one_item_per_dungeon",


### PR DESCRIPTION
With [goal hints](https://github.com/TestRunnerSRL/OoT-Randomizer/pull/1361) merged, the [All Goals Reachable](https://github.com/TestRunnerSRL/OoT-Randomizer/pull/1198) setting added, and @mracsys planning to PR the change to Required Only, the last missing part of #1165 is Triforce count per world as its own setting separate from the item pool setting. This is a cherry-pick of the commit adding that setting plus a changelog entry.