### PR TITLE
Remove references to “sanity” in setting display names

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -161,7 +161,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
         fill_dungeon_unique_item(window, worlds, search, fill_locations, progitempool)
         search.collect_locations()
 
-    # Place all progression items. This will include keys in keysanity.
+    # Place all progression items from the main item pool.
     # Items in this group will check for reachability and will be placed
     # such that the game is guaranteed beatable.
     logger.info('Placing progression items.')

--- a/Messages.py
+++ b/Messages.py
@@ -885,7 +885,6 @@ def update_item_messages(messages, world):
         update_message_by_id(messages, id, text, opt)
 
 
-# run all keysanity related patching to add messages for dungeon specific items
 def add_item_messages(messages, shop_items, world):
     move_shop_item_messages(messages, shop_items)
     update_item_messages(messages, world)

--- a/Patches.py
+++ b/Patches.py
@@ -1962,14 +1962,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     repack_messages(rom, messages, permutation)
 
-    # output a text dump, for testing...
-    #with open('keysanity_' + str(world.settings.seed) + '_dump.txt', 'w', encoding='utf-16') as f:
-    #     messages = read_messages(rom)
-    #     f.write('item_message_strings = {\n')
-    #     for m in messages:
-    #        f.write("\t0x%04X: \"%s\",\n" % (m.id, m.get_python_string()))
-    #     f.write('}\n')
-
     if world.settings.free_scarecrow:
         # Played song as adult
         save_context.write_bits(0x0EE6, 0x10)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3193,7 +3193,7 @@ setting_infos = [
     ),
     Combobox(
         name           = 'shopsanity',
-        gui_text       = 'Shopsanity',
+        gui_text       = 'Shuffle Shops',
         default        = 'off',
         choices        = {
             'off':    'Off',
@@ -3247,7 +3247,7 @@ setting_infos = [
     ),
     Combobox(
         name           = 'shopsanity_prices',
-        gui_text       = 'Shopsanity Prices',
+        gui_text       = 'Special Deal Prices',
         default        = 'random',
         choices        = {
             'random':          'Random',
@@ -3260,19 +3260,19 @@ setting_infos = [
         disable        = {
         },
         gui_tooltip    = '''\
-            Controls the randomization of prices for shopsanity items.
-            For more control, utilize the plandomizer.
+            Controls the randomization of prices for Special Deal
+            items in shops. For more control, utilize the plandomizer.
 
             'Random': The default randomization. Shop prices for
-            shopsanity items will range between 0 to 300 rupees,
+            Special Deals will range between 0 to 300 rupees,
             with a bias towards values slightly below the middle of the
             range, in multiples of 5.
 
-            'X Wallet': Shop prices for shopsanity items will range
+            'X Wallet': Shop prices for Special Deals will range
             between 0 and the specified wallet's maximum capacity,
             in multiples of 5.
 
-            'Affordable': Shop prices for shopsanity items will be
+            'Affordable': Shop prices for Special Deals will be
             fixed to 10 rupees.
         ''',
         disabled_default =  'random',
@@ -3283,7 +3283,7 @@ setting_infos = [
     ),
     Combobox(
         name           = 'tokensanity',
-        gui_text       = 'Tokensanity',
+        gui_text       = 'Shuffle Gold Skulltula Tokens',
         default        = 'off',
         choices        = {
             'off':       'Off',
@@ -4150,8 +4150,8 @@ setting_infos = [
             to beat the board. Goals which are completed simply
             by finding a specific item are not hinted
             (e.g. "Boomerang"). 
-            In addition, overworld tokensanity will always
-            hint the location of Sun's Song, and shopsanity
+            In addition, overworld token shuffle will always
+            hint the location of Sun's Song, and shop shuffle
             will always hint the location of a wallet.
 
             Leaving this entry blank or providing an


### PR DESCRIPTION
As discussed today in #rsl-discussion, these names can be confusing for newcomers, since the “in-” prefix is truncated. I have replaced them with more descriptive names:

* “Shopsanity” becomes “Shuffle Shops”
* “Shopsanity Prices” becomes “Special Deal Prices”
* “Tokensanity” becomes “Shuffle Gold Skulltula Tokens”

While I was in there, I also updated some outdated code comments and removed a commented-out block of code.

An open question is whether the internal names should be changed as well.