### PR TITLE
Change name of Enable Useful Cutscenes setting to Enable Specific Glitch-Useful Cutscenes and tooltip update

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2399,11 +2399,12 @@ setting_infos = [
     ),
     Checkbutton(
         name           = 'useful_cutscenes',
-        gui_text       = 'Enable Useful Cutscenes',
+        gui_text       = 'Enable Specific Glitch-Useful Cutscenes',
         gui_tooltip    = '''\
-            The cutscenes of the Poes in Forest Temple,
-            Darunia in Fire Temple, and the introduction
-            to Twinrova will not be skipped.
+            The cutscenes of the Poes in Forest Temple and Darunia in
+            Fire Temple will not be skipped. These cutscenes are useful
+            in glitched gameplay only and do not provide any timesave
+            for glitchless playthroughs.
         ''',
         shared         = True,
     ),


### PR DESCRIPTION
This PR changes the name of the Enable Useful Cutscenes setting to Enable Specific Glitch-Useful Cutscenes to more clearly define what the setting does. Also removes outdated reference in tooltip to the Twinrova cutscene, which is now default, and specifies that the setting is only a time saver when playing with glitchless.