### PR TITLE
Fix empty dungeons being hinted barren

### DIFF
--- a/World.py
+++ b/World.py
@@ -115,7 +115,7 @@ class World(object):
 
                 for area in HintArea:
                     if area.is_dungeon and area.dungeon_name in self:
-                        self[area.dungeon_name].hint_name = str(area)
+                        self[area.dungeon_name].hint_name = area
             
             def __missing__(self, dungeon_name):
                 return self.EmptyDungeonInfo(None)


### PR DESCRIPTION
On current dev (6.2.163), empty dungeons can be hinted as barren. This behavior was supposed to be prevented [in World.py (line 208)](https://github.com/TestRunnerSRL/OoT-Randomizer/blob/Dev/World.py#L208) but the piece of code doing that is incorrect. It is because unlike other `hint_type_override` groups, `hint_type_overrides['barren']` expect HintArea objects instead of just location names. Here is an easy one-line fix.

To reproduce the bug, one can use the settings string `ASCKMMEASJH2EAAJARUCSDEAAAEAJEACEFCAJSWJAABAACEUAASAJAESBSAHNCWAG2XL8U36HBLTCAYEBAEAAWYCAWHJBAUA` with seed `IKIIM9HMMW`. In this seed, the Shadow Temple is rolled empty and is also hinted barren on Gossip Stones. After the fix, this dungeon remains empty but no empty dungeon is hinted anymore.