### PR TITLE
Minor cleanup after yesterday's merges

### DIFF
--- a/Notes/extra-save-data.md
+++ b/Notes/extra-save-data.md
@@ -11,6 +11,7 @@ The unused field (offset 0x10) of the permanent scene flags (save context + 0xd4
 * Shopsanity: Scene 0x2C
 * FW in both ages: Scenes 0x3E–0x47
 * Triforce Hunt: Scene 0x48
+* Pending ice traps: Scene 0x49
 
 ## Collectibles field
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1057,12 +1057,12 @@ logic_tricks = {
         'name'    : 'logic_jabu_boss_hover',
         'tags'    : ("Jabu Jabu's Belly", "Skulltulas", "Entrance",),
         'tooltip' : '''\
-                    A box for the blue switch can be carried over 
-		    by backwalking with one while the elevator is
-		    at its peak. Alternatively, you can skip transporting
-		    a box by quickly rolling from the switch and 
-		    opening the door before it closes. However, 
-		    the timing for this is very tight.
+                    A box for the blue switch can be carried over
+                    by backwalking with one while the elevator is
+                    at its peak. Alternatively, you can skip transporting
+                    a box by quickly rolling from the switch and
+                    opening the door before it closes. However,
+                    the timing for this is very tight.
                     '''},
     'Jabu Boss Door Switch with Bombchus': {
         'name'    : 'logic_jabu_boss_door_chus',
@@ -2595,8 +2595,8 @@ setting_infos = [
             set to "GS Tokens".
 
             Heart Containers and Pieces of Heart only
-            count as major items if the bridge or LACS
-            requirements are set to "Hearts".
+            count as major items if the bridge or Ganon
+            Boss Key requirements are set to "Hearts".
 
             Bombchus only count as major items if they
             are considered in logic.


### PR DESCRIPTION
* The indentation for the trick description updated in #1557 is fixed to use spaces instead of tabs.
* The pending ice trap count (#1555) is included in the save data docs (#1535).
* The note about hearts being major items with heart wincons (#1517) is updated for the LACS condition's removal from the GUI (#1581).