### PR TITLE
Put Bean into base logic for the ZR Lower PoH

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1711,7 +1711,7 @@
                 can_play(Song_of_Time) and can_play(Song_of_Storms)",
             "ZR Frogs in the Rain": "is_child and can_play(Song_of_Storms)",
             "ZR Near Open Grotto Freestanding PoH": "
-                is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_lower)",
+                is_child or (is_adult and (plant_beans or Hover_Boots or logic_zora_river_lower))",
             "ZR Near Domain Freestanding PoH": "
                 is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_upper)",
             "ZR GS Ladder": "is_child and at_night and can_child_attack",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1723,7 +1723,7 @@
             "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Butterfly Fairy": "can_use(Sticks) and has_bottle",
             "Bug Shrub": "
-                (is_child or is_adult and (plant_beans or Hover_Boots or logic_zora_river_lower)) and
+                (is_child or (is_adult and (plant_beans or Hover_Boots or logic_zora_river_lower))) and
                 can_cut_shrubs and has_bottle"
         },
         "exits": {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1723,7 +1723,7 @@
             "Bean Plant Fairy": "can_plant_bean and can_play(Song_of_Storms) and has_bottle",
             "Butterfly Fairy": "can_use(Sticks) and has_bottle",
             "Bug Shrub": "
-                (is_child or can_use(Hover_Boots) or (is_adult and logic_zora_river_lower)) and
+                (is_child or is_adult and (plant_beans or Hover_Boots or logic_zora_river_lower)) and
                 can_cut_shrubs and has_bottle"
         },
         "exits": {


### PR DESCRIPTION
This PR adds the magic bean at ZR into base logic for the lower PoH, if the new "Plant Beans" setting is enabled. You can download a video showing how to do the jump here (it doesn't need a Discord login): https://cdn.discordapp.com/attachments/438697911753113600/963019355975721010/THE_LEGEND_OF_ZELDA_-_Project64_2.4.0.1688-ge230133_2022-04-11_12-13-16.mp4

I reopened PR #1549 due to an unexpected error. For some reason the old PR used AmazingAmpharos's Fork (2018).