### PR TITLE
HBA fanfare fix: no longer waits for fanfare to complete

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1313,7 +1313,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         # Update the first horseback archery text to make it clear both rewards are available from the start
         update_message_by_id(messages, 0x6040, "Hey newcomer, you have a fine \x01horse!\x04I don't know where you stole \x01it from, but...\x04OK, how about challenging this \x01\x05\x41horseback archery\x05\x40?\x04Once the horse starts galloping,\x01shoot the targets with your\x01arrows. \x04Let's see how many points you \x01can score. You get 20 arrows.\x04If you can score \x05\x411,000 points\x05\x40, I will \x01give you something good! And even \x01more if you score \x05\x411,500 points\x05\x40!\x0B\x02")
 
-    # Fix HBA to not wait for the fanfare to complete before 
+    # Fix HBA to not wait for the fanfare to complete before transitioning to claim reward
     rom.write_byte(0xC1C00B, 0x2)
     rom.write_byte(0xC1C01B, 0x2)
 

--- a/Patches.py
+++ b/Patches.py
@@ -1313,6 +1313,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         # Update the first horseback archery text to make it clear both rewards are available from the start
         update_message_by_id(messages, 0x6040, "Hey newcomer, you have a fine \x01horse!\x04I don't know where you stole \x01it from, but...\x04OK, how about challenging this \x01\x05\x41horseback archery\x05\x40?\x04Once the horse starts galloping,\x01shoot the targets with your\x01arrows. \x04Let's see how many points you \x01can score. You get 20 arrows.\x04If you can score \x05\x411,000 points\x05\x40, I will \x01give you something good! And even \x01more if you score \x05\x411,500 points\x05\x40!\x0B\x02")
 
+    # Fix HBA to not wait for the fanfare to complete before 
+    rom.write_byte(0xC1C00B, 0x2)
+    rom.write_byte(0xC1C01B, 0x2)
+
     # Sets hooks for gossip stone changes
 
     symbol = rom.sym("GOSSIP_HINT_CONDITION");


### PR DESCRIPTION
After the final shot is taken in Horseback Archery, the game has a check to only transition to claim the rewards after the current fanfare is no longer playing. This has led to issues with randomized fanfares, as certain fanfares play for a significant amount of time, leaving the player stuck on Epona waiting for the fanfare to finish. This is brought up in this issue here: https://github.com/TestRunnerSRL/OoT-Randomizer/issues/902

This PR removes the in-game check for the fanfare being completed, and uses decomp to figure out exactly what to change while being as minimally invasive as possible. The relevant code can be seen here:
https://github.com/engineer124/oot/blob/d9b77329e42bc6a1040f6c2e820f025500054665/src/overlays/actors/ovl_En_Horse/z_en_horse.c#L2506-L2509

Specifically, there is a function:
`isHorseGoalPlaying = Audio_IsSequencePlaying(NA_BGM_HORSE_GOAL);`
That returns `1` while the fanfare is playing, and returns `0` while the fanfare is not playing (note in decomp, we define false = 0 and true = 1)

Later on, the scene will only transition when the following condition is met:
```
if (isHorseGoalPlaying != true) {
     // Transition to claim reward
```

The fix I have presented changes this statement into:
`if (isHorseGoalPlaying != 2) {`

By only changing a single number, no registers are tinkered with. Also, `Audio_IsSequencePlaying` can only ever return 0 or 1. 
https://github.com/engineer124/oot/blob/d9b77329e42bc6a1040f6c2e820f025500054665/src/code/code_800EC960.c#L3905
Therefore, `isHorseGoalPlaying != 2` always returns true and is no longer a factor in determining when to transition.

The changes were testing against the "prelude fanfare" and the results can be seen here:
https://discord.com/channels/274180765816848384/512048482677424138/893450233042845697