### PR TITLE
Fix Plentiful Starting Hearts

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1107,9 +1107,6 @@ class Distribution(object):
 
         # add hearts
         if self.settings.starting_hearts > 3:
-            if not data['Piece of Heart (Treasure Chest Game)'].count:
-                data['Piece of Heart (Treasure Chest Game)'].count += 1
-                data['Piece of Heart'].count -= 1
             num_hearts_to_collect = self.settings.starting_hearts - 3
             if num_hearts_to_collect % 2 == 1:
                 data['Piece of Heart'].count += 4
@@ -1117,6 +1114,11 @@ class Distribution(object):
             for i in range(0, num_hearts_to_collect, 2):
                 data['Piece of Heart'].count += 4
                 data['Heart Container'].count += 1
+            if self.settings.starting_hearts >= 20:
+                data['Piece of Heart'].count -= 1
+            if self.settings.item_pool_value == 'plentiful':
+                data['Heart Container'].count += data['Piece of Heart'].count // 4
+                data['Piece of Heart'].count = data['Piece of Heart'].count % 4
 
         return data
 


### PR DESCRIPTION
Plentiful removes all but 3 Piece of Heart from the item pool in favor of Heart Containers, which was not taken into account in the Starting Hearts code. Plentiful will now remove one Heart Container per extra starting heart until 20 when it removes its 3 Piece of Heart.

Additionally, Piece of Heart (Treasure Chest Game) is no longer removed via Starting Hearts. Everyone can be a winner.