### PR TITLE
Allows hints to be tagged to explicit text IDs.

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -302,7 +302,7 @@ class WorldDistribution(object):
                     if self.distribution.settings.triforce_hunt:
                         self.major_group.append('Triforce Piece')
                     major_tokens = ((self.distribution.settings.shuffle_ganon_bosskey == 'on_lacs' and
-                            self.distribution.settings.lacs_condition == 'tokens') or 
+                            self.distribution.settings.lacs_condition == 'tokens') or
                             self.distribution.settings.shuffle_ganon_bosskey == 'tokens' or self.distribution.settings.bridge == 'tokens')
                     if self.distribution.settings.tokensanity == 'all' and major_tokens:
                         self.major_group.append('Gold Skulltula Token')
@@ -921,7 +921,12 @@ class WorldDistribution(object):
             matcher = self.pattern_matcher(name)
             stoneID = pull_random_element([stoneIDs], lambda id: matcher(gossipLocations[id].name))
             if stoneID is None:
-                raise RuntimeError('Gossip stone unknown or already assigned in world %d: %r. %s' % (self.id + 1, name, build_close_match(name, 'stone')))
+                # Allow planning of explicit textids
+                match = re.match('^\$([a-fA-F0-9]{4})$', name)
+                if match:
+                    stoneID = int(match[1], base=16)
+                else:
+                    raise RuntimeError('Gossip stone unknown or already assigned in world %d: %r. %s' % (self.id + 1, name, build_close_match(name, 'stone')))
             spoiler.hints[self.id][stoneID] = GossipText(text=record.text, colors=record.colors, prefix='')
 
 
@@ -1188,7 +1193,13 @@ class Distribution(object):
                             else:
                                 world_dist.goal_locations[cat_name][goal_text]['from World ' + str(location_world + 1)] = {loc.name: LocationRecord.from_item(loc.item).to_json() for loc in locations}
             world_dist.barren_regions = [*world.empty_areas]
-            world_dist.gossip_stones = {gossipLocations[loc].name: GossipRecord(spoiler.hints[world.id][loc].to_json()) for loc in spoiler.hints[world.id]}
+            world_dist.gossip_stones = {}
+            for loc in spoiler.hints[world.id]:
+                hint = GossipRecord(spoiler.hints[world.id][loc].to_json())
+                if loc in gossipLocations:
+                    world_dist.gossip_stones[gossipLocations[loc].name] = hint
+                else:
+                    world_dist.gossip_stones["${:04x}".format(loc)] = hint
 
         self.playthrough = {}
         for (sphere_nr, sphere) in spoiler.playthrough.items():


### PR DESCRIPTION
This change allows a hintstone to be located at "$[hex]" (e.g. "$04ff"),
which allows unused text IDs to be set to arbitrary texts.

This is most useful with allowing arbitrary code in hintstone texts to
chain multiple texts together, particularly when using sounds --
or in altering text of things like signs, shopkeeper gossip, end credits, etc.