### PR TITLE
Plando: Allow >100 Gold Skulltula Token Requirements

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -766,13 +766,22 @@ def generate_itempool(world):
 
     # set up item pool
     (pool, placed_items) = get_pool_core(world)
+    placed_items_count = {}
     world.itempool = ItemFactory(pool, world)
     for (location, item) in placed_items.items():
+        placed_items_count[item] = placed_items_count.get(item, 0) + 1
         world.push_item(location, ItemFactory(item, world))
         world.get_location(location).locked = True
 
     world.initialize_items()
     world.distribution.set_complete_itempool(world.itempool)
+
+    # make sure that there are enough gold skulltulas for bridge/ganon boss key/lacs
+    gold_skulltula_count = placed_items_count.get("Gold Skulltula Token", 0) \
+                         + pool.count("Gold Skulltula Token") \
+                         + world.distribution.starting_items.get("Gold Skulltula Token", 0)
+    if world.max_progressions["Gold Skulltula Token"] > gold_skulltula_count:
+        raise ValueError(f"Not enough available Gold Skulltula Tokens to meet requirements. Available: {gold_skulltula_count}, Required: {world.max_progressions['Gold Skulltula Token']}.")
 
 
 def try_collect_heart_container(world, pool):

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -777,11 +777,11 @@ def generate_itempool(world):
     world.distribution.set_complete_itempool(world.itempool)
 
     # make sure that there are enough gold skulltulas for bridge/ganon boss key/lacs
-    gold_skulltula_count = placed_items_count.get("Gold Skulltula Token", 0) \
-                         + pool.count("Gold Skulltula Token") \
-                         + world.distribution.starting_items.get("Gold Skulltula Token", 0)
-    if world.max_progressions["Gold Skulltula Token"] > gold_skulltula_count:
-        raise ValueError(f"Not enough available Gold Skulltula Tokens to meet requirements. Available: {gold_skulltula_count}, Required: {world.max_progressions['Gold Skulltula Token']}.")
+    world.available_tokens = placed_items_count.get("Gold Skulltula Token", 0) \
+                           + pool.count("Gold Skulltula Token") \
+                           + world.distribution.starting_items.get("Gold Skulltula Token", 0)
+    if world.max_progressions["Gold Skulltula Token"] > world.available_tokens:
+        raise ValueError(f"Not enough available Gold Skulltula Tokens to meet requirements. Available: {world.available_tokens}, Required: {world.max_progressions['Gold Skulltula Token']}.")
 
 
 def try_collect_heart_container(world, pool):

--- a/Patches.py
+++ b/Patches.py
@@ -1912,6 +1912,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         symbol = rom.sym('FAST_BUNNY_HOOD_ENABLED')
         rom.write_byte(symbol, 0x01)
 
+    # Have the Gold Skulltula Count in the pause menu turn red when equal to the
+    # available number of skulls in the world instead of 100.
+    rom.write_int16(0xBB340E, world.available_tokens)
+
     if world.settings.ocarina_songs:
         replace_songs(world, rom)
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2227,14 +2227,16 @@ setting_infos = [
         gui_text       = "Skulltulas Required for Bridge",
         default        = 100,
         min            = 1,
-        max            = 100,
+        max            = 999,
         gui_tooltip    = '''\
             Select the amount of Gold Skulltula Tokens required to spawn the rainbow bridge.
         ''',
         shared         = True,
         disabled_default = 0,
         gui_params     = {
-            "hide_when_disabled": True,
+            'hide_when_disabled': True,
+            'web:max': 100,
+            'electron:max': 100,
         },
     ),
     Checkbutton(
@@ -3465,7 +3467,7 @@ setting_infos = [
         gui_text       = "Gold Skulltula Tokens Required for Ganon's BK",
         default        = 100,
         min            = 1,
-        max            = 100,
+        max            = 999,
         gui_tooltip    = '''\
             Select the amount of Gold Skulltula Tokens
             required to receive Ganon's Castle Boss Key.
@@ -3474,6 +3476,8 @@ setting_infos = [
         disabled_default = 0,
         gui_params     = {
             "hide_when_disabled": True,
+            'web:max': 100,
+            'electron:max': 100,
         },
     ),
     Combobox(
@@ -3571,7 +3575,7 @@ setting_infos = [
         gui_text       = "Gold Skulltula Tokens Required for LACS",
         default        = 100,
         min            = 1,
-        max            = 100,
+        max            = 999,
         gui_tooltip    = '''\
             Select the amount of Gold Skulltula Tokens
             required to trigger the Light Arrow Cutscene.
@@ -3581,6 +3585,8 @@ setting_infos = [
         gui_params     = {
             'optional': True,
             "hide_when_disabled": True,
+            'web:max': 100,
+            'electron:max': 100,
         },
     ),
     Checkbutton(

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -80,19 +80,26 @@ def GetSettingJson(setting, web_version, as_array=False):
     if setting_info.disable != None:
         setting_disable = copy.deepcopy(setting_info.disable)
 
+    version_specific_keys = []
+
     for key, value in setting_info.gui_params.items():
+        version_specific = False
         if key.startswith('web:'):
             if web_version:
                 key = key[4:]
+                version_specific_keys.append(key)
+                version_specific = True
             else:
                 continue
         if key.startswith('electron:'):
             if not web_version:
                 key = key[9:]
+                version_specific_keys.append(key)
+                version_specific = True
             else:
                 continue
 
-        if key in setting_keys:
+        if key in setting_keys and (key not in version_specific_keys or version_specific):
             settingJson[key] = value
         if key == 'disable':
             for option,types in value.items():

--- a/World.py
+++ b/World.py
@@ -201,6 +201,9 @@ class World(object):
         # Additional Ruto's Letter become Bottle, so we may have to collect two.
         self.max_progressions['Rutos Letter'] = 2
 
+        # Available Gold Skulltula Tokens in world. Set to proper value in ItemPool.py.
+        self.available_tokens = 100
+
         # Disable goal hints if the hint distro does not require them.
         # WOTH locations are always searched.
         self.enable_goal_hints = False
@@ -277,6 +280,7 @@ class World(object):
 
         new_world.always_hints = list(self.always_hints)
         new_world.max_progressions = copy.copy(self.max_progressions)
+        new_world.available_tokens = self.available_tokens
 
         return new_world
 


### PR DESCRIPTION
This allows you to plando Bridge/Ganon Boss Key/LACS token requirements up to 999 while still only allowing those to be set up to 100 in the GUI. If there aren't enough tokens available in a world to meet the requirements set, you will get a specific error message.