### PR TITLE
Various fixes for starting items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,6 @@ common-key.bin
 .*.sw*
 *.wad
 
-data/Models/Adult/*.zobj
-data/Models/Adult/Pieces
-data/Models/Child/*.zobj
-data/Models/Child/Pieces
-
 tests/Output
 !tests/*.sav
 !tests/plando/*.json

--- a/Patches.py
+++ b/Patches.py
@@ -21,7 +21,7 @@ from OcarinaSongs import replace_songs
 from MQ import patch_files, File, update_dmadata, insert_space, add_relocations
 from SaveContext import SaveContext, Scenes, FlagType
 from version import __version__
-import StartingItems
+from ItemPool import song_list
 
 
 def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
@@ -244,7 +244,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # songs as items flag
     songs_as_items = world.settings.shuffle_song_items != 'song' or \
                      world.distribution.song_as_items or \
-                     world.settings.starting_songs
+                     any(name in song_list and record.count for name, record in world.settings.starting_items.items())
 
     if songs_as_items:
         rom.write_byte(rom.sym('SONGS_AS_ITEMS'), 1)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1132,8 +1132,10 @@ class Distribution(object):
             for name, record in self.settings.starting_items.items():
                 if name in world_names:
                     data[name] = {item_name: count if isinstance(count, StarterRecord) else StarterRecord(count) for item_name, count in record.items()}
+                    add_starting_ammo(data[name])
                 else:
                     data[name] = record if isinstance(record, StarterRecord) else StarterRecord(record)
+            add_starting_ammo(data)
         else:
             for itemsetting in itertools.chain(self.settings.starting_equipment, self.settings.starting_items, self.settings.starting_songs):
                 if itemsetting in StartingItems.everything:
@@ -1308,6 +1310,16 @@ class Distribution(object):
         json = self.to_str(spoiler=output_spoiler)
         with open(filename, 'w', encoding='utf-8') as outfile:
             outfile.write(json)
+
+
+def add_starting_ammo(starting_items):
+    for item in StartingItems.inventory.values():
+        if item.itemname in starting_items and item.ammo:
+            for ammo, qty in item.ammo.items():
+                # Add ammo to starter record, but not overriding existing count if present
+                if ammo not in starting_items:
+                    starting_items[ammo] = StarterRecord(0)
+                    starting_items[ammo].count = qty[starting_items[item.itemname].count - 1]
 
 
 def add_starting_item_with_ammo(starting_items, item_name, count=1):

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -980,11 +980,6 @@ class WorldDistribution(object):
     def configure_effective_starting_items(self, worlds, world):
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
 
-        # Add ammo for each starting item that needs it
-        item_names = [x for x in items.keys()]
-        for item_name in item_names:
-            add_starting_ammo(items, item_name)
-
         if world.settings.start_with_rupees:
             add_starting_item_with_ammo(items, 'Rupees', 999)
         if world.settings.start_with_consumables:
@@ -1036,9 +1031,6 @@ class Distribution(object):
             del self.src_dict['settings']
 
         self.__dict__.update(update_dict)
-
-        # Combine all starting lists into one dict, if necessary
-        startingListsToDict(self.settings)
 
         # Init we have to do every time we retry
         self.reset()
@@ -1118,9 +1110,9 @@ class Distribution(object):
     def starting_items_from_settings(self, world_id):
         data = defaultdict(lambda: StarterRecord(0))
         if isinstance(self.settings.starting_items, dict):
-            if "starting_equipment" in self.settings.distribution._settings:
+            if self.settings.starting_equipment:
                 raise ValueError('Incompatible starting item settings. Either move starting_equipment into starting_items or make starting_items a list')
-            if "starting_songs" in self.settings.distribution._settings:
+            if self.settings.starting_songs:
                 raise ValueError('Incompatible starting item settings. Either move starting_songs into starting_items or make starting_items a list')
 
             world_names = ['World %d' % (i + 1) for i in range(len(self.world_dists))]
@@ -1311,50 +1303,6 @@ class Distribution(object):
         with open(filename, 'w', encoding='utf-8') as outfile:
             outfile.write(json)
 
-
-def startingListsToDict(settings):
-    starting_dict = {}
-    # If starting items is a list, convert it to a dictionary
-    if not isinstance(settings.starting_items, dict):
-        for list_item in settings.starting_items:
-            list_item = "".join([x for x in list_item if not x.isdigit()])
-            item = StartingItems.inventory[list_item].itemname
-            if item == "Rutos Letter" and settings.zora_fountain == "open":
-                item = "Bottle"
-            if item in starting_dict:
-                starting_dict[item] += 1
-            else:
-                starting_dict[item] = 1
-    else:
-        # Otherwise, use the existing dictionary as the initial value
-        starting_dict = settings.starting_items
-    # Add starting equipment and song lists to the dictionary
-    for list_equipment in settings.starting_equipment:
-        list_equipment = "".join([x for x in list_equipment if not x.isdigit()])
-        item = StartingItems.equipment[list_equipment].itemname
-        if item in starting_dict:
-            starting_dict[item] += 1
-        else:
-            starting_dict[item] = 1
-    for list_song in settings.starting_songs:
-        item = StartingItems.songs[list_song].itemname
-        if item in starting_dict:
-            starting_dict[item] += 1
-        else:
-            starting_dict[item] = 1
-    # Set the full dictionary to be starting items
-    settings.starting_items = starting_dict
-
-
-def add_starting_ammo(starting_items, item_name):
-    for item in StartingItems.inventory.values():
-        if item.itemname == item_name and item.ammo:
-            for ammo, qty in item.ammo.items():
-                # Add ammo to starter record, but not overriding existing count if present
-                if ammo not in starting_items:
-                    starting_items[ammo] = StarterRecord(0)
-                    starting_items[ammo].count = qty[starting_items[item_name].count - 1]
-            break
 
 def add_starting_item_with_ammo(starting_items, item_name, count=1):
     if item_name not in starting_items:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -11,7 +11,7 @@ from Fill import FillError
 from EntranceShuffle import EntranceShuffleError, change_connections, confirm_replacement, validate_world, check_entrances_compatibility
 from Hints import gossipLocations, GossipText
 from Item import ItemFactory, ItemInfo, ItemIterator, IsItem
-from ItemPool import item_groups, get_junk_item
+from ItemPool import item_groups, get_junk_item, song_list
 from Location import LocationIterator, LocationFactory, IsLocation
 from LocationList import location_groups, location_table
 from Search import Search
@@ -801,7 +801,7 @@ class WorldDistribution(object):
             if record.item in item_groups['DungeonReward']:
                 raise RuntimeError('Cannot place dungeon reward %s in world %d in location %s.' % (record.item, self.id + 1, location_name))
 
-            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song' and not world.settings.starting_songs:
+            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song' and not any(name in song_list and record.count for name, record in world.settings.starting_items.items()):
                 record.item = '#JunkSong'
 
             ignore_pools = None

--- a/Rules.py
+++ b/Rules.py
@@ -1,7 +1,6 @@
-import collections
 import logging
+from ItemPool import song_list
 from Location import DisableType
-from SaveContext import SaveContext
 from Search import Search
 from State import State
 
@@ -19,8 +18,8 @@ def set_rules(world):
         if world.settings.shuffle_song_items == 'song':
             if location.type == 'Song':
                 # allow junk items, but songs must still have matching world
-                add_item_rule(location, lambda location, item: 
-                    ((location.world.distribution.song_as_items or world.settings.starting_songs)
+                add_item_rule(location, lambda location, item:
+                    ((location.world.distribution.song_as_items or any(name in song_list and record.count for name, record in world.settings.starting_items.items()))
                         and item.type != 'Song')
                     or (item.type == 'Song' and item.world.id == location.world.id))
             else:

--- a/Settings.py
+++ b/Settings.py
@@ -326,9 +326,7 @@ class Settings:
         return {setting.name: self.__dict__[setting.name] for setting in setting_infos
                 if setting.shared and (setting.name not in self._disabled or
                 # We want to still include settings disabled by randomized settings options if they're specified in distribution
-                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))
-                # Don't want to include list starting equipment and songs, these are consolidated into starting_items
-                and not (setting.name == "starting_equipment" or setting.name == "starting_songs")}
+                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))}
 
 
     def to_json_cosmetics(self):

--- a/Settings.py
+++ b/Settings.py
@@ -323,11 +323,23 @@ class Settings:
 
 
     def to_json(self):
-        return {setting.name: self.__dict__[setting.name] for setting in setting_infos
-                if setting.shared and (setting.name not in self._disabled or
+        return {
+            setting.name: (
+                {name: (
+                    {name: record.to_json() for name, record in record.items()} if isinstance(record, dict) else record.to_json()
+                ) for name, record in self.__dict__[setting.name].items()}
+                if setting.name == 'starting_items' else
+                self.__dict__[setting.name]
+            )
+            for setting in setting_infos
+            if setting.shared and (
+                setting.name not in self._disabled or
                 # We want to still include settings disabled by randomized settings options if they're specified in distribution
-                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys()))}
-
+                ('_settings' in self.distribution.src_dict and setting.name in self.distribution.src_dict['_settings'].keys())
+            )
+            # Don't want to include list starting equipment and songs, these are consolidated into starting_items
+            and not (setting.name == "starting_equipment" or setting.name == "starting_songs")
+        }
 
     def to_json_cosmetics(self):
         return {setting.name: self.__dict__[setting.name] for setting in setting_infos if setting.cosmetic}

--- a/StartingItems.py
+++ b/StartingItems.py
@@ -1,25 +1,21 @@
 from collections import namedtuple
 from itertools import chain
-import math
 
-    
-_Entry = namedtuple("_Entry", ['settingname', 'itemname', 'available', 'guitext', 'special', 'ammo'])
+
+_Entry = namedtuple("_Entry", ['settingname', 'itemname', 'available', 'guitext', 'special', 'ammo', 'i'])
 def _entry(settingname, itemname=None, available=1, guitext=None, special=False, ammo=None):
     if itemname is None:
         itemname = settingname.capitalize()
     if guitext is None:
         guitext = itemname
-    if available == 1:
-        return [(settingname, _Entry(settingname, itemname, available, guitext, special, ammo))]
-    else:
-        result = []
-        for i in range(available):
-            if i == 0:
-                name = settingname
-            else:
-                name = "{}{}".format(settingname, i+1)
-            result.append((name, _Entry(name, itemname, available, guitext, special, ammo)))
-        return result
+    result = []
+    for i in range(available):
+        if i == 0:
+            name = settingname
+        else:
+            name = "{}{}".format(settingname, i+1)
+        result.append((name, _Entry(name, itemname, available, guitext, special, ammo, i)))
+    return result
 
 # Ammo items must be declared in ItemList.py.
 inventory = dict(chain(


### PR DESCRIPTION
* An alternative implementation of #1614. Instead of adding redundant code for converting to the new starting items format, this applies the existing conversion to the settings directly so that it's reflected in the spoiler log and the rest of the rando code consistently sees the dictionary format. The new behavior for ammo is preserved. Fixes #1624.
* The code was still checking for `starting_songs` to determine songs-as-items. Updated to check whether `starting_items` contains any songs.
* The functions for encoding and decoding settings strings are updated to handle starting items by converting to/from the list format.