### PR TITLE
Added hint distributions for S6 tournament testing

### DIFF
--- a/data/Hints/tournament_test_goal.json
+++ b/data/Hints/tournament_test_goal.json
@@ -1,0 +1,45 @@
+{
+    "name":                  "tournament_test_goal",
+    "gui_name":              "Tournament Test (Goal)",
+    "description":           "Hint Distribution test for the upcoming S6 Tournament. 5 Goal Hints, 3 Barren Hints, 4 Sometimes hints, 8 Always hints (including skull mask and Sheik in Kakariko).",
+    "add_locations":         [
+        { "location": "Deku Theater Skull Mask", "types": ["always"] },
+        { "location": "Sheik in Kakariko", "types": ["always"] }
+    ],
+    "remove_locations":      [
+        { "location": "Ganons Castle Shadow Trial Golden Gauntlets Chest", "types": ["sometimes"] },
+        { "location": "Sheik in Forest", "types": ["sometimes"] },
+        { "location": "Sheik at Temple", "types": ["sometimes"] },
+        { "location": "Sheik in Crater", "types": ["sometimes"] },
+        { "location": "Sheik in Ice Cavern", "types": ["sometimes"] },
+        { "location": "Sheik at Colossus", "types": ["sometimes"] }
+    ],
+    "add_items":             [],
+    "remove_items":          [
+        { "item": "Zeldas Lullaby", "types": ["goal"] }
+    ],
+    "dungeons_woth_limit":   2,
+    "dungeons_barren_limit": 1,
+    "named_items_required":  true,
+    "vague_named_items":     false,
+    "use_default_goals":     true,
+    "distribution":          {
+        "trial":           {"order": 1, "weight": 0.0, "fixed":   0, "copies": 2},
+        "entrance_always": {"order": 2, "weight": 0.0, "fixed":   0, "copies": 2},
+        "always":          {"order": 3, "weight": 0.0, "fixed":   0, "copies": 2},
+        "goal":            {"order": 4, "weight": 0.0, "fixed":   5, "copies": 2},
+        "barren":          {"order": 5, "weight": 0.0, "fixed":   3, "copies": 2},
+        "entrance":        {"order": 6, "weight": 0.0, "fixed":   4, "copies": 2},
+        "sometimes":       {"order": 7, "weight": 0.0, "fixed": 100, "copies": 2},
+        "random":          {"order": 8, "weight": 9.0, "fixed":   0, "copies": 2},
+        "item":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "song":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "overworld":       {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "dungeon":         {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "junk":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "named-item":      {"order": 9, "weight": 0.0, "fixed":   0, "copies": 2},
+        "woth":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "dual_always":     {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0},
+        "dual":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0}
+    }
+}

--- a/data/Hints/tournament_test_woth.json
+++ b/data/Hints/tournament_test_woth.json
@@ -1,0 +1,45 @@
+{
+    "name":                  "tournament_test_woth",
+    "gui_name":              "Tournament Test (WoTH)",
+    "description":           "Hint Distribution test for the upcoming S6 Tournament. 5 WoTH Hints, 3 Barren Hints, 4 Sometimes hints, 8 Always hints (including skull mask and Sheik in Kakariko).",
+    "add_locations":         [
+        { "location": "Deku Theater Skull Mask", "types": ["always"] },
+        { "location": "Sheik in Kakariko", "types": ["always"] }
+    ],
+    "remove_locations":      [
+        { "location": "Ganons Castle Shadow Trial Golden Gauntlets Chest", "types": ["sometimes"] },
+        { "location": "Sheik in Forest", "types": ["sometimes"] },
+        { "location": "Sheik at Temple", "types": ["sometimes"] },
+        { "location": "Sheik in Crater", "types": ["sometimes"] },
+        { "location": "Sheik in Ice Cavern", "types": ["sometimes"] },
+        { "location": "Sheik at Colossus", "types": ["sometimes"] }
+    ],
+    "add_items":             [],
+    "remove_items":          [
+        { "item": "Zeldas Lullaby", "types": ["goal"] }
+    ],
+    "dungeons_woth_limit":   2,
+    "dungeons_barren_limit": 1,
+    "named_items_required":  true,
+    "vague_named_items":     false,
+    "use_default_goals":     true,
+    "distribution":          {
+        "trial":           {"order": 1, "weight": 0.0, "fixed":   0, "copies": 2},
+        "entrance_always": {"order": 2, "weight": 0.0, "fixed":   0, "copies": 2},
+        "always":          {"order": 3, "weight": 0.0, "fixed":   0, "copies": 2},
+        "goal":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "barren":          {"order": 5, "weight": 0.0, "fixed":   3, "copies": 2},
+        "entrance":        {"order": 6, "weight": 0.0, "fixed":   4, "copies": 2},
+        "sometimes":       {"order": 7, "weight": 0.0, "fixed": 100, "copies": 2},
+        "random":          {"order": 8, "weight": 9.0, "fixed":   0, "copies": 2},
+        "item":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "song":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "overworld":       {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "dungeon":         {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "junk":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "named-item":      {"order": 9, "weight": 0.0, "fixed":   0, "copies": 2},
+        "woth":            {"order": 4, "weight": 0.0, "fixed":   5, "copies": 2},
+        "dual_always":     {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0},
+        "dual":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0}
+    }
+}


### PR DESCRIPTION
This will add 2 different hint distributions (tournament_test_goal.json & tournament_test_woth.json) One utilizes path/goal hints while the other utilizes WoTH hints.