### PR TITLE
Address bonko logic comments

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -633,14 +633,6 @@ logic_tricks = {
                     Note that jumps of this distance are inconsistent, but
                     still possible.
                     '''},
-    'Shadow Temple MQ After Wind Gold Skulltula with Nothing': {
-        'name'    : 'logic_shadow_mq_after_wind_gs',
-        'tags'    : ("Shadow Temple", "Skulltulas",),
-        'tooltip' : '''\
-                    The Gold Skulltula in the rubble pile can be killed
-                    with a sword slash without blowing up the rubble. The
-                    reward will appear above the rubble pile.
-                    '''},
     'Backflip over Mido as Adult': {
         'name'    : 'logic_mido_backflip',
         'tags'    : ("the Lost Woods",),

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -64,7 +64,7 @@
     "can_bonk_tree": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
     "can_bonk_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love) or can_blast_or_smash",
     "can_bonk_underwater_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
-    "can_bonk_heated_crate": "((not deadly_bonks) or (Fairy and can_use(Goron_Tunic)) or can_use(Nayrus_Love) or can_blast_or_smash)",
+    "can_bonk_heated_crate": "((not deadly_bonks) or (Fairy and (can_use(Goron_Tunic) or damage_multiplier != 'ohko')) or can_use(Nayrus_Love) or can_blast_or_smash)",
 
     # can_use and helpers
     # The parser reduces this to smallest form based on item category.

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -64,7 +64,7 @@
     "can_bonk_tree": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
     "can_bonk_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love) or can_blast_or_smash",
     "can_bonk_underwater_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
-    "can_bonk_heated_crate": "((not deadly_bonks) or (Fairy and damage_multiplier != 'ohko') or can_use(Nayrus_Love) or can_blast_or_smash)",
+    "can_bonk_heated_crate": "((not deadly_bonks) or (Fairy and can_use(Goron_Tunic)) or can_use(Nayrus_Love) or can_blast_or_smash)",
 
     # can_use and helpers
     # The parser reduces this to smallest form based on item category.

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -64,6 +64,7 @@
     "can_bonk_tree": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
     "can_bonk_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love) or can_blast_or_smash",
     "can_bonk_underwater_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
+    "can_bonk_heated_crate": "((not deadly_bonks) or (Fairy and damage_multiplier != 'ohko') or can_use(Nayrus_Love) or can_blast_or_smash)",
 
     # can_use and helpers
     # The parser reduces this to smallest form based on item category.

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -61,9 +61,9 @@
             or (for_age == adult and (Bow or Hookshot))
             or (for_age == both and (Slingshot or Boomerang) and (Bow or Hookshot))
             or (for_age == either and (Slingshot or Boomerang or Bow or Hookshot))",
-    "can_bonk_tree": "deadly_bonks == False or Fairy or can_use(Nayrus_Love)",
-    "can_bonk_crate": "deadly_bonks == False or Fairy or can_use(Nayrus_Love) or can_blast_or_smash",
-    "can_bonk_underwater_crate": "deadly_bonks == False or Fairy or can_use(Nayrus_Love)",
+    "can_bonk_tree": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
+    "can_bonk_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love) or can_blast_or_smash",
+    "can_bonk_underwater_crate": "(not deadly_bonks) or Fairy or can_use(Nayrus_Love)",
 
     # can_use and helpers
     # The parser reduces this to smallest form based on item category.

--- a/data/World/Bosses.json
+++ b/data/World/Bosses.json
@@ -47,11 +47,11 @@
             "Dodongos Cavern King Dodongo Heart": "
                 ((can_use(Megaton_Hammer) and logic_dc_hammer_floor) or
                     has_explosives or king_dodongo_shortcuts) and
-                (Bombs or Progressive_Strength_Upgrade) and can_jumpslash",
+                (((Bombs or Progressive_Strength_Upgrade) and can_jumpslash) or deadly_bonks)",
             "King Dodongo": "
                 ((can_use(Megaton_Hammer) and logic_dc_hammer_floor) or
                     has_explosives or king_dodongo_shortcuts) and
-                (Bombs or Progressive_Strength_Upgrade) and can_jumpslash",
+                (((Bombs or Progressive_Strength_Upgrade) and can_jumpslash) or deadly_bonks)",
             "Fairy Pot": "has_bottle"
         },
         "exits": {

--- a/data/World/Deku Tree MQ.json
+++ b/data/World/Deku Tree MQ.json
@@ -7,7 +7,9 @@
             "Deku Tree MQ Slingshot Chest": "is_adult or can_child_attack",
             "Deku Tree MQ Slingshot Room Back Chest": "has_fire_source_with_torch or can_use(Bow)",
             "Deku Tree MQ Basement Chest": "has_fire_source_with_torch or can_use(Bow)",
-            "Deku Tree MQ GS Lobby": "is_adult or can_child_attack",
+            "Deku Tree MQ GS Lobby": "
+                is_adult or (Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or
+                ((Slingshot or Boomerang) and can_bonk_crate))",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
             "Deku Baba Nuts": "
                 is_adult or Slingshot or Sticks or 

--- a/data/World/Dodongos Cavern MQ.json
+++ b/data/World/Dodongos Cavern MQ.json
@@ -33,7 +33,9 @@
         "dungeon": "Dodongos Cavern",
         "locations": {
             "Dodongos Cavern MQ GS Song of Time Block Room": "
-                can_play(Song_of_Time) and (can_child_attack or is_adult)"
+                can_play(Song_of_Time) and (can_child_attack or is_adult)",
+            "Deku Baba Sticks": "is_adult or Kokiri_Sword or can_use(Boomerang)",
+            "Dodongos Cavern MQ Deku Scrub Staircase": "can_stun_deku"
         },
         "exits": {
             # Two routes available to get to upper level checks:
@@ -46,39 +48,44 @@
             # are accessible as explosives can break crates. If hammer was used, the
             # staircase can't be lowered, but the boulders can be broken. The boulders
             # are permanent even though the staircase is not, so child gets access once
-            # adult opens the way.
-            "Dodongos Cavern Upper Level": "here(can_bonk_crate and (is_adult or can_child_attack or Nuts))",
-            # Other exits are not affected by one bonk ko
+            # adult opens the way. Dins Fire can be used as either age to blow up the
+            # boulders with the bomb flower behind them.
+            "Dodongos Cavern Upper Level": "
+                here(can_bonk_crate and (is_adult or can_child_attack or Nuts)) or can_use(Dins_Fire)",
+            # Lower Right Side can be opened using the bomb flower at the top of the
+            # elevator if explosives/hammer are not available to break the wall normally.
+            # Din's Fire allows getting to the flower through the boulders, while the
+            # stick route goes through the staircase room to get to the other side of
+            # the boulders.
             "Dodongos Cavern Lower Right Side": "
-                here((can_use(Sticks) or can_use(Dins_Fire)) and
+                here(((can_use(Sticks) and can_bonk_crate) or can_use(Dins_Fire)) and
                     Progressive_Strength_Upgrade and can_take_damage)",
             "Dodongos Cavern Bomb Bag Area": "
                 (at('Dodongos Cavern Bomb Bag Area', is_adult) and has_explosives) or
                 (logic_dc_mq_child_bombs and (Kokiri_Sword or Sticks) and can_take_damage)",
+            # Opening the dino mouth without explosives requires access to the bomb
+            # flower behind the boulder near the top of the elevator. Din's Fire and hammer
+            # break through the boulders, while the other items go through the staircase
+            # room and either the upper Lizalfos fight or adult alternatives to skip the fight.
             "Dodongos Cavern Before Boss": "
                 has_explosives or
                 (Progressive_Strength_Upgrade and
                     here((logic_dc_mq_eyes_adult and is_adult) or (logic_dc_mq_eyes_child and is_child)) and
-                    here(can_use(Sticks) or can_use(Dins_Fire) or
-                        (is_adult and (logic_dc_jump or Megaton_Hammer or Hover_Boots or Hookshot))))"
+                    here((can_use(Sticks) and can_bonk_crate) or can_use(Dins_Fire) or
+                        (is_adult and (Megaton_Hammer or (can_bonk_crate and (logic_dc_jump or Hover_Boots or Hookshot))))))"
         }
     },
     {
         "region_name": "Dodongos Cavern Upper Level",
         "dungeon": "Dodongos Cavern",
         "locations": {
-            "Deku Baba Sticks": "is_adult or Kokiri_Sword or can_use(Boomerang)",
-            "Dodongos Cavern MQ Compass Chest": "is_adult or can_child_attack or Nuts",
+            "Dodongos Cavern MQ Compass Chest": "True",
             "Dodongos Cavern MQ Larvae Room Chest": "can_use(Sticks) or has_fire_source",
             "Dodongos Cavern MQ Torch Puzzle Room Chest": "
                 can_blast_or_smash or can_use(Sticks) or can_use(Dins_Fire) or
                 (is_adult and (logic_dc_jump or Hover_Boots or Progressive_Hookshot))",
             "Dodongos Cavern MQ GS Larvae Room": "can_use(Sticks) or has_fire_source",
-            "Dodongos Cavern MQ GS Lizalfos Room": "can_blast_or_smash",
-            "Dodongos Cavern MQ Deku Scrub Staircase": "can_stun_deku"
-        },
-        "exits": {
-            "Dodongos Cavern Elevator": "True"
+            "Dodongos Cavern MQ GS Lizalfos Room": "can_blast_or_smash"
         }
     },
     {

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -6,14 +6,13 @@
             "Fire Temple MQ Map Room Side Chest": "
                 is_adult or Kokiri_Sword or Sticks or Slingshot or Bombs or can_use(Dins_Fire)",
             "Fire Temple MQ Near Boss Chest": "
-                (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and
-                (((can_use(Hover_Boots) or ((logic_fire_mq_near_boss or 
-                (can_bonk_crate and not logic_fewer_tunic_requirements) or can_bonk_heated_crate)
-                and can_use(Bow))) and has_fire_source) or 
-                    (can_use(Hookshot) and (can_use(Fire_Arrows) or
-                        (can_use(Dins_Fire) and 
-                            ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or
-                                can_use(Goron_Tunic) or can_use(Bow) or can_use(Longshot))))))"
+                is_adult and (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and
+                ((logic_fire_mq_near_boss and has_fire_source and bow) or
+                    ((can_use(Hover_Boots) or can_use(Hookshot)) and
+                        ((can_use(Fire_Arrows) and can_bonk_heated_crate) or
+                            (can_use(Dins_Fire) and
+                                ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or
+                                can_use(Goron_Tunic) or can_use(Hover_Boots) or can_use(Bow) or can_use(Longshot))))))"
         },
         "exits": {
             "DMC Fire Temple Entrance": "True",

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -7,7 +7,7 @@
                 is_adult or Kokiri_Sword or Sticks or Slingshot or Bombs or can_use(Dins_Fire)",
             "Fire Temple MQ Near Boss Chest": "
                 is_adult and (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and
-                ((logic_fire_mq_near_boss and has_fire_source and bow) or
+                ((logic_fire_mq_near_boss and has_fire_source and can_use(Bow)) or
                     ((can_use(Hover_Boots) or can_use(Hookshot)) and
                         ((can_use(Fire_Arrows) and can_bonk_heated_crate) or
                             (can_use(Dins_Fire) and

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -7,7 +7,9 @@
                 is_adult or Kokiri_Sword or Sticks or Slingshot or Bombs or can_use(Dins_Fire)",
             "Fire Temple MQ Near Boss Chest": "
                 (logic_fewer_tunic_requirements or can_use(Goron_Tunic)) and
-                (((can_use(Hover_Boots) or (logic_fire_mq_near_boss and can_use(Bow))) and has_fire_source) or 
+                (((can_use(Hover_Boots) or ((logic_fire_mq_near_boss or 
+                (can_bonk_crate and not logic_fewer_tunic_requirements) or can_bonk_heated_crate)
+                and can_use(Bow))) and has_fire_source) or 
                     (can_use(Hookshot) and (can_use(Fire_Arrows) or
                         (can_use(Dins_Fire) and 
                             ((damage_multiplier != 'ohko' and damage_multiplier != 'quadruple') or

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1572,8 +1572,7 @@
             # inconvenience from being required, fairies are not in logic
             # for this crate with both OHKO and BONKO.
             "DMC GS Crate": "
-                is_child and can_child_attack and
-                ((not deadly_bonks) or (Fairy and damage_multiplier != 'ohko') or can_use(Nayrus_Love) or can_blast_or_smash)",
+                is_child and can_child_attack and can_bonk_heated_crate",
             "DMC Gossip Stone": "has_explosives",
             "Gossip Stone Fairy": "
                 has_explosives and can_summon_gossip_fairy_without_suns and has_bottle"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -442,7 +442,9 @@
             "LH Lab Dive": "
                 (Progressive_Scale, 2) or
                 (logic_lab_diving and Iron_Boots and can_use(Hookshot))",
-            "LH GS Lab Crate": "Iron_Boots and can_use(Hookshot) and can_bonk_underwater_crate"
+            "LH GS Lab Crate": "
+                Iron_Boots and can_use(Hookshot) and
+                ((not deadly_bonks) or Fairy or (can_use(Nayrus_Love) and shuffle_interior_entrances == 'off'))"
         },
         "exits": {
             "Lake Hylia": "True"
@@ -1563,8 +1565,15 @@
         "hint": "Death Mountain Crater",
         "locations": {
             "DMC Wall Freestanding PoH": "True",
-            # can_bonk_tree used here to exclude hammer usage
-            "DMC GS Crate": "is_child and can_child_attack and can_bonk_tree",
+            # OHKO and BONKO interact poorly with the heat timer.
+            # After being revived by a fairy after bonking the crate,
+            # lingering flames will kill the player in OHKO unless they
+            # immediately move to put them out. To prevent this unintended
+            # inconvenience from being required, fairies are not in logic
+            # for this crate with both OHKO and BONKO.
+            "DMC GS Crate": "
+                is_child and can_child_attack and
+                ((not deadly_bonks) or (Fairy and damage_multiplier != 'ohko') or can_use(Nayrus_Love) or can_blast_or_smash)",
             "DMC Gossip Stone": "has_explosives",
             "Gossip Stone Fairy": "
                 has_explosives and can_summon_gossip_fairy_without_suns and has_bottle"

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -132,8 +132,7 @@
         "locations": {
             "Shadow Temple MQ After Wind Enemy Chest": "True",
             "Shadow Temple MQ After Wind Hidden Chest": "has_explosives",
-            "Shadow Temple MQ GS After Wind": "
-                has_explosives or logic_shadow_mq_after_wind_gs",
+            "Shadow Temple MQ GS After Wind": "True",
             "Nut Pot": "True"
         },
         "exits": {


### PR DESCRIPTION
Fix #1612.

KD dying is intentionally not spoiled. It is now in logic if the shortcut is on.

Interior crates like lab crate will be addressed permanently by allowing casting Nayru's Love in areas where it was previously forbidden. Until this is complete, softlocks are prevented by taking NL out of logic for the lab crate if any form of interior shuffle is on.

`can_bonk_underwater_crate` is intended more for crate shuffle than the rando as-is. It also felt silly to make the lab skull `can_bonk_tree` without any nearby trees, crater skull logic notwithstanding.

I agree with r0b that we should not have tricks for this one-off meme setting. The logic added was just to ensure seeds remained beatable, not add new tech.