### PR TITLE
Check base rom size in build script

### DIFF
--- a/ASM/build.py
+++ b/ASM/build.py
@@ -32,6 +32,11 @@ run_dir = root_dir
 # Compile code
 
 os.chdir(run_dir)
+
+base_rom_size = os.stat('roms/base.z64').st_size
+if base_rom_size != 0x400_0000:
+    sys.exit(f'build.py: roms/base.z64 should be 0x4000000 bytes (64 MiB), but yours is 0x{base_rom_size:x} bytes ({base_rom_size / (1024 ** 2)} MiB). Make sure you have an uncompressed base ROM (see ../bin/Decompress).')
+
 if compile_c:
     clist = ['make']
     if dump_obj:


### PR DESCRIPTION
This clears up a confusion I had when starting out with rando development that I had forgotten about until someone else also ran into it: To build asm and/or C patches, you need to supply an uncompressed base rom. If you supply a compressed one instead, the build script produces data that causes randomized roms to crash. With this PR, the build script itself fails with a helpful error message if the base rom size is incorrect.