### PR TITLE
Fix AGR generation errors by making it work more like RO

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -392,7 +392,7 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
             if worlds[0].settings.reachable_locations == 'goals':
                 # If this item is required for a goal, it must be placed somewhere reachable.
                 # We also need to check to make sure the game is beatable, since custom goals might not imply that.
-                predicate = lambda state: state.won and state.has_all_item_goals
+                predicate = lambda state: state.won() and state.has_all_item_goals()
             else:
                 # If the game is not beatable without this item, it must be placed somewhere reachable.
                 predicate = State.won

--- a/Fill.py
+++ b/Fill.py
@@ -368,6 +368,7 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
     logging.getLogger('').debug(f'Placing {len(itempool)} items among {len(locations)} potential locations.')
 
     # loop until there are no items or locations
+    perform_access_check = False
     while itempool and locations:
         # if remaining count is 0, return. Negative means unbounded.
         if count == 0:
@@ -394,7 +395,7 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
         elif worlds[0].settings.reachable_locations == 'goals':
             # for All Goals Reachable, we have to track whether any goal items have been placed,
             # since we then have to start checking their reachability.
-            perform_access_check = item_to_place.goalitem or not max_search.can_beat_game(scan_for_items=False)
+            perform_access_check = perform_access_check or item_to_place.goalitem or not max_search.can_beat_game(scan_for_items=False)
             extra_location_checks = [location for world in worlds for location in world.get_filled_locations() if location.item.goalitem]
         else:
             # if any world can not longer be beatable with the remaining items
@@ -403,7 +404,7 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
             # stop checking, then we could place an item needed in one world
             # in an unreachable place in another world.
             # scan_for_items would cause an unnecessary copy+collect
-            perform_access_check = not max_search.can_beat_game(scan_for_items=False)
+            perform_access_check = perform_access_check or not max_search.can_beat_game(scan_for_items=False)
             extra_location_checks = []
 
         # find a location that the item can be placed. It must be a valid location

--- a/Fill.py
+++ b/Fill.py
@@ -391,7 +391,8 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
         if worlds[0].check_beatable_only:
             if worlds[0].settings.reachable_locations == 'goals':
                 # If this item is required for a goal, it must be placed somewhere reachable.
-                predicate = State.has_all_item_goals
+                # We also need to check to make sure the game is beatable, since custom goals might not imply that.
+                predicate = lambda state: state.won and state.has_all_item_goals
             else:
                 # If the game is not beatable without this item, it must be placed somewhere reachable.
                 predicate = State.won

--- a/Goals.py
+++ b/Goals.py
@@ -98,7 +98,7 @@ class GoalCategory(object):
     def is_beaten(self, search):
         # if the category requirements are already satisfied by starting items (such as Links Pocket),
         # do not generate hints for other goals in the category
-        starting_goals = search.can_beat_goals_fast({ self.name: self })
+        starting_goals = search.beatable_goals_fast({ self.name: self })
         return all(map(lambda s: len(starting_goals[self.name]['stateReverse'][s.world.id]) >= self.minimum_goals, search.state_list))
 
 
@@ -184,7 +184,7 @@ def update_goal_items(spoiler):
                 reachable_goals = {}
                 # Goals are changed for beatable-only accessibility per-world
                 category.update_reachable_goals(search, full_search)
-                reachable_goals = full_search.can_beat_goals_fast({ cat_name: category }, cat_world.id)
+                reachable_goals = full_search.beatable_goals_fast({ cat_name: category }, cat_world.id)
                 identified_locations = search_goals({ cat_name: category }, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_light_arrows)
                 # Multiworld can have all goals for one player's bridge entirely
                 # locked by another player's bridge. Therefore, we can't assume
@@ -208,7 +208,7 @@ def update_goal_items(spoiler):
         full_search.collect_locations()
         for cat_name, category in worlds[0].unlocked_goal_categories.items():
             category.update_reachable_goals(search, full_search)
-        reachable_goals = full_search.can_beat_goals_fast(worlds[0].unlocked_goal_categories)
+        reachable_goals = full_search.beatable_goals_fast(worlds[0].unlocked_goal_categories)
     identified_locations = search_goals(worlds[0].unlocked_goal_categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_light_arrows, search_woth=True)
     required_locations.update(identified_locations)
     woth_locations = list(required_locations['way of the hero'])
@@ -300,7 +300,7 @@ def search_goals(categories, reachable_goals, search, priority_locations, all_lo
             location.item = None
             # copies state! This is very important as we're in the middle of a search
             # already, but beneficially, has search it can start from
-            valid_goals = search.can_beat_goals(categories)
+            valid_goals = search.beatable_goals(categories)
             for cat_name, category in categories.items():
                 # Exit early if no goals are beatable with category locks
                 if category.name in reachable_goals and reachable_goals[category.name]:

--- a/Location.py
+++ b/Location.py
@@ -68,17 +68,14 @@ class Location(object):
         self.access_rules = [lambda_rule]
 
 
-    def can_fill(self, state, item, check_access=True, extra_location_checks=()):
+    def can_fill(self, state, item, check_access=True):
         if self.minor_only and item.majoritem:
             return False
-        if self.is_disabled() or not self.can_fill_fast(item) or (check_access and not state.search.spot_access(self, 'either')):
-            return False
-        if not extra_location_checks:
-            return True
-        search_with_this = state.search.copy()
-        search_with_this.collect(item)
-        search_with_this.collect_locations(list(chain(search_with_this.progression_locations(), extra_location_checks)))
-        return all(map(search_with_this.visited, extra_location_checks))
+        return (
+            not self.is_disabled() and
+            self.can_fill_fast(item) and
+            (not check_access or state.search.spot_access(self, 'either'))
+        )
 
 
     def can_fill_fast(self, item, manual=False):

--- a/Search.py
+++ b/Search.py
@@ -218,8 +218,7 @@ class Search(object):
     # conditions are possible, such as in Triforce Hunt, where only the total
     # amount of an item across all worlds matter, not specifcally who has it
     #
-    # Win condition can be a string that gets mapped to a function(state_list) here
-    # or just a function(state_list)
+    # predicate must be a function (state) -> bool, that will be applied to all states
     def can_beat_game(self, scan_for_items=True, predicate=State.won):
 
         # Check if already beaten

--- a/Search.py
+++ b/Search.py
@@ -220,10 +220,10 @@ class Search(object):
     #
     # Win condition can be a string that gets mapped to a function(state_list) here
     # or just a function(state_list)
-    def can_beat_game(self, scan_for_items=True):
+    def can_beat_game(self, scan_for_items=True, predicate=State.won):
 
         # Check if already beaten
-        if all(map(State.won, self.state_list)):
+        if all(map(predicate, self.state_list)):
             return True
 
         if scan_for_items:
@@ -232,12 +232,12 @@ class Search(object):
             search = self.copy()
             search.collect_locations()
             # if every state got the Triforce, then return True
-            return all(map(State.won, search.state_list))
+            return all(map(predicate, search.state_list))
         else:
             return False
 
 
-    def can_beat_goals_fast(self, goal_categories, world_filter = None):
+    def beatable_goals_fast(self, goal_categories, world_filter = None):
         valid_goals = self.test_category_goals(goal_categories, world_filter)
         if all(map(State.won, self.state_list)):
             valid_goals['way of the hero'] = True
@@ -246,7 +246,7 @@ class Search(object):
         return valid_goals
 
 
-    def can_beat_goals(self, goal_categories):
+    def beatable_goals(self, goal_categories):
         # collect all available items
         # make a new search since we might be iterating over one already
         search = self.copy()

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2236,7 +2236,7 @@ setting_infos = [
             to beat the game, but otherwise behaves like 'Required Only'.
             Goal items are the items required for the rainbow bridge and/or Ganon's Boss Key, so for example if the bridge is
             set to 1 Medallion and Ganon's Boss Key to 1 Gold Skulltula Token, all 6 Medallions and all 100 Tokens will
-            be obtainable. In Triforce Hunt, this will also guarantee that all Triforce Pieces can be obtained.
+            be obtainable. In Triforce Hunt, this will instead guarantee that all Triforce Pieces can be obtained.
 
             'Required Only': Only items and locations required to beat the game will be guaranteed reachable.
         ''',

--- a/State.py
+++ b/State.py
@@ -108,6 +108,14 @@ class State(object):
         return self.prog_items[item_goal['name']] >= per_world_max_quantity
 
 
+    def has_all_item_goals(self):
+        for category in self.world.goal_categories.values():
+            for goal in category.goals:
+                if not all(map(lambda i: self.has_full_item_goal(category, goal, i), goal.items)):
+                    return False
+        return True
+
+
     def had_night_start(self):
         stod = self.world.settings.starting_tod
         # These are all not between 6:30 and 18:00


### PR DESCRIPTION
**Edit:** [See this comment for the new fix.](https://github.com/TestRunnerSRL/OoT-Randomizer/pull/1441#issuecomment-973643433)

Updates the fill code to ensure that once it has started to do access checks, it will keep doing them for the rest of the fill. This seems to fix the generation failure with this plando:

```json
{
    "settings": {
        "reachable_locations": "goals",
        "bridge_medallions": 4,
        "shuffle_ganon_bosskey": "vanilla"
    }
}
```

It should also be a minor seed generation speed-up in AGR and RO since it won't do extra `can_beat_game` checks anymore to determine whether to do access checks if it's already doing access checks.
