### PR TITLE
Add a goal category for the Door of Time

### DIFF
--- a/World.py
+++ b/World.py
@@ -757,10 +757,12 @@ class World(object):
         # wording is used to distinguish the hint type even though the hintable location
         # set is identical to WOTH.
         if not self.settings.triforce_hunt:
-            if self.settings.starting_age == 'child' and not self.settings.open_door_of_time:
-                dot_items = [{'name': 'Song of Time', 'quantity': 2 if self.settings.shuffle_song_items == 'any' and self.settings.item_pool_value == 'plentiful' else 1, 'minimum': 1, 'hintable': True}]
-                if self.settings.shuffle_ocarinas:
-                    dot_items.append({'name': 'Ocarina', 'quantity': 3 if self.settings.item_pool_value == 'plentiful' else 2, 'minimum': 1, 'hintable': True})
+            if self.settings.starting_age == 'child':
+                dot_items = [{'name': 'Time Travel', 'quantity': 1, 'minimum': 1, 'hintable': True}]
+                if not self.settings.open_door_of_time:
+                    dot_items.append({'name': 'Song of Time', 'quantity': 2 if self.settings.shuffle_song_items == 'any' and self.settings.item_pool_value == 'plentiful' else 1, 'minimum': 1, 'hintable': True})
+                    if self.settings.shuffle_ocarinas:
+                        dot_items.append({'name': 'Ocarina', 'quantity': 3 if self.settings.item_pool_value == 'plentiful' else 2, 'minimum': 1, 'hintable': True})
                 dot.add_goal(Goal(self, 'Door of Time', 'path of time', 'Light Blue', items=dot_items))
                 self.goal_categories[dot.name] = dot
 

--- a/World.py
+++ b/World.py
@@ -758,7 +758,7 @@ class World(object):
         # set is identical to WOTH.
         if not self.settings.triforce_hunt:
             if self.settings.starting_age == 'child':
-                dot_items = [{'name': 'Time Travel', 'quantity': 1, 'minimum': 1, 'hintable': True}]
+                dot_items = [{'name': 'Temple of Time Access', 'quantity': 1, 'minimum': 1, 'hintable': True}]
                 if not self.settings.open_door_of_time:
                     dot_items.append({'name': 'Song of Time', 'quantity': 2 if self.settings.shuffle_song_items == 'any' and self.settings.item_pool_value == 'plentiful' else 1, 'minimum': 1, 'hintable': True})
                     if self.settings.shuffle_ocarinas:

--- a/World.py
+++ b/World.py
@@ -727,6 +727,7 @@ class World(object):
         # and Skull conditions, there is only one goal in the category
         # requesting X copies within the goal, so minimum goals has to
         # be 1 for these.
+        dot = GoalCategory('door_of_time', 5, lock_entrances=['Temple of Time -> Beyond Door of Time'], minimum_goals=1)
         b = GoalCategory('rainbow_bridge', 10, lock_entrances=['Ganons Castle Grounds -> Ganons Castle Lobby'])
         gbk = GoalCategory('ganon_bosskey', 20)
         trials = GoalCategory('trials', 30, minimum_goals=1)
@@ -756,6 +757,13 @@ class World(object):
         # wording is used to distinguish the hint type even though the hintable location
         # set is identical to WOTH.
         if not self.settings.triforce_hunt:
+            if self.settings.starting_age == 'child' and not self.settings.open_door_of_time:
+                dot_items = [{'name': 'Song of Time', 'quantity': 2 if self.settings.shuffle_song_items == 'any' and self.settings.item_pool_value == 'plentiful' else 1, 'minimum': 1, 'hintable': True}]
+                if self.settings.shuffle_ocarinas:
+                    dot_items.append({'name': 'Ocarina', 'quantity': 3 if self.settings.item_pool_value == 'plentiful' else 2, 'minimum': 1, 'hintable': True})
+                dot.add_goal(Goal(self, 'Door of Time', 'path of time', 'Light Blue', items=dot_items))
+                self.goal_categories[dot.name] = dot
+
             # Bridge goals will always be defined as they have the most immediate priority
             if self.settings.bridge != 'open' and not self.shuffle_special_dungeon_entrances:
                 # "Replace" hint text dictionaries are used to reference the

--- a/World.py
+++ b/World.py
@@ -304,9 +304,12 @@ class World(object):
         # over again after the first round through the categories.
         if len(self.goal_categories) > 0:
             self.one_hint_per_goal = True
-            goal_list1 = [goal.name for goal in list(self.goal_categories.values())[0].goals]
+            goal_list1 = []
             for category in self.goal_categories.values():
-                if goal_list1 != [goal.name for goal in category.goals]:
+                if category.name != 'door_of_time':
+                    goal_list1 = [goal.name for goal in category.goals]
+            for category in self.goal_categories.values():
+                if goal_list1 != [goal.name for goal in category.goals] and category.name != 'door_of_time':
                     self.one_hint_per_goal = False
 
         # initialize category check for first rounds of goal hints

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -419,6 +419,10 @@
     {
         "region_name": "Temple of Time",
         "hint": "TEMPLE_OF_TIME",
+        "events": {
+            # used for the "path of time" goal
+            "Temple of Time Access": "True"
+        },
         "locations": {
             "ToT Light Arrows Cutscene": "is_adult and can_trigger_lacs",
             "ToT Child Altar Hint": "is_child",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1086,6 +1086,10 @@
         "region_name": "Temple of Time",
         "scene": "Temple of Time",
         "hint": "TEMPLE_OF_TIME",
+        "events": {
+            # used for the "path of time" goal
+            "Temple of Time Access": "True"
+        },
         "locations": {
             "ToT Light Arrows Cutscene": "is_adult and can_trigger_lacs",
             "ToT Child Altar Hint": "is_child",
@@ -1100,10 +1104,6 @@
         "region_name": "Beyond Door of Time",
         "scene": "Temple of Time",
         "hint": "TEMPLE_OF_TIME",
-        "events": {
-            # used for the "path of time" goal
-            "Temple of Time Access": "True"
-        },
         "locations": {
             "Sheik at Temple": "Forest_Medallion and is_adult",
             "Master Sword Pedestal": "True"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1100,6 +1100,10 @@
         "region_name": "Beyond Door of Time",
         "scene": "Temple of Time",
         "hint": "TEMPLE_OF_TIME",
+        "events": {
+            # used for the "path of time" goal
+            "Temple of Time Access": "True"
+        },
         "locations": {
             "Sheik at Temple": "Forest_Medallion and is_adult",
             "Master Sword Pedestal": "True"

--- a/tests/plando/one-hint-per-goal-dungeons.json
+++ b/tests/plando/one-hint-per-goal-dungeons.json
@@ -11,6 +11,7 @@
         "shuffle_child_trade":                     "vanilla",
         "dungeon_shortcuts_choice":                "off",
         "open_forest":                             "closed_deku",
+        "open_door_of_time":                       true,
         "shuffle_kokiri_sword":                    true,
         "shuffle_ocarinas":                        true,
         "shuffle_song_items":                      "song",

--- a/tests/plando/one-hint-per-goal-hearts.json
+++ b/tests/plando/one-hint-per-goal-hearts.json
@@ -11,6 +11,7 @@
         "shuffle_child_trade":                     "vanilla",
         "dungeon_shortcuts_choice":                "off",
         "open_forest":                             "closed_deku",
+        "open_door_of_time":                       true,
         "shuffle_kokiri_sword":                    true,
         "shuffle_ocarinas":                        true,
         "shuffle_song_items":                      "song",

--- a/tests/plando/one-hint-per-goal-medallions.json
+++ b/tests/plando/one-hint-per-goal-medallions.json
@@ -11,6 +11,7 @@
         "shuffle_child_trade":                     "vanilla",
         "dungeon_shortcuts_choice":                "off",
         "open_forest":                             "closed_deku",
+        "open_door_of_time":                       true,
         "shuffle_kokiri_sword":                    true,
         "shuffle_ocarinas":                        true,
         "shuffle_song_items":                      "song",

--- a/tests/plando/one-hint-per-goal-skulls.json
+++ b/tests/plando/one-hint-per-goal-skulls.json
@@ -11,6 +11,7 @@
         "shuffle_child_trade":                     "vanilla",
         "dungeon_shortcuts_choice":                "off",
         "open_forest":                             "closed_deku",
+        "open_door_of_time":                       true,
         "shuffle_kokiri_sword":                    true,
         "shuffle_ocarinas":                        true,
         "shuffle_song_items":                      "song",

--- a/tests/plando/one-hint-per-goal-stones.json
+++ b/tests/plando/one-hint-per-goal-stones.json
@@ -11,6 +11,7 @@
         "shuffle_child_trade":                     "vanilla",
         "dungeon_shortcuts_choice":                "off",
         "open_forest":                             "closed_deku",
+        "open_door_of_time":                       true,
         "shuffle_kokiri_sword":                    true,
         "shuffle_ocarinas":                        true,
         "shuffle_song_items":                      "song",

--- a/tests/plando/one-hint-per-goal-triforce-hunt.json
+++ b/tests/plando/one-hint-per-goal-triforce-hunt.json
@@ -12,6 +12,7 @@
         "shuffle_child_trade":                     "vanilla",
         "dungeon_shortcuts_choice":                "off",
         "open_forest":                             "closed_deku",
+        "open_door_of_time":                       true,
         "shuffle_kokiri_sword":                    true,
         "shuffle_ocarinas":                        true,
         "shuffle_song_items":                      "song",


### PR DESCRIPTION
This goal category only appears in non-Triforce-hunt child-start seeds and hints access to the Time Travel event as “path of time”. In closed-DoT seeds, it also includes ocarinas (if shuffled) and Song of Time in the goal. The intent is to fix hints on other paths pointing to items that actually just lock the DoT. Having this goal also ensures that in AGR, all shuffled ocarinas (and both Songs of Time in plentiful song shuffle) will be reachable without going adult.

I generated a couple 3-world AGR seeds with goal hints to test the performance and they took between 25 and 35 seconds to generate.