### PR TITLE
Allow junk on disabled song locations sometimes

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -797,7 +797,7 @@ class WorldDistribution(object):
             if record.item in item_groups['DungeonReward']:
                 raise RuntimeError('Cannot place dungeon reward %s in world %d in location %s.' % (record.item, self.id + 1, location_name))
 
-            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song':
+            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song' and not world.settings.starting_songs:
                 record.item = '#JunkSong'
 
             ignore_pools = None


### PR DESCRIPTION
Specifically, when starting with any songs, one or more song locations would have junk anyway, so place #Junk instead of #JunkSong.

This should fix issues with #1593 always having Serenade on Sheik in Kakariko.