### PR TITLE
Prevent plando negative location patterns from filling with Buy Item pool

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -813,6 +813,12 @@ class WorldDistribution(object):
             # location.price will be None for Shop Buy items
             if location.type == 'Shop' and location.price is None:
                 ignore_pools = [i for i in range(len(item_pools)) if i != 0]
+            else:
+                # Prevent assigning Shop Buy items to non-Shop locations
+                if ignore_pools is None:
+                    ignore_pools = [0]
+                else:
+                    ignore_pools.append(0)
 
             item = self.get_item(ignore_pools, item_pools, location, player_id, record, worlds)
 

--- a/Unittest.py
+++ b/Unittest.py
@@ -272,6 +272,7 @@ class TestPlandomizer(unittest.TestCase):
             "plando-boss-shuffle-allmq",
             "plando-boss-shuffle-limited-dungeon-shuffle",
             "dual-hints",
+            "negative-pattern-test",
         ]
         for filename in filenames:
             with self.subTest(filename):

--- a/tests/plando/negative-pattern-test.json
+++ b/tests/plando/negative-pattern-test.json
@@ -1,0 +1,12 @@
+{
+  "settings": {
+    "shopsanity": "4"
+  },
+  "locations": {
+    "Kak 10 Gold Skulltula Reward": "!Gold Skulltula Token",
+    "Kak 20 Gold Skulltula Reward": "!Gold Skulltula Token",
+    "Kak 30 Gold Skulltula Reward": "!Gold Skulltula Token",
+    "Kak 40 Gold Skulltula Reward": "!Gold Skulltula Token",
+    "Kak 50 Gold Skulltula Reward": "!Gold Skulltula Token"
+  }
+}


### PR DESCRIPTION
From discord bug reports, errors similar to the following happen with negative plando patterns:

`"Cannot assign item Buy Deku Stick (1) to location Kak 30 Gold Skulltula Reward"`

This happens with the following location plando:

`"Kak 30 Gold Skulltula Reward": "!Gold Skulltula Token"`

A unit test plando is added for future verification.