### PR TITLE
Patch text boxes for vanilla warp songs

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -1016,7 +1016,7 @@ def update_warp_song_text(messages, world):
     }
 
     for id, entr in msg_list.items():
-        if 'warp_songs' in world.settings.misc_hints:
+        if 'warp_songs' in world.settings.misc_hints or not world.settings.warp_songs:
             destination = world.get_entrance(entr).connected_region
             destination_name = HintArea.at(destination)
             color = COLOR_MAP[destination_name.color]

--- a/Patches.py
+++ b/Patches.py
@@ -2081,9 +2081,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     elif world.settings.text_shuffle == 'complete':
         permutation = shuffle_messages(messages, except_hints=False)
 
-    # If Warp Song ER is on, update text boxes
-    if world.settings.warp_songs:
-        update_warp_song_text(messages, world)
+    # update warp song preview text boxes
+    update_warp_song_text(messages, world)
 
     if world.settings.blue_fire_arrows:
         rom.write_byte(0xC230C1, 0x29) #Adds AT_TYPE_OTHER to arrows to allow collision with red ice

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4507,7 +4507,8 @@ setting_infos = [
             Stones will never hint the Light Arrows.
 
             Playing a warp song will tell you where
-            it leads.
+            it leads. (If warp song destinations
+            are vanilla, this is always enabled.)
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs'],

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4507,8 +4507,7 @@ setting_infos = [
             Stones will never hint the Light Arrows.
 
             Playing a warp song will tell you where
-            it leads. (If warp song destinations
-            are vanilla, the vanilla text is used.)
+            it leads.
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs'],


### PR DESCRIPTION
This changes the `update_warp_song_text` patch to run even if warp song destinations aren't shuffled. This has the following effects:

* Minuet now says “Sacred Forest Meadow” instead of “Lost Woods”. This is arguably a bugfix, since even though you might consider SFM part of the Lost Woods, the randomizer's hint area system doesn't, so referring to it as such in this text box could be confusing. See our fixes for “Keatan Mask” and the child ToT altar text box for precedent.
* Bolero can no longer be used to tell vanilla warp songs apart from a Bolero destination that happened to be rolled vanilla. Without this PR, the vanilla text has a line break, but the text for shuffled warps doesn't.
* #1679 proposes to add capitalization to the graveyard hint area, which would reintroduce a tell for warp song destination shuffle since the vanilla Nocturne text box still wouldn't be capitalized. Merging this PR first or at the same time would avoid that issue.
* ~~If warp song destinations are vanilla and the misc. hints option for warp songs is off, the text box will now say “Warp to a mysterious place?” This is only really relevant in random settings Pictionary spoiler log races, where I think it's a positive change because it removes a source of information from the runner and forces the pilot to do their job of conveying information via drawing.~~