### PR TITLE
Add chaos hint distribution

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -28,7 +28,7 @@ bingoBottlesForHints = (
 )
 
 defaultHintDists = [
-    'balanced.json', 'bingo.json', 'ddr.json', 'scrubs.json', 'strong.json', 'tournament.json', 'useless.json', 'very_strong.json', 'very_strong_magic.json', 'weekly.json'
+    'balanced.json', 'bingo.json', 'chaos.json', 'ddr.json', 'scrubs.json', 'strong.json', 'tournament.json', 'useless.json', 'very_strong.json', 'very_strong_magic.json', 'weekly.json'
 ]
 
 unHintableWothItems = ['Triforce Piece', 'Gold Skulltula Token']

--- a/data/Hints/chaos.json
+++ b/data/Hints/chaos.json
@@ -1,0 +1,32 @@
+{
+    "name": "chaos",
+    "gui_name": "Chaos!!!",
+    "description": "A completely randomized hint distribution with single copies",
+    "add_locations": [],
+    "remove_locations": [],
+    "add_items": [],
+    "remove_items": [],
+    "dungeons_woth_limit": 40,
+    "dungeons_barren_limit": 40,
+    "named_items_required":  true,
+    "vague_named_items": false,
+    "use_default_goals": true,
+    "distribution": {
+        "trial":      {"order":  1, "weight": 1.0, "fixed": 0, "copies": 1},
+        "always":     {"order":  2, "weight": 1.0, "fixed": 0, "copies": 1},
+        "dual_always":{"order":  3, "weight": 1.0, "fixed": 0, "copies": 1},
+        "woth":       {"order":  4, "weight": 1.0, "fixed": 0, "copies": 1},
+        "goal":       {"order":  5, "weight": 1.0, "fixed": 0, "copies": 1},
+        "barren":     {"order":  6, "weight": 1.0, "fixed": 0, "copies": 1},
+        "item":       {"order":  7, "weight": 1.0, "fixed": 0, "copies": 1},
+        "sometimes":  {"order":  8, "weight": 1.0, "fixed": 0, "copies": 1},
+        "dual":       {"order":  9, "weight": 1.0, "fixed": 0, "copies": 1},
+        "song":       {"order": 10, "weight": 1.0, "fixed": 0, "copies": 1},
+        "overworld":  {"order": 11, "weight": 1.0, "fixed": 0, "copies": 1},
+        "dungeon":    {"order": 12, "weight": 1.0, "fixed": 0, "copies": 1},
+        "entrance":   {"order": 13, "weight": 1.0, "fixed": 0, "copies": 1},
+        "random":     {"order": 14, "weight": 1.0, "fixed": 0, "copies": 1},
+        "junk":       {"order": 15, "weight": 1.0, "fixed": 0, "copies": 1},
+        "named-item": {"order": 16, "weight": 1.0, "fixed": 0, "copies": 1}
+    }
+}

--- a/data/Hints/chaos.json
+++ b/data/Hints/chaos.json
@@ -8,7 +8,7 @@
     "remove_items": [],
     "dungeons_woth_limit": 40,
     "dungeons_barren_limit": 40,
-    "named_items_required":  true,
+    "named_items_required": false,
     "vague_named_items": false,
     "use_default_goals": true,
     "distribution": {


### PR DESCRIPTION
This is a hint distribution with single copies of completely randomized types, all evenly weighted. It's not truly fully random because trial, always, and dual_always hints have special behavior, and named-item hints just don't generate by default, but it's as close as we get with current randomizer features.

I think this hint distribution is worth including with the randomizer because the definition is straightforward, the type of player who likes to shuffle everything without resorting to the no-hints flavor of Hell Mode will like it, and it's being considered for inclusion in the Random Settings League.

From personal experience having played with it, the hint distribution is usually fairly weak but can occasionally be strong due to its random nature. Having everything be single-copy also makes gossip stones that are otherwise rarely seen more relevant.