### PR TITLE
Fix warp song dialog text

### DIFF
--- a/Dungeon.py
+++ b/Dungeon.py
@@ -1,6 +1,6 @@
 class Dungeon(object):
 
-    def __init__(self, world, name, hint, boss_key, small_keys, dungeon_items):
+    def __init__(self, world, name, hint, font_color, boss_key, small_keys, dungeon_items):
         def to_array(obj):
             if obj == None:
                 return []
@@ -12,6 +12,7 @@ class Dungeon(object):
         self.world = world
         self.name = name
         self.hint = hint
+        self.font_color = font_color
         self.regions = []
         self.boss_key = to_array(boss_key)
         self.small_keys = to_array(small_keys)
@@ -28,7 +29,7 @@ class Dungeon(object):
         new_small_keys = [item.copy(new_world) for item in self.small_keys]
         new_dungeon_items = [item.copy(new_world) for item in self.dungeon_items]
 
-        new_dungeon = Dungeon(new_world, self.name, self.hint, new_boss_key, new_small_keys, new_dungeon_items)
+        new_dungeon = Dungeon(new_world, self.name, self.hint, self.font_color, new_boss_key, new_small_keys, new_dungeon_items)
 
         return new_dungeon
 

--- a/DungeonList.py
+++ b/DungeonList.py
@@ -9,6 +9,8 @@ from Utils import data_path
 dungeon_table = [
     {
         'name': 'Deku Tree',
+        'hint': 'the Deku Tree',
+        'font_color': 'Green',
         'boss_key':     0, 
         'small_key':    0,
         'small_key_mq': 0,
@@ -17,6 +19,7 @@ dungeon_table = [
     {
         'name': 'Dodongos Cavern',
         'hint': 'Dodongo\'s Cavern',
+        'font_color': 'Red',
         'boss_key':     0, 
         'small_key':    0,
         'small_key_mq': 0,
@@ -25,6 +28,7 @@ dungeon_table = [
     {
         'name': 'Jabu Jabus Belly',
         'hint': 'Jabu Jabu\'s Belly',
+        'font_color': 'Blue',
         'boss_key':     0, 
         'small_key':    0,
         'small_key_mq': 0,
@@ -32,6 +36,8 @@ dungeon_table = [
     },
     {
         'name': 'Forest Temple',
+        'hint': 'the Forest Temple',
+        'font_color': 'Green',
         'boss_key':     1, 
         'small_key':    5,
         'small_key_mq': 6,
@@ -39,6 +45,8 @@ dungeon_table = [
     },
     {
         'name': 'Bottom of the Well',
+        'hint': 'the Bottom of the Well',
+        'font_color': 'Pink',
         'boss_key':     0, 
         'small_key':    3,
         'small_key_mq': 2,
@@ -46,6 +54,8 @@ dungeon_table = [
     },
     {
         'name': 'Fire Temple',
+        'hint': 'the Fire Temple',
+        'font_color': 'Red',
         'boss_key':     1, 
         'small_key':    8,
         'small_key_mq': 5,
@@ -53,6 +63,8 @@ dungeon_table = [
     },
     {
         'name': 'Ice Cavern',
+        'hint': 'the Ice Cavern',
+        'font_color': 'Blue',
         'boss_key':     0, 
         'small_key':    0,
         'small_key_mq': 0,
@@ -60,6 +72,8 @@ dungeon_table = [
     },
     {
         'name': 'Water Temple',
+        'hint': 'the Water Temple',
+        'font_color': 'Blue',
         'boss_key':     1, 
         'small_key':    6,
         'small_key_mq': 2,
@@ -67,6 +81,8 @@ dungeon_table = [
     },
     {
         'name': 'Shadow Temple',
+        'hint': 'the Shadow Temple',
+        'font_color': 'Pink',
         'boss_key':     1, 
         'small_key':    5,
         'small_key_mq': 6,
@@ -74,6 +90,8 @@ dungeon_table = [
     },
     {
         'name': 'Gerudo Training Ground',
+        'hint': 'the Gerudo Training Ground',
+        'font_color': 'Yellow',
         'boss_key':     0, 
         'small_key':    9,
         'small_key_mq': 3,
@@ -81,6 +99,8 @@ dungeon_table = [
     },
     {
         'name': 'Spirit Temple',
+        'hint': 'the Spirit Temple',
+        'font_color': 'Yellow',
         'boss_key':     1, 
         'small_key':    5,
         'small_key_mq': 7,
@@ -101,6 +121,7 @@ def create_dungeons(world):
     for dungeon_info in dungeon_table:
         name = dungeon_info['name']
         hint = dungeon_info['hint'] if 'hint' in dungeon_info else name
+        font_color = dungeon_info['font_color'] if 'font_color' in dungeon_info else 'White'
         
         if world.settings.logic_rules == 'glitched':
             if not world.dungeon_mq[name]:
@@ -127,5 +148,5 @@ def create_dungeons(world):
             for item in dungeon_items:
                 item.priority = True
 
-        world.dungeons.append(Dungeon(world, name, hint, boss_keys, small_keys, dungeon_items))
+        world.dungeons.append(Dungeon(world, name, hint, font_color, boss_keys, small_keys, dungeon_items))
 

--- a/Hints.py
+++ b/Hints.py
@@ -13,7 +13,7 @@ import itertools
 
 from HintList import getHint, getHintGroup, Hint, hintExclusions
 from Item import MakeEventItem
-from Messages import update_message_by_id
+from Messages import COLOR_MAP, update_message_by_id
 from Search import Search
 from StartingItems import everything
 from TextBox import line_wrap
@@ -270,17 +270,6 @@ def getSimpleHintNoPrefix(item):
 
 
 def colorText(gossip_text):
-    colorMap = {
-        'White':      '\x40',
-        'Red':        '\x41',
-        'Green':      '\x42',
-        'Blue':       '\x43',
-        'Light Blue': '\x44',
-        'Pink':       '\x45',
-        'Yellow':     '\x46',
-        'Black':      '\x47',
-    }
-
     text = gossip_text.text
     colors = list(gossip_text.colors) if gossip_text.colors is not None else []
     color = 'White'
@@ -296,7 +285,7 @@ def colorText(gossip_text):
                 splitText[1] = splitText[1][len(prefix):]
                 break
 
-        splitText[1] = '\x05' + colorMap[color] + splitText[1] + '\x05\x40'
+        splitText[1] = '\x05' + COLOR_MAP[color] + splitText[1] + '\x05\x40'
         text = ''.join(splitText)
 
     return text

--- a/Messages.py
+++ b/Messages.py
@@ -304,66 +304,22 @@ REGION_NAMES = {
     "Gerudo Training Ground":         [['Gerudo Training Ground Lobby'], '\46'],
 
     # Indoors
-    "Mido's House":                   [['KF Midos House'], '\44'],
-    "Saria's House":                  [['KF Sarias House'], '\44'],
-    "House of Twins":                 [['KF House of Twins'], '\44'],
-    "Know It All House":              [['KF Know It All House'], '\44'],
-    "the Kokiri Shop":                [['KF Kokiri Shop'], '\44'],
-    "the Lakeside Laboratory":        [['LH Lab'], '\44'],
-    "the Fishing Pond":               [['LH Fishing Hole'], '\44'],
-    "the Carpenter's Tent":           [['GV Carpenter Tent'], '\44'],
-    "the Guard House":                [['Market Guard House'], '\44'],
-    "the Mask Shop":                  [['Market Mask Shop'], '\44'],
-    "the Bombchu Bowling Alley":      [['Market Bombchu Bowling'], '\44'],
-    "the Potion Shop":                [['Market Potion Shop', 'Kak Potion Shop Front', 'Kak Potion Shop Back'], '\44'],
-    "the Treasure Chest Game":        [['Market Treasure Chest Game'], '\44'],
-    "the Bombchu Shop":               [['Market Bombchu Shop'], '\44'],
-    "a Back Alley House":             [['Market Man in Green House'], '\44'],
-    "the Carpenter's House":          [['Kak Carpenter Boss House'], '\44'],
-    "the House of Skulltula":         [['Kak House of Skulltula'], '\44'],
-    "Impa's House":                   [['Kak Impas House', 'Kak Impas House Back'], '\44'],
-    "the Oddity Shop":                [['Kak Odd Medicine Building'], '\44'],
-    "Damp\x96's House":               [['Graveyard Dampes House'], '\44'],
-    "the Goron Shop":                 [['GC Shop'], '\44'],
     "the Zora Shop":                  [['ZD Shop'], '\44'],
     "Talon's House":                  [['LLR Talons House'], '\44'],
     "Lon Lon Stable":                 [['LLR Stables'], '\44'],
     "Lon Lon Tower":                  [['LLR Tower'], '\44'],
-    "the Bazaar":                     [['Market Bazaar', 'Kak Bazaar'], '\44'],
-    "the Shooting Gallery":           [['Market Shooting Gallery', 'Kak Shooting Gallery'], '\44'],
     "a Great Fairy Fountain":         [['Colossus Great Fairy Fountain', 'HC Great Fairy Fountain', 'OGC Great Fairy Fountain', 'DMC Great Fairy Fountain', 'DMT Great Fairy Fountain', 'ZF Great Fairy Fountain'], '\44'],
-    "\x0F's House":                   [['KF Links House'], '\44'],
-    "the Temple of Time":             [['Temple of Time'], '\44'],
-    "the Windmill":                   [['Kak Windmill'], '\44'],
 
     # Overworld
-    "Kokiri Forest":                 [['Kokiri Forest'], '\41'],
-    "the Lost Woods Bridge":         [['LW Bridge From Forest', 'LW Bridge'], '\42'],
-    "the Lost Woods":                [['Lost Woods', 'LW Beyond Mido', 'LW Forest Exit'], '\42'],
-    "Goron City":                    [['GC Woods Warp', 'GC Darunias Chamber', 'Goron City'], '\41'],
     "Zora's River":                  [['Zora River', 'ZR Behind Waterfall', 'ZR Front'], '\43'],
-    "the Sacred Forest Meadow":      [['SFM Entryway'], '\41'],
-    "Hyrule Field":                  [['Hyrule Field'], '\44'],
-    "Lake Hylia":                    [['Lake Hylia'], '\43'],
-    "Gerudo Valley":                 [['Gerudo Valley', 'GV Fortress Side'], '\46'],
-    "the Market Entrance":           [['Market Entrance'], '\44'],
     "Kakariko Village":              [['Kakariko Village', 'Kak Behind Gate', 'Kak Impas Ledge'], '\45'],
     "Lon Lon Ranch":                 [['Lon Lon Ranch'], '\46'],
     "Zora's Domain":                 [['Zoras Domain', 'ZD Behind King Zora'], '\43'],
-    "Gerudo Fortress":               [['Gerudo Fortress', 'GF Outside Gate'], '\41'],
-    "the Haunted Wasteland":         [['Wasteland Near Fortress', 'Wasteland Near Colossus'], '\46'],
-    "the Desert Colossus":           [['Desert Colossus'], '\44'],
-    "the Market":                    [['Market'], '\44'],
-    "the Castle Grounds":            [['Castle Grounds'], '\44'],
-    "the Temple of Time Entrance":   [['ToT Entrance'], '\44'],
-    "the Graveyard":                 [['Graveyard'], '\45'],
     "Death Mountain Trail":          [['Death Mountain', 'Death Mountain Summit'], '\41'],
     "Death Mountain Crater":         [['DMC Lower Local', 'DMC Lower Nearby', 'DMC Upper Local', 'DMC Upper Nearby'], '\41'],
     "Zora's Fountain":               [['Zoras Fountain'], '\43'],
 
     # Grottos
-    "the Royal Family's Tomb":       [['Graveyard Royal Familys Tomb'], '\44'],
-    "Damp\x96's Grave":              [['Graveyard Dampes Grave'], '\44'],
     "the Wolfos Grotto":             [['SFM Wolfos Grotto'], '\44'],
     "the ReDead Grotto":             [['Kak Redead Grotto'], '\44'],
     "a Deku Scrub Grotto":           [['GV Storms Grotto', 'Colossus Grotto', 'LLR Grotto', 'SFM Storms Grotto', 'HF Inside Fence Grotto', 'GC Grotto', 'DMC Hammer Grotto', 'LW Scrubs Grotto', 'LH Grotto', 'ZR Storms Grotto'], '\44'],
@@ -373,8 +329,6 @@ REGION_NAMES = {
     "a Fairy Fountain":              [['SFM Fairy Grotto', 'HF Fairy Grotto', 'ZD Storms Grotto', 'GF Storms Grotto', 'ZR Fairy Grotto'], '\44'],
     "the Octorok Grotto":            [['GV Octorok Grotto'], '\44'],
     "a Skulltula Grotto":            [['HF Near Kak Grotto', 'HC Storms Grotto'], '\44'],
-    "the Shield Grave":              [['Graveyard Shield Grave'], '\44'],
-    "the ReDead Grave":              [['Graveyard Heart Piece Grave'], '\44'],
     "the Cow Grotto":                [['DMT Cow Grotto'], '\44'],
     "the Spider Cow Grotto":         [['HF Cow Grotto'], '\44'],
 }
@@ -1060,6 +1014,7 @@ def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
     return permutation
 
 # Update warp song text boxes for ER
+import sys
 def update_warp_song_text(messages, world):
     msg_list = {
         0x088D: 'Minuet of Forest Warp -> Sacred Forest Meadow',

--- a/Messages.py
+++ b/Messages.py
@@ -288,49 +288,15 @@ KEYSANITY_MESSAGES = {
     0x00A9: "\x13\x77\x08You found a \x05\x41Small Key\x05\x40\x01for the \x05\x45Shadow Temple\x05\x40!\x09",
 }
 
-#   Styled Name                    Entrance Names       Text Color
-REGION_NAMES = {
-    # Dungeons
-    "the Deku Tree":                  [['Deku Tree Lobby'], '\42'],
-    "Dodongo's Cavern":               [['Dodongos Cavern Beginning'], '\41'],
-    "Jabu Jabu's Belly":              [['Jabu Jabus Belly Beginning'], '\43'],
-    "the Forest Temple":              [['Forest Temple Lobby'], '\42'],
-    "the Fire Temple":                [['Fire Temple Lower'], '\41'],
-    "the Water Temple":               [['Water Temple Lobby'], '\43'],
-    "the Spirit Temple":              [['Spirit Temple Lobby'], '\46'],
-    "the Shadow Temple":              [['Shadow Temple Entryway'], '\45'],
-    "the Bottom of the Well":         [['Bottom of the Well'], '\45'],
-    "the Ice Cavern":                 [['Ice Cavern Beginning'], '\44'],
-    "Gerudo Training Ground":         [['Gerudo Training Ground Lobby'], '\46'],
-
-    # Indoors
-    "the Zora Shop":                  [['ZD Shop'], '\44'],
-    "Talon's House":                  [['LLR Talons House'], '\44'],
-    "Lon Lon Stable":                 [['LLR Stables'], '\44'],
-    "Lon Lon Tower":                  [['LLR Tower'], '\44'],
-    "a Great Fairy Fountain":         [['Colossus Great Fairy Fountain', 'HC Great Fairy Fountain', 'OGC Great Fairy Fountain', 'DMC Great Fairy Fountain', 'DMT Great Fairy Fountain', 'ZF Great Fairy Fountain'], '\44'],
-
-    # Overworld
-    "Zora's River":                  [['Zora River', 'ZR Behind Waterfall', 'ZR Front'], '\43'],
-    "Kakariko Village":              [['Kakariko Village', 'Kak Behind Gate', 'Kak Impas Ledge'], '\45'],
-    "Lon Lon Ranch":                 [['Lon Lon Ranch'], '\46'],
-    "Zora's Domain":                 [['Zoras Domain', 'ZD Behind King Zora'], '\43'],
-    "Death Mountain Trail":          [['Death Mountain', 'Death Mountain Summit'], '\41'],
-    "Death Mountain Crater":         [['DMC Lower Local', 'DMC Lower Nearby', 'DMC Upper Local', 'DMC Upper Nearby'], '\41'],
-    "Zora's Fountain":               [['Zoras Fountain'], '\43'],
-
-    # Grottos
-    "the Wolfos Grotto":             [['SFM Wolfos Grotto'], '\44'],
-    "the ReDead Grotto":             [['Kak Redead Grotto'], '\44'],
-    "a Deku Scrub Grotto":           [['GV Storms Grotto', 'Colossus Grotto', 'LLR Grotto', 'SFM Storms Grotto', 'HF Inside Fence Grotto', 'GC Grotto', 'DMC Hammer Grotto', 'LW Scrubs Grotto', 'LH Grotto', 'ZR Storms Grotto'], '\44'],
-    "the Tektite Grotto":            [['HF Tektite Grotto'], '\44'],
-    "the Deku Theater":              [['Deku Theater'], '\44'],
-    "a Generic Grotto":              [['KF Storms Grotto', 'HF Near Market Grotto', 'HF Southeast Grotto', 'ZR Open Grotto', 'DMC Upper Grotto', 'Kak Open Grotto', 'DMT Storms Grotto', 'LW Near Shortcuts Grotto', 'HF Open Grotto'], '\44'],
-    "a Fairy Fountain":              [['SFM Fairy Grotto', 'HF Fairy Grotto', 'ZD Storms Grotto', 'GF Storms Grotto', 'ZR Fairy Grotto'], '\44'],
-    "the Octorok Grotto":            [['GV Octorok Grotto'], '\44'],
-    "a Skulltula Grotto":            [['HF Near Kak Grotto', 'HC Storms Grotto'], '\44'],
-    "the Cow Grotto":                [['DMT Cow Grotto'], '\44'],
-    "the Spider Cow Grotto":         [['HF Cow Grotto'], '\44'],
+COLOR_MAP = {
+    'White':      '\x40',
+    'Red':        '\x41',
+    'Green':      '\x42',
+    'Blue':       '\x43',
+    'Light Blue': '\x44',
+    'Pink':       '\x45',
+    'Yellow':     '\x46',
+    'Black':      '\x47',
 }
 
 MISC_MESSAGES = {
@@ -1014,7 +980,6 @@ def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
     return permutation
 
 # Update warp song text boxes for ER
-import sys
 def update_warp_song_text(messages, world):
     msg_list = {
         0x088D: 'Minuet of Forest Warp -> Sacred Forest Meadow',
@@ -1026,22 +991,17 @@ def update_warp_song_text(messages, world):
     }
 
     for id, entr in msg_list.items():
-        destination_raw = world.get_entrance(entr).connected_region.name
+        destination = world.get_entrance(entr).connected_region
 
-        # Format the region name
-        destination, color = None, None
-        for formatted_region, info in REGION_NAMES.items():
-            raw_region_list, region_color = info
-            if destination_raw in raw_region_list:
-                destination = formatted_region
-                color = region_color
-                break
+        if destination.pretty_name:
+            destination_name = destination.pretty_name
+        elif destination.hint:
+            destination_name = destination.hint
+        elif destination.dungeon:
+            destination_name = destination.dungeon.hint
+        else:
+            destination_name = destination.name
+        color = COLOR_MAP[destination.font_color or 'White']
 
-        # Check if region name isn't found
-        if destination is None:
-            logging.error("MISSING REGION NAME: " + destination_raw)
-            destination = destination_raw
-            color = "\40"
-
-        new_msg = f"\x08\x05{color}Warp to {destination}?\x05\40\x09\x01\x01\x1b\x05{color}OK\x01No\x05\40"
+        new_msg = f"\x08\x05{color}Warp to {destination_name}?\x05\40\x09\x01\x01\x1b\x05{color}OK\x01No\x05\40"
         update_message_by_id(messages, id, new_msg)

--- a/Region.py
+++ b/Region.py
@@ -40,6 +40,8 @@ class Region(object):
         self.time_passes = False
         self.provides_time = TimeOfDay.NONE
         self.scene = None
+        self.pretty_name = None
+        self.font_color = None
 
 
     def copy(self, new_world):
@@ -50,6 +52,8 @@ class Region(object):
         new_region.time_passes = self.time_passes
         new_region.provides_time = self.provides_time
         new_region.scene = self.scene
+        new_region.pretty_name = self.pretty_name
+        new_region.font_color = self.font_color
 
         if self.dungeon:
             new_region.dungeon = self.dungeon.name

--- a/World.py
+++ b/World.py
@@ -387,6 +387,10 @@ class World(object):
         for region in region_json:
             new_region = Region(region['region_name'])
             new_region.world = self
+            if 'pretty_name' in region:
+                new_region.pretty_name = region['pretty_name']
+            if 'font_color' in region:
+                new_region.font_color = region['font_color']
             if 'scene' in region:
                 new_region.scene = region['scene']
             if 'hint' in region:

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -74,6 +74,8 @@
     },
     {
         "region_name": "Kokiri Forest",
+        "pretty_name": "Kokiri Forest",
+        "font_color": "\41",
         "scene": "Kokiri Forest",
         "hint": "Kokiri Forest",
         "events": {
@@ -108,6 +110,8 @@
     },
     {
         "region_name": "KF Outside Deku Tree",
+        "pretty_name": "Kokiri Forest",
+        "font_color": "\41",
         "scene": "Kokiri Forest",
         "hint": "Kokiri Forest",
         "events": {
@@ -132,6 +136,7 @@
     },
     {
         "region_name": "KF Links House",
+        "pretty_name": "\x0F's House",
         "scene": "KF Links House",
         "locations": {
             "KF Links House Cow": "is_adult and can_play(Eponas_Song) and 'Links Cow'"
@@ -142,6 +147,7 @@
     },
     {
         "region_name": "KF Midos House",
+        "pretty_name": "Mido's House",
         "scene": "KF Midos House",
         "locations": {
             "KF Midos Top Left Chest": "True",
@@ -155,6 +161,7 @@
     },
     {
         "region_name": "KF Sarias House",
+        "pretty_name": "Saria's House",
         "scene": "KF Sarias House",
         "exits": {
             "Kokiri Forest": "True"
@@ -162,6 +169,7 @@
     },
     {
         "region_name": "KF House of Twins",
+        "pretty_name": "House of Twins",
         "scene": "KF House of Twins",
         "exits": {
             "Kokiri Forest": "True"
@@ -169,6 +177,7 @@
     },
     {
         "region_name": "KF Know It All House",
+        "pretty_name": "Know It All House",
         "scene": "KF Know it All House",
         "exits": {
             "Kokiri Forest": "True"
@@ -176,6 +185,7 @@
     },
     {
         "region_name": "KF Kokiri Shop",
+        "pretty_name": "the Kokiri Shop",
         "scene": "KF Kokiri Shop",
         "locations": {
             "KF Shop Item 1": "True",
@@ -201,6 +211,8 @@
     },
     {
         "region_name": "Lost Woods",
+        "pretty_name": "the Lost Woods",
+        "font_color": "\42",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "events": {
@@ -232,6 +244,8 @@
     },
     {
         "region_name": "LW Beyond Mido",
+        "pretty_name": "the Lost Woods",
+        "font_color": "\42",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "locations": {
@@ -265,6 +279,8 @@
     },
     {
         "region_name": "SFM Entryway",
+        "pretty_name": "the Sacred Forest Meadow",
+        "font_color": "\41",
         "scene": "Sacred Forest Meadow",
         "hint": "Sacred Forest Meadow",
         "exits": {
@@ -277,6 +293,8 @@
     },
     {
         "region_name": "Sacred Forest Meadow",
+        "pretty_name": "the Sacred Forest Meadow",
+        "font_color": "\41",
         "scene": "Sacred Forest Meadow",
         "hint": "Sacred Forest Meadow",
         "locations": {
@@ -297,6 +315,8 @@
     },
     {
         "region_name": "SFM Forest Temple Entrance Ledge",
+        "pretty_name": "the Sacred Forest Meadow",
+        "font_color": "\41",
         "scene": "Sacred Forest Meadow",
         "hint": "Sacred Forest Meadow",
         "exits": {
@@ -306,6 +326,8 @@
     },
     {
         "region_name": "LW Bridge From Forest",
+        "pretty_name": "the Lost Woods",
+        "font_color": "\42",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "locations": {
@@ -317,6 +339,8 @@
     },
     {
         "region_name": "LW Bridge",
+        "pretty_name": "the Lost Woods",
+        "font_color": "\42",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "exits": {
@@ -327,6 +351,7 @@
     },
     {
         "region_name": "Hyrule Field",
+        "pretty_name": "Hyrule Field",
         "scene": "Hyrule Field",
         "hint": "Hyrule Field",
         "time_passes": true,
@@ -356,6 +381,8 @@
     },
     {
         "region_name": "Lake Hylia",
+        "pretty_name": "Lake Hylia",
+        "font_color": "\43",
         "scene": "Lake Hylia",
         "hint": "Lake Hylia",
         "time_passes": true,
@@ -401,6 +428,8 @@
     },
     {
         "region_name": "LH Fishing Island",
+        "pretty_name": "Lake Hylia",
+        "font_color": "\43",
         "scene": "Lake Hylia",
         "hint": "Lake Hylia",
         "exits": {
@@ -418,6 +447,7 @@
     },
     {
         "region_name": "LH Lab",
+        "pretty_name": "the Lakeside Laboratory",
         "scene": "LH Lab",
         "events": {
             "Eyedrops Access": "
@@ -436,6 +466,7 @@
     },
     {
         "region_name": "LH Fishing Hole",
+        "pretty_name": "the Fishing Pond",
         "scene": "LH Fishing Hole",
         "locations": {
             "LH Child Fishing": "is_child",
@@ -447,6 +478,8 @@
     },
     {
         "region_name": "Gerudo Valley",
+        "pretty_name": "Gerudo Valley",
+        "font_color": "\46",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -466,6 +499,8 @@
     },
     {
         "region_name": "GV Upper Stream",
+        "pretty_name": "Gerudo Valley",
+        "font_color": "\46",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -483,6 +518,8 @@
     },
     {
         "region_name": "GV Lower Stream",
+        "pretty_name": "Gerudo Valley",
+        "font_color": "\46",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -492,6 +529,8 @@
     },
     {
         "region_name": "GV Grotto Ledge",
+        "pretty_name": "Gerudo Valley",
+        "font_color": "\46",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -503,6 +542,8 @@
     },
     {
         "region_name": "GV Crate Ledge",
+        "pretty_name": "Gerudo Valley",
+        "font_color": "\46",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -515,6 +556,8 @@
     },
     {
         "region_name": "GV Fortress Side",
+        "pretty_name": "Gerudo Valley",
+        "font_color": "\46",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -540,6 +583,7 @@
     },
     {
         "region_name": "GV Carpenter Tent",
+        "pretty_name": "the Carpenter's Tent",
         "scene": "GV Carpenter Tent",
         "exits": {
             "GV Fortress Side": "True"
@@ -547,6 +591,8 @@
     },
     {
         "region_name": "Gerudo Fortress",
+        "pretty_name": "Gerudo Fortress",
+        "font_color": "\41",
         "scene": "Gerudo Fortress",
         "hint": "Gerudo's Fortress",
         "events": {
@@ -584,6 +630,8 @@
     },
     {
         "region_name": "GF Outside Gate",
+        "pretty_name": "Gerudo Fortress",
+        "font_color": "\41",
         "scene": "Gerudo Fortress",
         "hint": "Gerudo's Fortress",
         "exits": {
@@ -593,6 +641,8 @@
     },
     {
         "region_name": "Wasteland Near Fortress",
+        "pretty_name": "the Haunted Wasteland",
+        "font_color": "\46",
         "scene": "Haunted Wasteland",
         "hint": "Haunted Wasteland",
         "exits": {
@@ -603,6 +653,8 @@
     },
     {
         "region_name": "Haunted Wasteland",
+        "pretty_name": "the Haunted Wasteland",
+        "font_color": "\46",
         "scene": "Haunted Wasteland",
         "hint": "Haunted Wasteland",
         "locations": {
@@ -622,6 +674,8 @@
     },
     {
         "region_name": "Wasteland Near Colossus",
+        "pretty_name": "the Haunted Wasteland",
+        "font_color": "\46",
         "scene": "Haunted Wasteland",
         "hint": "Haunted Wasteland",
         "exits": {
@@ -631,6 +685,7 @@
     },
     {
         "region_name": "Desert Colossus",
+        "pretty_name": "the Desert Colossus",
         "scene": "Desert Colossus",
         "hint": "Desert Colossus",
         "time_passes": true,
@@ -667,6 +722,7 @@
     },
     {
         "region_name": "Colossus Great Fairy Fountain",
+        "pretty_name": "a Great Fairy Fountain",
         "scene": "Colossus Great Fairy Fountain",
         "locations": {
             "Colossus Great Fairy Reward": "can_play(Zeldas_Lullaby)"
@@ -677,6 +733,7 @@
     },
     {
         "region_name": "Market Entrance",
+        "pretty_name": "the Market Entrance",
         "scene": "Market Entrance",
         "hint": "the Market",
         "exits": {
@@ -687,6 +744,7 @@
     },
     {
         "region_name": "Market",
+        "pretty_name": "the Market",
         "scene": "Market",
         "hint": "the Market",
         "exits": {
@@ -704,6 +762,7 @@
     },
     {
         "region_name": "Market Back Alley",
+        "pretty_name": "the Market",
         "scene": "Market",
         "hint": "the Market",
         "exits": {
@@ -715,6 +774,7 @@
     },
     {
         "region_name": "ToT Entrance",
+        "pretty_name": "the Temple of Time Entrance",
         "scene": "ToT Entrance",
         "hint": "the Market",
         "locations": {
@@ -731,6 +791,7 @@
     },
     {
         "region_name": "Temple of Time",
+        "pretty_name": "the Temple of Time",
         "scene": "Temple of Time",
         "hint": "Temple of Time",
         "locations": {
@@ -743,6 +804,7 @@
     },
     {
         "region_name": "Beyond Door of Time",
+        "pretty_name": "the Temple of Time",
         "scene": "Temple of Time",
         "hint": "Temple of Time",
         "locations": {
@@ -755,6 +817,7 @@
     },
     {
         "region_name": "Castle Grounds",
+        "pretty_name": "the Castle Grounds",
         "scene": "Castle Grounds",
         "exits": {
             "Market": "is_child or at_dampe_time",
@@ -764,6 +827,7 @@
     },
     {
         "region_name": "Hyrule Castle Grounds",
+        "pretty_name": "the Castle Grounds",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
         "time_passes": true,
@@ -785,6 +849,7 @@
     },
     {
         "region_name": "HC Garden",
+        "pretty_name": "the Castle Grounds",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
         "exits": {
@@ -795,6 +860,7 @@
     {
         # Directly reachable from Root in "Free Zelda"
         "region_name": "HC Garden Locations",
+        "pretty_name": "the Castle Grounds",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
         "locations": {
@@ -804,6 +870,7 @@
     },
     {
         "region_name": "HC Great Fairy Fountain",
+        "pretty_name": "a Great Fairy Fountain",
         "scene": "HC Great Fairy Fountain",
         "locations": {
             "HC Great Fairy Reward": "can_play(Zeldas_Lullaby)"
@@ -814,6 +881,7 @@
     },
     {
         "region_name": "Ganons Castle Grounds",
+        "pretty_name": "the Castle Grounds",
         "scene": "Castle Grounds",
         "hint": "outside Ganon's Castle",
         "locations": {
@@ -827,6 +895,7 @@
     },
     {
         "region_name": "OGC Great Fairy Fountain",
+        "pretty_name": "a Great Fairy Fountain",
         "scene": "OGC Great Fairy Fountain",
         "locations": {
             "OGC Great Fairy Reward": "can_play(Zeldas_Lullaby)"
@@ -837,6 +906,7 @@
     },
     {
         "region_name": "Market Guard House",
+        "pretty_name": "the Gaurd House",
         "scene": "Market Guard House",
         "events": {
             "Sell Big Poe": "is_adult and Bottle_with_Big_Poe"
@@ -853,6 +923,7 @@
     },
     {
         "region_name": "Market Bazaar",
+        "pretty_name": "a Bazaar",
         "scene": "Market Bazaar",
         "locations": {
             "Market Bazaar Item 1": "True",
@@ -870,6 +941,7 @@
     },
     {
         "region_name": "Market Mask Shop",
+        "pretty_name": "the Mask Shop",
         "scene": "Market Mask Shop",
         "events": {
             "Skull Mask": "Zeldas_Letter and (complete_mask_quest or at('Kakariko Village', is_child))",
@@ -885,6 +957,7 @@
     },
     {
         "region_name": "Market Shooting Gallery",
+        "pretty_name": "a Shooting Gallery",
         "scene": "Market Shooting Gallery",
         "locations": {
             "Market Shooting Gallery Reward": "is_child"
@@ -895,6 +968,7 @@
     },
     {
         "region_name": "Market Bombchu Bowling",
+        "pretty_name": "the Bombchu Bowling Alley",
         "scene": "Market Bombchu Bowling",
         "locations": {
             "Market Bombchu Bowling First Prize": "found_bombchus",
@@ -907,6 +981,7 @@
     },
     {
         "region_name": "Market Potion Shop",
+        "pretty_name": "a Potion Shop",
         "scene": "Market Potion Shop",
         "locations": {
             "Market Potion Shop Item 1": "True",
@@ -924,6 +999,7 @@
     },
     {
         "region_name": "Market Treasure Chest Game",
+        "pretty_name": "the Treasure Chest Game",
         "scene": "Market Treasure Chest Game",
         "locations": {
             "Market Treasure Chest Game Reward": "can_use(Lens_of_Truth)"
@@ -934,6 +1010,7 @@
     },
     {
         "region_name": "Market Bombchu Shop",
+        "pretty_name": "the Bombchu Shop",
         "scene": "Market Bombchu Shop",
         "locations": {
             "Market Bombchu Shop Item 1": "True",
@@ -951,6 +1028,7 @@
     },
     {
         "region_name": "Market Dog Lady House",
+        "pretty_name": "the Dog Lady House",
         "scene": "Market Dog Lady House",
         "locations": {
             "Market Lost Dog": "is_child and at_night"
@@ -961,6 +1039,7 @@
     },
     {
         "region_name": "Market Man in Green House",
+        "pretty_name": "the Man in Green House",
         "scene": "Market Man in Green House",
         "exits": {
             "Market Back Alley": "True"
@@ -968,6 +1047,8 @@
     },
     {
         "region_name": "Kakariko Village",
+        "pretty_name": "Kakariko Village",
+        "font_color": "\45",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "events": {
@@ -1017,6 +1098,8 @@
     },
     {
         "region_name": "Kak Impas Ledge",
+        "pretty_name": "Kakariko Village",
+        "font_color": "\45",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "exits": {
@@ -1026,6 +1109,8 @@
     },
     {
         "region_name": "Kak Impas Rooftop",
+        "pretty_name": "Kakariko Village",
+        "font_color": "\45",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "locations": {
@@ -1038,6 +1123,8 @@
     },
     {
         "region_name": "Kak Odd Medicine Rooftop",
+        "pretty_name": "Kakariko Village",
+        "font_color": "\45",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "locations": {
@@ -1050,6 +1137,8 @@
     },
     {
         "region_name": "Kak Backyard",
+        "pretty_name": "Kakariko Village",
+        "font_color": "\45",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "exits": {
@@ -1061,6 +1150,7 @@
     },
     {
         "region_name": "Kak Carpenter Boss House",
+        "pretty_name": "the Carpenter's House",
         "scene": "Kak Carpenter Boss House",
         "events": {
             "Wake Up Adult Talon": "is_adult and (Pocket_Egg or Pocket_Cucco)"
@@ -1071,6 +1161,7 @@
     },
     {
         "region_name": "Kak House of Skulltula",
+        "pretty_name": "the House of Skulltula",
         "scene": "Kak House of Skulltula",
         "locations": {
             "Kak 10 Gold Skulltula Reward": "(Gold_Skulltula_Token, 10)",
@@ -1085,6 +1176,7 @@
     },
     {
         "region_name": "Kak Impas House",
+        "pretty_name": "Impa's House",
         "scene": "Kak Impas House",
         "exits": {
             "Kakariko Village": "True",
@@ -1093,6 +1185,7 @@
     },
     {
         "region_name": "Kak Impas House Back",
+        "pretty_name": "Impa's House",
         "scene": "Kak Impas House",
         "locations": {
             "Kak Impas House Freestanding PoH": "True"
@@ -1104,6 +1197,7 @@
     },
     {
         "region_name": "Kak Impas House Near Cow",
+        "pretty_name": "Impa's House",
         "scene": "Kak Impas House",
         "locations": {
             "Kak Impas House Cow": "can_play(Eponas_Song)"
@@ -1111,6 +1205,7 @@
     },
     {
         "region_name": "Kak Windmill",
+        "pretty_name": "the Windmill",
         "scene": "Windmill and Dampes Grave",
         "events": {
             "Drain Well": "is_child and can_play(Song_of_Storms)"
@@ -1127,6 +1222,7 @@
     },
     {
         "region_name": "Kak Bazaar",
+        "pretty_name": "a Bazaar",
         "scene": "Kak Bazaar",
         "locations": {
             "Kak Bazaar Item 1": "True",
@@ -1144,6 +1240,7 @@
     },
     {
         "region_name": "Kak Shooting Gallery",
+        "pretty_name": "a Shooting Gallery",
         "scene": "Kak Shooting Gallery",
         "locations": {
             "Kak Shooting Gallery Reward": "is_adult and Bow"
@@ -1154,6 +1251,7 @@
     },
     {
         "region_name": "Kak Potion Shop Front",
+        "pretty_name": "a Potion Shop",
         "scene": "Kak Potion Shop",
         "locations": {
             "Kak Potion Shop Item 1": "is_adult",
@@ -1172,6 +1270,7 @@
     },
     {
         "region_name": "Kak Potion Shop Back",
+        "pretty_name": "a Potion Shop",
         "scene": "Kak Potion Shop",
         "exits": {
             "Kak Backyard": "is_adult",
@@ -1180,6 +1279,7 @@
     },
     {
         "region_name": "Kak Odd Medicine Building",
+        "pretty_name": "the Oddity Shop",
         "scene": "Kak Odd Medicine Building",
         "events": {
             "Odd Potion Access": "
@@ -1192,6 +1292,8 @@
     },
     {
         "region_name": "Graveyard",
+        "pretty_name": "Graveyard",
+        "font_color": "\45",
         "scene": "Graveyard",
         "hint": "the Graveyard",
         "locations": {
@@ -1216,6 +1318,7 @@
     },
     {
         "region_name": "Graveyard Shield Grave",
+        "pretty_name": "the Shield Grave",
         "scene": "Graveyard Shield Grave",
         "locations": {
             "Graveyard Shield Grave Chest": "True",
@@ -1227,6 +1330,7 @@
     },
     {
         "region_name": "Graveyard Heart Piece Grave",
+        "pretty_name": "the Heart Piece Grave",
         "scene": "Graveyard Heart Piece Grave",
         "locations": {
             "Graveyard Heart Piece Grave Chest": "can_play(Suns_Song)"
@@ -1237,6 +1341,7 @@
     },
     {
         "region_name": "Graveyard Royal Familys Tomb",
+        "pretty_name": "the Royal Family's Tomb",
         "scene": "Graveyard Royal Familys Tomb",
         "locations": {
             "Graveyard Royal Familys Tomb Chest": "has_fire_source",
@@ -1251,6 +1356,7 @@
     },
     {
         "region_name": "Graveyard Dampes Grave",
+        "pretty_name": "Dampe's Grave",
         "scene": "Windmill and Dampes Grave",
         "events": {
             "Dampes Windmill Access": "is_adult and can_play(Song_of_Time)"
@@ -1267,6 +1373,7 @@
     },
     {
         "region_name": "Graveyard Dampes House",
+        "pretty_name": "Dampe's House",
         "scene": "Graveyard Dampes House",
         "exits": {
             "Graveyard": "True"
@@ -1274,6 +1381,8 @@
     },
     {
         "region_name": "Graveyard Warp Pad Region",
+        "pretty_name": "Graveyard",
+        "font_color": "\45",
         "scene": "Graveyard",
         "hint": "the Graveyard",
         "locations": {
@@ -1289,6 +1398,8 @@
     },
     {
         "region_name": "Kak Behind Gate",
+        "pretty_name": "Kakariko Village",
+        "font_color": "\45",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "exits": {
@@ -1299,6 +1410,8 @@
     },
     {
         "region_name": "Death Mountain",
+        "pretty_name": "Death Mountain Trail",
+        "font_color": "\41",
         "scene": "Death Mountain",
         "hint": "Death Mountain Trail",
         "time_passes": true,
@@ -1338,6 +1451,8 @@
     },
     {
         "region_name": "Death Mountain Summit",
+        "pretty_name": "Death Mountain Trail",
+        "font_color": "\41",
         "scene": "Death Mountain",
         "hint": "Death Mountain Trail",
         "time_passes": true,
@@ -1373,6 +1488,8 @@
     },
     {
         "region_name": "Goron City",
+        "pretty_name": "Goron City",
+        "font_color": "\41",
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
@@ -1437,6 +1554,8 @@
     },
     {
         "region_name": "GC Woods Warp",
+        "pretty_name": "Goron City",
+        "font_color": "\41",
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
@@ -1449,6 +1568,8 @@
     },
     {
         "region_name": "GC Darunias Chamber",
+        "pretty_name": "Goron City",
+        "font_color": "\41",
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
@@ -1464,6 +1585,8 @@
     },
     {
         "region_name": "GC Grotto Platform",
+        "pretty_name": "Goron City",
+        "font_color": "\41",
         "scene": "Goron City",
         "hint": "Goron City",
         "exits": {
@@ -1476,6 +1599,7 @@
     },
     {
         "region_name": "GC Shop",
+        "pretty_name": "the Goron Shop",
         "scene": "GC Shop",
         "locations": {
             "GC Shop Item 1": "True",
@@ -1493,6 +1617,8 @@
     },
     {
         "region_name": "DMC Upper Nearby",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1503,6 +1629,8 @@
     },
     {
         "region_name": "DMC Upper Local",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1523,6 +1651,8 @@
     },
     {
         "region_name": "DMC Ladder Area Nearby",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1537,6 +1667,8 @@
     },
     {
         "region_name": "DMC Lower Nearby",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1548,6 +1680,8 @@
     },
     {
         "region_name": "DMC Lower Local",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1561,6 +1695,8 @@
     },
     {
         "region_name": "DMC Central Nearby",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1576,6 +1712,8 @@
     },
     {
         "region_name": "DMC Central Local",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1595,6 +1733,8 @@
     },
     {
         "region_name": "DMC Fire Temple Entrance",
+        "pretty_name": "Death Mountain Crater",
+        "font_color": "\41",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1604,6 +1744,7 @@
     },
     {
         "region_name": "DMC Great Fairy Fountain",
+        "pretty_name": "a Great Fairy Fountain",
         "scene": "DMC Great Fairy Fountain",
         "locations": {
             "DMC Great Fairy Reward": "can_play(Zeldas_Lullaby)"
@@ -1614,6 +1755,7 @@
     },
     {
         "region_name": "DMT Great Fairy Fountain",
+        "pretty_name": "a Great Fairy Fountain",
         "scene": "DMT Great Fairy Fountain",
         "locations": {
             "DMT Great Fairy Reward": "can_play(Zeldas_Lullaby)"
@@ -1624,6 +1766,8 @@
     },
     {
         "region_name": "ZR Front",
+        "pretty_name": "Zora's River",
+        "font_color": "\43",
         "scene": "Zora River",
         "hint": "Zora's River",
         "time_passes": true,
@@ -1637,6 +1781,8 @@
     },
     {
         "region_name": "Zora River",
+        "pretty_name": "Zora's River",
+        "font_color": "\43",
         "scene": "Zora River",
         "hint": "Zora's River",
         "time_passes": true,
@@ -1677,6 +1823,8 @@
     },
     {
         "region_name": "ZR Behind Waterfall",
+        "pretty_name": "Zora's River",
+        "font_color": "\43",
         "scene": "Zora River",
         "hint": "Zora's River",
         "exits": {
@@ -1686,6 +1834,8 @@
     },
     {
         "region_name": "ZR Top of Waterfall",
+        "pretty_name": "Zora's River",
+        "font_color": "\43",
         "scene": "Zora River",
         "hint": "Zora's River",
         "exits": {
@@ -1694,6 +1844,8 @@
     },
     {
         "region_name": "Zoras Domain",
+        "pretty_name": "Zora's Domain",
+        "font_color": "\43",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "events": {
@@ -1730,6 +1882,8 @@
     },
     {
         "region_name": "ZD Behind King Zora",
+        "pretty_name": "Zora's Domain",
+        "font_color": "\43",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "exits": {
@@ -1741,6 +1895,8 @@
     },
     {
         "region_name": "ZD Eyeball Frog Timeout",
+        "pretty_name": "Zora's Domain",
+        "font_color": "\43",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "exits": {
@@ -1749,6 +1905,8 @@
     },
     {
         "region_name": "Zoras Fountain",
+        "pretty_name": "Zora's Fountain",
+        "font_color": "\43",
         "scene": "Zoras Fountain",
         "hint": "Zora's Fountain",
         "locations": {
@@ -1774,6 +1932,8 @@
     },
     {
         "region_name": "ZF Ice Ledge",
+        "pretty_name": "Zora's Domain",
+        "font_color": "\43",
         "scene": "Zoras Fountain",
         "hint": "Zora's Fountain",
         "exits": {
@@ -1783,6 +1943,7 @@
     },
     {
         "region_name": "ZD Shop",
+        "pretty_name": "the Zora Shop",
         "scene": "ZD Shop",
         "locations": {
             "ZD Shop Item 1": "True",
@@ -1800,6 +1961,7 @@
     },
     {
         "region_name": "ZF Great Fairy Fountain",
+        "pretty_name": "a Great Fairy Fountain",
         "scene": "ZF Great Fairy Fountain",
         "locations": {
             "ZF Great Fairy Reward": "can_play(Zeldas_Lullaby)"
@@ -1810,6 +1972,8 @@
     },
     {
         "region_name": "Lon Lon Ranch",
+        "pretty_name": "Lon Lon Ranch",
+        "font_color": "\46",
         "scene": "Lon Lon Ranch",
         "hint": "Lon Lon Ranch",
         "events": {
@@ -1833,6 +1997,7 @@
     },
     {
         "region_name": "LLR Talons House",
+        "pretty_name": "Talon's House",
         "scene": "LLR Talons House",
         "locations": {
             "LLR Talons Chickens": "is_child and at_day and Zeldas_Letter"
@@ -1843,6 +2008,7 @@
     },
     {
         "region_name": "LLR Stables",
+        "pretty_name": "Lon Lon Stable",
         "scene": "LLR Stables",
         "locations": {
             "LLR Stables Left Cow": "can_play(Eponas_Song)",
@@ -1854,6 +2020,7 @@
     },
     {
         "region_name": "LLR Tower",
+        "pretty_name": "Lon Lon Tower",
         "scene": "LLR Tower",
         "locations": {
             "LLR Freestanding PoH": "is_child",
@@ -1866,6 +2033,7 @@
     },
     {
         "region_name": "Ganons Castle Tower",
+        "pretty_name": "Ganon's Castle",
         "dungeon": "Ganons Castle",
         "locations": {
             "Ganons Tower Boss Key Chest": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -74,8 +74,7 @@
     },
     {
         "region_name": "Kokiri Forest",
-        "pretty_name": "Kokiri Forest",
-        "font_color": "\41",
+        "font_color": "Green",
         "scene": "Kokiri Forest",
         "hint": "Kokiri Forest",
         "events": {
@@ -110,8 +109,7 @@
     },
     {
         "region_name": "KF Outside Deku Tree",
-        "pretty_name": "Kokiri Forest",
-        "font_color": "\41",
+        "font_color": "Green",
         "scene": "Kokiri Forest",
         "hint": "Kokiri Forest",
         "events": {
@@ -136,7 +134,7 @@
     },
     {
         "region_name": "KF Links House",
-        "pretty_name": "\x0F's House",
+        "pretty_name": "your house",
         "scene": "KF Links House",
         "locations": {
             "KF Links House Cow": "is_adult and can_play(Eponas_Song) and 'Links Cow'"
@@ -169,7 +167,7 @@
     },
     {
         "region_name": "KF House of Twins",
-        "pretty_name": "House of Twins",
+        "pretty_name": "the House of Twins",
         "scene": "KF House of Twins",
         "exits": {
             "Kokiri Forest": "True"
@@ -177,7 +175,7 @@
     },
     {
         "region_name": "KF Know It All House",
-        "pretty_name": "Know It All House",
+        "pretty_name": "the Know-it-All House",
         "scene": "KF Know it All House",
         "exits": {
             "Kokiri Forest": "True"
@@ -203,6 +201,7 @@
     },
     {
         "region_name": "LW Forest Exit",
+        "font_color": "Green",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "exits": {
@@ -211,8 +210,7 @@
     },
     {
         "region_name": "Lost Woods",
-        "pretty_name": "the Lost Woods",
-        "font_color": "\42",
+        "font_color": "Green",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "events": {
@@ -244,8 +242,7 @@
     },
     {
         "region_name": "LW Beyond Mido",
-        "pretty_name": "the Lost Woods",
-        "font_color": "\42",
+        "font_color": "Green",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "locations": {
@@ -271,6 +268,7 @@
     },
     {
         "region_name": "Lost Woods Mushroom Timeout",
+        "font_color": "Green",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "exits": {
@@ -279,10 +277,9 @@
     },
     {
         "region_name": "SFM Entryway",
-        "pretty_name": "the Sacred Forest Meadow",
-        "font_color": "\41",
+        "font_color": "Green",
         "scene": "Sacred Forest Meadow",
-        "hint": "Sacred Forest Meadow",
+        "hint": "the Sacred Forest Meadow",
         "exits": {
             "LW Beyond Mido": "True",
             "Sacred Forest Meadow": "
@@ -293,10 +290,9 @@
     },
     {
         "region_name": "Sacred Forest Meadow",
-        "pretty_name": "the Sacred Forest Meadow",
-        "font_color": "\41",
+        "font_color": "Green",
         "scene": "Sacred Forest Meadow",
-        "hint": "Sacred Forest Meadow",
+        "hint": "the Sacred Forest Meadow",
         "locations": {
             "Song from Saria": "is_child and Zeldas_Letter",
             "Sheik in Forest": "is_adult",
@@ -315,10 +311,9 @@
     },
     {
         "region_name": "SFM Forest Temple Entrance Ledge",
-        "pretty_name": "the Sacred Forest Meadow",
-        "font_color": "\41",
+        "font_color": "Green",
         "scene": "Sacred Forest Meadow",
-        "hint": "Sacred Forest Meadow",
+        "hint": "the Sacred Forest Meadow",
         "exits": {
             "Sacred Forest Meadow": "True",
             "Forest Temple Lobby": "True"
@@ -326,8 +321,7 @@
     },
     {
         "region_name": "LW Bridge From Forest",
-        "pretty_name": "the Lost Woods",
-        "font_color": "\42",
+        "font_color": "Green",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "locations": {
@@ -339,8 +333,7 @@
     },
     {
         "region_name": "LW Bridge",
-        "pretty_name": "the Lost Woods",
-        "font_color": "\42",
+        "font_color": "Green",
         "scene": "Lost Woods",
         "hint": "the Lost Woods",
         "exits": {
@@ -351,7 +344,7 @@
     },
     {
         "region_name": "Hyrule Field",
-        "pretty_name": "Hyrule Field",
+        "font_color": "Light Blue",
         "scene": "Hyrule Field",
         "hint": "Hyrule Field",
         "time_passes": true,
@@ -381,8 +374,7 @@
     },
     {
         "region_name": "Lake Hylia",
-        "pretty_name": "Lake Hylia",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Lake Hylia",
         "hint": "Lake Hylia",
         "time_passes": true,
@@ -428,8 +420,7 @@
     },
     {
         "region_name": "LH Fishing Island",
-        "pretty_name": "Lake Hylia",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Lake Hylia",
         "hint": "Lake Hylia",
         "exits": {
@@ -478,8 +469,7 @@
     },
     {
         "region_name": "Gerudo Valley",
-        "pretty_name": "Gerudo Valley",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -499,8 +489,7 @@
     },
     {
         "region_name": "GV Upper Stream",
-        "pretty_name": "Gerudo Valley",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -518,8 +507,7 @@
     },
     {
         "region_name": "GV Lower Stream",
-        "pretty_name": "Gerudo Valley",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -529,8 +517,7 @@
     },
     {
         "region_name": "GV Grotto Ledge",
-        "pretty_name": "Gerudo Valley",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -542,8 +529,7 @@
     },
     {
         "region_name": "GV Crate Ledge",
-        "pretty_name": "Gerudo Valley",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -556,8 +542,7 @@
     },
     {
         "region_name": "GV Fortress Side",
-        "pretty_name": "Gerudo Valley",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Gerudo Valley",
         "hint": "Gerudo Valley",
         "time_passes": true,
@@ -591,8 +576,7 @@
     },
     {
         "region_name": "Gerudo Fortress",
-        "pretty_name": "Gerudo Fortress",
-        "font_color": "\41",
+        "font_color": "Yellow",
         "scene": "Gerudo Fortress",
         "hint": "Gerudo's Fortress",
         "events": {
@@ -630,8 +614,7 @@
     },
     {
         "region_name": "GF Outside Gate",
-        "pretty_name": "Gerudo Fortress",
-        "font_color": "\41",
+        "font_color": "Yellow",
         "scene": "Gerudo Fortress",
         "hint": "Gerudo's Fortress",
         "exits": {
@@ -641,10 +624,9 @@
     },
     {
         "region_name": "Wasteland Near Fortress",
-        "pretty_name": "the Haunted Wasteland",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Haunted Wasteland",
-        "hint": "Haunted Wasteland",
+        "hint": "the Haunted Wasteland",
         "exits": {
             "GF Outside Gate": "True",
             "Haunted Wasteland": "
@@ -653,10 +635,9 @@
     },
     {
         "region_name": "Haunted Wasteland",
-        "pretty_name": "the Haunted Wasteland",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Haunted Wasteland",
-        "hint": "Haunted Wasteland",
+        "hint": "the Haunted Wasteland",
         "locations": {
             "Wasteland Chest": "has_fire_source",
             "Wasteland Bombchu Salesman": "
@@ -674,10 +655,9 @@
     },
     {
         "region_name": "Wasteland Near Colossus",
-        "pretty_name": "the Haunted Wasteland",
-        "font_color": "\46",
+        "font_color": "Yellow",
         "scene": "Haunted Wasteland",
-        "hint": "Haunted Wasteland",
+        "hint": "the Haunted Wasteland",
         "exits": {
             "Desert Colossus": "True",
             "Haunted Wasteland": "logic_reverse_wasteland"
@@ -685,9 +665,9 @@
     },
     {
         "region_name": "Desert Colossus",
-        "pretty_name": "the Desert Colossus",
+        "font_color": "Yellow",
         "scene": "Desert Colossus",
-        "hint": "Desert Colossus",
+        "hint": "the Desert Colossus",
         "time_passes": true,
         "locations": {
             "Colossus Freestanding PoH": "is_adult and here(can_plant_bean)",
@@ -711,8 +691,9 @@
     },
     {
         "region_name": "Desert Colossus From Spirit Lobby",
+        "font_color": "Yellow",
         "scene": "Desert Colossus",
-        "hint": "Desert Colossus",
+        "hint": "the Desert Colossus",
         "locations": {
             "Sheik at Colossus": "True"
         },
@@ -734,6 +715,7 @@
     {
         "region_name": "Market Entrance",
         "pretty_name": "the Market Entrance",
+        "font_color": "Light Blue",
         "scene": "Market Entrance",
         "hint": "the Market",
         "exits": {
@@ -744,7 +726,7 @@
     },
     {
         "region_name": "Market",
-        "pretty_name": "the Market",
+        "font_color": "Light Blue",
         "scene": "Market",
         "hint": "the Market",
         "exits": {
@@ -762,7 +744,7 @@
     },
     {
         "region_name": "Market Back Alley",
-        "pretty_name": "the Market",
+        "font_color": "Light Blue",
         "scene": "Market",
         "hint": "the Market",
         "exits": {
@@ -775,6 +757,7 @@
     {
         "region_name": "ToT Entrance",
         "pretty_name": "the Temple of Time Entrance",
+        "font_color": "Light Blue",
         "scene": "ToT Entrance",
         "hint": "the Market",
         "locations": {
@@ -791,9 +774,9 @@
     },
     {
         "region_name": "Temple of Time",
-        "pretty_name": "the Temple of Time",
+        "font_color": "Light Blue",
         "scene": "Temple of Time",
-        "hint": "Temple of Time",
+        "hint": "the Temple of Time",
         "locations": {
             "ToT Light Arrows Cutscene": "is_adult and can_trigger_lacs"
         },
@@ -804,9 +787,9 @@
     },
     {
         "region_name": "Beyond Door of Time",
-        "pretty_name": "the Temple of Time",
+        "font_color": "Light Blue",
         "scene": "Temple of Time",
-        "hint": "Temple of Time",
+        "hint": "the Temple of Time",
         "locations": {
             "Master Sword Pedestal": "True",
             "Sheik at Temple": "Forest_Medallion and is_adult"
@@ -818,6 +801,7 @@
     {
         "region_name": "Castle Grounds",
         "pretty_name": "the Castle Grounds",
+        "font_color": "Light Blue",
         "scene": "Castle Grounds",
         "exits": {
             "Market": "is_child or at_dampe_time",
@@ -828,6 +812,7 @@
     {
         "region_name": "Hyrule Castle Grounds",
         "pretty_name": "the Castle Grounds",
+        "font_color": "Light Blue",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
         "time_passes": true,
@@ -850,6 +835,7 @@
     {
         "region_name": "HC Garden",
         "pretty_name": "the Castle Grounds",
+        "font_color": "Light Blue",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
         "exits": {
@@ -861,6 +847,7 @@
         # Directly reachable from Root in "Free Zelda"
         "region_name": "HC Garden Locations",
         "pretty_name": "the Castle Grounds",
+        "font_color": "Light Blue",
         "scene": "Castle Grounds",
         "hint": "Hyrule Castle",
         "locations": {
@@ -882,6 +869,7 @@
     {
         "region_name": "Ganons Castle Grounds",
         "pretty_name": "the Castle Grounds",
+        "font_color": "Light Blue",
         "scene": "Castle Grounds",
         "hint": "outside Ganon's Castle",
         "locations": {
@@ -1047,8 +1035,7 @@
     },
     {
         "region_name": "Kakariko Village",
-        "pretty_name": "Kakariko Village",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "events": {
@@ -1098,8 +1085,7 @@
     },
     {
         "region_name": "Kak Impas Ledge",
-        "pretty_name": "Kakariko Village",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "exits": {
@@ -1109,8 +1095,7 @@
     },
     {
         "region_name": "Kak Impas Rooftop",
-        "pretty_name": "Kakariko Village",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "locations": {
@@ -1123,8 +1108,7 @@
     },
     {
         "region_name": "Kak Odd Medicine Rooftop",
-        "pretty_name": "Kakariko Village",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "locations": {
@@ -1137,8 +1121,7 @@
     },
     {
         "region_name": "Kak Backyard",
-        "pretty_name": "Kakariko Village",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "exits": {
@@ -1292,8 +1275,7 @@
     },
     {
         "region_name": "Graveyard",
-        "pretty_name": "Graveyard",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Graveyard",
         "hint": "the Graveyard",
         "locations": {
@@ -1356,7 +1338,7 @@
     },
     {
         "region_name": "Graveyard Dampes Grave",
-        "pretty_name": "Dampe's Grave",
+        "pretty_name": "Damp\u00e9's Grave",
         "scene": "Windmill and Dampes Grave",
         "events": {
             "Dampes Windmill Access": "is_adult and can_play(Song_of_Time)"
@@ -1373,7 +1355,7 @@
     },
     {
         "region_name": "Graveyard Dampes House",
-        "pretty_name": "Dampe's House",
+        "pretty_name": "Damp\u00e9's House",
         "scene": "Graveyard Dampes House",
         "exits": {
             "Graveyard": "True"
@@ -1381,8 +1363,7 @@
     },
     {
         "region_name": "Graveyard Warp Pad Region",
-        "pretty_name": "Graveyard",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Graveyard",
         "hint": "the Graveyard",
         "locations": {
@@ -1398,8 +1379,7 @@
     },
     {
         "region_name": "Kak Behind Gate",
-        "pretty_name": "Kakariko Village",
-        "font_color": "\45",
+        "font_color": "Pink",
         "scene": "Kakariko Village",
         "hint": "Kakariko Village",
         "exits": {
@@ -1410,8 +1390,7 @@
     },
     {
         "region_name": "Death Mountain",
-        "pretty_name": "Death Mountain Trail",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain",
         "hint": "Death Mountain Trail",
         "time_passes": true,
@@ -1451,8 +1430,7 @@
     },
     {
         "region_name": "Death Mountain Summit",
-        "pretty_name": "Death Mountain Trail",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain",
         "hint": "Death Mountain Trail",
         "time_passes": true,
@@ -1488,8 +1466,7 @@
     },
     {
         "region_name": "Goron City",
-        "pretty_name": "Goron City",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
@@ -1554,8 +1531,7 @@
     },
     {
         "region_name": "GC Woods Warp",
-        "pretty_name": "Goron City",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
@@ -1568,8 +1544,7 @@
     },
     {
         "region_name": "GC Darunias Chamber",
-        "pretty_name": "Goron City",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Goron City",
         "hint": "Goron City",
         "events": {
@@ -1585,8 +1560,7 @@
     },
     {
         "region_name": "GC Grotto Platform",
-        "pretty_name": "Goron City",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Goron City",
         "hint": "Goron City",
         "exits": {
@@ -1617,8 +1591,7 @@
     },
     {
         "region_name": "DMC Upper Nearby",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1629,8 +1602,7 @@
     },
     {
         "region_name": "DMC Upper Local",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1651,8 +1623,7 @@
     },
     {
         "region_name": "DMC Ladder Area Nearby",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1667,8 +1638,7 @@
     },
     {
         "region_name": "DMC Lower Nearby",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1680,8 +1650,7 @@
     },
     {
         "region_name": "DMC Lower Local",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1695,8 +1664,7 @@
     },
     {
         "region_name": "DMC Central Nearby",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1712,8 +1680,7 @@
     },
     {
         "region_name": "DMC Central Local",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "locations": {
@@ -1733,8 +1700,7 @@
     },
     {
         "region_name": "DMC Fire Temple Entrance",
-        "pretty_name": "Death Mountain Crater",
-        "font_color": "\41",
+        "font_color": "Red",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1766,8 +1732,7 @@
     },
     {
         "region_name": "ZR Front",
-        "pretty_name": "Zora's River",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zora River",
         "hint": "Zora's River",
         "time_passes": true,
@@ -1781,8 +1746,7 @@
     },
     {
         "region_name": "Zora River",
-        "pretty_name": "Zora's River",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zora River",
         "hint": "Zora's River",
         "time_passes": true,
@@ -1823,8 +1787,7 @@
     },
     {
         "region_name": "ZR Behind Waterfall",
-        "pretty_name": "Zora's River",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zora River",
         "hint": "Zora's River",
         "exits": {
@@ -1834,8 +1797,7 @@
     },
     {
         "region_name": "ZR Top of Waterfall",
-        "pretty_name": "Zora's River",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zora River",
         "hint": "Zora's River",
         "exits": {
@@ -1844,8 +1806,7 @@
     },
     {
         "region_name": "Zoras Domain",
-        "pretty_name": "Zora's Domain",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "events": {
@@ -1882,8 +1843,7 @@
     },
     {
         "region_name": "ZD Behind King Zora",
-        "pretty_name": "Zora's Domain",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "exits": {
@@ -1895,8 +1855,7 @@
     },
     {
         "region_name": "ZD Eyeball Frog Timeout",
-        "pretty_name": "Zora's Domain",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
         "exits": {
@@ -1905,8 +1864,7 @@
     },
     {
         "region_name": "Zoras Fountain",
-        "pretty_name": "Zora's Fountain",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zoras Fountain",
         "hint": "Zora's Fountain",
         "locations": {
@@ -1932,8 +1890,7 @@
     },
     {
         "region_name": "ZF Ice Ledge",
-        "pretty_name": "Zora's Domain",
-        "font_color": "\43",
+        "font_color": "Blue",
         "scene": "Zoras Fountain",
         "hint": "Zora's Fountain",
         "exits": {
@@ -1972,8 +1929,7 @@
     },
     {
         "region_name": "Lon Lon Ranch",
-        "pretty_name": "Lon Lon Ranch",
-        "font_color": "\46",
+        "font_color": "Light Blue",
         "scene": "Lon Lon Ranch",
         "hint": "Lon Lon Ranch",
         "events": {
@@ -2043,6 +1999,7 @@
     },
     {
         "region_name": "GF Storms Grotto",
+        "pretty_name": "a Fairy Fountain",
         "scene": "GF Storms Grotto",
         "locations": {
             "Free Fairies": "has_bottle"
@@ -2053,6 +2010,7 @@
     },
     {
         "region_name": "ZD Storms Grotto",
+        "pretty_name": "a Fairy Fountain",
         "scene": "ZD Storms Grotto",
         "locations": {
             "Free Fairies": "has_bottle"
@@ -2063,6 +2021,7 @@
     },
     {
         "region_name": "KF Storms Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "KF Storms Grotto",
         "locations": {
             "KF Storms Grotto Chest": "True",
@@ -2078,6 +2037,7 @@
     },
     {
         "region_name": "LW Near Shortcuts Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "LW Near Shortcuts Grotto",
         "locations": {
             "LW Near Shortcuts Grotto Chest": "True",
@@ -2093,6 +2053,7 @@
     },
     {
         "region_name": "Deku Theater",
+        "pretty_name": "the Deku Theater",
         "scene": "Deku Theater",
         "locations": {
             "Deku Theater Skull Mask": "is_child and 'Skull Mask'",
@@ -2104,6 +2065,7 @@
     },
     {
         "region_name": "LW Scrubs Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "LW Scrubs Grotto",
         "locations": {
             "LW Deku Scrub Grotto Rear": "can_stun_deku",
@@ -2115,6 +2077,7 @@
     },
     {
         "region_name": "SFM Fairy Grotto",
+        "pretty_name": "a Fairy Fountain",
         "scene": "SFM Fairy Grotto",
         "locations": {
             "Free Fairies": "has_bottle"
@@ -2125,6 +2088,7 @@
     },
     {
         "region_name": "SFM Storms Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "SFM Storms Grotto",
         "locations": {
             "SFM Deku Scrub Grotto Rear": "can_stun_deku",
@@ -2136,6 +2100,7 @@
     },
     {
         "region_name": "SFM Wolfos Grotto",
+        "pretty_name": "the Wolfos Grotto",
         "scene": "SFM Wolfos Grotto",
         "locations": {
             "SFM Wolfos Grotto Chest": "
@@ -2148,6 +2113,7 @@
     },
     {
         "region_name": "LLR Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "LLR Grotto",
         "locations": {
             "LLR Deku Scrub Grotto Left": "can_stun_deku",
@@ -2160,6 +2126,7 @@
     },
     {
         "region_name": "HF Southeast Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "HF Southeast Grotto",
         "locations": {
             "HF Southeast Grotto Chest": "True",
@@ -2175,6 +2142,7 @@
     },
     {
         "region_name": "HF Open Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "HF Open Grotto",
         "locations": {
             "HF Open Grotto Chest": "True",
@@ -2190,6 +2158,7 @@
     },
     {
         "region_name": "HF Inside Fence Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "HF Inside Fence Grotto",
         "locations": {
             "HF Deku Scrub Grotto": "can_stun_deku"
@@ -2200,6 +2169,7 @@
     },
     {
         "region_name": "HF Cow Grotto",
+        "pretty_name": "the Spider Cow Grotto",
         "scene": "HF Cow Grotto",
         "locations": {
             "HF GS Cow Grotto": "
@@ -2216,6 +2186,7 @@
     },
     {
         "region_name": "HF Near Market Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "HF Near Market Grotto",
         "locations": {
             "HF Near Market Grotto Chest": "True",
@@ -2231,6 +2202,7 @@
     },
     {
         "region_name": "HF Fairy Grotto",
+        "pretty_name": "a Fairy Fountain",
         "scene": "HF Fairy Grotto",
         "locations": {
             "Free Fairies": "has_bottle"
@@ -2241,6 +2213,7 @@
     },
     {
         "region_name": "HF Near Kak Grotto",
+        "pretty_name": "a Skulltula Grotto",
         "scene": "HF Near Kak Grotto",
         "locations": {
             "HF GS Near Kak Grotto": "can_use(Boomerang) or can_use(Hookshot)"
@@ -2251,6 +2224,7 @@
     },
     {
         "region_name": "HF Tektite Grotto",
+        "pretty_name": "the Tektite Grotto",
         "scene": "HF Tektite Grotto",
         "locations": {
             "HF Tektite Grotto Freestanding PoH": "
@@ -2262,6 +2236,7 @@
     },
     {
         "region_name": "HC Storms Grotto",
+        "pretty_name": "a Skulltula Grotto",
         "scene": "HC Storms Grotto",
         "locations": {
             "HC GS Storms Grotto": "
@@ -2278,6 +2253,7 @@
     },
     {
         "region_name": "Kak Redead Grotto",
+        "pretty_name": "the ReDead Grotto",
         "scene": "Kak Redead Grotto",
         "locations": {
             "Kak Redead Grotto Chest": "
@@ -2290,6 +2266,7 @@
     },
     {
         "region_name": "Kak Open Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "Kak Open Grotto",
         "locations": {
             "Kak Open Grotto Chest": "True",
@@ -2305,6 +2282,7 @@
     },
     {
         "region_name": "DMT Cow Grotto",
+        "pretty_name": "the Cow Grotto",
         "scene": "DMT Cow Grotto",
         "locations": {
             "DMT Cow Grotto Cow": "can_play(Eponas_Song)"
@@ -2315,6 +2293,7 @@
     },
     {
         "region_name": "DMT Storms Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "DMT Storms Grotto",
         "locations": {
             "DMT Storms Grotto Chest": "True",
@@ -2330,6 +2309,7 @@
     },
     {
         "region_name": "GC Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "GC Grotto",
         "locations": {
             "GC Deku Scrub Grotto Left": "can_stun_deku",
@@ -2342,6 +2322,7 @@
     },
     {
         "region_name": "DMC Upper Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "DMC Upper Grotto",
         "locations": {
             "DMC Upper Grotto Chest": "True",
@@ -2357,6 +2338,7 @@
     },
     {
         "region_name": "DMC Hammer Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "DMC Hammer Grotto",
         "locations": {
             "DMC Deku Scrub Grotto Left": "can_stun_deku",
@@ -2369,6 +2351,7 @@
     },
     {
         "region_name": "ZR Open Grotto",
+        "pretty_name": "a Generic Grotto",
         "scene": "ZR Open Grotto",
         "locations": {
             "ZR Open Grotto Chest": "True",
@@ -2384,6 +2367,7 @@
     },
     {
         "region_name": "ZR Fairy Grotto",
+        "pretty_name": "a Fairy Fountain",
         "scene": "ZR Fairy Grotto",
         "locations": {
             "Free Fairies": "has_bottle"
@@ -2394,6 +2378,7 @@
     },
     {
         "region_name": "ZR Storms Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "ZR Storms Grotto",
         "locations": {
             "ZR Deku Scrub Grotto Rear": "can_stun_deku",
@@ -2405,6 +2390,7 @@
     },
     {
         "region_name": "LH Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "LH Grotto",
         "locations": {
             "LH Deku Scrub Grotto Left": "can_stun_deku",
@@ -2417,6 +2403,7 @@
     },
     {
         "region_name": "Colossus Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "Colossus Grotto",
         "locations": {
             "Colossus Deku Scrub Grotto Rear": "can_stun_deku",
@@ -2428,6 +2415,7 @@
     },
     {
         "region_name": "GV Octorok Grotto",
+        "pretty_name": "the Octorok Grotto",
         "scene": "GV Octorok Grotto",
         "exits": {
             "GV Grotto Ledge": "True"
@@ -2435,6 +2423,7 @@
     },
     {
         "region_name": "GV Storms Grotto",
+        "pretty_name": "a Deku Scrub Grotto",
         "scene": "GV Storms Grotto",
         "locations": {
             "GV Deku Scrub Grotto Rear": "can_stun_deku",


### PR DESCRIPTION
* Moves the warp song texts into the region files.
* Adds warp song text for some regions that were previously missing. Fixes #1427.
* Makes minor adjustments to some warp song texts ([player name]'s house → your house, Dampe → Dampé, Know It All → Know-it-All).
* Changes warp song text colors to be more consistent both with vanilla and internally: All interiors and grottos are white (rather than some being white and others light blue), and the overworld and dungeons are assigned the 6 vanilla warp song text colors by association with the medallions.
* Adds “the” to some hint area names to improve grammar. The original warp song text PR did this for warp songs to match vanilla, but did not change other hints. This allows the warp song text to use the hint area name for most overworld regions.