### PR TITLE
Fix drag and drop (GUI)

### DIFF
--- a/GUI/src/app/components/guiListbox/guiListbox.scss
+++ b/GUI/src/app/components/guiListbox/guiListbox.scss
@@ -6,6 +6,7 @@ div.record-picker {
   position: relative;
   min-height: calc(100% - 4.9rem);
   max-height: calc(100% - 4.9rem);
+  height: 100%;
 
   @media (max-width: 960px) and (max-height: 960px) {
     min-height: calc(100% - 3.5rem);
@@ -48,6 +49,7 @@ div.record-picker {
 .record-picker ul {
     margin: 0;
     padding: 0 0 1px 0;
+    height: 100%;
 }
 
 .record-picker li {


### PR DESCRIPTION
Tiny bugfix for a drag and drop issue within the GUI.

Current behaviour:
![old](https://user-images.githubusercontent.com/17959794/185735571-fcc8387f-3e05-444c-bb93-33eb5a4505b9.gif)

New behaviour:
![new](https://user-images.githubusercontent.com/17959794/185735570-07175c87-7391-4acb-a5a3-8bd5e7ed1f1e.gif)

