### PR TITLE
Fix hint generation crash due to conflict between required named-item hints and Ganondorf Light Arrows hint

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -891,6 +891,9 @@ def buildGossipHints(spoiler, worlds):
             if light_arrow_world.id not in checkedLocations:
                 checkedLocations[light_arrow_world.id] = set()
             checkedLocations[light_arrow_world.id].add(location.name)
+            # Prevent conflicts with named-item hints and Ganondorf
+            if 'Light Arrows' in world.item_hints:
+                world.item_hints.remove('Light Arrows')
 
     # Build all the hints.
     for world in worlds:

--- a/Hints.py
+++ b/Hints.py
@@ -550,7 +550,7 @@ def get_specific_item_hint(spoiler, world, checked):
     if len(world.named_item_pool) == 0:
         logger = logging.getLogger('')
         logger.info("Named item hint requested, but pool is empty.")
-        return None  
+        return None
     if world.settings.world_count == 1:
         while True:
             itemname = world.named_item_pool.pop(0)
@@ -891,9 +891,6 @@ def buildGossipHints(spoiler, worlds):
             if light_arrow_world.id not in checkedLocations:
                 checkedLocations[light_arrow_world.id] = set()
             checkedLocations[light_arrow_world.id].add(location.name)
-            # Prevent conflicts with named-item hints and Ganondorf
-            if 'Light Arrows' in world.item_hints:
-                world.item_hints.remove('Light Arrows')
 
     # Build all the hints.
     for world in worlds:
@@ -1071,9 +1068,17 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
         if hint_dist['named-item'][1] == 0:
             raise Exception('User-provided item hints were requested, but copies per named-item hint is zero')
         else:
+            # Prevent conflict between Ganondorf Light Arrows hint and required named item hints.
+            # Assumes that a "wasted" hint is desired since Light Arrows have to be added
+            # explicitly to the list for named item hints.
+            filtered_checked = set(checkedLocations | checkedAlwaysLocations)
+            for location in (checkedLocations | checkedAlwaysLocations):
+                if world.get_location(location).item.name == 'Light Arrows':
+                    filtered_checked.remove(location)
             for i in range(0, len(world.named_item_pool)):
-                hint = get_specific_item_hint(spoiler, world, checkedLocations | checkedAlwaysLocations)
+                hint = get_specific_item_hint(spoiler, world, filtered_checked)
                 if hint:
+                    checkedLocations.update(filtered_checked - checkedAlwaysLocations)
                     gossip_text, location = hint
                     place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
                     if not place_ok:


### PR DESCRIPTION
If all named-item hints are required in the hint distro, Light Arrows are one of the items, and Ganondorf miscellaneous hint is enabled, generation fails as Light Arrows are already in a hint-checked location. This change allows named-item hints to "duplicate" the Ganondorf Light Arrows hint. If all named-item hints are not required and the Ganondorf miscellaneous hint is reachable, Light Arrows will not be hintable as usual, and hint generation moves to the next item or hint type.