### PR TITLE
Fix bugs with starting items in multiworld

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -936,8 +936,17 @@ class WorldDistribution(object):
 
 
     def give_items(self, save_context):
+        # copy Triforce pieces to all worlds
+        triforce_count = sum(
+            world_dist.effective_starting_items['Triforce Piece'].count
+            for world_dist in self.distribution.world_dists
+            if 'Triforce Piece' in world_dist.effective_starting_items
+        )
+        if triforce_count > 0:
+            save_context.give_item('Triforce Piece', triforce_count)
+
         for (name, record) in self.effective_starting_items.items():
-            if record.count == 0:
+            if name == 'Triforce Piece' or record.count == 0:
                 continue
             save_context.give_item(name, record.count)
 


### PR DESCRIPTION
This fixes two bugs:

* The new `starting_items` plando syntax introduced in #1352 not supporting per-world syntax (e.g. `{"World 1": {"Megaton Hammer": 1}, "World 2": {"Kokiri Sword": 1}}`)
* #1425