### PR TITLE
Update weirdshot crash protection to correct value

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -108,9 +108,9 @@ def patch_tunic_colors(rom, settings, log, symbols):
         else:
             color = hex_to_color(tunic_option)
             tunic_option = 'Custom'
-        # "Weird" weirdshots will crash if the Kokiri Tunic Green value is > 0x99. Brickwall it.
+        # "Weird" weirdshots will crash if the Kokiri Tunic Green value is > 0x89. Brickwall it on glitch/no logic.
         if settings.logic_rules != 'glitchless' and tunic == 'Kokiri Tunic':
-            color[1] = min(color[1],0x98)
+            color[1] = min(color[1],0x88)
         rom.write_bytes(address, color)
 
         # patch the tunic icon


### PR DESCRIPTION
Recently zfg posted a report indicating that the crash was still happening. After substantial testing, it was found that the crash happened at green values as low as 0x90, even with BOoT. This rules out the possibility of it being a rando change that broke weirdshots - I suspect that capping it at 0x90 (and later 0x98) simply made the crash far less common.

As I suspect the original writeup just had a typo, I'm changing it to 0x88. Although 0x89 was found to be safe, I'm adding a slight buffer just in case it crashes on higher blue values (which is hypothesized to be possible at high values, such as XX89FF).

It would be nice for more values to be tested to confirm what the safe range is. Ideally, XX88FF, XX89FF, XX8AXX, and XX8FFF should all be tested, with Goron Tunic's red set to FF (as it turns out that the red of Goron tunic is indeed part of what's read, which *might* be just enough, in very specific circumstances, to push it just over the edge into crashing territory), so we can accurately pinpoint the *exact* value the crashing starts at. If someone can confirm an always-safe value, I'll edit this PR to whatever the highest guaranteed-safe green value is.

More ideally, it'd be nice if we could find a way to add a sanity check on the ROM's side, so that VC doesn't get handed an invalid instruction. It's obviously a bit hard to make VC less awful at emulating accurately, but it might be possible to make sure that whatever function is being read when a weirdshot happens is set to something that'll be harmless. I dunno, fixing bugs with VC by patching the rom is *way* beyond what I can do more than vaguely speculate on.

I'm also slightly expanding the comment to indicate that this change only takes place without glitchless logic for completion's sake, even though that's *fairly* obvious from the code itself.