### PR TITLE
Fix winner heart piece text in multiworld, part 2

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -865,7 +865,7 @@ def make_player_message(text):
 
     wrapped_text = line_wrap(new_text, False, False, False)
     if wrapped_text != new_text:
-        new_text = line_wrap(new_text, True, True, False)
+        new_text = line_wrap(new_text, True, False, False)
 
     return new_text
 


### PR DESCRIPTION
In #1545 I fixed the text box for the treasure chest game heart piece to do the same “you”→name replacement as other item text boxes. I didn't actually test it though, and this ended up creating another issue where the box break would be removed because the `make_player_message` function just removes all existing box breaks for whatever reason. None of the other messages this function runs on even have box breaks in the first place, and it definitely looks better with the box breaks intact, so this PR removes that behavior from `make_player_message`.

# Before

![image](https://user-images.githubusercontent.com/641386/186045846-c6d2d494-cfa0-402a-9144-f967a677d303.png)

# After

![image](https://user-images.githubusercontent.com/641386/186045847-1ebf12df-6ec5-4eea-8023-b4e46d755fca.png)
![image](https://user-images.githubusercontent.com/641386/186045851-d363a1a9-ee12-4331-864e-34b257cf0770.png)