### PR TITLE
Disable LH bean destinations dual hint in indoor ER

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -236,12 +236,13 @@ conditional_dual_always = {
 
 # Some sometimes, dual, and entrance hints should only be enabled under certain settings
 conditional_sometimes = {
-    # Conditionnal sometimes hints
+    # Conditional sometimes hints
     'HC Great Fairy Reward':                    lambda world: world.settings.shuffle_interior_entrances == 'off',
     'OGC Great Fairy Reward':                   lambda world: world.settings.shuffle_interior_entrances == 'off',
 
-    # Conditionnal dual hints
+    # Conditional dual hints
     'GV Pieces of Heart Ledges':                lambda world: not world.settings.shuffle_cows and world.settings.tokensanity not in ['overworld', 'all'],
+    'LH Adult Bean Destination Checks':         lambda world: world.settings.shuffle_interior_entrances == 'off',
 
     'Fire Temple Lower Loop':                   lambda world: world.settings.tokensanity not in ['dungeon', 'all'],
     'Water Temple River Loop Chests':           lambda world: world.settings.tokensanity not in ['dungeon', 'all'],


### PR DESCRIPTION
There is a `LH Adult Bean Destination Checks` dual hint for `LH Freestanding PoH` and `LH Adult Fishing`. If interiors are shuffled, the latter most likely isn't actually at Lake Hylia, so it no longer makes sense to combine the two locations. This is similar to how the sometimes hints for `HC Great Fairy Reward` and `OGC Great Fairy Reward` are disabled in indoor ER.