### PR TITLE
Add carpet merchant jump slash note to logic_wasteland_crossing

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -632,6 +632,8 @@ logic_tricks = {
         'tooltip' : '''\
                     You can beat the quicksand by backwalking across it
                     in a specific way.
+                    Note that jumping to the carpet merchant as child
+                    typically requires a fairly precise jump slash.
                     '''},
     'Colossus Hill GS with Hookshot': {
         'name'    : 'logic_colossus_gs',


### PR DESCRIPTION
The access rule for the bombchu salesman is just `Progressive_Wallet and (is_adult or Sticks or Kokiri_Sword)`, i.e. jump slashing as child to reach the carpet is in base logic. This is okay because reaching the wasteland as child in the first place requires either `logic_reverse_wasteland` or `logic_wasteland_crossing`. The former's description has a note about the jump slash, so this PR adds it to the latter's as well.