### PR TITLE
Handle legacy hint distros without goal hint type

### DIFF
--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -248,7 +248,10 @@ def CreateJSON(path, web_version=False):
     
     for d in HintDistFiles():
         dist = read_json(d)
-        if dist['distribution']['goal']['weight'] != 0 or dist['distribution']['goal']['fixed'] != 0:
+        if ('distribution' in dist and
+           'goal' in dist['distribution'] and
+           (dist['distribution']['goal']['fixed'] != 0 or
+                dist['distribution']['goal']['weight'] != 0)):
             settingOutputJson['distroArray'].append(dist['name'])
 
     with open(path, 'w') as f:

--- a/World.py
+++ b/World.py
@@ -118,7 +118,7 @@ class World(object):
         if 'distribution' in self.hint_dist_user and 'goal' not in self.hint_dist_user['distribution']:
             self.hint_dist_user['distribution']['goal'] = {"order": 0, "weight": 0.0, "fixed": 0, "copies": 0}
         if 'use_default_goals' not in self.hint_dist_user:
-            self.hint_dist_user['use_default_goals'] = False
+            self.hint_dist_user['use_default_goals'] = True
 
         # Validate hint distribution format
         # Originally built when I was just adding the type distributions

--- a/World.py
+++ b/World.py
@@ -126,7 +126,7 @@ class World(object):
         if not hint_dist_valid:
             raise InvalidFileException("""Hint distributions require all hint types be present in the distro 
                                           (trial, always, woth, barren, item, song, overworld, dungeon, entrance,
-                                          sometimes, random, junk, named-item). If a hint type should not be
+                                          sometimes, random, junk, named-item, goal). If a hint type should not be
                                           shuffled, set its order to 0. Hint type format is \"type\": { 
                                           \"order\": 0, \"weight\": 0.0, \"fixed\": 0, \"copies\": 0 }""")
         
@@ -193,7 +193,12 @@ class World(object):
 
         # Disable goal hints if the hint distro does not require them.
         # WOTH locations are always searched.
-        self.enable_goal_hints = self.hint_dist_user['distribution']['goal']['fixed'] != 0 or self.hint_dist_user['distribution']['goal']['weight'] != 0
+        self.enable_goal_hints = False
+        if ('distribution' in self.hint_dist_user and
+           'goal' in self.hint_dist_user['distribution'] and
+           (self.hint_dist_user['distribution']['goal']['fixed'] != 0 or
+                self.hint_dist_user['distribution']['goal']['weight'] != 0)):
+            self.enable_goal_hints = True
 
         # Initialize default goals for win condition
         self.goal_categories = OrderedDict()

--- a/World.py
+++ b/World.py
@@ -112,7 +112,14 @@ class World(object):
         else:
             self.settings.hint_dist = 'custom'
             self.hint_dist_user = self.settings.hint_dist_user
-            
+
+        # Hack for legacy hint distributions from before the goal hint
+        # type was created. Keeps validation happy.
+        if 'distribution' in self.hint_dist_user and 'goal' not in self.hint_dist_user['distribution']:
+            self.hint_dist_user['distribution']['goal'] = {"order": 0, "weight": 0.0, "fixed": 0, "copies": 0}
+        if 'use_default_goals' not in self.hint_dist_user:
+            self.hint_dist_user['use_default_goals'] = False
+
         # Validate hint distribution format
         # Originally built when I was just adding the type distributions
         # Location/Item Additions and Overrides are not validated


### PR DESCRIPTION
Fixes the GUI crashing on load and seed generation failing at distro validation. These problems only existed if a user had an old custom hint distribution in their `data` folder, or they attempted to use an old plando with custom hints but no goal type defined.