### PR TITLE
Add contact links to “new issue” page

### DIFF
--- a/.github/ISSUE_TEMPLATE/.config.yml
+++ b/.github/ISSUE_TEMPLATE/.config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Randomizer setup help
+    url: https://discord.gg/BGRrKKn
+    about: "Get help with generating seeds in #setup-support on our Discord server."
+  - name: Game progression help
+    url: https://discord.gg/6Nypg4U73C
+    about: "If you get stuck, please ask for help in #gameplay-and-tricks on our Discord server before reporting a bug."
+  - name: Feature suggestions
+    url: https://discord.gg/DjEm3s7XQY
+    about: "You can open an issue to suggest a new feature, but if you prefer, you can also post to #dev-suggestions on our Discord server."


### PR DESCRIPTION
If this PR is merged, clicking “new issue” on the repo will display [a page like this (example from BizHawk)](https://github.com/TASEmulators/BizHawk/issues/new/choose) instead of immediately showing the issue form. This could help direct people to the appropriate Discord channels.

I intentionally omitted a link to #dev-bug-reports since I think reporting confirmed bugs here on GitHub makes things easier for us.