### PR TITLE
Add trick to open chests through flaming circles

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -252,6 +252,15 @@ logic_tricks = {
                     - MQ Fire Temple Lizalfos Maze.
                     - MQ Spirit Trial.
                     '''},
+    'Open Chests Through Flaming Circles': {
+        'name'    : 'logic_flaming_circles',
+        'tags'    : ("Spirit Temple", "Gerudo Training Ground",),
+        'tooltip' : '''\
+                    The chests encircled in flames in Gerudo
+                    Training Ground and Spirit Temple can be
+                    opened by running into the flames while
+                    Link is invincible after taking damage.
+                    '''},
     'Bottom of the Well Map Chest with Strength & Sticks': {
         'name'    : 'logic_botw_basement',
         'tags'    : ("Bottom of the Well",),

--- a/data/World/Gerudo Training Ground MQ.json
+++ b/data/World/Gerudo Training Ground MQ.json
@@ -71,7 +71,7 @@
         "locations": {
             "Gerudo Training Ground MQ Eye Statue Chest": "Bow",
             "Gerudo Training Ground MQ Second Iron Knuckle Chest": "True",
-            "Gerudo Training Ground MQ Flame Circle Chest": "can_use(Hookshot) or Bow or has_explosives"
+            "Gerudo Training Ground MQ Flame Circle Chest": "(can_use(Hookshot) or Bow or has_explosives) or (can_take_damage and logic_flaming_circles)"
         },
         "exits": {
             "Gerudo Training Ground Central Maze Right": "Megaton_Hammer",

--- a/data/World/Gerudo Training Ground.json
+++ b/data/World/Gerudo Training Ground.json
@@ -65,7 +65,7 @@
         "dungeon": "Gerudo Training Ground",
         "locations": {
             "Gerudo Training Ground Hammer Room Clear Chest": "True",
-            "Gerudo Training Ground Hammer Room Switch Chest": "can_use(Megaton_Hammer)"
+            "Gerudo Training Ground Hammer Room Switch Chest": "can_use(Megaton_Hammer) or (can_take_damage and logic_flaming_circles)"
         },
         "exits": {
             "Gerudo Training Ground Eye Statue Lower": "can_use(Megaton_Hammer) and Bow",

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -197,8 +197,7 @@
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Boss Key Chest": "
-                can_play(Zeldas_Lullaby) and Bow and 
-                Progressive_Hookshot",
+                can_play(Zeldas_Lullaby) and ((Bow and Progressive_Hookshot) or (can_take_damage and logic_flaming_circles))",
             "Spirit Temple Topmost Chest": "Mirror_Shield"
         },
         "exits": {


### PR DESCRIPTION
Adds a trick to open certain chests through flaming circles. This can easily be accomplished by walking into the fire, taking damage, and quickly walking back into the chest while still having invincibility and mash A to open them. I made sure that it also works with Nayru's Love, and after being revived by a fairy so that the `can_take_damage` helper can be used safely.

This applies to 3 chests: The boss key chest in Spirit, the hammer switch chest in GTG, and a chest in the same room in MQ GTG which requires you to hit a wall crystal switch. Other flaming chests, such as the Fire Temple scarecrow chest and hammer chest, the fire is too wide around the chest so this trick cannot be done.

There was discussion on whether or not this was a glitchless trick, as this technique is allowed in unrestricted glitchless, but not restricted glitchless. I'm not the expert on that stuff so I'll leave it to someone else to determine if this is too much of a glitch to be on the tricks list.