### PR TITLE
Move disable battle music to SFX main section

### DIFF
--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -471,9 +471,10 @@
           "name": "sfx_main_section",
           "is_sfx": true,
           "col_span": 4,
-          "row_span": [1,1,1],
+          "row_span": [2,2,2],
           "settings": [
-            "randomize_all_sfx"
+            "randomize_all_sfx",
+            "disable_battle_music"
           ]
         },
         {
@@ -483,7 +484,6 @@
           "row_span": [6,6,13],
           "settings": [
             "background_music",
-            "disable_battle_music",
             "fanfares",
             "ocarina_fanfares",
             "sfx_low_hp",


### PR DESCRIPTION
There are two reasons for doing this:

1) It makes more sense to me for the toggle to be in the main section than in the section where you set the background music, same way all the Cosmetics toggles are in the main section.
2) Having it in the music section means that it gets disabled when randomize sfx is enabled, even though it's not actually randomized by the toggle (and shouldn't be).