### PR TITLE
Bug Fix (Vanilla): Add Missing MQ Hammer Chest to Both Minimap and Pause Map

### DIFF
--- a/data/mqu.json
+++ b/data/mqu.json
@@ -20348,7 +20348,7 @@
         "Icons": [
           {
             "Icon": 0,
-            "Count": 5,
+            "Count": 6,
             "IconPoints": [
               {
                 "Flag": 1,
@@ -20374,6 +20374,11 @@
                 "Flag": 12,
                 "x": 47,
                 "y": -26
+              },
+              {
+                "Flag": 0,
+                "x": 48,
+                "y": -17
               }
             ]
           },
@@ -20469,12 +20474,18 @@
       {
         "Icons": [
           {
-            "Icon": -1,
-            "Count": 0,
-            "IconPoints": []
+            "Icon": 0,
+            "Count": 1,
+            "IconPoints": [
+              {
+                "Flag": 0,
+                "x": 71,
+                "y": 60
+              }
+            ]
           },
           {
-            "Icon": 0,
+            "Icon": -1,
             "Count": 0,
             "IconPoints": []
           },


### PR DESCRIPTION
This PR addresses this issue: https://github.com/TestRunnerSRL/OoT-Randomizer/issues/1435

In MQ fire temple, the devs did not add the hammer chest to the mini-map or the pause-map. This PR adds them both in. This is more important in rando as newcomers to rando often depend on theses maps for trying to find chests. The coordinates used for both maps were taken from the equivalent chest in vanilla fire temple. 

This chest is tied to flag 0, which was confirmed through decomp and through testing (i.e. the chest will be removed from these maps once it's opened).

Here's the chest on the two maps:

![image](https://user-images.githubusercontent.com/47598039/146326776-1d7b4ea1-62ef-4a39-b549-85bed639f979.png)

![image](https://user-images.githubusercontent.com/47598039/146326903-ce9913b3-4000-41e7-89c5-5a2e8273114b.png)

And then immediately opening it:

![image](https://user-images.githubusercontent.com/47598039/146327008-5b670b0e-e5e3-4152-aaed-95afc687e946.png)

![image](https://user-images.githubusercontent.com/47598039/146327051-b142c3be-0cdb-48ac-bd34-b7e9bdbd3a06.png)