### PR TITLE
Document ammo count fields used for MW queue size

### DIFF
--- a/Notes/extra-save-data.md
+++ b/Notes/extra-save-data.md
@@ -1,5 +1,9 @@
 This file documents parts of the OoT save data that go unused in vanilla but are used by the randomizer. **It may be incomplete.**
 
+# Ammo counts
+
+The ammunition count fields for fire arrows (save context + 0x90) and Din's Fire (save context + 0x91) are repurposed as a single unsigned 16-bit integer field representing the number of items received from the network in a multiworld seed.
+
 # Scene flags
 
 ## Unused field


### PR DESCRIPTION
This value is [updated](https://github.com/TestRunnerSRL/OoT-Randomizer/blob/5df99700ad34b1462f67fd74039d3382262e948f/ASM/c/get_items.c#L207-L208) in the `after_key_received` function in `get_items.c`, and multiworld plugins check it to determine which item, if any, should be queued next.