### PR TITLE
Use UTC timestamp for seed info

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -187,7 +187,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         world_str = ""
     rom.write_bytes(rom.sym('WORLD_STRING_TXT'), makebytes(world_str, 12))
 
-    time_str = "at " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    time_str = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M") + " UTC"
     rom.write_bytes(rom.sym('TIME_STRING_TXT'), makebytes(time_str, 25))
 
     if world.settings.show_seed_info:


### PR DESCRIPTION
I have received feedback that the seed generation timestamp added in #1253 is not very useful because it doesn't include timezone info, making it highly ambiguous. However, Python's standard library has only had [facilities for generating human-readable timezone abbreviations](https://docs.python.org/3/library/zoneinfo.html) since version 3.9. Displaying the timestamp in UTC allows hardcoding the abbreviation and makes more sense than using the local system time where the seed was generated for shared seeds, especially considering that [ootrandomizer.com](https://ootrandomizer.com/) appears to be on Berlin time.