### PR TITLE
Add validation options for item_hints

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3670,12 +3670,12 @@ setting_infos = [
         },
     ),
     Setting_Info(
-        name = 'item_hints',
-        type =  list,
-        gui_type = None,
-        gui_text = None,
-        shared = True,
-        choices = [everything[i][1] for i in everything]
+        name           = 'item_hints',
+        type           =  list,
+        gui_type       = None,
+        gui_text       = None,
+        shared         = True,
+        choices        = [everything[i][1] for i in everything]
     ),
     Setting_Info('hint_dist_user',    dict, None, None, True, {}),
     Combobox(

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -15,6 +15,7 @@ from Location import LocationIterator
 import Sounds as sfx
 import StartingItems
 from Utils import data_path
+from StartingItems import everything
 
 # holds the info for a single setting
 class Setting_Info():
@@ -3668,7 +3669,14 @@ setting_infos = [
             "hide_when_disabled" : True,
         },
     ),
-    Setting_Info('item_hints',    list, None, None, True, {}),
+    Setting_Info(
+        name = 'item_hints',
+        type =  list,
+        gui_type = None,
+        gui_text = None,
+        shared = True,
+        choices = [everything[i][1] for i in everything]
+    ),
     Setting_Info('hint_dist_user',    dict, None, None, True, {}),
     Combobox(
         name           = 'text_shuffle',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -15,7 +15,7 @@ from Location import LocationIterator
 import Sounds as sfx
 import StartingItems
 from Utils import data_path
-from StartingItems import everything
+from ItemList import item_table
 
 # holds the info for a single setting
 class Setting_Info():
@@ -3675,7 +3675,7 @@ setting_infos = [
         gui_type       = None,
         gui_text       = None,
         shared         = True,
-        choices        = [everything[i][1] for i in everything]
+        choices        = [i for i in item_table if item_table[i][0] == 'Item']
     ),
     Setting_Info('hint_dist_user',    dict, None, None, True, {}),
     Combobox(


### PR DESCRIPTION
- Adds the list of all item names from ItemList as choices to item_hints
- This prevents the plando validation tool from crashing if any items are supplied in that list in the plando