### PR TITLE
Apply plando hint text override to dual hints

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -74,7 +74,7 @@ def getHintGroup(group, world):
             conditional_keep = conditional_sometimes[hint.name](world)
 
         # Hint inclusion override from distribution
-        if (group in world.added_hint_types or group in world.item_added_hint_types) and group not in ['dual', 'dual_always']:
+        if (group in world.added_hint_types or group in world.item_added_hint_types):
             if hint.name in world.added_hint_types[group]:
                 hint.type = group
                 type_append = True

--- a/Hints.py
+++ b/Hints.py
@@ -787,7 +787,10 @@ def get_multi_hint(spoiler, world, checked, type):
     for location in locations:
         checked.add(location.name)
 
-    multi_text = hint.text
+    if hint.name in world.hint_text_overrides:
+        multi_text = world.hint_text_overrides[hint.name]
+    else:
+        multi_text = hint.text
     if '#' not in multi_text:
         multi_text = '#%s#' % multi_text
 
@@ -1105,7 +1108,10 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
             alwaysNamedItem(world, [firstLocation, secondLocation])
 
-            location_text = getHint(hint.name, world.settings.clearer_hints).text
+            if hint.name in world.hint_text_overrides:
+                location_text = world.hint_text_overrides[hint.name]
+            else:
+                location_text = getHint(hint.name, world.settings.clearer_hints).text
             if '#' not in location_text:
                 location_text = '#%s#' % location_text
             first_item_text = getHint(getItemGenericName(firstLocation.item), world.settings.clearer_hints).text

--- a/Unittest.py
+++ b/Unittest.py
@@ -272,6 +272,7 @@ class TestPlandomizer(unittest.TestCase):
             "plando-boss-shuffle-allmq",
             "plando-boss-shuffle-limited-dungeon-shuffle",
             "dual-hints",
+            "dual-hints-custom-text",
         ]
         for filename in filenames:
             with self.subTest(filename):

--- a/World.py
+++ b/World.py
@@ -179,9 +179,6 @@ class World(object):
 
         self.hint_text_overrides = {}
         for loc in self.hint_dist_user['add_locations']:
-            if 'types' in loc:
-                if any(type in ['dual', 'dual_always'] for type in loc['types']):
-                    raise Exception('Custom dual hints are not yet supported')
             if 'text' in loc:
                 # Arbitrarily throw an error at 80 characters to prevent overfilling the text box.
                 if len(loc['text']) > 80:

--- a/tests/plando/dual-hints-custom-text.json
+++ b/tests/plando/dual-hints-custom-text.json
@@ -1,0 +1,39 @@
+{
+    "settings": {
+        "shuffle_song_items":                      "any",
+        "hint_dist_user": {
+            "name":                  "dualHintsUnitTest",
+            "gui_name":              "Dual Hints Unit Test",
+            "description":           "Custom hint distribution to test dual hints. Based on the balanced hint distribution",
+            "add_locations":         [
+				{"location": "Spirit Temple Child Lower", "types": ["dual_always"], "text": "Requiem might be hard-required? Because #Spirit Lower Child# holds^"}
+			],
+            "remove_locations":      [],
+            "add_items":             [],
+            "remove_items":          [],
+            "dungeons_woth_limit":   2,
+            "dungeons_barren_limit": 1,
+            "named_items_required":  true,
+            "vague_named_items":     false,
+            "use_default_goals":     true,
+            "distribution":          {
+                "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 1},
+                "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 1},
+                "woth":       {"order":  3, "weight": 3.5, "fixed":   0, "copies": 1},
+                "goal":       {"order":  4, "weight": 2.0, "fixed":   0, "copies": 1},
+                "barren":     {"order":  5, "weight": 2.0, "fixed":   0, "copies": 1},
+                "entrance":   {"order":  6, "weight": 3.0, "fixed":   0, "copies": 1},
+                "sometimes":  {"order":  7, "weight": 0.0, "fixed":   0, "copies": 1},
+                "random":     {"order":  8, "weight": 0.0, "fixed":   0, "copies": 1},
+                "item":       {"order":  9, "weight": 5.0, "fixed":   0, "copies": 1},
+                "song":       {"order": 10, "weight": 1.0, "fixed":   0, "copies": 1},
+                "overworld":  {"order": 11, "weight": 2.0, "fixed":   0, "copies": 1},
+                "dungeon":    {"order": 12, "weight": 1.5, "fixed":   0, "copies": 1},
+                "junk":       {"order": 13, "weight": 3.0, "fixed":   0, "copies": 1},
+                "named-item": {"order": 14, "weight": 0.0, "fixed":   0, "copies": 1},
+                "dual_always":{"order": 15, "weight": 0.0, "fixed":   0, "copies": 1},
+                "dual":       {"order": 16, "weight": 3.0, "fixed":   0, "copies": 1}
+            }
+        }
+    }
+}


### PR DESCRIPTION
(Had I known it was that simple, it would've been in the main PR)

A couple of modifications so the text override of the plando's add_locations works properly on dual and dual_always hints