### PR TITLE
Validate MultipleSelect settings are arrays before applying in GUI.

### DIFF
--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -715,6 +715,10 @@ export class GUIGlobal {
               this.verifyNumericSetting(settingsObj, setting, false);
               this.generator_settingsMap[setting.name] = settingsObj[setting.name];
             }
+            else if (setting.type == "MultipleSelect") { //Validate list types before applying them
+              if (Array.isArray(settingsObj[setting.name]))
+                this.generator_settingsMap[setting.name] = settingsObj[setting.name];
+            }
             else { //Everything else
               this.generator_settingsMap[setting.name] = settingsObj[setting.name];
             }

--- a/Settings.py
+++ b/Settings.py
@@ -100,10 +100,6 @@ class Settings:
                 i_bits = [1 if digit=='1' else 0 for digit in bin(value)[2:]]
                 i_bits.reverse()
             if setting.type == list:
-                if not isinstance(value, (list, tuple, set)):
-                    # If the setting type is list but the value of the setting is not, use an empty list.
-                    # TODO: Add sanity checks for 'MultipleSelect' in the GUI function 'applySettingsObject'.
-                    value = []
                 if len(value) > len(setting.choice_list) / 2:
                     value = [item for item in setting.choice_list if item not in value]
                     terminal = [1] * setting.bitwidth

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-__version__ = '6.2.71 f.LUM'
+__version__ = '6.2.72 f.LUM'


### PR DESCRIPTION
This prevents the GUI from silently setting MultipleSelects to value that isn't a collection in cases of old/broken setting saves and presets.

This reverts commit f06d58d37bb278eb91cbf7f0587a83f272aceda0, which is no longer necessary.