### PR TITLE
Fix handling of starting tokens

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -223,7 +223,7 @@ def generate_itempool(world):
     # make sure that there are enough gold skulltulas for bridge/ganon boss key/lacs
     world.available_tokens = placed_items_count.get("Gold Skulltula Token", 0) \
                            + pool.count("Gold Skulltula Token") \
-                           + world.distribution.starting_items.get("Gold Skulltula Token", 0)
+                           + world.distribution.get_starting_item("Gold Skulltula Token")
     if world.max_progressions["Gold Skulltula Token"] > world.available_tokens:
         raise ValueError(f"Not enough available Gold Skulltula Tokens to meet requirements. Available: {world.available_tokens}, Required: {world.max_progressions['Gold Skulltula Token']}.")
 


### PR DESCRIPTION
This fixes a bug that causes seeds with gold skulltula tokens specified in the starting items to fail to generate, because the values in `world.distribution.starting_items` are `Plandomizer.StarterRecord`s, not numbers.