### PR TITLE
Fix logic bug in Dodongo's Cavern

### DIFF
--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -70,9 +70,9 @@
             "Dodongos Cavern Far Bridge": "
                 (is_adult and (Hover_Boots or can_use(Longshot) or logic_dc_jump)) or
                 ((here(can_blast_or_smash) or Progressive_Strength_Upgrade) and
-                (is_child and (Slingshot or
-                    (logic_dc_slingshot_skip and (Sticks or Bombs or Kokiri_Sword)))) or 
-                (is_adult and Bow))"
+                    ((is_child and (Slingshot or
+                        (logic_dc_slingshot_skip and (Sticks or Bombs or Kokiri_Sword)))) or
+                    (is_adult and Bow)))"
         }
     },
     {


### PR DESCRIPTION
This fixes a logic bug discovered by @Hamsda and confirmed by @r0bd0g that can lead to seeds that are only beatable with the spike trap room jump even when that trick is not in logic. The issue was discussed in #dev-public-talk on 2022-03-09.