### PR TITLE
Minor cleanup

### DIFF
--- a/ASM/c/models.c
+++ b/ASM/c/models.c
@@ -30,7 +30,7 @@ void load_object_file(uint32_t object_id, uint8_t *buf) {
         entry = &(z64_object_table[object_id]);
     } else {
         z64_object_table_t *extended_table = (z64_object_table_t *) (&EXTENDED_OBJECT_TABLE);
-        entry = extended_table + (object_id - num_vanilla_objects - 1) * sizeof(z64_object_table_t) / 8;
+        entry = &extended_table[object_id - num_vanilla_objects - 1];
     }
     uint32_t vrom_start = entry->vrom_start;
     uint32_t size = entry->vrom_end - vrom_start;

--- a/ASM/src/config.asm
+++ b/ASM/src/config.asm
@@ -106,7 +106,7 @@ TIME_STRING_TXT:
 INITIAL_SAVE_DATA:
 .endarea
 
-.area 0x20, 0
+.area 0x20, 0 ; size must be at least 8 * ((max object_id parameter Patches.add_to_extended_object_table is called with) - 0x192)
 EXTENDED_OBJECT_TABLE:
 .endarea
 

--- a/CI.py
+++ b/CI.py
@@ -21,7 +21,7 @@ def error(msg):
 # Run Unit Tests
 stream = StringIO()
 runner = unittest.TextTestRunner(stream=stream)
-tests = ([cls for name, cls in Tests.__dict__.items() if isinstance(cls, type) and issubclass(cls, unittest.TestCase)])
+tests = filter(lambda cls: isinstance(cls, type) and issubclass(cls, unittest.TestCase), Tests.__dict__.values())
 suite = unittest.TestSuite()
 for test in tests:
     suite.addTests(unittest.makeSuite(test))

--- a/Goals.py
+++ b/Goals.py
@@ -343,7 +343,7 @@ def search_goals(categories, reachable_goals, search, priority_locations, all_lo
 
 
 def maybe_set_misc_item_hints(location):
-    for hint_type, data in misc_item_hint_table.items():
+    for hint_type in misc_item_hint_table:
         item = location.item.world.misc_hint_items[hint_type]
         if hint_type not in location.item.world.misc_hint_item_locations and location.item and location.item.name == item:
             location.item.world.misc_hint_item_locations[hint_type] = location

--- a/Hints.py
+++ b/Hints.py
@@ -812,7 +812,7 @@ def get_specific_hint(spoiler, world, checked, type):
         return None
 
     hint = random.choice(hintGroup)
-    
+
     if world.hint_dist_user['upgrade_hints'] in ['on', 'limited']:
         upgrade_list = getUpgradeHintList(world, [hint.name])
         upgrade_list = list(filter(lambda upgrade: is_not_checked([world.get_location(location) for location in getMulti(upgrade.name).locations], checked), upgrade_list))
@@ -830,7 +830,7 @@ def get_specific_hint(spoiler, world, checked, type):
             if multi:
                 return get_specific_multi_hint(spoiler, world, checked, hint)
 
-    
+
     location = world.get_location(hint.name)
     checked.add(location.name)
 
@@ -1148,7 +1148,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
         if world.settings.shopsanity != "off" and "Progressive Wallet" not in world.item_hints:
             world.item_hints.append("Progressive Wallet")
-                
+
 
     #Removes items from item_hints list if they are included in starting gear.
     #This method ensures that the right number of copies are removed, e.g.
@@ -1168,7 +1168,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             world.hint_dist_user['distribution']['always']['copies'] = 1
             world.hint_dist_user['distribution']['trial']['copies'] = 1
 
-            
+
     # Load hint distro from distribution file or pre-defined settings
     #
     # 'fixed' key is used to mimic the tournament distribution, creating a list of fixed hint types to fill

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1,7 +1,6 @@
-import logging
 import random
 from collections import OrderedDict
-from decimal import Decimal, ROUND_HALF_UP, ROUND_UP
+from decimal import Decimal, ROUND_UP
 
 from Item import ItemFactory, ItemInfo
 from Utils import random_choices
@@ -663,13 +662,15 @@ def get_pool_core(world):
         # Songs are in the unrestricted pool even if their fill is restricted. Filter from candidates
         duplicate_candidates = [item for item in ludicrous_items_extended if item in pool and (ItemInfo.items[item].type != 'Song' or world.settings.shuffle_song_items == 'any')]
         duplicate_candidates.extend(ludicrous_items_base)
-        junk_items = [item for item in pool \
-                                    if item not in duplicate_candidates
-                                    and ItemInfo.items[item].type != 'Shop'
-                                    and ItemInfo.items[item].type != 'Song'
-                                    and not ItemInfo.items[item].trade
-                                    and item not in normal_bottles
-                                    and item not in ludicrous_exclusions]
+        junk_items = [
+            item for item in pool
+            if item not in duplicate_candidates
+            and ItemInfo.items[item].type != 'Shop'
+            and ItemInfo.items[item].type != 'Song'
+            and not ItemInfo.items[item].trade
+            and item not in normal_bottles
+            and item not in ludicrous_exclusions
+        ]
         max_extra_copies = int(Decimal(len(junk_items) / len(duplicate_candidates)).to_integral_value(rounding=ROUND_UP))
         duplicate_items = [item for item in duplicate_candidates for _ in range(max_extra_copies)]
         pool = [item if item not in junk_items else duplicate_items.pop(0) for item in pool]

--- a/Unittest.py
+++ b/Unittest.py
@@ -3,7 +3,6 @@
 # See `python -m unittest -h` or `pytest -h` for more options.
 
 from collections import Counter, defaultdict
-from fileinput import filename
 import json
 import logging
 import os
@@ -13,10 +12,9 @@ import unittest
 
 from EntranceShuffle import EntranceShuffleError
 from Item import ItemInfo
-from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions, item_groups
-from LocationList import location_groups, location_is_viewable
-from Main import main, resolve_settings, build_world_graphs, place_items
-from Search import Search
+from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions
+from LocationList import location_is_viewable
+from Main import main, resolve_settings, build_world_graphs
 from Settings import Settings, get_preset_files
 
 test_dir = os.path.join(os.path.dirname(__file__), 'tests')

--- a/data/Hints/tournament.json
+++ b/data/Hints/tournament.json
@@ -2,8 +2,12 @@
     "name":                  "tournament",
     "gui_name":              "Tournament",
     "description":           "Hint Distribution for the S5 Tournament. 5 Goal Hints, 3 Barren Hints, 5 Sometimes hints, 7 Always hints (including skull mask).",
-    "add_locations":         [{ "location": "Deku Theater Skull Mask", "types": ["always"]}],
-    "remove_locations":      [{"location": "Ganons Castle Shadow Trial Golden Gauntlets Chest", "types": ["sometimes"]}],
+    "add_locations":         [
+        { "location": "Deku Theater Skull Mask", "types": ["always"] }
+    ],
+    "remove_locations":      [
+        {"location": "Ganons Castle Shadow Trial Golden Gauntlets Chest", "types": ["sometimes"] }
+    ],
     "add_items":             [],
     "remove_items":          [
         { "item": "Zeldas Lullaby", "types": ["goal"] }

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -819,9 +819,8 @@
     },
     {
         "region_name": "Castle Grounds From Ganons Castle",
-        "font_color": "Light Blue",
         "scene": "Castle Grounds",
-        "hint": "outside Ganon's Castle",
+        "hint": "OUTSIDE_GANONS_CASTLE",
         "exits": {
             # the rainbow bridge cutscene trigger doesn't extend to the castle entrance
             "Ganons Castle Grounds": "is_adult and bridge == 'open'"


### PR DESCRIPTION
* The extended object table access is expressed as an array index instead of explicitly calculating the pointer offset. The table's definition gains a comment explaining its size.
* Fixes the hint area for `Castle Grounds From Ganons Castle`, which I had apparently missed when rebasing #1546 onto #1590.
* The usual indentation/trailing whitespace/unused imports/minor code style fixes.