### PR TITLE
Minor Settings Changes

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2563,9 +2563,9 @@ setting_infos = [
         default        = 'off',
         choices        = {
             'off':       'Off',
-            'choice':    'Choose dungeons',
-            'all':       'All dungeons',
-            'random':    'Random dungeons'
+            'choice':    'Specific Dungeons',
+            'all':       'All Dungeons',
+            'random':    'Random Dungeons'
         },
         gui_tooltip    = '''\
             Shortcuts to dungeon bosses are available

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2353,7 +2353,7 @@ setting_infos = [
         gui_text       = 'Triforces Per World',
         default        = 30,
         min            = 1,
-        max            = 200,
+        max            = 999,
         shared         = True,
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces placed in each world.
@@ -2367,6 +2367,8 @@ setting_infos = [
         ''',
         gui_params     = {
             "hide_when_disabled": True,
+            'web:max': 200,
+            'electron:max': 200,
         },
     ),
     Scale(
@@ -2374,7 +2376,7 @@ setting_infos = [
         gui_text       = 'Required Triforces Per World',
         default        = 20,
         min            = 1,
-        max            = 100,
+        max            = 999,
         shared         = True,
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces required to beat the game.
@@ -2385,6 +2387,8 @@ setting_infos = [
         ''',
         gui_params     = {
             "hide_when_disabled": True,
+            'web:max': 100,
+            'electron:max': 100,
         },
     ),
     Combobox(


### PR DESCRIPTION
**Plando: Allow Higher Triforce Counts for Triforce Hunt**: Similar to the Gold Skulltula goals, now allows a maximum of 999 for both the per-world count and goal of Triforce Pieces. GUI limits unchanged.

**Reword 'Dungeon Boss Shortcuts Mode' Options**: Fixes capitalization, changes "Choose dungeons" to "Specific Dungeons" for consistency.