### PR TITLE
Ensure boss rooms are added to regions for 1 major per dungeon

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -291,7 +291,15 @@ def fill_dungeon_unique_item(window, worlds, search, fill_locations, itempool):
 
     # iterate of all the dungeons in a random order, placing the item there
     for dungeon in dungeons:
-        dungeon_locations = [location for region in dungeon.regions for location in region.locations if location in fill_locations]
+        # Need to re-get dungeon regions to ensure boss rooms are considered
+        regions = []
+        for region in dungeon.world.regions:
+            try:
+                if HintArea.at(region).dungeon_name == dungeon.name:
+                    regions.append(region)
+            except:
+                pass
+        dungeon_locations = [location for region in regions for location in region.locations if location in fill_locations]
 
         # cache this list to flag afterwards
         all_dungeon_locations.extend(dungeon_locations)


### PR DESCRIPTION
Fixes #1671

When getting the locations for 1 major per dungeon, boss regions were not considered since they are no longer part of each `dungeon.regions` list as `dungeon` for the boss regions is set to `None`. This PR changes it so instead of checking `dungeon.regions`, it uses the `HintArea.at` function used elsewhere to detect which dungeon a boss room belongs to.