### PR TITLE
Fix named_items_required with entrance_always hints

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1303,8 +1303,11 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             # explicitly to the list for named item hints.
             filtered_checked = set(checkedLocations | checkedAlwaysLocations)
             for location in (checkedLocations | checkedAlwaysLocations):
-                if world.get_location(location).item.name == 'Light Arrows':
-                    filtered_checked.remove(location)
+                try:
+                    if world.get_location(location).item.name == 'Light Arrows':
+                        filtered_checked.remove(location)
+                except KeyError:
+                    pass # checkedAlwaysLocations can also contain entrances from entrance_always hints, ignore those here
             for i in range(0, len(world.named_item_pool)):
                 hint = get_specific_item_hint(spoiler, world, filtered_checked)
                 if hint:


### PR DESCRIPTION
The code for `named_items_required` previously assumed that `checkedAlwaysLocations` only contains location names. Since `entrance_always` hints were added, this is no longer the case, as entrance names are now stored in the same set. This mirrors usage of `checkedLocations`, which already worked this way but is still empty at the point `named_items_required` is handled.