### PR TITLE
Allow foolish hints for areas with always hints but not other hint types

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -896,6 +896,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
     if checkedLocations is None:
         checkedLocations = set()
+    checkedAlwaysLocations = set()
 
     stoneIDs = list(gossipLocations.keys())
 
@@ -1020,7 +1021,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
         alwaysLocations = getHintGroup('always', world)
         for hint in alwaysLocations:
             location = world.get_location(hint.name)
-            checkedLocations.add(hint.name)
+            checkedAlwaysLocations.add(hint.name)
             if location.item.name in bingoBottlesForHints and world.settings.hint_dist == 'bingo':
                 always_item = 'Bottle'
             else:
@@ -1059,7 +1060,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             raise Exception('User-provided item hints were requested, but copies per named-item hint is zero')
         else:
             for i in range(0, len(world.named_item_pool)):
-                hint = get_specific_item_hint(spoiler, world, checkedLocations)
+                hint = get_specific_item_hint(spoiler, world, set.union(checkedLocations, checkedAlwaysLocations))
                 if hint:
                     gossip_text, location = hint
                     place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
@@ -1116,7 +1117,12 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             except IndexError:
                 raise Exception('Not enough valid hints to fill gossip stone locations.')
 
-        hint = hint_func[hint_type](spoiler, world, checkedLocations)
+        allCheckedLocations = set.union(checkedLocations, checkedAlwaysLocations)
+        if hint_type == 'barren':
+            hint = hint_func[hint_type](spoiler, world, checkedLocations)
+        else:
+            hint = hint_func[hint_type](spoiler, world, allCheckedLocations)
+        checkedLocations.update(allCheckedLocations.difference(set.union(checkedLocations, checkedAlwaysLocations)))
 
         if hint == None:
             index = hint_types.index(hint_type)

--- a/Hints.py
+++ b/Hints.py
@@ -1060,7 +1060,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             raise Exception('User-provided item hints were requested, but copies per named-item hint is zero')
         else:
             for i in range(0, len(world.named_item_pool)):
-                hint = get_specific_item_hint(spoiler, world, set.union(checkedLocations, checkedAlwaysLocations))
+                hint = get_specific_item_hint(spoiler, world, checkedLocations | checkedAlwaysLocations)
                 if hint:
                     gossip_text, location = hint
                     place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
@@ -1117,12 +1117,12 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             except IndexError:
                 raise Exception('Not enough valid hints to fill gossip stone locations.')
 
-        allCheckedLocations = set.union(checkedLocations, checkedAlwaysLocations)
+        allCheckedLocations = checkedLocations | checkedAlwaysLocations
         if hint_type == 'barren':
             hint = hint_func[hint_type](spoiler, world, checkedLocations)
         else:
             hint = hint_func[hint_type](spoiler, world, allCheckedLocations)
-        checkedLocations.update(allCheckedLocations.difference(set.union(checkedLocations, checkedAlwaysLocations)))
+            checkedLocations.update(allCheckedLocations - checkedAlwaysLocations)
 
         if hint == None:
             index = hint_types.index(hint_type)


### PR DESCRIPTION
Maintain two separate lists of checked locations, one with the Always-hinted locations and the other with everything else. Foolish hints only check the latter list, while all other hint types check both. This lets foolish hints share areas with always hints, but not sometimes hints.