### PR TITLE
Fix misc. item hints sometimes not finding their items

### DIFF
--- a/Goals.py
+++ b/Goals.py
@@ -337,7 +337,7 @@ def search_goals(categories, reachable_goals, search, priority_locations, all_lo
             if search_woth and not valid_goals['way of the hero']:
                 required_locations['way of the hero'].append(location)
             location.item = old_item
-            _maybe_set_misc_item_hints(location)
+        _maybe_set_misc_item_hints(location)
         search.state_list[location.item.world.id].collect(location.item)
     return required_locations
 

--- a/Goals.py
+++ b/Goals.py
@@ -163,11 +163,6 @@ def update_goal_items(spoiler):
 
     # getHintGroup relies on hint exclusion list
     always_locations = [location.name for world in worlds for location in getHintGroup('always', world)]
-    if spoiler.playthrough:
-        # Skip even the checks
-        _maybe_set_misc_item_hints = lambda _: None
-    else:
-        _maybe_set_misc_item_hints = maybe_set_misc_item_hints
 
     if worlds[0].enable_goal_hints:
         # References first world for goal categories only
@@ -189,7 +184,7 @@ def update_goal_items(spoiler):
                 # Goals are changed for beatable-only accessibility per-world
                 category.update_reachable_goals(search, full_search)
                 reachable_goals = full_search.beatable_goals_fast({ cat_name: category }, cat_world.id)
-                identified_locations = search_goals({ cat_name: category }, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_misc_item_hints)
+                identified_locations = search_goals({ cat_name: category }, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations)
                 # Multiworld can have all goals for one player's bridge entirely
                 # locked by another player's bridge. Therefore, we can't assume
                 # accurate required location lists by locking every world's
@@ -213,7 +208,7 @@ def update_goal_items(spoiler):
         for cat_name, category in worlds[0].unlocked_goal_categories.items():
             category.update_reachable_goals(search, full_search)
         reachable_goals = full_search.beatable_goals_fast(worlds[0].unlocked_goal_categories)
-    identified_locations = search_goals(worlds[0].unlocked_goal_categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_misc_item_hints, search_woth=True)
+    identified_locations = search_goals(worlds[0].unlocked_goal_categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, search_woth=True)
     required_locations.update(identified_locations)
     woth_locations = list(required_locations['way of the hero'])
     del required_locations['way of the hero']
@@ -291,7 +286,7 @@ def unlock_category_entrances(category_locks, state_list):
             exit.access_rule = access_rule
 
 
-def search_goals(categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, _maybe_set_misc_item_hints, search_woth=False):
+def search_goals(categories, reachable_goals, search, priority_locations, all_locations, item_locations, always_locations, search_woth=False):
     # required_locations[category.name][goal.name][world_id] = [...]
     required_locations = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     world_ids = [state.world.id for state in search.state_list]
@@ -337,7 +332,7 @@ def search_goals(categories, reachable_goals, search, priority_locations, all_lo
             if search_woth and not valid_goals['way of the hero']:
                 required_locations['way of the hero'].append(location)
             location.item = old_item
-        _maybe_set_misc_item_hints(location)
+        maybe_set_misc_item_hints(location)
         search.state_list[location.item.world.id].collect(location.item)
     return required_locations
 

--- a/Hints.py
+++ b/Hints.py
@@ -1535,8 +1535,8 @@ def buildMiscItemHints(world, messages):
                     text = data['default_item_text'].format(area=area)
                 else:
                     text = data['custom_item_text'].format(area=area, item=getHint(getItemGenericName(location.item), world.settings.clearer_hints).text)
-            elif 'fallback' in data:
-                if item == data['default_item']:
+            elif 'custom_item_fallback' in data:
+                if 'default_item_fallback' in data and item == data['default_item']:
                     text = data['default_item_fallback']
                 else:
                     text = data['custom_item_fallback'].format(item=item)

--- a/Main.py
+++ b/Main.py
@@ -650,7 +650,8 @@ def copy_worlds(worlds):
 
 def find_misc_hint_items(spoiler):
     search = Search([world.state for world in spoiler.worlds])
-    for location in search.iter_reachable_locations(search.progression_locations()):
+    all_locations = [location for world in spoiler.worlds for location in world.get_filled_locations()]
+    for location in search.iter_reachable_locations(all_locations):
         search.collect(location.item)
         maybe_set_misc_item_hints(location)
 


### PR DESCRIPTION
* Minor items are considered as candidates for misc. item hints. This fixes fallback lines appearing when the hint distribution customizes the hinted item to be a minor one.
* Items that don't appear in the spoiler log playthrough are considered as candidates for misc. item hints after those that do. This fixes fallback lines appearing when the item doesn't appear in the playthrough.
* The conditional for which fallback line to display is fixed so the fallback for Dampé's diary (which can still appear if the hinted item does not exist) doesn't use the one for Ganondorf.