### PR TITLE
Fix winner heart piece text in multiworld

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -248,6 +248,10 @@ ITEM_MESSAGES = {
     0x00F1: "\x08You got a \x05\x45Purple Rupee\x05\x40!\x01That's \x05\x45fifty Rupees\x05\x40!",
     0x00F2: "\x08You got a \x05\x46Huge Rupee\x05\x40!\x01This Rupee is worth a whopping\x01\x05\x46two hundred Rupees\x05\x40!",
     0x00F9: "\x08\x13\x1EYou put a \x05\x41Big Poe \x05\x40in a bottle!\x01Let's sell it at the \x05\x41Ghost Shop\x05\x40!\x01Something good might happen!",
+    0x00FA: "\x08\x06\x49\x05\x41WINNER\x05\x40!\x04\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01Collect four pieces total to get\x01another Heart Container.",
+    0x00FB: "\x08\x06\x49\x05\x41WINNER\x05\x40!\x04\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01So far, you've collected two \x01pieces.",
+    0x00FC: "\x08\x06\x49\x05\x41WINNER\x05\x40!\x04\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01Now you've collected three \x01pieces!",
+    0x00FD: "\x08\x06\x49\x05\x41WINNER\x05\x40!\x04\x13\x73You got a \x05\x41Piece of Heart\x05\x40!\x01You've completed another Heart\x01Container!",
     0x9003: "\x08You found a piece of the \x05\x41Triforce\x05\x40!",
 }
 


### PR DESCRIPTION
The function `Messages.make_player_message` is called in multiworld seeds to replace the first “You” in each item get text box with the appropriate player name. Previously, the vanilla text boxes for the treasure chest game heart piece were used, so this function never ran on them. This PR fixes that by adding custom text boxes for it (with text equivalent to that for regular heart pieces, plus the “WINNER!” page).