### PR TITLE
Adds option to disable standard battle music

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -38,6 +38,9 @@ def patch_music(rom, settings, log, symbols):
         log.errors.extend(errors)
     else:
         music.restore_music(rom)
+    # Remove battle music
+    if settings.disable_battle_music:
+        rom.write_byte(0xBE447F, 0x00)
 
 
 def patch_model_colors(rom, color, model_addresses):

--- a/Patches.py
+++ b/Patches.py
@@ -1771,6 +1771,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.settings.ocarina_songs:
         replace_songs(world, rom)
 
+    # Remove battle music
+    if world.settings.disable_battle_music:
+        rom.write_byte(0xBE447F, 0x00)
+
     # actually write the save table to rom
     world.distribution.give_items(save_context)
     if world.settings.starting_age == 'adult':

--- a/Patches.py
+++ b/Patches.py
@@ -1771,10 +1771,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.settings.ocarina_songs:
         replace_songs(world, rom)
 
-    # Remove battle music
-    if world.settings.disable_battle_music:
-        rom.write_byte(0xBE447F, 0x00)
-
     # actually write the save table to rom
     world.distribution.give_items(save_context)
     if world.settings.starting_age == 'adult':

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3930,6 +3930,9 @@ setting_infos = [
         cosmetic       = True,
         gui_tooltip    = '''\
             Disable standard battle music.
+	    This prevents background music from being
+	    interrupted by the battle theme when being
+	    near enemies.
         ''',
         default        = False,
     ),

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3923,6 +3923,16 @@ setting_infos = [
             'web:option_remove': ['random_custom_only'],
         },
     ),
+    Checkbutton(
+        name           = 'disable_battle_music',
+        gui_text       = 'Disable battle music',
+        shared         = False,
+        cosmetic       = True,
+        gui_tooltip    = '''\
+            Disable standard battle music.
+        ''',
+        default        = False,
+    ),
     Combobox(
         name           = 'fanfares',
         gui_text       = 'Fanfares',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -451,6 +451,7 @@
           "row_span": [6,6,13],
           "settings": [
             "background_music",
+            "disable_battle_music",
             "fanfares",
             "ocarina_fanfares",
             "sfx_low_hp",


### PR DESCRIPTION
All credits to Engineer124 for his amazing work on audio decomp and basically telling me exactly what modification was needed.

This adds a checkbox to disable the standard battle music when being near enemies. This is especially useful when using custom music, else it keeps being interrupted in dense areas like dungeons.

This byte should change the only spot where the music sequence get updated with the enemy one (here : https://github.com/engineer124/oot/blob/4bd3778922b46afe7f9fcc09bef14a320344778f/src/overlays/actors/ovl_player_actor/z_player.c#L9708)

I've tested this on Retroarch and saw/heard no problem while playing 2 full seeds. Mracsys also gave it a try on Everdrive and also saw no problem.