### PR TITLE
Fix #MajorItem placing hearts without heart bridge

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -252,7 +252,10 @@ exclude_from_major = [
     'Bombchus (10)',
     'Bombchus (20)',
     'Odd Potion',
-    'Triforce Piece'
+    'Triforce Piece',
+    'Heart Container', 
+    'Piece of Heart', 
+    'Piece of Heart (Treasure Chest Game)',
 ]
 
 item_groups = {


### PR DESCRIPTION
At some point heart containers and pieces were changed to be set to advancement by default, which meant they were added to the MajorItem search group by default. This meant that the code that checked for heart bridge conditions to add hearts to #MajorItem didn't matter as the hearts were in there already. This PR just adds the hearts to the list to exclude them from the MajorItem search group by default.