### PR TITLE
Fix King Dodongo shortcut behavior

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -482,7 +482,7 @@ def get_pool_core(world):
             world.state.collect(ItemFactory('Small Key (Spirit Temple)'))
             world.state.collect(ItemFactory('Small Key (Spirit Temple)'))
             world.state.collect(ItemFactory('Small Key (Spirit Temple)'))
-        if 'shadow_temple' in world.settings.dungeon_shortcuts:
+        if 'Shadow Temple' in world.settings.dungeon_shortcuts:
             # Reverse Shadow is broken with vanilla keys in both vanilla/MQ
             world.state.collect(ItemFactory('Small Key (Shadow Temple)'))
             world.state.collect(ItemFactory('Small Key (Shadow Temple)'))

--- a/Patches.py
+++ b/Patches.py
@@ -993,17 +993,17 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     save_context = SaveContext()
 
     # Initial Save Data
-    if not world.settings.useful_cutscenes and 'forest_temple' not in world.settings.dungeon_shortcuts:
+    if not world.settings.useful_cutscenes and 'Forest Temple' not in world.settings.dungeon_shortcuts:
         save_context.write_bits(0x00D4 + 0x03 * 0x1C + 0x04 + 0x0, 0x08) # Forest Temple switch flag (Poe Sisters cutscene)
 
-    if 'deku_tree' in world.settings.dungeon_shortcuts:
+    if 'Deku Tree' in world.settings.dungeon_shortcuts:
         # Deku Tree, flags are the same between vanilla/MQ
         save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x1, 0x01) # Deku Block down
         save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.CLEAR,  0x2, 0x02) # Deku 231/312
         save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x3, 0x20) # Deku 1st Web
         save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x3, 0x40) # Deku 2nd Web
 
-    if 'dodongos_cavern' in world.settings.dungeon_shortcuts:
+    if 'Dodongos Cavern' in world.settings.dungeon_shortcuts:
         # Dodongo's Cavern, flags are the same between vanilla/MQ
         save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x3, 0x80) # DC Entrance Mud Wall
         save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x04) # DC Mouth
@@ -1012,7 +1012,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         if world.dungeon_mq['Dodongos Cavern']:
             save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x02) # Armos wall switch
 
-    if 'jabu_jabus_belly' in world.settings.dungeon_shortcuts:
+    if 'Jabu Jabus Belly' in world.settings.dungeon_shortcuts:
         # Jabu
         if not world.dungeon_mq['Jabu Jabus Belly']:
             save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x0, 0x20) # Jabu Pathway down
@@ -1023,16 +1023,16 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x2, 0x08) # Jabu Red Slimy Thing not in front of boss lobby
             save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x1, 0x10) # Jabu Boss Door Switch Activated
         
-    if 'forest_temple' in world.settings.dungeon_shortcuts:
+    if 'Forest Temple' in world.settings.dungeon_shortcuts:
         # Forest, flags are the same between vanilla/MQ
         save_context.write_permanent_flag(Scenes.FOREST_TEMPLE, FlagType.SWITCH, 0x0, 0x10) # Forest Elevator up
         save_context.write_permanent_flag(Scenes.FOREST_TEMPLE, FlagType.SWITCH, 0x1, 0x01 + 0x02 + 0x04) # Forest Basement Puzzle Done
 
-    if 'fire_temple' in world.settings.dungeon_shortcuts:
+    if 'Fire Temple' in world.settings.dungeon_shortcuts:
         # Fire, flags are the same between vanilla/MQ
         save_context.write_permanent_flag(Scenes.FIRE_TEMPLE, FlagType.SWITCH, 0x2, 0x40) # Fire Pillar down
 
-    if 'spirit_temple' in world.settings.dungeon_shortcuts:
+    if 'Spirit Temple' in world.settings.dungeon_shortcuts:
         # Spirit
         if not world.dungeon_mq['Spirit Temple']:
             save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x1, 0x80) # Spirit Chains
@@ -1044,7 +1044,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x1, 0x80) # Spirit Chains
             save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x3, 0x10) # Spirit Face
         
-    if 'shadow_temple' in world.settings.dungeon_shortcuts:
+    if 'Shadow Temple' in world.settings.dungeon_shortcuts:
         # Shadow
         if not world.dungeon_mq['Shadow Temple']:
             save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x08) # Shadow Truthspinner
@@ -1312,7 +1312,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.settings.shuffle_smallkeys == 'vanilla':
         if world.dungeon_mq['Spirit Temple']:
             save_context.addresses['keys']['spirit'].value = 3
-        if 'shadow_temple' in world.settings.dungeon_shortcuts:
+        if 'Shadow Temple' in world.settings.dungeon_shortcuts:
             save_context.addresses['keys']['shadow'].value = 2
 
     if world.settings.start_with_rupees:

--- a/Patches.py
+++ b/Patches.py
@@ -1007,7 +1007,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         # Dodongo's Cavern, flags are the same between vanilla/MQ
         save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x3, 0x80) # DC Entrance Mud Wall
         save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x04) # DC Mouth
-        save_context.write_permanent_flag(Scenes.KING_DODONGO_LOBBY, FlagType.SWITCH, 0x3, 0x02) # DC Boss Floor
         # Extra permanent flag in MQ for the child route
         if world.dungeon_mq['Dodongos Cavern']:
             save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x02) # Armos wall switch
@@ -1057,6 +1056,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.CLEAR,  0x3, 0x40) # Shadow Spinning Blades room Skulltulas defeated
             save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x20) # Shadow Boat Block
             save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x1, 0x01) # Shadow Bird Bridge
+
+    if world.region_has_shortcuts('King Dodongo Boss Room', 'Dodongos Cavern'):
+        save_context.write_permanent_flag(Scenes.KING_DODONGO_LOBBY, FlagType.SWITCH, 0x3, 0x02) # DC Boss Floor
 
     set_spirit_shortcut_actors(rom) # Change elevator starting position to avoid waiting a half cycle from the temple entrance
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2651,7 +2651,7 @@ setting_infos = [
             'Jabu Jabus Belly': "Jabu Jabu's Belly",
             'Forest Temple':    "Forest Temple",
             'Fire Temple':      "Fire Temple",
-            'Water Temple':     "Water Temple",  # doesn't do anything, but added to prevent confusion
+            'Water Temple':     "Water Temple",  # affects King Dodongo if he's in Water
             'Shadow Temple':    "Shadow Temple",
             'Spirit Temple':    "Spirit Temple",
         },

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2614,6 +2614,8 @@ setting_infos = [
             <b>Forest Temple</b>: elevator raised and
             basement gates open
             <b>Fire Temple</b>: pillar knocked down
+            <b>Water Temple</b>: no change, but see the
+            note on "Shuffle Boss Entrances" below
             <b>Shadow Temple</b>: Truthspinner solved, boat
             block moved, and statue bridge moved. You start
             with 2 small keys if Shuffle Small Keys is set
@@ -2621,6 +2623,12 @@ setting_infos = [
             <b>Spirit Temple</b>: lobby elevator activated,
             shortcut silver blocks moved, central room
             platform lowered, and statue face melted
+
+            With "Shuffle Boss Entrances", the floor above
+            King Dodongo's arena is opened based on the
+            shortcut setting for the dungeon that contains
+            the entrance to King Dodongo's boss room, not
+            necessarily Dodongo's Cavern.
 
             Choose: Select dungeons with shortcuts
             All: Enable all dungeons shortcuts

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2638,14 +2638,14 @@ setting_infos = [
         multiple_select = True,
         gui_text        = 'Dungeon Boss Shortcuts',
         choices         = {
-            'deku_tree':        "Deku Tree",
-            'dodongos_cavern':  "Dodongo's Cavern",
-            'jabu_jabus_belly': "Jabu Jabu's Belly",
-            'forest_temple':    "Forest Temple",
-            'fire_temple':      "Fire Temple",
-            'water_temple':     "Water Temple",  # doesn't do anything, but added to prevent confusion
-            'shadow_temple':    "Shadow Temple",
-            'spirit_temple':    "Spirit Temple",
+            'Deku Tree':        "Deku Tree",
+            'Dodongos Cavern':  "Dodongo's Cavern",
+            'Jabu Jabus Belly': "Jabu Jabu's Belly",
+            'Forest Temple':    "Forest Temple",
+            'Fire Temple':      "Fire Temple",
+            'Water Temple':     "Water Temple",  # doesn't do anything, but added to prevent confusion
+            'Shadow Temple':    "Shadow Temple",
+            'Spirit Temple':    "Spirit Temple",
         },
         default        = [],
         gui_params     = {

--- a/State.py
+++ b/State.py
@@ -167,11 +167,7 @@ class State(object):
 
 
     def region_has_shortcuts(self, region_name, fallback_dungeon):
-        region = self.world.get_region(region_name)
-        dungeon_name = (region.dungeon and region.dungeon.name) or fallback_dungeon
-        if not dungeon_name:
-            return False
-        return dungeon_name in self.world.settings.dungeon_shortcuts
+        return self.world.region_has_shortcuts(region_name, fallback_dungeon)
 
 
     def __getstate__(self):

--- a/World.py
+++ b/World.py
@@ -990,6 +990,13 @@ class World(object):
     def reverse_boss_map(self):
         return {y: x for x, y in self.get_boss_map().items()}
 
+    def region_has_shortcuts(self, region_name, fallback_dungeon):
+        region = self.get_region(region_name)
+        dungeon_name = (region.dungeon and region.dungeon.name) or fallback_dungeon
+        if not dungeon_name:
+            return False
+        return dungeon_name in self.settings.dungeon_shortcuts
+
 
     def has_beaten_game(self, state):
         return state.has('Triforce')

--- a/World.py
+++ b/World.py
@@ -354,12 +354,12 @@ class World(object):
             self.randomized_list.append('chicken_count')
         
         # Determine dungeons with shortcuts
+        dungeons = ['Deku Tree', 'Dodongos Cavern', 'Jabu Jabus Belly', 'Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']
         if (self.settings.dungeon_shortcuts_choice == 'random'):
-            dungeons = ['deku_tree', 'dodongos_cavern', 'jabu_jabus_belly', 'forest_temple', 'fire_temple', 'water_temple', 'shadow_temple', 'spirit_temple']
             self.settings.dungeon_shortcuts = random.sample(dungeons, random.randint(0, len(dungeons)))
             self.randomized_list.append('dungeon_shortcuts')
         elif (self.settings.dungeon_shortcuts_choice == 'all'):
-            self.settings.dungeon_shortcuts = ['deku_tree', 'dodongos_cavern', 'jabu_jabus_belly', 'forest_temple', 'fire_temple', 'water_temple', 'shadow_temple', 'spirit_temple']
+            self.settings.dungeon_shortcuts = dungeons
 
         # Handle random Rainbow Bridge condition
         if (self.settings.bridge == 'random'

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -120,12 +120,12 @@
          shuffle_ganon_bosskey != 'dungeons' and shuffle_ganon_bosskey != 'tokens')",
 
     # Dungeon Shortcuts
-    "deku_tree_shortcuts": "'deku_tree' in dungeon_shortcuts",
-    "dodongos_cavern_shortcuts": "'dodongos_cavern' in dungeon_shortcuts",
-    "jabu_shortcuts": "'jabu_jabus_belly' in dungeon_shortcuts",
-    "forest_temple_shortcuts": "'forest_temple' in dungeon_shortcuts",
-    "fire_temple_shortcuts": "'fire_temple' in dungeon_shortcuts",
-    "shadow_temple_shortcuts": "'shadow_temple' in dungeon_shortcuts",
-    "spirit_temple_shortcuts": "'spirit_temple' in dungeon_shortcuts",
+    "deku_tree_shortcuts": "'Deku Tree' in dungeon_shortcuts",
+    "dodongos_cavern_shortcuts": "'Dodongos Cavern' in dungeon_shortcuts",
+    "jabu_shortcuts": "'Jabu Jabus Belly' in dungeon_shortcuts",
+    "forest_temple_shortcuts": "'Forest Temple' in dungeon_shortcuts",
+    "fire_temple_shortcuts": "'Fire Temple' in dungeon_shortcuts",
+    "shadow_temple_shortcuts": "'Shadow Temple' in dungeon_shortcuts",
+    "spirit_temple_shortcuts": "'Spirit Temple' in dungeon_shortcuts",
     "king_dodongo_shortcuts": "region_has_shortcuts('King Dodongo Boss Room', 'Dodongos Cavern')"
 }


### PR DESCRIPTION
The options for the “Dungeon Boss Shortcuts” setting are changed to match the internal dungeon names and the “Key Rings” and “MQ Dungeons” settings. This fixes a logic bug where the `king_dodongo_shortcuts` helper would always evaluate to false.

The patch opening the shortcut in King Dodongo's boss room is changed to be enabled based on the dungeon that has King Dodongo instead of Dodongo's Cavern. This was the intended behavior as the logic was changed from being based on DC to this, but the patch was never adjusted accordingly.

The tooltip for dungeon shortcuts is updated to explain this behavior as well as the reason for the Water Temple option's existence.