### PR TITLE
Show good error message with trial/mq count plando mismatch, minor ruto's letter plando issue

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -826,7 +826,7 @@ def get_pool_core(world):
     if world.settings.zora_fountain == 'open':
         ruto_bottles = 0
     elif world.settings.item_pool_value == 'plentiful':
-        ruto_bottles += 1
+        pending_junk_pool.append('Rutos Letter')
 
     if world.settings.skip_child_zelda:
         placed_items['HC Malon Egg'] = 'Recovery Heart'

--- a/World.py
+++ b/World.py
@@ -360,9 +360,11 @@ class World(object):
             self.settings.trials = dist_num_chosen + random.randint(0, len(trial_pool))
             self.randomized_list.append('trials')
         num_trials = int(self.settings.trials)
-        choosen_trials = random.sample(trial_pool, num_trials - dist_num_chosen)
+        if num_trials < dist_num_chosen:
+            raise RuntimeError("%d trials set to active on world %d, but only %d active trials allowed." % (dist_num_chosen, self.id, num_trials))
+        chosen_trials = random.sample(trial_pool, num_trials - dist_num_chosen)
         for trial in self.skipped_trials:
-            if trial not in choosen_trials and trial not in dist_chosen:
+            if trial not in chosen_trials and trial not in dist_chosen:
                 self.skipped_trials[trial] = True
 
         # Determine MQ Dungeons
@@ -375,6 +377,8 @@ class World(object):
             self.settings.mq_dungeons = list(self.dungeon_mq.values()).count(True)
             self.randomized_list.append('mq_dungeons')
         else:
+            if self.settings.mq_dungeons < dist_num_mq:
+                raise RuntimeError("%d dungeons are set to MQ on world %d, but only %d MQ dungeons allowed." % (dist_num_mq, self.id, self.settings.mq_dungeons))
             mqd_picks = random.sample(dungeon_pool, self.settings.mq_dungeons - dist_num_mq)
             for dung in mqd_picks:
                 self.dungeon_mq[dung] = True


### PR DESCRIPTION
1) If a plando sets more active trials than the `trials` value, and similarly for mq dungeons, previously a vague error was displayed. Now a more informative error is displayed, ex, `RuntimeError: 6 trials set to active on world 0, but only 4 active trials allowed.`

2) I realized as I was writing this how much of an edge case this issue is, but if you have a plentiful item pool (which normally sets ruto bottles to 2), used plando to set Rutos Letter to 1, and plando'd all 3 other bottles in specific locations, it would fail to generate due to the 2nd Rutos Letter being placed in the main item pool instead of the pending junk pool. Fixed this by just adding a Rutos Letter to the pending junk pool instead of incrementing the count for it to be placed in the main pool.