### PR TITLE
Don't list non-required effective starting items in playthrough

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -684,7 +684,7 @@ def create_playthrough(spoiler):
 
     search.checkpoint()
     search.collect_pseudo_starting_items()
-    
+
     while True:
         search.checkpoint()
         # Not collecting while the generator runs means we only get one sphere at a time
@@ -755,7 +755,7 @@ def create_playthrough(spoiler):
     # Regenerate the spheres as we might not reach places the same way anymore.
     search.reset() # search state has no items, okay to reuse sphere 0 cache
     collection_spheres = []
-    collection_spheres.append(list(search.iter_pseudo_starting_locations()))
+    collection_spheres.append(list(filter(lambda loc: loc in required_locations, search.iter_pseudo_starting_locations())))
     entrance_spheres = []
     remaining_entrances = set(required_entrances)
     collected = set()


### PR DESCRIPTION
#1608 added an explicit sphere 0 containing the effective starting items to the spoiler log playthrough. Those items are currently always listed even if they're junk or otherwise not required. This PR fixes that by simply only listing them if they're included in the required locations as determined by the playthrough algorithm.