### PR TITLE
Move Fast Text After Problematic Icons

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -3,6 +3,7 @@
 import logging
 import random
 from TextBox import line_wrap
+from Utils import find_last
 
 TEXT_START = 0x92D000
 ENG_TEXT_SIZE_LIMIT = 0x39000
@@ -531,12 +532,14 @@ class Message:
         ending_codes = [0x02, 0x07, 0x0A, 0x0B, 0x0E, 0x10]
         box_breaks = [0x04, 0x0C]
         slows_text = [0x08, 0x09, 0x14]
+        slow_icons = [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x04, 0x02]
 
         text_codes = []
+        instant_text_code = Text_Code(0x08, 0)
 
         # # speed the text
         if speed_up_text:
-            text_codes.append(Text_Code(0x08, 0)) # allow instant
+            text_codes.append(instant_text_code) # allow instant
 
         # write the message
         for code in self.text_codes:
@@ -557,10 +560,14 @@ class Message:
                     self.id == 0x7070
                 ):   # zelda ending text
                     text_codes.append(code)
-                    text_codes.append(Text_Code(0x08, 0))  # allow instant
+                    text_codes.append(instant_text_code)  # allow instant
                 else:
                     text_codes.append(Text_Code(0x04, 0))  # un-delayed break
-                    text_codes.append(Text_Code(0x08, 0))  # allow instant
+                    text_codes.append(instant_text_code)  # allow instant
+            elif speed_up_text and code.code == 0x13 and code.data in slow_icons:
+                text_codes.append(code)
+                text_codes.pop(find_last(text_codes, instant_text_code))  # remove last instance of instant text
+                text_codes.append(instant_text_code)  # allow instant
             else:
                 text_codes.append(code)
 

--- a/Utils.py
+++ b/Utils.py
@@ -194,3 +194,10 @@ def check_python_version():
     python_version = '.'.join([str(num) for num in sys.version_info[0:3]])
     if compare_version(python_version, '3.6.0') < 0:
         raise VersionError('Randomizer requires at least version 3.6 and you are using %s' % python_version, "https://www.python.org/downloads/")
+
+
+# https://stackoverflow.com/a/23146126
+def find_last(source_list, sought_element):
+    for reverse_index, element in enumerate(reversed(source_list)):
+        if element == sought_element:
+            return len(source_list) - 1 - reverse_index


### PR DESCRIPTION
As with flagrama's fix in PR #1482, this should fix slow text on:

> - Bombchus (item icon is 0x09, same as MESSAGE_QUICKTEXT_DISABLE)
> - Hookshot (item icon is 0x0A, same as MESSAGE_PERSISTENT)
> - Longshot (item icon is 0x0B, same as MESSAGE_EVENT)
> - Ice Arrow (item icon is 0x0C, same as MESSAGE_BOX_BREAK_DELAYED)
> - Farore's Wind (item icon is 0x0D, same as MESSAGE_AWAIT_BUTTON_PRESS)
> - Fire Arrow (item icon is 0x04, same as MESSAGE_BOX_BREAK)
> - Bomb refill (item icon is 0x02, same as MESSAGE_END)

The difference is that this PR will also fix message boxes in a multi-box message containing one of those icons and it only affects those with a problematic icon as listed above.

See the following discussion on discord for the explanation of why this issue has existed: https://discord.com/channels/274180765816848384/512048482677424138/917539239565086801

Fixes #117.

Before/After video: https://youtu.be/pvc8uflKW1g