### PR TITLE
Fix warp song menu item color

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -1003,5 +1003,5 @@ def update_warp_song_text(messages, world):
             destination_name = destination.name
         color = COLOR_MAP[destination.font_color or 'White']
 
-        new_msg = f"\x08\x05{color}Warp to {destination_name}?\x05\40\x09\x01\x01\x1b\x05{color}OK\x01No\x05\40"
+        new_msg = f"\x08\x05{color}Warp to {destination_name}?\x05\40\x09\x01\x01\x1b\x05\x42OK\x01No\x05\40"
         update_message_by_id(messages, id, new_msg)


### PR DESCRIPTION
The color of the “OK” and “No” options was changed to match that of the “Warp to [destination]” text if warp songs are shuffled in #1323. This PR reverts them to always be green, as in the vanilla game. The “Warp to [destination]” text remains color-coded by medallion area as introduced in #1428.