### PR TITLE
Fix MW regression from goal hints

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -1322,15 +1322,15 @@ goalTable = {
 
 # This specifies which hints will never appear due to either having known or known useless contents or due to the locations not existing.
 def hintExclusions(world, clear_cache=False):
-    if not clear_cache and hintExclusions.exclusions is not None:
-        return hintExclusions.exclusions
+    if not clear_cache and world.id in hintExclusions.exclusions:
+        return hintExclusions.exclusions[world.id]
 
-    hintExclusions.exclusions = []
-    hintExclusions.exclusions.extend(world.settings.disabled_locations)
+    hintExclusions.exclusions[world.id] = []
+    hintExclusions.exclusions[world.id].extend(world.settings.disabled_locations)
 
     for location in world.get_locations():
         if location.locked:
-            hintExclusions.exclusions.append(location.name)
+            hintExclusions.exclusions[world.id].append(location.name)
 
     world_location_names = [
         location.name for location in world.get_locations()]
@@ -1348,10 +1348,10 @@ def hintExclusions(world, clear_cache=False):
             location_hints.append(hint)
 
     for hint in location_hints:
-        if hint.name not in world_location_names and hint.name not in hintExclusions.exclusions:
-            hintExclusions.exclusions.append(hint.name)
+        if hint.name not in world_location_names and hint.name not in hintExclusions.exclusions[world.id]:
+            hintExclusions.exclusions[world.id].append(hint.name)
 
-    return hintExclusions.exclusions
+    return hintExclusions.exclusions[world.id]
 
 def nameIsLocation(name, hint_type, world):
     if isinstance(hint_type, (list, tuple)):
@@ -1362,4 +1362,4 @@ def nameIsLocation(name, hint_type, world):
         return True
     return False
 
-hintExclusions.exclusions = None
+hintExclusions.exclusions = {}


### PR DESCRIPTION
Goal hints changed hint exclusion calculations to a one-time calculation for all worlds prior to generating hints instead of separate calls for each world's hints. The hintExclusion function already took a world as an argument, but the generated list did not include world information. This change refactors the function to support multiple worlds in the same list keyed on world IDs.

Test with setting string BJSGWCHYKAB67RAA253BN8TJVXYTTL62TGBAACABNAGSCZJGYTQEEDKKQUWNFBSNCAAAGAACKEE on 6.0.121 Dev-R.

Fixes #1421 