### PR TITLE
Fix starting_hearts set to 20 only starting with 19 hearts

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1,6 +1,6 @@
 import itertools
 import json
-import logging
+import math
 import re
 import random
 
@@ -1132,18 +1132,16 @@ class Distribution(object):
         # add hearts
         if self.settings.starting_hearts > 3:
             num_hearts_to_collect = self.settings.starting_hearts - 3
-            if num_hearts_to_collect % 2 == 1:
-                data['Piece of Heart'].count += 4
-                num_hearts_to_collect -= 1
-            for i in range(0, num_hearts_to_collect, 2):
-                data['Piece of Heart'].count += 4
-                data['Heart Container'].count += 1
-            if self.settings.starting_hearts >= 20:
-                data['Piece of Heart'].count -= 1
-                data['Piece of Heart (Treasure Chest Game)'].count += 1
             if self.settings.item_pool_value == 'plentiful':
-                data['Heart Container'].count += data['Piece of Heart'].count // 4
-                data['Piece of Heart'].count = data['Piece of Heart'].count % 4
+                if self.settings.starting_hearts >= 20:
+                    num_hearts_to_collect -= 1
+                    data['Piece of Heart'].count += 4
+                data['Heart Container'].count += num_hearts_to_collect
+            else:
+                # evenly split the difference between heart pieces and heart containers removed from the pool,
+                # removing an extra 4 pieces in case of an odd number since there's 9*4 of them but only 8 containers
+                data['Piece of Heart'].count += 4 * math.ceil(num_hearts_to_collect / 2)
+                data['Heart Container'].count += math.floor(num_hearts_to_collect / 2)
 
         return data
 


### PR DESCRIPTION
This bug was introduced in #1515 as a side effect of a change intended to keep the winner heart piece around even in plentiful and/or when starting with 20 hearts. I've rewritten the section of code that handles the `starting_hearts` to more directly state the intent.

A side effect of this implementation is that the 3 regular heart pieces in plentiful remain in the item pool for `starting_hearts` values of up to 19. I think this is fine because this way you don't end up with an odd number of heart pieces in the pool.