### PR TITLE
Make Ganon Boss Key anywhere pedestal hint a little clearer

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -1281,7 +1281,7 @@ hintTable = {
     'ganonBK_vanilla':                                          ("kept in a big chest #inside its tower#", None, 'ganonBossKey'),
     'ganonBK_overworld':                                        ("hidden #outside of dungeons# in Hyrule", None, 'ganonBossKey'),
     'ganonBK_any_dungeon':                                      ("hidden #inside a dungeon# in Hyrule", None, 'ganonBossKey'),
-    'ganonBK_keysanity':                                        ("hidden somewhere #in Hyrule#", None, 'ganonBossKey'),
+    'ganonBK_keysanity':                                        ("hidden #anywhere in Hyrule#", None, 'ganonBossKey'),
     'ganonBK_triforce':                                         ("given to the Hero once the #Triforce# is completed", None, 'ganonBossKey'),
     'ganonBK_medallions':                                       ("Medallions", None, 'ganonBossKey'),
     'ganonBK_stones':                                           ("Spiritual Stones", None, 'ganonBossKey'),


### PR DESCRIPTION
The current Ganon Boss Key pedestal hint is a little unclear if you do not know the full list of options. This changes the full keysanity hint to be a little clearer that it can be anywhere. Too often is the previous hint read as overworld keysanity.