### PR TITLE
Fix replacing “Ganon's” with “my” in Ganondorf hint

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -1708,7 +1708,8 @@ misc_item_hint_table = {
         'default_item_text': "Ha ha ha... You'll never beat me by reflecting my lightning bolts and unleashing the arrows from {area}!",
         'custom_item_text': "Ha ha ha... You'll never find {item} from {area}!",
         'replace': {
-            "from #Ganon's Castle#": "from #my castle#",
+            "from #inside Ganon's Castle#": "from #inside my castle#",
+            "from #outside Ganon's Castle#": "from #outside my castle#",
         },
     },
 }


### PR DESCRIPTION
This was broken in #1621 because the find/replace was looking for `from #Ganon's Castle#` but the actual text is `from #inside Ganon's Castle#` or `from #outside Ganon's Castle#`. The “from” needs to be included to prevent the text being replaced if the light arrows are in another world (see #1105).