### PR TITLE
Add Dampé diary hint and allow customizing misc. hint items

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -9,6 +9,7 @@ from Rules import set_entrances_based_rules
 from State import State
 from Item import ItemFactory
 from Hints import HintArea, HintAreaNotFound
+from HintList import misc_item_hint_table
 
 
 def set_all_entrances_data(world):
@@ -823,7 +824,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
                 if not max_search.visited(location):
                     raise EntranceShuffleError('%s is unreachable' % location.name)
 
-    if world.shuffle_interior_entrances and ('ganondorf' in world.settings.misc_hints or world.settings.hints != 'none') and \
+    if world.shuffle_interior_entrances and (any(hint_type in world.settings.misc_hints for hint_type in misc_item_hint_table) or world.settings.hints != 'none') and \
        (entrance_placed == None or entrance_placed.type in ['Interior', 'SpecialInterior']):
         # Ensure Kak Potion Shop entrances are in the same hint area so there is no ambiguity as to which entrance is used for hints
         potion_front_entrance = get_entrance_replacing(world.get_region('Kak Potion Shop Front'), 'Kakariko Village -> Kak Potion Shop Front')

--- a/Goals.py
+++ b/Goals.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict, defaultdict
 import logging
 
-from HintList import goalTable, getHintGroup, hintExclusions
+from HintList import goalTable, getHintGroup, hintExclusions, misc_item_hint_table
 from ItemList import item_table
 from Search import Search
 
@@ -165,9 +165,9 @@ def update_goal_items(spoiler):
     always_locations = [location.name for world in worlds for location in getHintGroup('always', world)]
     if spoiler.playthrough:
         # Skip even the checks
-        _maybe_set_light_arrows = lambda _: None
+        _maybe_set_misc_item_hints = lambda _: None
     else:
-        _maybe_set_light_arrows = maybe_set_light_arrows
+        _maybe_set_misc_item_hints = maybe_set_misc_item_hints
 
     if worlds[0].enable_goal_hints:
         # References first world for goal categories only
@@ -189,7 +189,7 @@ def update_goal_items(spoiler):
                 # Goals are changed for beatable-only accessibility per-world
                 category.update_reachable_goals(search, full_search)
                 reachable_goals = full_search.beatable_goals_fast({ cat_name: category }, cat_world.id)
-                identified_locations = search_goals({ cat_name: category }, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_light_arrows)
+                identified_locations = search_goals({ cat_name: category }, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_misc_item_hints)
                 # Multiworld can have all goals for one player's bridge entirely
                 # locked by another player's bridge. Therefore, we can't assume
                 # accurate required location lists by locking every world's
@@ -213,7 +213,7 @@ def update_goal_items(spoiler):
         for cat_name, category in worlds[0].unlocked_goal_categories.items():
             category.update_reachable_goals(search, full_search)
         reachable_goals = full_search.beatable_goals_fast(worlds[0].unlocked_goal_categories)
-    identified_locations = search_goals(worlds[0].unlocked_goal_categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_light_arrows, search_woth=True)
+    identified_locations = search_goals(worlds[0].unlocked_goal_categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_misc_item_hints, search_woth=True)
     required_locations.update(identified_locations)
     woth_locations = list(required_locations['way of the hero'])
     del required_locations['way of the hero']
@@ -291,7 +291,7 @@ def unlock_category_entrances(category_locks, state_list):
             exit.access_rule = access_rule
 
 
-def search_goals(categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_light_arrows, search_woth=False):
+def search_goals(categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_misc_item_hints, search_woth=False):
     # required_locations[category.name][goal.name][world_id] = [...]
     required_locations = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     world_ids = [state.world.id for state in search.state_list]
@@ -337,12 +337,14 @@ def search_goals(categories, reachable_goals, search, priority_locations, all_lo
             if search_woth and not valid_goals['way of the hero']:
                 required_locations['way of the hero'].append(location)
             location.item = old_item
-            _maybe_set_light_arrows(location)
+            _maybe_set_misc_item_hints(location)
         search.state_list[location.item.world.id].collect(location.item)
     return required_locations
 
 
-def maybe_set_light_arrows(location):
-    if not location.item.world.light_arrow_location and location.item and location.item.name == 'Light Arrows':
-        location.item.world.light_arrow_location = location
-        logging.getLogger('').debug(f'Light Arrows [{location.item.world.id}] set to [{location.name}]')
+def maybe_set_misc_item_hints(location):
+    for hint_type, data in misc_item_hint_table.items():
+        item = location.item.world.misc_hint_items[hint_type]
+        if hint_type not in location.item.world.misc_hint_item_locations and location.item and location.item.name == item:
+            location.item.world.misc_hint_item_locations[hint_type] = location
+            logging.getLogger('').debug(f'{item} [{location.item.world.id}] set to [{location.name}]')

--- a/HintList.py
+++ b/HintList.py
@@ -1568,7 +1568,6 @@ hintTable = {
     'Adult Altar Text End':                                     ("Together with the Hero of Time,&the awakened ones will bind the&evil and return the light of peace&to the world...", None, 'altar'),
 
     'Validation Line':                                          ("Hmph... Since you made it this far,&I'll let you know what glorious&prize of Ganon's you likely&missed out on in my tower.^Behold...^", None, 'validation line'),
-    'Light Arrow Location':                                     ("Ha ha ha... You'll never beat me by&reflecting my lightning bolts&and unleashing the arrows from&", None, 'Light Arrow Location'),
     '2001':                                                     ("Oh! It's @.&I was expecting someone called&Sheik. Do you know what&happened to them?", None, 'ganonLine'),
     '2002':                                                     ("I knew I shouldn't have put the key&on the other side of my door.", None, 'ganonLine'),
     '2003':                                                     ("Looks like it's time for a&round of tennis.", None, 'ganonLine'),
@@ -1631,6 +1630,31 @@ multiTable = {
     'Ice Cavern Final Room':                                    ['Ice Cavern Iron Boots Chest', 'Sheik in Ice Cavern'],
     'Ice Cavern MQ Final Room':                                 ['Ice Cavern MQ Iron Boots Chest', 'Sheik in Ice Cavern'],
     'Ganons Castle Spirit Trial Chests':                        ['Ganons Castle Spirit Trial Crystal Switch Chest', 'Ganons Castle Spirit Trial Invisible Chest'],
+}
+
+misc_item_hint_table = {
+    'dampe_diary': {
+        'id': 0x5003,
+        'hint_location': 'Dampe Diary Hint',
+        'default_item': 'Progressive Hookshot',
+        'default_item_text': "Whoever reads this, please enter {area}. I will let you have my stretching, shrinking keepsake.^I'm waiting for you.&--Dampé",
+        'custom_item_text': "Whoever reads this, please enter {area}. I will let you have {item}.^I'm waiting for you.&--Dampé",
+        'default_item_fallback': "Whoever reads this, I'm sorry, but I seem to have #misplaced# my stretching, shrinking keepsake.&--Dampé",
+        'custom_item_fallback': "Whoever reads this, I'm sorry, but I seem to have #misplaced# {item}.&--Dampé",
+        'replace': {
+            "enter #your pocket#. I will let you have": "check #your pocket#. You will find",
+        },
+    },
+    'ganondorf': {
+        'id': 0x70CC,
+        'hint_location': 'Ganondorf Hint',
+        'default_item': 'Light Arrows',
+        'default_item_text': "Ha ha ha... You'll never beat me by reflecting my lightning bolts and unleashing the arrows from {area}!",
+        'custom_item_text': "Ha ha ha... You'll never find {item} from {area}!",
+        'replace': {
+            "from #Ganon's Castle#": "from #my castle#",
+        },
+    },
 }
 
 # Separate table for goal names to avoid duplicates in the hint table.

--- a/Hints.py
+++ b/Hints.py
@@ -8,7 +8,7 @@ import json
 from enum import Enum
 import itertools
 
-from HintList import getHint, getMulti, getHintGroup, hintExclusions
+from HintList import getHint, getMulti, getHintGroup, hintExclusions, misc_item_hint_table
 from Item import MakeEventItem
 from Messages import COLOR_MAP, update_message_by_id
 from Region import Region
@@ -1020,16 +1020,14 @@ def alwaysNamedItem(world, locations):
 
 def buildGossipHints(spoiler, worlds):
     checkedLocations = dict()
-    # Add Light Arrow locations to "checked" locations if Ganondorf is reachable without it.
+    # Add misc. item hint locations to "checked" locations if the respective hint is reachable without the hinted item.
     for world in worlds:
-        location = world.light_arrow_location
-        if location is None:
-            continue
-        if 'ganondorf' in world.settings.misc_hints and can_reach_hint(worlds, world.get_location("Ganondorf Hint"), location):
-            light_arrow_world = location.world
-            if light_arrow_world.id not in checkedLocations:
-                checkedLocations[light_arrow_world.id] = set()
-            checkedLocations[light_arrow_world.id].add(location.name)
+        for hint_type, location in world.misc_hint_item_locations.items():
+            if hint_type in world.settings.misc_hints and can_reach_hint(worlds, world.get_location(misc_item_hint_table[hint_type]['hint_location']), location):
+                item_world = location.world
+                if item_world.id not in checkedLocations:
+                    checkedLocations[item_world.id] = set()
+                checkedLocations[item_world.id].add(location.name)
 
     # Build all the hints.
     for world in worlds:
@@ -1447,28 +1445,38 @@ def buildGanonText(world, messages):
     text = get_raw_text(ganonLines.pop().text)
     update_message_by_id(messages, 0x70CB, text)
 
-    # light arrow hint or validation chest item
-    if 'Light Arrows' in world.distribution.effective_starting_items and world.distribution.effective_starting_items['Light Arrows'].count > 0:
-        text = getHint('Light Arrow Location', world.settings.clearer_hints).text
-        text += "#your pocket#"
-    elif world.light_arrow_location:
-        text = getHint('Light Arrow Location', world.settings.clearer_hints).text
-        location = world.light_arrow_location
-        if world.id != location.world.id:
-            text += HintArea.at(location).text(world.settings.clearer_hints, world=location.world.id + 1)
-        else:
-            text += HintArea.at(location).text(world.settings.clearer_hints).replace('Ganon\'s Castle', 'my castle')
-        text += '!'
-        text = str(GossipText(text, ['Green'], prefix=''))
-    else:
-        text = get_raw_text(getHint('Validation Line', world.settings.clearer_hints).text)
-        for location in world.get_filled_locations():
-            if location.name == 'Ganons Tower Boss Key Chest':
-                text += get_raw_text(getHint(getItemGenericName(location.item), world.settings.clearer_hints).text)
-                break
-        text += '!'
 
-    update_message_by_id(messages, 0x70CC, text)
+def buildMiscItemHints(world, messages):
+    for hint_type, data in misc_item_hint_table.items():
+        if hint_type in world.settings.misc_hints:
+            item = world.misc_hint_items[hint_type]
+            if item in world.distribution.effective_starting_items and world.distribution.effective_starting_items[item].count > 0:
+                if item == data['default_item']:
+                    text = data['default_item_text'].format(area='#your pocket#')
+                else:
+                    text = data['custom_item_text'].format(area='#your pocket#', item=item)
+            elif hint_type in world.misc_hint_item_locations:
+                location = world.misc_hint_item_locations[hint_type]
+                area = HintArea.at(location).text(world.settings.clearer_hints, world=None if location.world.id == world.id else location.world.id + 1)
+                if item == data['default_item']:
+                    text = data['default_item_text'].format(area=area)
+                else:
+                    text = data['custom_item_text'].format(area=area, item=getHint(getItemGenericName(location.item), world.settings.clearer_hints).text)
+            elif 'fallback' in data:
+                if item == data['default_item']:
+                    text = data['default_item_fallback']
+                else:
+                    text = data['custom_item_fallback'].format(item=item)
+            else:
+                text = getHint('Validation Line', world.settings.clearer_hints).text
+                for location in world.get_filled_locations():
+                    if location.name == 'Ganons Tower Boss Key Chest':
+                        text += f"#{getHint(getItemGenericName(location.item), world.settings.clearer_hints).text}#"
+                        break
+            for find, replace in data.get('replace', {}).items():
+                text = text.replace(find, replace)
+
+            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')))
 
 
 def get_raw_text(string):

--- a/LocationList.py
+++ b/LocationList.py
@@ -888,6 +888,7 @@ location_table = OrderedDict([
     ("DMT Storms Grotto Gossip Stone",                               ("HintStone",    None,  None, None,                        None,                                    None)),
     ("DMC Upper Grotto Gossip Stone",                                ("HintStone",    None,  None, None,                        None,                                    None)),
 
+    ("Dampe Diary Hint",                                             ("Hint",         None,  None, None,                        None,                                    None)),
     ("Ganondorf Hint",                                               ("Hint",         None,  None, None,                        None,                                    None)),
 ])
 

--- a/Main.py
+++ b/Main.py
@@ -24,7 +24,7 @@ from Fill import distribute_items_restrictive, ShuffleError
 from Item import Item
 from ItemPool import generate_itempool
 from Hints import buildGossipHints
-from HintList import clearHintExclusionCache
+from HintList import clearHintExclusionCache, misc_item_hint_table
 from Utils import default_output_path, is_bundled, run_process, data_path
 from N64Patch import create_patch_file, apply_patch_file
 from MBSDIFFPatch import apply_ootr_3_web_patch
@@ -34,7 +34,7 @@ from Plandomizer import Distribution
 from Search import Search, RewindableSearch
 from EntranceShuffle import set_entrances
 from LocationList import set_drop_location_names
-from Goals import update_goal_items, maybe_set_light_arrows, replace_goal_names
+from Goals import update_goal_items, maybe_set_misc_item_hints, replace_goal_names
 from version import __version__
 
 
@@ -206,9 +206,8 @@ def make_spoiler(settings, worlds, window=dummy_window()):
         update_goal_items(spoiler)
         buildGossipHints(spoiler, worlds)
         window.update_progress(55)
-    elif 'ganondorf' in settings.misc_hints:
-        # Ganon may still provide the Light Arrows hint
-        find_light_arrows(spoiler)
+    elif any(hint_type in settings.misc_hints for hint_type in misc_item_hint_table):
+        find_misc_hint_items(spoiler)
     spoiler.build_file_hash()
     return spoiler
 
@@ -649,11 +648,11 @@ def copy_worlds(worlds):
     return worlds
 
 
-def find_light_arrows(spoiler):
+def find_misc_hint_items(spoiler):
     search = Search([world.state for world in spoiler.worlds])
     for location in search.iter_reachable_locations(search.progression_locations()):
         search.collect(location.item)
-        maybe_set_light_arrows(location)
+        maybe_set_misc_item_hints(location)
 
 
 def create_playthrough(spoiler):
@@ -696,7 +695,7 @@ def create_playthrough(spoiler):
         for location in collected:
             # Collect the item for the state world it is for
             search.state_list[location.item.world.id].collect(location.item)
-            maybe_set_light_arrows(location)
+            maybe_set_misc_item_hints(location)
     logger.info('Collected %d spheres', len(collection_spheres))
     spoiler.full_playthrough = dict((location.name, i + 1) for i, sphere in enumerate(collection_spheres) for location in sphere)
     spoiler.max_sphere = len(collection_spheres)
@@ -781,11 +780,11 @@ def create_playthrough(spoiler):
 
     # Then we can finally output our playthrough
     spoiler.playthrough = OrderedDict((str(i + 1), {location: location.item for location in sphere}) for i, sphere in enumerate(collection_spheres))
-    # Copy our light arrows, since we set them in the world copy
+    # Copy our misc. hint items, since we set them in the world copy
     for w, sw in zip(worlds, spoiler.worlds):
-        if w.light_arrow_location:
+        for hint_type, item_location in w.misc_hint_item_locations.items():
             # But the actual location saved here may be in a different world
-            sw.light_arrow_location = spoiler.worlds[w.light_arrow_location.world.id].get_location(w.light_arrow_location.name)
+            sw.misc_hint_item_locations[hint_type] = spoiler.worlds[item_location.world.id].get_location(item_location.name)
 
     if worlds[0].entrance_shuffle:
         spoiler.entrance_playthrough = OrderedDict((str(i + 1), list(sphere)) for i, sphere in enumerate(entrance_spheres))

--- a/Messages.py
+++ b/Messages.py
@@ -1,7 +1,7 @@
 # text details: https://wiki.cloudmodding.com/oot/Text_Format
 
-import logging
 import random
+from HintList import misc_item_hint_table
 from TextBox import line_wrap
 from Utils import find_last
 
@@ -108,7 +108,6 @@ for char, byte in CHARACTER_MAP.items():
 GOSSIP_STONE_MESSAGES = list( range(0x0401, 0x04FF) ) # ids of the actual hints
 GOSSIP_STONE_MESSAGES += [0x2053, 0x2054] # shared initial stone messages
 TEMPLE_HINTS_MESSAGES = [0x7057, 0x707A] # dungeon reward hints from the temple of time pedestal
-LIGHT_ARROW_HINT = [0x70CC] # ganondorf's light arrow hint line
 GS_TOKEN_MESSAGES = [0x00B4, 0x00B5] # Get Gold Skulltula Token messages
 ERROR_MESSAGE = 0x0001
 
@@ -962,7 +961,8 @@ def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
 
     def is_exempt(m):
         hint_ids = (
-            GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES + LIGHT_ARROW_HINT +
+            GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES +
+            [data['id'] for data in misc_item_hint_table.values()] +
             list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages +
             shuffle_messages.scrubs_message_ids +
             [0x5036, 0x70F5] # Chicken count and poe count respectively

--- a/Patches.py
+++ b/Patches.py
@@ -11,7 +11,7 @@ from Rom import Rom
 from Spoiler import Spoiler
 from LocationList import business_scrubs
 from Hints import writeGossipStoneHints, buildAltarHints, \
-        buildGanonText, getSimpleHintNoPrefix
+        buildGanonText, buildMiscItemHints, getSimpleHintNoPrefix
 from Utils import data_path
 from Messages import read_messages, update_message_by_id, read_shop_items, update_warp_song_text, \
         write_shop_items, remove_unused_messages, make_player_message, \
@@ -1584,6 +1584,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # build silly ganon lines
     if 'ganondorf' in world.settings.misc_hints:
         buildGanonText(world, messages)
+
+    # build misc. item hints
+    buildMiscItemHints(world, messages)
 
     # Write item overrides
     override_table = get_override_table(world)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4375,9 +4375,10 @@ setting_infos = [
         multiple_select = True,
         gui_text        = 'Misc. Hints',
         choices         = {
-            'altar':      'Temple of Time Altar',
-            'ganondorf':  'Ganondorf',
-            'warp_songs': 'Warp Songs',
+            'altar':       'Temple of Time Altar',
+            'dampe_diary': "Dampé's Diary (Hookshot)",
+            'ganondorf':   'Ganondorf (Light Arrows)',
+            'warp_songs':  'Warp Songs',
         },
         gui_tooltip    = '''\
             This setting adds some hints at locations
@@ -4394,6 +4395,10 @@ setting_infos = [
             is enabled), as well as the conditions for
             building the Rainbow Bridge and getting the
             Boss Key for Ganon's Castle.
+
+            Reading the diary of Dampé the gravekeeper
+            as adult will tell you the location of one
+            of the Hookshots.
 
             Talking to Ganondorf in his boss room will
             tell you the location of the Light Arrows.

--- a/World.py
+++ b/World.py
@@ -5,7 +5,7 @@ import random
 
 from Entrance import Entrance
 from Goals import Goal, GoalCategory
-from HintList import getRequiredHints
+from HintList import getRequiredHints, misc_item_hint_table
 from Hints import HintArea, hint_dist_keys, HintDistFiles
 from Item import ItemFactory, ItemInfo, MakeEventItem
 from Location import Location, LocationFactory
@@ -32,7 +32,7 @@ class World(object):
         self.shop_prices = {}
         self.scrub_prices = {}
         self.maximum_wallets = 0
-        self.light_arrow_location = None
+        self.misc_hint_item_locations = {}
         self.triforce_count = 0
         self.total_starting_triforce_count = 0
         self.bingosync_url = None
@@ -185,6 +185,8 @@ class World(object):
         self.named_item_pool = list(self.item_hints)
 
         self.always_hints = [hint.name for hint in getRequiredHints(self)]
+
+        self.misc_hint_items = {hint_type: self.hint_dist_user.get('misc_hint_items', {}).get(hint_type, data['default_item']) for hint_type, data in misc_item_hint_table.items()}
 
         self.state = State(self)
 

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -748,7 +748,10 @@
         }
     },
     {
-        "region_name": "Graveyard Dampes House"
+        "region_name": "Graveyard Dampes House",
+        "locations": {
+            "Dampe Diary Hint": "is_adult"
+        }
     },
     {
         "region_name": "Graveyard Warp Pad Region",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1270,6 +1270,9 @@
     {
         "region_name": "Graveyard Dampes House",
         "scene": "Graveyard Dampes House",
+        "locations": {
+            "Dampe Diary Hint": "is_adult"
+        },
         "exits": {
             "Graveyard": "True"
         }

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -78,7 +78,7 @@
     "clearer_hints": true,
     "hints": "always",
     "hint_dist": "very_strong",
-    "misc_hints": ["altar", "ganondorf", "warp_songs"],
+    "misc_hints": ["altar", "dampe_diary", "ganondorf", "warp_songs"],
     "text_shuffle": "none",
     "damage_multiplier": "normal",
     "starting_tod": "default",


### PR DESCRIPTION
An option is added to the “Misc. Hints” setting which modifies the adult-era text in Dampé's diary (located in his house) to hint at the location of a hookshot, in the same way Ganondorf hints at the location of the light arrows.

A new optional entry `misc_hint_items` is added to hint distributions which allows the item types hinted by Ganondorf and/or Dampé's diary to be customized. The entry takes the keys `ganondorf` and `dampe_diary` (the internal names of the `misc_hints` options). When used, the hint text is modified appropriately.

Concerns have been raised that the algorithm for determining the first accessible light arrows, which is now also used to determine which hookshot to hint, would require players to track playthrough spheres while racing to play optimally. I believe that this is not an issue since a direct hookshot hint at a known, easily accessible location is too strong to be used in races anyway. As such, it's off by default in all presets except for Easy Mode, where it seems appropriate due to the preset's name and since it uses the Very Strong hint distribution.