### PR TITLE
Allow sections to be excluded from web/electron individually

### DIFF
--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -415,7 +415,36 @@ export class GUIGlobal {
 
       this.generator_tabsVisibilityMap[tab.name] = true;
 
-      tab.sections.forEach(section => {
+      for (let sectionIndex = 0; sectionIndex < tab.sections.length; sectionIndex++) {
+
+        let section = tab.sections[sectionIndex];
+
+        //Skip sections that don't belong to this app and delete them from the guiSettings
+        if ("app_type" in section && section.app_type && section.app_type.indexOf(this.getGlobalVar("appType")) == -1) {
+
+          tab.sections.splice(sectionIndex, 1);
+          sectionIndex--;
+
+          let foundInCosmeticsTab = guiSettings.cosmeticsArray.find(entryTab => {
+
+            let index = entryTab.sections.findIndex(entry => entry.name == section.name);
+
+            if (index != -1) {
+              entryTab.sections.splice(index, 1);
+              return true;
+            }
+
+            return false;
+          });
+
+          delete guiSettings.settingsObj[tab.name].sections[section.name];
+
+          if (foundInCosmeticsTab) {
+            delete guiSettings.cosmeticsObj[foundInCosmeticsTab.name].sections[section.name];
+          }
+
+          continue;
+        }
         section.settings.forEach(setting => {
 
           this.generator_settingsVisibilityMap[setting.name] = true;
@@ -474,7 +503,7 @@ export class GUIGlobal {
             }
           }
         });
-      });
+      }
     }
 
     //Add GUI only options

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -8,7 +8,7 @@ import copy
 
 
 tab_keys     = ['text', 'app_type', 'footer']
-section_keys = ['text', 'is_colors', 'is_sfx', 'col_span', 'row_span', 'subheader']
+section_keys = ['text', 'app_type', 'is_colors', 'is_sfx', 'col_span', 'row_span', 'subheader']
 setting_keys = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function', 'option_remove']
 types_with_options = ['Checkbutton', 'Radiobutton', 'Combobox', 'SearchBox', 'MultipleSelect']
 
@@ -221,6 +221,11 @@ def GetTabJson(tab, web_version, as_array=False):
 
     for section in tab['sections']:
         sectionJson = GetSectionJson(section, web_version, as_array)
+        if section.get('exclude_from_web', False) and web_version:
+            continue
+        elif section.get('exclude_from_electron', False) and not web_version:
+            continue
+        
         if as_array:
             tabJson['sections'].append(sectionJson)
         else:


### PR DESCRIPTION
Similar to how Tabs can be excluded from web or electron via the exclude_from keys, this allows us to exclude sections.

In combination with the app_type filter, this allows a more granular type of differentiation needed in the future for models patching.

On top, this will allow us to shrink the settings_mapping.json quite a bit cause we won't need to duplicate entire tabs anymore (I see you, general tab).

The standalone patcher on the website's generator page is not included in this and will need to be checked at a later date.

JS Code courtesy of DB.