### PR TITLE
Reset location.price on fill failure

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -333,6 +333,7 @@ def fill_ownworld_restrictive(window, worlds, search, locations, ownpool, itempo
                 logger.info("Failed to place %s items for world %s. Will retry %s more times.", description, (world.id+1), world_attempts)
                 for location in prize_locs_dict[world.id]:
                     location.item = None
+                    location.price = None
                     if location.disabled == DisableType.DISABLED:
                         location.disabled = DisableType.PENDING
                 logger.info('\t%s' % str(e))


### PR DESCRIPTION
This is the actual cause of the bug I mentioned in #1504 

location.price was not reset between fill failures, which means that this line:
```py
item.price = location.price if location.price is not None else item.price
```

Would cause the location price to stick between failures, thus applying to items as well. So, for example, if Deku Shield was placed in KF Shop Item 1, then that location's price would be set to 40. If the fill then failed, the next attempt, 'KF Shop Item 1'.price would still equal 40, so logic and the spoiler would still consider the price of whatever is placed there to be 40.