### PR TITLE
Fix multiworld random trials interaction

### DIFF
--- a/Goals.py
+++ b/Goals.py
@@ -40,7 +40,7 @@ class Goal(object):
         self._item_cache = {}
     
     def copy(self):
-        new_goal = Goal(self.world, self.name, self.hint_text, self.color, self.items, self.locations, self.lock_locations, self.lock_entrances, self.required_locations)
+        new_goal = Goal(self.world, self.name, self.hint_text, self.color, self.items, self.locations, self.lock_locations, self.lock_entrances, self.required_locations, True)
         return new_goal
 
     def get_item(self, item):

--- a/Search.py
+++ b/Search.py
@@ -273,11 +273,12 @@ class Search(object):
                 if world_filter is not None and state.world.id != world_filter:
                     continue
                 valid_goals[category_name]['stateReverse'][state.world.id] = []
-                for goal in category.goals:
+                world_category = state.world.goal_categories[category_name]
+                for goal in world_category.goals:
                     if goal.name not in valid_goals[category_name]:
                         valid_goals[category_name][goal.name] = []
                     # Check if already beaten
-                    if all(map(lambda i: state.has_full_item_goal(category, goal, i), goal.items)):
+                    if all(map(lambda i: state.has_full_item_goal(world_category, goal, i), goal.items)):
                         valid_goals[category_name][goal.name].append(state.world.id)
                         # Reverse lookup for checking if the category is already beaten.
                         # Only used to check if starting items satisfy the category.

--- a/World.py
+++ b/World.py
@@ -754,7 +754,10 @@ class World(object):
                 trials.goal_count += 1
 
             # Trials category is finalized and saved only if at least one trial is on
-            if self.settings.trials > 0:
+            # If random trials are on and one world in multiworld gets 0 trials, still
+            # add the goal to prevent key errors. Since no items fulfill the goal, it
+            # will always be invalid for that world and not generate hints.
+            if self.settings.trials > 0 or self.settings.trials_random:
                 trials.add_goal(trial_goal)
                 self.goal_categories[trials.name] = trials
 


### PR DESCRIPTION
MW seeds with random trials on can fail to generate if the trials enabled in World 1 are not enabled in other worlds. The system also failed if one world has no trials as the trials category key does not exist during goal/woth calculations. This should also affect a fixed number of trials on in MW as which trials are enabled is still random.

Goal hints do NOT need to be active for the failure to occur. This PR is recommended as a hotfix for 6.1.