### PR TITLE
Make Gerudo guard on Wasteland side of the gate always spawn

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1377,6 +1377,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x0C + 0x2, 0xC4) # Thieves' Hideout collection flags (picked up keys, marks fights finished as well)
 
     # Add a gate opening guard on the Wasteland side of the Gerudo Fortress' gate
+    # Overrides the generic guard at the bottom of the ladder in Gerudo Fortress
     new_gate_opening_guard = [0x0138, 0xFAC8, 0x005D, 0xF448, 0x0000, 0x95B0, 0x0000, 0x0301]
     rom.write_int16s(0x21BD3EC, new_gate_opening_guard)  # Adult Day
     rom.write_int16s(0x21BD62C, new_gate_opening_guard)  # Adult Night

--- a/Patches.py
+++ b/Patches.py
@@ -1376,14 +1376,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x3, 0xDC) # Thieves' Hideout switch flags (heard yells/unlocked doors)
         save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x0C + 0x2, 0xC4) # Thieves' Hideout collection flags (picked up keys, marks fights finished as well)
 
-    # Add a gate-opening guard on the Wasteland side of the Gerudo gate when the card is shuffled or certain levels of ER.
-    # Overrides the generic guard at the bottom of the ladder in Gerudo Fortress
-    if world.settings.shuffle_gerudo_card or world.settings.shuffle_overworld_entrances or \
-       world.shuffle_special_interior_entrances or world.settings.spawn_positions:
-        # Add a gate opening guard on the Wasteland side of the Gerudo Fortress' gate
-        new_gate_opening_guard = [0x0138, 0xFAC8, 0x005D, 0xF448, 0x0000, 0x95B0, 0x0000, 0x0301]
-        rom.write_int16s(0x21BD3EC, new_gate_opening_guard)  # Adult Day
-        rom.write_int16s(0x21BD62C, new_gate_opening_guard)  # Adult Night
+    # Add a gate opening guard on the Wasteland side of the Gerudo Fortress' gate
+    new_gate_opening_guard = [0x0138, 0xFAC8, 0x005D, 0xF448, 0x0000, 0x95B0, 0x0000, 0x0301]
+    rom.write_int16s(0x21BD3EC, new_gate_opening_guard)  # Adult Day
+    rom.write_int16s(0x21BD62C, new_gate_opening_guard)  # Adult Night
 
     # start with maps/compasses
     if world.settings.shuffle_mapcompass == 'startwith':


### PR DESCRIPTION
The consensus about #1516 was that we may as well always spawn the guard, since she doesn't do any harm by being there and is only beneficial/convenient, and it's not something worth having a setting for.

As discussed in the same PR, no logic changes are necessary for this.