### PR TITLE
Fix Glitched Logic Patching

### DIFF
--- a/data/Glitched World/Dodongos Cavern MQ.json
+++ b/data/Glitched World/Dodongos Cavern MQ.json
@@ -44,11 +44,11 @@
             "Dodongos Cavern Gossip Stone": "True"
         },
         "exits": {
-            "Dodongos Cavern Boss Area": "has_explosives"
+            "King Dodongo Boss Room": "has_explosives"
         }
     },
     {
-        "region_name": "Dodongos Cavern Boss Area",
+        "region_name": "King Dodongo Boss Room",
         "dungeon": "Dodongos Cavern",
         "locations": {
             "Dodongos Cavern MQ Under Grave Chest": "True",

--- a/data/Glitched World/Dodongos Cavern.json
+++ b/data/Glitched World/Dodongos Cavern.json
@@ -63,12 +63,12 @@
                 or (can_live_dmg(0.5) and can_use(Hover_Boots)) or can_hover"
         },
         "exits": {
-            "Dodongos Cavern Boss Area": "has_explosives",
+            "King Dodongo Boss Room": "has_explosives",
             "Dodongos Cavern Lobby": "True"
         }
     },
     {
-        "region_name": "Dodongos Cavern Boss Area",
+        "region_name": "King Dodongo Boss Room",
         "dungeon": "Dodongos Cavern",
         "locations": {
             "Dodongos Cavern Boss Room Chest": "True",


### PR DESCRIPTION
Fixes an error causing Glitched Logic seeds to fail to patch by renaming the "Dodongos Cavern Boss Area" region to "King Dodongo Boss Room".