### PR TITLE
Remove the Long Animation When Equipping Magic Arrows

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -588,6 +588,14 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # Speed up Death Mountain Trail Owl Flight
     rom.write_bytes(0x223B6B2, [0x00, 0x01])
 
+    # Speed up magic arrow equips
+    rom.write_int16(0xBB84CE, 0x0000) # Skips the initial growing glowing orb phase
+    rom.write_byte(0xBB84B7, 0xFF) # Set glowing orb above magic arrow to be small sized immediately
+    rom.write_byte(0xBB84CB, 0x01) # Sets timer for holding icon above magic arrow (1 frame)
+    rom.write_byte(0xBB7E67, 0x04) # speed up magic arrow icon -> bow icon interpolation (4 frames)
+    rom.write_byte(0xBB8957, 0x01) # Sets timer for holding icon above bow (1 frame)
+    rom.write_byte(0xBB854B, 0x05) # speed up bow icon -> c button interpolation (5 frames)
+
     # Poacher's Saw no longer messes up Forest Stage
     rom.write_bytes(0xAE72CC, [0x00, 0x00, 0x00, 0x00])
 


### PR DESCRIPTION
This addresses the following request provided in the Trello:

Description: Removes the long animation when equipping magic arrows.

Purpose: The animation is long, and doesn't serve any significant purpose.

In this PR, I removed the growing glowing orb stage when you first equip a magic arrow (before the orb icon moves from the magic arrow to the bow slot in the pause menu).

I modified the timers for various stages of the magic arrow equip animation. I chose values that felt natural to me, although I encourage devs to try different timer values if the current values are too fast or too slow. The attached video is how the equips are currently programed to be. However, all the timers are customizable from the addresses given in this PR. Just be careful not to set any timers to be 0, or else that will result in a soft-lock

https://user-images.githubusercontent.com/47598039/145679610-c11ce853-3985-4129-a599-334e27e4c4e4.mp4

