### PR TITLE
Remove the item restriction for Song from Impa

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -4,7 +4,7 @@ from State import State
 from Rules import set_shop_rules
 from Location import DisableType
 from LocationList import location_groups
-from ItemPool import song_list, get_junk_item, item_groups, remove_junk_items
+from ItemPool import IGNORE_LOCATION, song_list, get_junk_item, item_groups, remove_junk_items
 from Item import ItemFactory, ItemInfo
 from Search import Search
 from functools import reduce
@@ -507,6 +507,9 @@ def fast_fill(window, locations, itempool):
     while itempool and locations:
         spot_to_fill = locations.pop()
         item_to_place = itempool.pop()
+        # Ice traps are currently unsupported as starting items, but forbidding them on Song from Impa would noticeably increase the chance of a major item there in Ice Trap Onslaught.
+        if spot_to_fill.world.settings.skip_child_zelda and spot_to_fill.name == 'Song from Impa' and item_to_place.name == 'Ice Trap':
+            item_to_place = ItemFactory(IGNORE_LOCATION, spot_to_fill.world)
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)
         window.fillcount += 1
         window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))

--- a/Fill.py
+++ b/Fill.py
@@ -507,10 +507,6 @@ def fast_fill(window, locations, itempool):
     while itempool and locations:
         spot_to_fill = locations.pop()
         item_to_place = itempool.pop()
-        # Impa can't presently hand out refills at the start of the game.
-        # Only replace her item with a rupee if it's junk.
-        if spot_to_fill.world.settings.skip_child_zelda and spot_to_fill.name == 'Song from Impa' and item_to_place.name in set(remove_junk_items):
-            item_to_place = ItemFactory('Rupee (1)', spot_to_fill.world)
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)
         window.fillcount += 1
         window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))

--- a/Patches.py
+++ b/Patches.py
@@ -1914,7 +1914,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     )
 
     # actually write the save table to rom
-    world.distribution.give_items(save_context)
+    world.distribution.give_items(world, save_context)
     if world.settings.starting_age == 'adult':
         # When starting as adult, the pedestal doesn't handle child default equips when going back child the first time, so we have to equip them ourselves
         save_context.equip_default_items('child')

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -935,7 +935,7 @@ class WorldDistribution(object):
             spoiler.hints[self.id][stoneID] = GossipText(text=record.text, colors=record.colors, prefix='')
 
 
-    def give_items(self, save_context):
+    def give_items(self, world, save_context):
         # copy Triforce pieces to all worlds
         triforce_count = sum(
             world_dist.effective_starting_items['Triforce Piece'].count
@@ -943,12 +943,12 @@ class WorldDistribution(object):
             if 'Triforce Piece' in world_dist.effective_starting_items
         )
         if triforce_count > 0:
-            save_context.give_item('Triforce Piece', triforce_count)
+            save_context.give_item(world, 'Triforce Piece', triforce_count)
 
         for (name, record) in self.effective_starting_items.items():
             if name == 'Triforce Piece' or record.count == 0:
                 continue
-            save_context.give_item(name, record.count)
+            save_context.give_item(world, name, record.count)
 
 
     def get_starting_item(self, item):

--- a/Rules.py
+++ b/Rules.py
@@ -50,7 +50,7 @@ def set_rules(world):
             add_item_rule(location, lambda location, item: item.type != 'Shop')
 
         if world.settings.skip_child_zelda and location.name == 'Song from Impa':
-            limit_to_itemset(location, SaveContext.giveable_items)
+            forbid_item(location, 'Ice Trap') # starting ice traps are currently unsupported
             if world.settings.triforce_hunt and world.total_starting_triforce_count >= world.triforce_goal - world.settings.world_count:
                 # We have enough starting Triforce pieces that putting a piece on every world's Song from Impa would hit the goal count
                 # and render the game unbeatable, so for simplicity's sake we forbid putting pieces on any world's Song from Impa.

--- a/Rules.py
+++ b/Rules.py
@@ -50,7 +50,6 @@ def set_rules(world):
             add_item_rule(location, lambda location, item: item.type != 'Shop')
 
         if world.settings.skip_child_zelda and location.name == 'Song from Impa':
-            forbid_item(location, 'Ice Trap') # starting ice traps are currently unsupported
             if world.settings.triforce_hunt and world.total_starting_triforce_count >= world.triforce_goal - world.settings.world_count:
                 # We have enough starting Triforce pieces that putting a piece on every world's Song from Impa would hit the goal count
                 # and render the game unbeatable, so for simplicity's sake we forbid putting pieces on any world's Song from Impa.

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -259,7 +259,7 @@ class SaveContext():
 
         self.addresses['health_capacity'].value       = int(health) * 0x10
         self.addresses['health'].value                = int(health) * 0x10
-        self.addresses['quest']['heart_pieces'].value = int((health % 1) * 4)
+        self.addresses['quest']['heart_pieces'].value = int((health % 1) * 4) * 0x10
 
 
     def give_item(self, item, count=1):
@@ -830,6 +830,11 @@ class SaveContext():
             'item_slot.stick'            : 'stick',
             'upgrades.stick_upgrade'     : [2,3],
         },
+        "Deku Stick": {
+            'item_slot.stick'            : 'stick',
+            'upgrades.stick_upgrade'     : 1,
+            'ammo.stick'                 : None,
+        },
         "Deku Sticks": {
             'item_slot.stick'            : 'stick',
             'upgrades.stick_upgrade'     : 1,
@@ -957,16 +962,59 @@ class SaveContext():
             'double_magic'          : [False, True],
         },
         "Rupee"                     : {'rupees' : None},
+        "Rupee (Treasure Chest Game)" : {'rupees' : None},
         "Rupees"                    : {'rupees' : None},
         "Magic Bean Pack" : {
             'item_slot.beans'       : 'beans',
             'ammo.beans'            : 10
         },
         "Triforce Piece"            : {'triforce_pieces': None},
+        "Boss Key (Forest Temple)"                : {'dungeon_items.forest.boss_key': True},
+        "Boss Key (Fire Temple)"                  : {'dungeon_items.fire.boss_key': True},
+        "Boss Key (Water Temple)"                 : {'dungeon_items.water.boss_key': True},
+        "Boss Key (Spirit Temple)"                : {'dungeon_items.spirit.boss_key': True},
+        "Boss Key (Shadow Temple)"                : {'dungeon_items.shadow.boss_key': True},
+        "Boss Key (Ganons Castle)"                : {'dungeon_items.gt.boss_key': True},
+        "Compass (Deku Tree)"                     : {'dungeon_items.deku.compass': True},
+        "Compass (Dodongos Cavern)"               : {'dungeon_items.dodongo.compass': True},
+        "Compass (Jabu Jabus Belly)"              : {'dungeon_items.jabu.compass': True},
+        "Compass (Forest Temple)"                 : {'dungeon_items.forest.compass': True},
+        "Compass (Fire Temple)"                   : {'dungeon_items.fire.compass': True},
+        "Compass (Water Temple)"                  : {'dungeon_items.water.compass': True},
+        "Compass (Spirit Temple)"                 : {'dungeon_items.spirit.compass': True},
+        "Compass (Shadow Temple)"                 : {'dungeon_items.shadow.compass': True},
+        "Compass (Bottom of the Well)"            : {'dungeon_items.botw.compass': True},
+        "Compass (Ice Cavern)"                    : {'dungeon_items.ice.compass': True},
+        "Map (Deku Tree)"                         : {'dungeon_items.deku.map': True},
+        "Map (Dodongos Cavern)"                   : {'dungeon_items.dodongo.map': True},
+        "Map (Jabu Jabus Belly)"                  : {'dungeon_items.jabu.map': True},
+        "Map (Forest Temple)"                     : {'dungeon_items.forest.map': True},
+        "Map (Fire Temple)"                       : {'dungeon_items.fire.map': True},
+        "Map (Water Temple)"                      : {'dungeon_items.water.map': True},
+        "Map (Spirit Temple)"                     : {'dungeon_items.spirit.map': True},
+        "Map (Shadow Temple)"                     : {'dungeon_items.shadow.map': True},
+        "Map (Bottom of the Well)"                : {'dungeon_items.botw.map': True},
+        "Map (Ice Cavern)"                        : {'dungeon_items.ice.map': True},
+        "Small Key (Forest Temple)"               : {'keys.forest': None},
+        "Small Key (Fire Temple)"                 : {'keys.fire': None},
+        "Small Key (Water Temple)"                : {'keys.water': None},
+        "Small Key (Spirit Temple)"               : {'keys.spirit': None},
+        "Small Key (Shadow Temple)"               : {'keys.shadow': None},
+        "Small Key (Bottom of the Well)"          : {'keys.botw': None},
+        "Small Key (Gerudo Training Ground)"      : {'keys.gtg': None},
+        "Small Key (Thieves Hideout)"             : {'keys.fortress': None},
+        "Small Key (Ganons Castle)"               : {'keys.gc': None},
+        #HACK: we don't know whether the dungeon is MQ here so we give enough keys for either variant
+        "Small Key Ring (Forest Temple)"          : {'keys.forest': 6},
+        "Small Key Ring (Fire Temple)"            : {'keys.fire': 8},
+        "Small Key Ring (Water Temple)"           : {'keys.water': 6},
+        "Small Key Ring (Spirit Temple)"          : {'keys.spirit': 7},
+        "Small Key Ring (Shadow Temple)"          : {'keys.shadow': 6},
+        "Small Key Ring (Bottom of the Well)"     : {'keys.botw': 3},
+        "Small Key Ring (Gerudo Training Ground)" : {'keys.gtg': 9},
+        "Small Key Ring (Thieves Hideout)"        : {'keys.fortress': 4},
+        "Small Key Ring (Ganons Castle)"          : {'keys.gc': 3},
     }
-
-    giveable_items = set(chain(save_writes_table.keys(), bottle_types.keys(),
-        ["Piece of Heart", "Piece of Heart (Treasure Chest Game)", "Heart Container", "Rupee (1)", "Recovery Heart"]))
 
 
     equipable_items = {


### PR DESCRIPTION
* Support is added for any item that can be on `Song from Impa` to be a starting item. These have all been tested and seem to be working as expected, with the following exceptions:
    * Odd Mushroom, Eyeball Frog, and Eyedrops are displayed as such on the file select screen but immediately revert when the file is loaded for the first time (unless `disable_trade_revert` is in effect). The proper fix would be to prevent the revert from happening on first load, but #1527 serves as a preliminary fix.
    * `Bombchus` (i.e. the variable-amount pack for chus in logic) only gives 19 bombchus, not 20. No idea what's going on here.
    * ~~Since the code handling the save context currently doesn't know about settings, I configured key rings to give enough keys regardless of whether the dungeon is MQ (e.g. 9 GTG keys or 3 Ganon keys).~~ Fixed.
    * Ice traps remain forbidden with plando, while randomly placed ones become recovery hearts so that the chance of a major item on Impa isn't significantly increased in Ice Trap Onslaught. Adding support would require functionality to freeze Link immediately upon loading the file for the first time.
    * Refills for items you don't start with are ignored rather than being replaced with blue rupees.
* Junk items randomly placed on Impa are no longer replaced with green rupees in Skip Child Zelda.
* A bug where starting heart pieces weren't set correctly is fixed.

Fixes #1227. Fixes #1278. Fixes #1510.