### PR TITLE
Add bombchus in gilded chests setting

### DIFF
--- a/Item.py
+++ b/Item.py
@@ -138,6 +138,9 @@ class Item(object):
         if self.type in ('Drop', 'Event', 'Shop', 'DungeonReward') or not self.advancement:
             return False
 
+        if self.name.startswith('Bombchus') and self.world.settings.bombchus_major_item_appearance and self.world.settings.one_item_per_dungeon:
+            return True
+
         if self.name.startswith('Bombchus') and not self.world.settings.bombchus_in_logic:
             return False
 

--- a/Patches.py
+++ b/Patches.py
@@ -1899,7 +1899,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     SILVER_CHEST = 13
     SKULL_CHEST_SMALL = 14
     SKULL_CHEST_BIG =  15
-    if world.settings.bombchus_in_logic:
+    if world.settings.bombchus_in_logic or world.settings.bombchus_gilded_chest_appearance:
         bombchu_ids = [0x6A, 0x03, 0x6B]
         for i in bombchu_ids:
             item = read_rom_item(rom, i)

--- a/Patches.py
+++ b/Patches.py
@@ -1899,7 +1899,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     SILVER_CHEST = 13
     SKULL_CHEST_SMALL = 14
     SKULL_CHEST_BIG =  15
-    if world.settings.bombchus_in_logic or world.settings.bombchus_gilded_chest_appearance:
+    if world.settings.bombchus_in_logic or world.settings.bombchus_major_item_appearance:
         bombchu_ids = [0x6A, 0x03, 0x6B]
         for i in bombchu_ids:
             item = read_rom_item(rom, i)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4245,6 +4245,9 @@ setting_infos = [
             Boss keys will remain in their fancy chest, while small key will be in a
             smaller version of the fancy chest.
         ''',
+        disable    = {
+            'off' : {'settings' : ['bombchus_gilded_chest_appearance'] }
+        },
         shared         = True,
     ),
     Checkbutton(
@@ -4255,6 +4258,21 @@ setting_infos = [
             the Lens of Truth. Lens is not logically
             required for normally visible chests.
         ''',
+        shared         = True,
+    ),
+    Checkbutton(
+        name           = 'bombchus_gilded_chest_appearance',
+        gui_text       = 'Bombchus in Gilded Chests',
+        gui_tooltip    = '''\
+                         If enabled, bombchus will appear inside 
+                         Gilded chests instead of Wooden chests.
+
+                         Requires "Texture" to be enabled for the
+                         "Chest Appearance Matches Contents" setting.
+                         ''',
+        gui_params={
+            "hide_when_disabled": True,
+        },
         shared         = True,
     ),
     Checkbutton(

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4246,7 +4246,7 @@ setting_infos = [
             smaller version of the fancy chest.
         ''',
         disable    = {
-            'off' : {'settings' : ['bombchus_gilded_chest_appearance'] }
+            'off' : {'settings' : ['bombchus_major_item_appearance'] }
         },
         shared         = True,
     ),
@@ -4261,13 +4261,11 @@ setting_infos = [
         shared         = True,
     ),
     Checkbutton(
-        name           = 'bombchus_gilded_chest_appearance',
-        gui_text       = 'Bombchus in Gilded Chests',
+        name           = 'bombchus_major_item_appearance',
+        gui_text       = 'Bombchus Appear as Major Items',
         gui_tooltip    = '''\
                          If enabled, bombchus will appear inside 
-                         Gilded chests instead of Wooden chests.
-
-                         Requires "Texture" to be enabled for the
+                         major item chests using the textures determined by the
                          "Chest Appearance Matches Contents" setting.
                          ''',
         gui_params={

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -358,6 +358,7 @@
             "ocarina_songs",
             "correct_chest_appearances",
             "invisible_chests",
+            "bombchus_gilded_chest_appearance",
             "clearer_hints",
             "hints",
             "hint_dist",

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -358,7 +358,7 @@
             "ocarina_songs",
             "correct_chest_appearances",
             "invisible_chests",
-            "bombchus_gilded_chest_appearance",
+            "bombchus_major_item_appearance",
             "clearer_hints",
             "hints",
             "hint_dist",


### PR DESCRIPTION
This is a setting that we've been using in Triforce Blitz, and was requested for the upcoming SGL tournament.  It's pretty short and sweet as far as implementation goes.