### PR TITLE
Fix egregious logic error

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -927,7 +927,7 @@ logic_tricks = {
         'name'    : 'logic_shadow_bongo_ice',
         'tags'    : ("Shadow Temple",),
         'tooltip' : '''\
-	            Bongo Bongo can technically be defeated without first freezing
+                    Bongo Bongo can technically be defeated without first freezing
                     him with the Ice Arrows, but it's basically impossible.
                     '''},
     'Shadow Temple Bongo Bongo with Nothing': {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -928,7 +928,7 @@ logic_tricks = {
         'tags'    : ("Shadow Temple",),
         'tooltip' : '''\
 	            Bongo Bongo can technically be defeated without first freezing
-		    him with the Ice Arrows, but it's basically impossible.
+                    him with the Ice Arrows, but it's basically impossible.
                     '''},
     'Shadow Temple Bongo Bongo with Nothing': {
         'name'    : 'logic_shadow_bongo',
@@ -937,7 +937,7 @@ logic_tricks = {
                     If Shadow Temple dungeon shortcuts are enabled, 
                     Bongo Bongo can be fought without projectiles
                     using precise sword slashes. This trick supersedes
-		    "Shadow Temple Bongo Bongo without Ice Arrows".
+                    "Shadow Temple Bongo Bongo without Ice Arrows".
                     '''},
     'Stop Link the Goron with Din\'s Fire': {
         'name'    : 'logic_link_goron_dins',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -923,13 +923,21 @@ logic_tricks = {
                     needing a Bow.
                     Applies in both vanilla and MQ Shadow.
                     '''},
+    'Shadow Temple Bongo Bongo without Ice Arrows': {
+        'name'    : 'logic_shadow_bongo_ice',
+        'tags'    : ("Shadow Temple",),
+        'tooltip' : '''\
+	            Bongo Bongo can technically be defeated without first freezing
+		    him with the Ice Arrows, but it's basically impossible.
+                    '''},
     'Shadow Temple Bongo Bongo with Nothing': {
         'name'    : 'logic_shadow_bongo',
         'tags'    : ("Shadow Temple",),
         'tooltip' : '''\
                     If Shadow Temple dungeon shortcuts are enabled, 
                     Bongo Bongo can be fought without projectiles
-                    using precise sword slashes.
+                    using precise sword slashes. This trick supersedes
+		    "Shadow Temple Bongo Bongo without Ice Arrows".
                     '''},
     'Stop Link the Goron with Din\'s Fire': {
         'name'    : 'logic_link_goron_dins',

--- a/World.py
+++ b/World.py
@@ -1025,7 +1025,6 @@ class World(object):
         # these are items that can never be required but are still considered major items
         exclude_item_list = [
             'Double Defense',
-            'Ice Arrows',
         ]
         if (self.settings.damage_multiplier != 'ohko' and self.settings.damage_multiplier != 'quadruple' and 
             self.settings.shuffle_scrubs == 'off' and not self.settings.shuffle_grotto_entrances):

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -72,7 +72,7 @@
     "_is_magic_item(item)": "item == Dins_Fire or item == Farores_Wind or item == Nayrus_Love or item == Lens_of_Truth",
     "_is_adult_item(item)": "item == Bow or item == Megaton_Hammer or item == Iron_Boots or item == Hover_Boots or item == Hookshot or item == Longshot or item == Silver_Gauntlets or item == Golden_Gauntlets or item == Goron_Tunic or item == Zora_Tunic or item == Scarecrow or item == Distant_Scarecrow or item == Mirror_Shield",
     "_is_child_item(item)": "item == Slingshot or item == Boomerang or item == Kokiri_Sword or item == Sticks or item == Deku_Shield",
-    "_is_magic_arrow(item)": "item == Fire_Arrows or item == Light_Arrows",
+    "_is_magic_arrow(item)": "item == Fire_Arrows or item == Ice_Arrows or item == Light_Arrows",
 
     # Biggoron's trade path
     # ER with certain settings disables timers and prevents items from reverting on save warp.

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -179,9 +179,11 @@
         "dungeon": "Shadow Temple",
         "locations": {
             "Shadow Temple Bongo Bongo Heart": "
-                Boss_Key_Shadow_Temple and (logic_shadow_bongo or Bow or Hookshot)",
+                Boss_Key_Shadow_Temple and
+                (logic_shadow_bongo or (can_use(Ice_Arrows) or (logic_shadow_bongo_ice and (Bow or Hookshot))))",
             "Bongo Bongo": "
-                Boss_Key_Shadow_Temple and (logic_shadow_bongo or Bow or Hookshot)",
+                Boss_Key_Shadow_Temple and
+                (logic_shadow_bongo or (can_use(Ice_Arrows) or (logic_shadow_bongo_ice and (Bow or Hookshot))))",
             "Shadow Temple MQ GS Near Boss": "has_projectile(adult) or can_use(Dins_Fire)"
         }
     }

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -132,8 +132,10 @@
         "region_name": "Shadow Temple Boss Room",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Bongo Bongo Heart": "logic_shadow_bongo or Bow or Hookshot",
-            "Bongo Bongo": "logic_shadow_bongo or Bow or Hookshot"
+            "Shadow Temple Bongo Bongo Heart": "
+                logic_shadow_bongo or (can_use(Ice_Arrows) or (logic_shadow_bongo_ice and (Bow or Hookshot)))",
+            "Bongo Bongo": "
+                logic_shadow_bongo or (can_use(Ice_Arrows) or (logic_shadow_bongo_ice and (Bow or Hookshot)))"
         }
     }
 ]


### PR DESCRIPTION
Bongo used to not required the Ice Arrows, which honestly is just unfair, so now it's finally a trick.
This also means Ice Arrows is no longer able to be foolish.

Note: Made no effort to test whether or not this actually works.