### PR TITLE
Add missing hint area font colors to Market Entrance and ToT Entrance

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -704,6 +704,7 @@
     },
     {
         "region_name": "Market Entrance",
+        "font_color": "Light Blue",
         "scene": "Market Entrance",
         "hint": "the Market",
         "exits": {
@@ -744,6 +745,7 @@
     },
     {
         "region_name": "ToT Entrance",
+        "font_color": "Light Blue",
         "scene": "ToT Entrance",
         "hint": "the Market",
         "locations": {


### PR DESCRIPTION
These regions are both part of “the Market” hint area, which means their warp song text should be light blue, but I missed them in #1428.