### PR TITLE
Disable shopsanity_prices setting when shopsanity is set to 0

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3206,6 +3206,7 @@ setting_infos = [
         },
         disable        = {
             'off':  {'settings': ['shopsanity_prices']},
+            '0':    {'settings': ['shopsanity_prices']},
         },
         gui_tooltip    = '''\
             Randomizes Shop contents.


### PR DESCRIPTION
The `shopsanity_prices` setting only affects special deals, so it doesn't do anything in shopsanity 0. For clarity, it should be disabled like for shopsanity off.