### PR TITLE
Fix Ruleparser being unaware of True and False constants in newer py versions

### DIFF
--- a/RuleParser.py
+++ b/RuleParser.py
@@ -381,12 +381,12 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             self.current_spot = event
             # This could, in theory, create further subrules.
             access_rule = self.make_access_rule(self.visit(node))
-            if access_rule is self.rule_cache.get('NameConstant(False)'):
+            if access_rule is self.rule_cache.get('NameConstant(False)') or access_rule is self.rule_cache.get('Constant(False)'):
                 event.access_rule = None
                 event.never = True
                 logging.getLogger('').debug('Dropping unreachable delayed event: %s', event.name)
             else:
-                if access_rule is self.rule_cache.get('NameConstant(True)'):
+                if access_rule is self.rule_cache.get('NameConstant(True)') or access_rule is self.rule_cache.get('Constant(True)'):
                     event.always = True
                 event.set_rule(access_rule)
                 region.locations.append(event)
@@ -479,7 +479,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
 
         access_rule = self.parse_rule(rule, spot)
         spot.set_rule(access_rule)
-        if access_rule is self.rule_cache.get('NameConstant(False)'):
+        if access_rule is self.rule_cache.get('NameConstant(False)') or access_rule is self.rule_cache.get('Constant(False)'):
             spot.never = True
-        elif access_rule is self.rule_cache.get('NameConstant(True)'):
+        elif access_rule is self.rule_cache.get('NameConstant(True)') or access_rule is self.rule_cache.get('Constant(True)'):
             spot.always = True


### PR DESCRIPTION
Discovered via bug in Boss Shuffle. Python 3.8 apparently changed True and False from `NameConstant`s (now a deprecated class as of 3.8) to ordinary `Constant`s

No idea what this actually affects since it took a new feature to even discover the issue, but it at least keeps consistency between all 3.6+ versions.