### PR TITLE
Remove Random Spawns check from Prelude/Serenade foolish calculation

### DIFF
--- a/World.py
+++ b/World.py
@@ -951,7 +951,7 @@ class World(object):
         if self.settings.logic_grottos_without_agony and self.settings.hints != 'agony':
             # Stone of Agony skippable if not used for hints or grottos
             exclude_item_list.append('Stone of Agony')
-        if not self.shuffle_special_interior_entrances and not self.settings.shuffle_overworld_entrances and not self.settings.warp_songs and not self.settings.spawn_positions:
+        if not self.shuffle_special_interior_entrances and not self.settings.shuffle_overworld_entrances and not self.settings.warp_songs:
             # Serenade and Prelude are never required unless one of those settings is enabled
             exclude_item_list.append('Serenade of Water')
             exclude_item_list.append('Prelude of Light')

--- a/tests/plando/plando-er-colossus-spawn-validity.json
+++ b/tests/plando/plando-er-colossus-spawn-validity.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "logic_rules":                             "glitchless",
+    "shuffle_interior_entrances":              "off",
+    "shuffle_overworld_entrances":             false,
+    "warp_songs":                              false,
+    "spawn_positions":                         true,
+    "starting_items":                          [
+      "ocarina"
+    ],
+    "starting_age":                            "adult"
+  },
+  "entrances": {
+    "Adult Spawn -> Temple of Time": {"region": "Desert Colossus", "from": "Colossus Great Fairy Fountain"}
+  }
+}

--- a/tests/plando/plando-er-warp-destination-reachability.json
+++ b/tests/plando/plando-er-warp-destination-reachability.json
@@ -1,9 +1,0 @@
-{
-  "settings": {
-    "logic_rules":                             "glitchless",
-    "shuffle_interior_entrances":              "off",
-    "shuffle_overworld_entrances":             false,
-    "warp_songs":                              false,
-    "spawn_positions":                         true
-  }
-}

--- a/tests/plando/plando-er-warp-destination-reachability.json
+++ b/tests/plando/plando-er-warp-destination-reachability.json
@@ -1,0 +1,9 @@
+{
+  "settings": {
+    "logic_rules":                             "glitchless",
+    "shuffle_interior_entrances":              "off",
+    "shuffle_overworld_entrances":             false,
+    "warp_songs":                              false,
+    "spawn_positions":                         true
+  }
+}


### PR DESCRIPTION
Fixes #1360 

Serenade and Prelude are not logically relevant with just random spawns as documented in the issue. To prove this, a unit test `test_spawn_point_warp_reachability` was added to test reachability to the Serenade and Prelude destination regions with no items.