### PR TITLE
Revert one-way hint area restrictions to be separate for each pool

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -787,10 +787,12 @@ def check_entrances_compatibility(entrance, target, rollbacks=(), placed_one_way
         except HintAreaNotFound:
             pass # not connected to a hint area yet, will be checked when shuffling two-way entrances
         else:
-            for placed_entrance in (*rollbacks, *placed_one_way_entrances):
+            # Check all already placed entrances of the same type (including priority entrances placed separately)
+            for rollback in (*rollbacks, *placed_one_way_entrances):
                 try:
-                    if HintArea.at(placed_entrance[0].connected_region) == hint_area:
-                        raise EntranceShuffleError(f'Another one-way entrance already leads to {hint_area}')
+                    placed_entrance = rollback[0]
+                    if entrance.type == placed_entrance.type and HintArea.at(placed_entrance.connected_region) == hint_area:
+                        raise EntranceShuffleError(f'Another {entrance.type} entrance already leads to {hint_area}')
                 except HintAreaNotFound:
                     pass
 
@@ -881,14 +883,16 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
     # so the restriction also needs to be checked here
     for idx1 in range(len(placed_one_way_entrances)):
         try:
-            hint_area1 = HintArea.at(placed_one_way_entrances[idx1][0].connected_region)
+            entrance1 = placed_one_way_entrances[idx1][0]
+            hint_area1 = HintArea.at(entrance1.connected_region)
         except HintAreaNotFound:
             pass
         else:
             for idx2 in range(idx1):
                 try:
-                    if hint_area1 == HintArea.at(placed_one_way_entrances[idx2][0].connected_region):
-                        raise EntranceShuffleError(f'Multiple one-way entrances lead to {hint_area1}')
+                    entrance2 = placed_one_way_entrances[idx2][0]
+                    if entrance1.type == entrance2.type and hint_area1 == HintArea.at(entrance2.connected_region):
+                        raise EntranceShuffleError(f'Multiple {entrance1.type} entrances lead to {hint_area1}')
                 except HintAreaNotFound:
                     pass
 


### PR DESCRIPTION
This reverts one of the changes made in PR #1537 that changed the area restriction to be shared throughout all pools (ie. warp songs, spawns and owl drops).

Imo it doesn't seem right to have the restriction apply to all pools at once, and it should be possible for a spawn, warp song and/or owl drop to lead to the same hint area. In fact, this is even the case in vanilla, with the adult spawn and prelude both leading to ToT, so it makes sense to allow it in ER as well. Also there aren't that many hint areas, which means that forcing all spawns, warp songs and owl drops to different areas limits randomization quite a lot. So overall I think it's better to revert this part and it's my reasoning behind making this PR.

Note that the restriction still uses hint areas, which was the main goal of the original PR.
