### PR TITLE
Easier Fire Arrow Entry Setting

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1991,6 +1991,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         warp=world.settings.ocarina_songs in ('warp', 'all'),
     )
 
+    # Sets the torch count to open the entrance to Shadow Temple
+    if world.settings.easier_fire_arrow_entry:
+        torch_count = world.settings.fae_torch_count
+        rom.write_byte(0xCA61E3, torch_count)
+
     # actually write the save table to rom
     world.distribution.give_items(world, save_context)
     if world.settings.starting_age == 'adult':

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -5324,6 +5324,35 @@ setting_infos = [
             ]
         }
     ),
+    Checkbutton(
+        name           = 'easier_fire_arrow_entry',
+        gui_text       = 'Easier Fire Arrow Entry',
+        gui_tooltip    = '''\
+            It is possible to open the Shadow Temple entrance
+            by lighting the torches with Fire Arrows, but
+            can be difficult to light all 24 torches in time.
+            Enabling this setting allows you to reduce the
+            number of torches that need to be lit to open
+            the entrance, making it easier to perform
+            Fire Arrow Entry.
+        ''',
+        disable        = {
+            False : {'settings' : ['fae_torch_count']}
+        },
+        shared         = True,
+    ),
+    Scale(
+        name           = 'fae_torch_count',
+        gui_text       = 'FAE Torch Count',
+        default        = 3,
+        min            = 1,
+        max            = 23,
+        gui_tooltip    = '''\
+            The entrance to Shadow Temple will open
+            after the chosen number of torches are lit.
+        ''',
+        shared         = True,
+    ),
 ]
 
 

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -336,7 +336,9 @@
             "chicken_count_random",
             "chicken_count",
             "big_poe_count_random",
-            "big_poe_count"
+            "big_poe_count",
+            "easier_fire_arrow_entry",
+            "fae_torch_count"
           ]
         },
         {


### PR DESCRIPTION
The actor params for torches contain four bits that store a torch count. Once the number of the lit torches equals or exceeds the torch count, it triggers whatever action those specific torch actors control.

For the Shadow Temple entrance there are 24 torches, but four bits isn't enough to store a torch count of 24. So the Shadow Temple torch actors use a value of 10 instead. The ObjSyokudai_Update function checks if the torch count is 10 and if so sets the torch count to 24. That if statement makes it stupidly easy to patch in whatever torch count you want for the shadow temple entrance.

This PR adds an 'Easier Fire Arrow Entry' setting. When enabled, you can choose a torch count of 1 to 23 and that value will be patched into the rom as the new shadow temple torch count, overwriting the default value of 24. Which specific torches you light doesn't matter as long as the number of lit torches equals or exceeds the torch count. Once you hit the torch count, the entrance opens and all torches are lit permanently.

This setting does not make any logic changes. Base logic still requires dins to open the entrance and the existing FAE trick can be enabled to put FAE into logic. This setting only makes it easier to perform FAE by reducing the number of torches you need to light.

I made a demo video with the torch count set to 3. I used save states to open the entrance a few times in order to demonstrate that it doesn't matter which torches you light, you just have to light 3 of them:
[https://youtu.be/LKrWLpupRMg](url)