### PR TITLE
Ganon Tower Shuffle

### DIFF
--- a/DungeonList.py
+++ b/DungeonList.py
@@ -1,3 +1,4 @@
+'''test'''
 import random
 import os
 

--- a/DungeonList.py
+++ b/DungeonList.py
@@ -1,4 +1,3 @@
-'''test'''
 import random
 import os
 

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -99,6 +99,8 @@ entrance_shuffle_table = [
                         ('Ice Cavern Beginning -> ZF Ice Ledge',                            { 'index': 0x03D4 })),
     ('Dungeon',         ('Gerudo Fortress -> Gerudo Training Ground Lobby',                 { 'index': 0x0008 }),
                         ('Gerudo Training Ground Lobby -> Gerudo Fortress',                 { 'index': 0x03A8 })),
+    ('DungeonSpecial',  ('Ganons Castle Grounds -> Ganons Castle Lobby',                    { 'index': 0x0467 }),
+                        ('Ganons Castle Lobby -> Castle Grounds',                    		{ 'index': 0x023D })),
 
     ('Interior',        ('Kokiri Forest -> KF Midos House',                                 { 'index': 0x0433 }),
                         ('KF Midos House -> Kokiri Forest',                                 { 'index': 0x0443 })),
@@ -403,6 +405,8 @@ def shuffle_random_entrances(worlds):
             # not really a closed forest anymore, so specifically remove Deku Tree from closed forest.
             if worlds[0].settings.open_forest == 'closed':
                 entrance_pools['Dungeon'].remove(world.get_entrance('KF Outside Deku Tree -> Deku Tree Lobby'))
+            if worlds[0].shuffle_special_dungeon_entrances:
+                entrance_pools['Dungeon'] += world.get_shufflable_entrances(type='DungeonSpecial', only_primary=True)
 
         if worlds[0].shuffle_interior_entrances:
             entrance_pools['Interior'] = world.get_shufflable_entrances(type='Interior', only_primary=True)
@@ -708,7 +712,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
     # This means we need to hard check that none of the relevant entrances are ever reachable as that age
     # This is mostly relevant when shuffling special interiors (such as windmill or kak potion shop)
     # Warp Songs and Overworld Spawns can also end up inside certain indoors so those need to be handled as well
-    CHILD_FORBIDDEN = ['OGC Great Fairy Fountain -> Castle Grounds', 'GV Carpenter Tent -> GV Fortress Side']
+    CHILD_FORBIDDEN = ['OGC Great Fairy Fountain -> Castle Grounds', 'GV Carpenter Tent -> GV Fortress Side', 'Ganons Castle Lobby -> Castle Grounds']
     ADULT_FORBIDDEN = ['HC Great Fairy Fountain -> Castle Grounds', 'HC Storms Grotto -> Castle Grounds']
 
     for entrance in world.get_shufflable_entrances():

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -398,7 +398,7 @@ def shuffle_random_entrances(worlds):
                 if not worlds[0].settings.shuffle_dungeon_entrances and not worlds[0].settings.shuffle_overworld_entrances:
                     one_way_priorities['Requiem'] = priority_entrance_table['Requiem']
 
-        if worlds[0].settings.shuffle_dungeon_entrances:
+        if worlds[0].shuffle_dungeon_entrances:
             entrance_pools['Dungeon'] = world.get_shufflable_entrances(type='Dungeon', only_primary=True)
             # The fill algorithm will already make sure gohma is reachable, however it can end up putting
             # a forest escape via the hands of spirit on Deku leading to Deku on spirit in logic. This is

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2731,21 +2731,33 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
     ),
-    Checkbutton(
+    Combobox(
         name           = 'shuffle_dungeon_entrances',
         gui_text       = 'Shuffle Dungeon Entrances',
+		default		   = 'off',
+		choices		   = {
+			'off':		 'Off',
+			'simple':	 'Dungeon',
+			'all':		 'Dungeon and Ganon',
+		},
         gui_tooltip    = '''\
-            Shuffle the pool of dungeon entrances, including Bottom 
-            of the Well, Ice Cavern, and Gerudo Training Ground.
-            However, Ganon's Castle and Thieves' Hideout are not shuffled.
-
+            Dungeon Shuffle will the pool of dungeon entrances, including 
+			Bottom of the Well, Ice Cavern, and Gerudo Training Ground.
+            
+			With Dungeon and Ganon selected, all dungeon's including Ganons
+			castle will be shuffled.
+			
             Additionally, the entrances of Deku Tree, Fire Temple and 
             Bottom of the Well are opened for both adult and child.
         ''',
-        default        = False,
         shared         = True,
         gui_params     = {
             'randomize_key': 'randomize_settings',
+			'distribution': [
+				('off', 2),
+				('simple', 1),
+				('all', 1),
+			]
         },
     ),
     Checkbutton(

--- a/World.py
+++ b/World.py
@@ -61,7 +61,7 @@ class World(object):
         self.shuffle_special_dungeon_entrances = settings.shuffle_dungeon_entrances == 'all'
         self.shuffle_dungeon_entrances = settings.shuffle_dungeon_entrances in ['simple', 'all']
 
-        self.entrance_shuffle = self.shuffle_interior_entrances or settings.shuffle_grotto_entrances or settings.shuffle_dungeon_entrances or \
+        self.entrance_shuffle = self.shuffle_interior_entrances or settings.shuffle_grotto_entrances or self.shuffle_dungeon_entrances or \
                                 settings.shuffle_overworld_entrances or settings.owl_drops or settings.warp_songs or settings.spawn_positions
 
         self.ensure_tod_access = self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.spawn_positions

--- a/World.py
+++ b/World.py
@@ -58,6 +58,9 @@ class World(object):
         self.shuffle_special_interior_entrances = settings.shuffle_interior_entrances == 'all'
         self.shuffle_interior_entrances = settings.shuffle_interior_entrances in ['simple', 'all']
 
+        self.shuffle_special_dungeon_entrances = settings.shuffle_dungeon_entrances == 'all'
+        self.shuffle_dungeon_entrances = settings.shuffle_dungeon_entrances in ['simple', 'all']
+
         self.entrance_shuffle = self.shuffle_interior_entrances or settings.shuffle_grotto_entrances or settings.shuffle_dungeon_entrances or \
                                 settings.shuffle_overworld_entrances or settings.owl_drops or settings.warp_songs or settings.spawn_positions
 

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -4,11 +4,11 @@
         "dungeon": "Ganons Castle",
         "exits": {
             "Castle Grounds": "True",
-            "Ganons Castle Forest Trial": "True",
-            "Ganons Castle Fire Trial": "True",
-            "Ganons Castle Water Trial": "True",
-            "Ganons Castle Shadow Trial": "True",
-            "Ganons Castle Spirit Trial": "True",
+            "Ganons Castle Forest Trial": "is_adult or (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang))",
+            "Ganons Castle Fire Trial": "is_adult or (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang))",
+            "Ganons Castle Water Trial": "is_adult or (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang))",
+            "Ganons Castle Shadow Trial": "is_adult or (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang))",
+            "Ganons Castle Spirit Trial": "is_adult or (Kokiri_Sword and (Sticks or has_explosives or Nuts or Boomerang))",
             "Ganons Castle Light Trial": "can_use(Golden_Gauntlets)",
             "Ganons Castle Tower": "
                 (skipped_trials[Forest] or 'Forest Trial Clear') and 
@@ -24,11 +24,11 @@
         "region_name": "Ganons Castle Deku Scrubs",
         "dungeon": "Ganons Castle",
         "locations": {
-            "Ganons Castle MQ Deku Scrub Center-Left": "True",
-            "Ganons Castle MQ Deku Scrub Center": "True",
-            "Ganons Castle MQ Deku Scrub Center-Right": "True",
-            "Ganons Castle MQ Deku Scrub Left": "True",
-            "Ganons Castle MQ Deku Scrub Right": "True",
+            "Ganons Castle MQ Deku Scrub Center-Left": "can_stun_deku",
+            "Ganons Castle MQ Deku Scrub Center": "can_stun_deku",
+            "Ganons Castle MQ Deku Scrub Center-Right": "can_stun_deku",
+            "Ganons Castle MQ Deku Scrub Left": "can_stun_deku",
+            "Ganons Castle MQ Deku Scrub Right": "can_stun_deku",
             "Free Fairies": "has_bottle"
         }
     },
@@ -39,9 +39,9 @@
             "Forest Trial Clear": "can_use(Light_Arrows) and can_play(Song_of_Time)"
         },
         "locations": {
-            "Ganons Castle MQ Forest Trial Eye Switch Chest": "Bow",
+            "Ganons Castle MQ Forest Trial Eye Switch Chest": "Bow or Slingshot",
             "Ganons Castle MQ Forest Trial Frozen Eye Switch Chest": "has_fire_source",
-            "Ganons Castle MQ Forest Trial Freestanding Key": "Progressive_Hookshot"
+            "Ganons Castle MQ Forest Trial Freestanding Key": "Progressive_Hookshot or Boomerang"
         }
     },
     {

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -24,10 +24,10 @@
         "region_name": "Ganons Castle Deku Scrubs",
         "dungeon": "Ganons Castle",
         "locations": {
-            "Ganons Castle Deku Scrub Center-Left": "True",
-            "Ganons Castle Deku Scrub Center-Right": "True",
-            "Ganons Castle Deku Scrub Right": "True",
-            "Ganons Castle Deku Scrub Left": "True",
+            "Ganons Castle Deku Scrub Center-Left": "can_stun_deku",
+            "Ganons Castle Deku Scrub Center-Right": "can_stun_deku",
+            "Ganons Castle Deku Scrub Right": "can_stun_deku",
+            "Ganons Castle Deku Scrub Left": "can_stun_deku",
             "Free Fairies": "has_bottle"
         }
     },
@@ -38,7 +38,8 @@
             "Forest Trial Clear": "can_use(Light_Arrows) and (Fire_Arrows or Dins_Fire)"
         },
         "locations": {
-            "Ganons Castle Forest Trial Chest": "True"
+            "Ganons Castle Forest Trial Chest": "is_adult or Slingshot or Sticks or 
+                Kokiri_Sword or can_use(Dins_Fire)"
         }
     },
     {
@@ -75,7 +76,7 @@
         "locations": {
             "Ganons Castle Shadow Trial Front Chest": "
                 can_use(Fire_Arrows) or Progressive_Hookshot or 
-                Hover_Boots or can_play(Song_of_Time)",
+                Hover_Boots or can_play(Song_of_Time) or is_child",
             "Ganons Castle Shadow Trial Golden Gauntlets Chest": "
                 can_use(Fire_Arrows) or 
                 (can_use(Longshot) and (Hover_Boots or can_use(Dins_Fire)))"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1868,7 +1868,7 @@
         "region_name": "Ganons Castle Tower",
         "dungeon": "Ganons Castle",
         "locations": {
-            "Ganons Tower Boss Key Chest": "True",
+            "Ganons Tower Boss Key Chest": "is_adult or Kokiri_Sword",
             "Ganondorf Hint": "Boss_Key_Ganons_Castle",
             "Ganon": "Boss_Key_Ganons_Castle and can_use(Light_Arrows)"
         }


### PR DESCRIPTION
Added a new option to Dungeon ER to allow for shuffling Ganon's Tower which would change a win condition.  The version of this code is for main branch w/o mixed pools however, I also have an updated branch with considerations for mixed pools and decoupled.