### PR TITLE
Make spoiler starting items/equipment/songs a dict when chosen with GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ common-key.bin
 .*.sw*
 *.wad
 
+data/Models/Adult/*.zobj
+data/Models/Adult/Pieces
+data/Models/Child/*.zobj
+data/Models/Child/Pieces
+
 tests/Output
 !tests/*.sav
 !tests/plando/*.json

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1344,9 +1344,10 @@ def add_starting_ammo(starting_items, item_name):
     for item in StartingItems.inventory.values():
         if item.itemname == item_name and item.ammo:
             for ammo, qty in item.ammo.items():
+                # Add ammo to starter record, but not overriding existing count if present
                 if ammo not in starting_items:
                     starting_items[ammo] = StarterRecord(0)
-                starting_items[ammo].count = qty[starting_items[item_name].count - 1]
+                    starting_items[ammo].count = qty[starting_items[item_name].count - 1]
             break
 
 def add_starting_item_with_ammo(starting_items, item_name, count=1):

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -974,6 +974,11 @@ class WorldDistribution(object):
     def configure_effective_starting_items(self, worlds, world):
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
 
+        # Add ammo for each starting item that needs it
+        item_names = [x for x in items.keys()]
+        for item_name in item_names:
+            add_starting_ammo(items, item_name)
+
         if world.settings.start_with_rupees:
             add_starting_item_with_ammo(items, 'Rupees', 999)
         if world.settings.start_with_consumables:
@@ -1025,6 +1030,9 @@ class Distribution(object):
             del self.src_dict['settings']
 
         self.__dict__.update(update_dict)
+
+        # Combine all starting lists into one dict, if necessary
+        startingListsToDict(self.settings)
 
         # Init we have to do every time we retry
         self.reset()
@@ -1104,9 +1112,9 @@ class Distribution(object):
     def starting_items_from_settings(self, world_id):
         data = defaultdict(lambda: StarterRecord(0))
         if isinstance(self.settings.starting_items, dict):
-            if self.settings.starting_equipment:
+            if "starting_equipment" in self.settings.distribution._settings:
                 raise ValueError('Incompatible starting item settings. Either move starting_equipment into starting_items or make starting_items a list')
-            if self.settings.starting_songs:
+            if "starting_songs" in self.settings.distribution._settings:
                 raise ValueError('Incompatible starting item settings. Either move starting_songs into starting_items or make starting_items a list')
 
             world_names = ['World %d' % (i + 1) for i in range(len(self.world_dists))]
@@ -1297,6 +1305,49 @@ class Distribution(object):
         with open(filename, 'w', encoding='utf-8') as outfile:
             outfile.write(json)
 
+
+def startingListsToDict(settings):
+    starting_dict = {}
+    # If starting items is a list, convert it to a dictionary
+    if not isinstance(settings.starting_items, dict):
+        for list_item in settings.starting_items:
+            list_item = "".join([x for x in list_item if not x.isdigit()])
+            item = StartingItems.inventory[list_item].itemname
+            if item == "Rutos Letter" and settings.zora_fountain == "open":
+                item = "Bottle"
+            if item in starting_dict:
+                starting_dict[item] += 1
+            else:
+                starting_dict[item] = 1
+    else:
+        # Otherwise, use the existing dictionary as the initial value
+        starting_dict = settings.starting_items
+    # Add starting equipment and song lists to the dictionary
+    for list_equipment in settings.starting_equipment:
+        list_equipment = "".join([x for x in list_equipment if not x.isdigit()])
+        item = StartingItems.equipment[list_equipment].itemname
+        if item in starting_dict:
+            starting_dict[item] += 1
+        else:
+            starting_dict[item] = 1
+    for list_song in settings.starting_songs:
+        item = StartingItems.songs[list_song].itemname
+        if item in starting_dict:
+            starting_dict[item] += 1
+        else:
+            starting_dict[item] = 1
+    # Set the full dictionary to be starting items
+    settings.starting_items = starting_dict
+
+
+def add_starting_ammo(starting_items, item_name):
+    for item in StartingItems.inventory.values():
+        if item.itemname == item_name and item.ammo:
+            for ammo, qty in item.ammo.items():
+                if ammo not in starting_items:
+                    starting_items[ammo] = StarterRecord(0)
+                starting_items[ammo].count = qty[starting_items[item_name].count - 1]
+            break
 
 def add_starting_item_with_ammo(starting_items, item_name, count=1):
     if item_name not in starting_items:

--- a/Settings.py
+++ b/Settings.py
@@ -326,7 +326,9 @@ class Settings:
         return {setting.name: self.__dict__[setting.name] for setting in setting_infos
                 if setting.shared and (setting.name not in self._disabled or
                 # We want to still include settings disabled by randomized settings options if they're specified in distribution
-                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))}
+                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))
+                # Don't want to include list starting equipment and songs, these are consolidated into starting_items
+                and not (setting.name == "starting_equipment" or setting.name == "starting_songs")}
 
 
     def to_json_cosmetics(self):


### PR DESCRIPTION
As plandomizer now combines starting items, equipment, and songs into a unified dict under settings, the spoiler output was changed to match this as well. This is accomplished by coalescing all 3 properties into a single dictionary which tracks how many of each item is added from the GUI list of added items. Since GUI elements use ocarina, ocarina2 etc., the function just strips the number from the name, uses the `StartingItems` list to get the actual item name, and either initializes the dict entry to 1 or adds 1 to the existing entry.

I also changed the error when using `starting_equipment` and `starting_songs` with a dict `starting_items` to only apply when they're specified in plando, meaning you can actually use GUI equipment and songs in combination with plando starting items if you so desire. I'm not 100% certain if this change is good, if it's not the error message should at least be changed to make it clear that setting them in the GUI is a problem as well.

Something about this change required adding a line to add ammo for all items that require it in `configure_effective_starting_items` to actually get ammo with your starting items.

This should resolve the last item in #1349 