### PR TITLE
Place instant text code after icon if a message has an icon

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -534,10 +534,6 @@ class Message:
 
         text_codes = []
 
-        # # speed the text
-        if speed_up_text:
-            text_codes.append(Text_Code(0x08, 0)) # allow instant
-
         # write the message
         for code in self.text_codes:
             # ignore ending codes if it's going to be replaced
@@ -563,6 +559,13 @@ class Message:
                     text_codes.append(Text_Code(0x08, 0))  # allow instant
             else:
                 text_codes.append(code)
+
+        # # speed the text
+        if speed_up_text:
+            if 'icon' in self.text:
+                text_codes.insert(1, Text_Code(0x08, 0)) # put instant text after icon
+            else:
+                text_codes.insert(0, Text_Code(0x08, 0)) # allow instant
 
         if replace_ending:
             if ending:

--- a/Messages.py
+++ b/Messages.py
@@ -562,10 +562,10 @@ class Message:
 
         # # speed the text
         if speed_up_text:
-            if 'icon' in self.text:
-                text_codes.insert(1, Text_Code(0x08, 0)) # put instant text after icon
+            if text_codes[0].code == 19:  # Check if first text_code is icon
+                text_codes.insert(1, Text_Code(0x08, 0))  # put instant text after icon
             else:
-                text_codes.insert(0, Text_Code(0x08, 0)) # allow instant
+                text_codes.insert(0, Text_Code(0x08, 0))  # allow instant
 
         if replace_ending:
             if ending:


### PR DESCRIPTION
This should fix slow text on 

> - Bombchus (item icon is 0x09, same as MESSAGE_QUICKTEXT_DISABLE)
> - Hookshot (item icon is 0x0A, same as MESSAGE_PERSISTENT)
> - Longshot (item icon is 0x0B, same as MESSAGE_EVENT)
> - Ice Arrow (item icon is 0x0C, same as MESSAGE_BOX_BREAK_DELAYED)
> - Farore's Wind (item icon is 0x0D, same as MESSAGE_AWAIT_BUTTON_PRESS)
> - Fire Arrow (item icon is 0x04, same as MESSAGE_BOX_BREAK)
> - Bomb refill (item icon is 0x02, same as MESSAGE_END)