### PR TITLE
Don't include Pre-planted Beans in Randomize Main Rules

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2806,9 +2806,6 @@ setting_infos = [
         ''',
         default        = False,
         shared         = True,
-        gui_params     = {
-            'randomize_key': 'randomize_settings',
-        },
     ),
     Checkbutton(
         name           = 'chicken_count_random',


### PR DESCRIPTION
Fixes #1576 by removing the setting from the shuffled settings, since it's not on the Main Rules tab.