### PR TITLE
Make Triforce Hunt reachability and hints compatible with Beatable Only

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1173,6 +1173,11 @@ class Distribution(object):
                         goal = spoiler.goal_categories[world.id][cat_name].get_goal(goal_name)
                         goal_text = goal.hint_text.replace('#', '')
                         goal_text = goal_text[0].upper() + goal_text[1:]
+                        # Add Token/Triforce Piece reachability data
+                        if goal.items[0]['name'] == 'Triforce Piece':
+                            goal_text +=  ' (' + str(goal.items[0]['quantity']) + '/' + str(world.triforce_count) + ' reachable)'
+                        if goal.items[0]['name'] == 'Gold Skulltula Token':
+                            goal_text +=  ' (' + str(goal.items[0]['quantity']) + '/100 reachable)'
                         world_dist.goal_locations[cat_name][goal_text] = {}
                         for location_world, locations in location_worlds.items():
                             if len(self.world_dists) == 1:

--- a/State.py
+++ b/State.py
@@ -41,7 +41,7 @@ class State(object):
 
 
     def won_triforce_hunt(self):
-        return self.has('Triforce Piece', self.world.triforce_count)
+        return self.has('Triforce Piece', self.world.settings.triforce_goal_per_world)
 
 
     def won_normal(self):


### PR DESCRIPTION
As discussed in #1403, changes Triforce Hunt to not require all Triforce Pieces be reachable when Guarantee Reachable Locations is Required Only. All Goals Reachable uses the default path of gold goal to guarantee TP accessibility. For all location reachability settings, Way of the Hero hints will only point to items required to meet the minimum Triforce Piece goal instead of any one Piece. Path of Gold was previously moved to the goal hint type and continues to hint items for any Piece.

This also adds reachable Skulltula Token and Triforce Piece counts to the `:goal_locations` section. This makes the feature easier to test and provides useful spoiler information for tight requirements.