### PR TITLE
roll goal locations independent of parent goal

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import random
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import urllib.request
 from urllib.error import URLError, HTTPError
 import json
@@ -514,21 +514,14 @@ def get_goal_hint(spoiler, world, checked):
         return None
 
     goals = goal_category.goals
-    goal_locations = []
+    category_locations = []
 
-    # Choose random goal and check if any locations are already hinted.
-    # If all locations for a goal are hinted, remove the goal from the list and try again.
-    # If all locations for all goals are hinted, try remaining goal categories
+    # Collect unhinted locations for the category across all category goals.
+    # If all locations for all goals in the category are hinted, try remaining goal categories
     # If all locations for all goal categories are hinted, return no hint.
-    while not goal_locations:
-        if not goals:
-            del world.goal_categories[goal_category.name]
-            goal_category = get_goal_category(spoiler, world, world.goal_categories)
-            if not goal_category:
-                return None
-            else:
-                goals = goal_category.goals
+    while not category_locations:
 
+        # Filter hinted goals until every goal in the category has been hinted.
         weights = []
         zero_weights = True
         for goal in goals:
@@ -536,30 +529,42 @@ def get_goal_hint(spoiler, world, checked):
                 zero_weights = False
             weights.append(goal.weight)
 
-        if zero_weights:
-            goal = random.choice(goals)
-        else:
-            goal = random.choices(goals, weights=weights)[0]
+        # Collect set of unhinted locations for the category. Reduces the bias
+        # from locations in multiple goals for the category.
+        category_locations = []
+        location_reverse_map = defaultdict(list)
+        for goal in goals:
+            if zero_weights or goal.weight > 0:
+                goal_locations = list(filter(lambda location:
+                    location not in category_locations
+                    and location[0].name not in checked
+                    and location[0].name not in world.hint_exclusions
+                    and location[0].name not in world.hint_type_overrides['goal']
+                    and location[0].item.name not in world.item_hint_type_overrides['goal']
+                    and location[0].item.name not in unHintableWothItems,
+                    goal.required_locations))
+                for location in goal_locations:
+                    location_reverse_map[location[0]].append(goal)
+                category_locations.extend(goal_locations)
 
-        goal_locations = list(filter(lambda location:
-            location[0].name not in checked
-            and location[0].name not in world.hint_exclusions
-            and location[0].name not in world.hint_type_overrides['goal']
-            and location[0].item.name not in world.item_hint_type_overrides['goal']
-            and location[0].item.name not in unHintableWothItems,
-            goal.required_locations))
+        if not category_locations:
+            del world.goal_categories[goal_category.name]
+            goal_category = get_goal_category(spoiler, world, world.goal_categories)
+            if not goal_category:
+                return None
+            else:
+                goals = goal_category.goals
 
-        if not goal_locations:
-            goals.remove(goal)
-
-    # Goal weight to zero mitigates double hinting this goal
-    # Once all goals in a category are 0, selection is true random
-    goal.weight = 0
-    location_tuple = random.choice(goal_locations)
+    location_tuple = random.choice(category_locations)
     location = location_tuple[0]
     world_ids = location_tuple[3]
     world_id = random.choice(world_ids)
     checked.add(location.name)
+
+    # Goal weight to zero mitigates double hinting this goal
+    # Once all goals in a category are 0, selection is true random
+    goal = random.choice(location_reverse_map[location])
+    goal.weight = 0
 
     location_text = HintArea.at(location).text(world.settings.clearer_hints)
     if world_id == world.id:


### PR DESCRIPTION
Requested for Standard S6.

Previously, goal hints used a 3-stage process to select a location to hint:
1) Select the goal category (bridge, GBK, trials, etc)
2) Select a goal within the category
3) Select a location required for the goal

This design is biased towards locations that exist in multiple goals. Since locations can only be hinted for one category, this PR changes the selection process to group locations by only their category for random selection. Previous restrictions for hinting all goals within a category before re-hinting a goal remain in effect.

As an example:
* A bow is a required item in 4/5 goals for the bridge
* The Longshot is required for 3/5 goals for the bridge
* The Kokiri Sword is required for 1/5 goals for the bridge
* No other categories exist for the seed

Under the previous algorithm, the bow has the highest probability of being picked as it participates in all but one goal, ignoring impacts from additional required items for those goals. With the new algorithm, the chance is closer to equal with the Longshot and Kokiri Sword. It is not exactly equal as locations for hinted goals get filtered out until all goals are hinted once. Locations in less goals are more likely to get filtered, preserving some of the bias that previously existed.

Someone better at math might be able to quantify the difference. I will prepare empirical comparisons in a few days.