### PR TITLE
Fix Skulltula Tokens in Big Chests with Ganon's Boss Key on Tokens

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1621,7 +1621,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             item = read_rom_item(rom, i)
             item['chest_type'] = 0
             write_rom_item(rom, i, item)
-    if world.settings.bridge == 'tokens' or world.settings.lacs_condition == 'tokens':
+    if world.settings.bridge == 'tokens' or world.settings.lacs_condition == 'tokens' or world.settings.shuffle_ganon_bosskey == 'tokens':
         item = read_rom_item(rom, 0x5B)
         item['chest_type'] = 0
         write_rom_item(rom, 0x5B, item)


### PR DESCRIPTION
With Ganon's Boss Key on Tokens, Rainbow Bridge NOT on tokens, and Chest Size Matches Content, chests with skulltula tokens currently show as small chests despite being major items. Introduced in #1367, partially fixed in #1390.