### PR TITLE
DMC Logic Bug

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1589,9 +1589,10 @@
         "exits": {
             "DMC Upper Nearby": "is_adult",
             "DMC Lower Nearby": "
-                can_use(Hover_Boots) or at('DMC Lower Nearby', can_use(Megaton_Hammer)) or
-                ((logic_crater_boulder_jumpslash or logic_crater_boulder_skip) and can_use(Megaton_Hammer)) or
-                (logic_crater_boulder_skip and can_use(Goron_Tunic))"
+                is_adult and
+                    (Hover_Boots or at('DMC Lower Nearby', can_use(Megaton_Hammer)) or
+                    ((logic_crater_boulder_jumpslash or logic_crater_boulder_skip) and Megaton_Hammer) or
+                    (logic_crater_boulder_skip and Goron_Tunic))"
         }
     },
     {


### PR DESCRIPTION
The change I made to allow destroying that boulder from below so you could go back from upper to lower later, it wasn't enforcing is adult, so the logic was allowing child to make use of it. Technically the seed is still possible in this case but good luck with that. I made no attempt to test this fix, so you might want to make sure seeds at least generate.