### PR TITLE
Refactor hint distro loading and fix some default goal colors

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -14,7 +14,7 @@ from Messages import COLOR_MAP, update_message_by_id
 from Region import Region
 from Search import Search
 from TextBox import line_wrap
-from Utils import random_choices, data_path, read_json
+from Utils import random_choices, data_path
 
 
 bingoBottlesForHints = (
@@ -978,13 +978,15 @@ def buildBingoHintList(boardURL):
     except (URLError, HTTPError) as e:
         logger = logging.getLogger('')
         logger.info(f"Could not retrieve board info. Using default bingo hints instead: {e}")
-        genericBingo = read_json(data_path('Bingo/generic_bingo_hints.json'))
+        with open(data_path('Bingo/generic_bingo_hints.json'), 'r') as bingoFile:
+            genericBingo = json.load(bingoFile)
         return genericBingo['settings']['item_hints']
 
     # Goal list returned from Bingosync is a sequential list of all of the goals on the bingo board, starting at top-left and moving to the right.
     # Each goal is a dictionary with attributes for name, slot, and colours. The only one we use is the name
     goalList = [goal['name'] for goal in json.loads(goalList)]
-    goalHintRequirements = read_json(data_path('Bingo/bingo_goals.json'))
+    with open(data_path('Bingo/bingo_goals.json'), 'r') as bingoFile:
+        goalHintRequirements = json.load(bingoFile)
 
     hintsToAdd = {}
     for goal in goalList:
@@ -1095,7 +1097,8 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     # Create list of items for which we want hints. If Bingosync URL is supplied, include items specific to that bingo.
     # If not (or if the URL is invalid), use generic bingo hints
     if world.settings.hint_dist == "bingo":
-        bingoDefaults = read_json(data_path('Bingo/generic_bingo_hints.json'))
+        with open(data_path('Bingo/generic_bingo_hints.json'), 'r') as bingoFile:
+            bingoDefaults = json.load(bingoFile)
         if world.bingosync_url is not None and world.bingosync_url.startswith("https://bingosync.com/"): # Verify that user actually entered a bingosync URL
             logger = logging.getLogger('')
             logger.info("Got Bingosync URL. Building board-specific goals.")
@@ -1497,7 +1500,8 @@ def HintDistFiles():
 def HintDistList():
     dists = {}
     for d in HintDistFiles():
-        dist = read_json(d)
+        with open(d, 'r') as dist_file:
+            dist = json.load(dist_file)
         dist_name = dist['name']
         gui_name = dist['gui_name']
         dists.update({ dist_name: gui_name })
@@ -1513,7 +1517,8 @@ def HintDistTips():
             tips = tips + "\n"
         else:
             first_dist = False
-        dist = read_json(d)
+        with open(d, 'r') as dist_file:
+            dist = json.load(dist_file)
         gui_name = dist['gui_name']
         desc = dist['description']
         i = 0

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -8,7 +8,7 @@ from Item import ItemInfo, MakeEventItem
 from Location import Location
 from Region import TimeOfDay
 from State import State
-from Utils import data_path, read_json
+from Utils import data_path, read_logic_file
 
 
 escaped_items = {}
@@ -32,7 +32,7 @@ rule_aliases = {}
 nonaliases = set()
 
 def load_aliases():
-    j = read_json(data_path('LogicHelpers.json'))
+    j = read_logic_file(data_path('LogicHelpers.json'))
     for s, repl in j.items():
         if '(' in s:
             rule, args = s[:-1].split('(', 1)

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from Hints import HintDistFiles
 from SettingsList import setting_infos, setting_map, get_setting_info, get_settings_from_section, get_settings_from_tab
-from Utils import data_path, read_json
+from Utils import data_path
 import sys
 import json
 import copy
@@ -254,7 +254,8 @@ def CreateJSON(path, web_version=False):
             settingOutputJson['cosmeticsArray'].append(tabJsonArr)
     
     for d in HintDistFiles():
-        dist = read_json(d)
+        with open(d, 'r') as dist_file:
+            dist = json.load(dist_file)
         if ('distribution' in dist and
            'goal' in dist['distribution'] and
            (dist['distribution']['goal']['fixed'] != 0 or

--- a/Utils.py
+++ b/Utils.py
@@ -54,7 +54,7 @@ def default_output_path(path):
     return path
 
 
-def read_json(file_path):
+def read_logic_file(file_path):
     json_string = ""
     with io.open(file_path, 'r') as file:
         for line in file.readlines():

--- a/World.py
+++ b/World.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import copy
 import logging
 import random
+import json
 
 from Entrance import Entrance
 from Goals import Goal, GoalCategory
@@ -15,7 +16,7 @@ from Region import Region, TimeOfDay
 from RuleParser import Rule_AST_Transformer
 from SettingsList import get_setting_info, get_settings_from_section
 from State import State
-from Utils import read_json
+from Utils import read_logic_file
 
 class World(object):
 
@@ -110,7 +111,8 @@ class World(object):
 
         if len(settings.hint_dist_user) == 0:
             for d in HintDistFiles():
-                dist = read_json(d)
+                with open(d, 'r') as dist_file:
+                    dist = json.load(dist_file)
                 if dist['name'] == self.settings.hint_dist:
                     self.hint_dist_user = dist
         else:
@@ -425,7 +427,7 @@ class World(object):
 
 
     def load_regions_from_json(self, file_path):
-        region_json = read_json(file_path)
+        region_json = read_logic_file(file_path)
 
         for region in region_json:
             new_region = Region(region['region_name'])
@@ -637,7 +639,7 @@ class World(object):
         gbk = GoalCategory('ganon_bosskey', 20)
         trials = GoalCategory('trials', 30, minimum_goals=1)
         th = GoalCategory('triforce_hunt', 30, goal_count=round(self.settings.triforce_goal_per_world / 10), minimum_goals=1)
-        trial_goal = Goal(self, 'the Tower', 'path to the Tower', 'White', items=[], create_empty=True)
+        trial_goal = Goal(self, 'the Tower', 'path to #the Tower#', 'White', items=[], create_empty=True)
 
         if self.settings.triforce_hunt and self.settings.triforce_goal_per_world > 0:
             # "Hintable" value of False means the goal items themselves cannot
@@ -650,7 +652,7 @@ class World(object):
             # Key, which makes these items directly hintable in their respective goals
             # assuming they do not get hinted by another hint type (always, woth with
             # an earlier order in the hint distro, etc).
-            th.add_goal(Goal(self, 'gold', 'path of gold', 'Yellow', items=[{'name': 'Triforce Piece', 'quantity': self.settings.triforce_count_per_world, 'minimum': self.settings.triforce_goal_per_world, 'hintable': False}]))
+            th.add_goal(Goal(self, 'gold', 'path of #gold#', 'Yellow', items=[{'name': 'Triforce Piece', 'quantity': self.settings.triforce_count_per_world, 'minimum': self.settings.triforce_goal_per_world, 'hintable': False}]))
             self.goal_categories[th.name] = th
         # Category goals are defined for each possible setting for each category.
         # Bridge can be Stones, Medallions, Dungeons, Skulls, or Vanilla.
@@ -697,7 +699,7 @@ class World(object):
                             arrows = 2
                         else:
                             arrows = 1
-                        b.add_goal(Goal(self, 'Evil\'s Bane', 'path to Evil\'s Bane', 'Light Blue', items=[{'name': 'Light Arrows', 'quantity': arrows, 'minimum': 1, 'hintable': True}]))
+                        b.add_goal(Goal(self, 'Evil\'s Bane', 'path to #Evil\'s Bane#', 'Light Blue', items=[{'name': 'Light Arrows', 'quantity': arrows, 'minimum': 1, 'hintable': True}]))
                         min_goals += 1
                     b.minimum_goals = min_goals
                 # Goal count within a category is currently unused. Testing is in progress
@@ -709,7 +711,7 @@ class World(object):
                             or self.settings.bridge_tokens >= self.settings.ganon_bosskey_tokens)
                     and (self.settings.shuffle_ganon_bosskey != 'on_lacs' or self.settings.lacs_condition != 'tokens'
                             or self.settings.bridge_tokens >= self.settings.lacs_tokens)):
-                    b.add_goal(Goal(self, 'Skulls', 'path of Skulls', 'Light Blue', items=[{'name': 'Gold Skulltula Token', 'quantity': 100, 'minimum': self.settings.bridge_tokens, 'hintable': False}]))
+                    b.add_goal(Goal(self, 'Skulls', 'path of #Skulls#', 'Pink', items=[{'name': 'Gold Skulltula Token', 'quantity': 100, 'minimum': self.settings.bridge_tokens, 'hintable': False}]))
                     b.goal_count = round(self.settings.bridge_tokens / 10)
                     b.minimum_goals = 1
                 if (self.settings.bridge_hearts > self.settings.starting_hearts
@@ -718,7 +720,7 @@ class World(object):
                             or self.settings.bridge_hearts >= self.settings.ganon_bosskey_hearts)
                     and (self.settings.shuffle_ganon_bosskey != 'on_lacs' or self.settings.lacs_condition != 'hearts'
                             or self.settings.bridge_hearts >= self.settings.lacs_hearts)):
-                    b.add_goal(Goal(self, 'hearts', 'path of hearts', 'Light Blue', items=[{'name': 'Piece of Heart', 'quantity': (20 - self.settings.starting_hearts) * 4, 'minimum': (self.settings.bridge_hearts - self.settings.starting_hearts) * 4, 'hintable': False}]))
+                    b.add_goal(Goal(self, 'hearts', 'path of #hearts#', 'Red', items=[{'name': 'Piece of Heart', 'quantity': (20 - self.settings.starting_hearts) * 4, 'minimum': (self.settings.bridge_hearts - self.settings.starting_hearts) * 4, 'hintable': False}]))
                     b.goal_count = round((self.settings.bridge_hearts - 3) / 2)
                     b.minimum_goals = 1
                 self.goal_categories[b.name] = b
@@ -796,28 +798,28 @@ class World(object):
                 and self.settings.shuffle_ganon_bosskey == 'tokens'
                 and (self.settings.bridge != 'tokens'
                         or self.settings.bridge_tokens < self.settings.ganon_bosskey_tokens)):
-                gbk.add_goal(Goal(self, 'Skulls', 'path of Skulls', 'Light Blue', items=[{'name': 'Gold Skulltula Token', 'quantity': 100, 'minimum': self.settings.ganon_bosskey_tokens, 'hintable': False}]))
+                gbk.add_goal(Goal(self, 'Skulls', 'path of #Skulls#', 'Pink', items=[{'name': 'Gold Skulltula Token', 'quantity': 100, 'minimum': self.settings.ganon_bosskey_tokens, 'hintable': False}]))
                 gbk.goal_count = round(self.settings.ganon_bosskey_tokens / 10)
                 gbk.minimum_goals = 1
             if (self.settings.lacs_tokens > 0
                 and self.settings.shuffle_ganon_bosskey == 'on_lacs' and self.settings.lacs_condition == 'tokens'
                 and (self.settings.bridge != 'tokens'
                         or self.settings.bridge_tokens < self.settings.lacs_tokens)):
-                gbk.add_goal(Goal(self, 'Skulls', 'path of Skulls', 'Light Blue', items=[{'name': 'Gold Skulltula Token', 'quantity': 100, 'minimum': self.settings.lacs_tokens, 'hintable': False}]))
+                gbk.add_goal(Goal(self, 'Skulls', 'path of #Skulls#', 'Pink', items=[{'name': 'Gold Skulltula Token', 'quantity': 100, 'minimum': self.settings.lacs_tokens, 'hintable': False}]))
                 gbk.goal_count = round(self.settings.lacs_tokens / 10)
                 gbk.minimum_goals = 1
             if (self.settings.ganon_bosskey_hearts > self.settings.starting_hearts
                 and self.settings.shuffle_ganon_bosskey == 'hearts'
                 and (self.settings.bridge != 'hearts'
                         or self.settings.bridge_hearts < self.settings.ganon_bosskey_hearts)):
-                gbk.add_goal(Goal(self, 'hearts', 'path of hearts', 'Light Blue', items=[{'name': 'Piece of Heart', 'quantity': (20 - self.settings.starting_hearts) * 4, 'minimum': (self.settings.ganon_bosskey_hearts - self.settings.starting_hearts) * 4, 'hintable': False}]))
+                gbk.add_goal(Goal(self, 'hearts', 'path of #hearts#', 'Red', items=[{'name': 'Piece of Heart', 'quantity': (20 - self.settings.starting_hearts) * 4, 'minimum': (self.settings.ganon_bosskey_hearts - self.settings.starting_hearts) * 4, 'hintable': False}]))
                 gbk.goal_count = round((self.settings.ganon_bosskey_hearts - 3) / 2)
                 gbk.minimum_goals = 1
             if (self.settings.lacs_hearts > self.settings.starting_hearts
                 and self.settings.shuffle_ganon_bosskey == 'on_lacs' and self.settings.lacs_condition == 'hearts'
                 and (self.settings.bridge != 'hearts'
                         or self.settings.bridge_hearts < self.settings.lacs_hearts)):
-                gbk.add_goal(Goal(self, 'hearts', 'path of hearts', 'Light Blue', items=[{'name': 'Piece of Heart', 'quantity': (20 - self.settings.starting_hearts) * 4, 'minimum': (self.settings.lacs_hearts - self.settings.starting_hearts) * 4, 'hintable': False}]))
+                gbk.add_goal(Goal(self, 'hearts', 'path of #hearts#', 'Red', items=[{'name': 'Piece of Heart', 'quantity': (20 - self.settings.starting_hearts) * 4, 'minimum': (self.settings.lacs_hearts - self.settings.starting_hearts) * 4, 'hintable': False}]))
                 gbk.goal_count = round((self.settings.lacs_hearts - 3) / 2)
                 gbk.minimum_goals = 1
 
@@ -833,7 +835,7 @@ class World(object):
                     keys = 2
                 else:
                     keys = 1
-                gbk.add_goal(Goal(self, 'the Key', 'path to the Key', 'Light Blue', items=[{'name': 'Boss Key (Ganons Castle)', 'quantity': keys, 'minimum': 1, 'hintable': True}]))
+                gbk.add_goal(Goal(self, 'the Key', 'path to #the Key#', 'Light Blue', items=[{'name': 'Boss Key (Ganons Castle)', 'quantity': keys, 'minimum': 1, 'hintable': True}]))
                 gbk.minimum_goals = 1
             if gbk.goals:
                 self.goal_categories[gbk.name] = gbk
@@ -870,7 +872,7 @@ class World(object):
             if self.settings.bridge == 'open' and (self.settings.shuffle_ganon_bosskey == 'remove' or self.settings.shuffle_ganon_bosskey == 'vanilla') and self.settings.trials == 0:
                 g = GoalCategory('ganon', 30, goal_count=1)
                 # Equivalent to WOTH, but added in case WOTH hints are disabled in favor of goal hints
-                g.add_goal(Goal(self, 'the hero', 'path of the hero', 'White', items=[{'name': 'Triforce', 'quantity': 1, 'minimum': 1, 'hintable': True}]))
+                g.add_goal(Goal(self, 'the hero', 'path of #the hero#', 'White', items=[{'name': 'Triforce', 'quantity': 1, 'minimum': 1, 'hintable': True}]))
                 g.minimum_goals = 1
                 self.goal_categories[g.name] = g
 


### PR DESCRIPTION
Hint distro loading used the same function as the logic files. The post-processing for logic pseudo-json removed the `#` symbols from custom goal hint text. In most cases this breaks the distro and crashes the GUI before it can load. This is refactored to use the standard json library functions for loading the hint distros. The logic `read_json` function is renamed `read_logic_file` to prevent future misuse.

All unit tests pass.

These changes are required for the league S3 hint distro.