### PR TITLE
Plando bugfix when applying randomized settings in plando files.

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -408,8 +408,11 @@ class WorldDistribution(object):
 
     # Add randomized_settings defined in distribution to world's randomized settings list
     def configure_randomized_settings(self, world):
+        settings = world.settings
         for name, record in self.randomized_settings.items():
-            setattr(world, name, record)
+            if not hasattr(settings, name):
+                raise RuntimeError(f"Unknown random setting in world {self.id + 1}: '{name}'")
+            setattr(settings, name, record)
             if name not in world.randomized_list:
                 world.randomized_list.append(name)
 


### PR DESCRIPTION
At some point in the past, settings were moved off of World into a Settings object.  This caused randomized_settings in plando files to stop applying, since they set attributes on the World object rather than on the Settings object.

This PR fixes it.  Additionally, sane error messaging is shown if the Settings lacks the attribute in question rather than simply having no visible effect.

Tested with a 5-person multiworld seed with random starting age and all 5 seeds plando'd to be starting age child.