### PR TITLE
Version Refactor

### DIFF
--- a/GUI/electron/src/preload.ts
+++ b/GUI/electron/src/preload.ts
@@ -103,7 +103,7 @@ post.on('getCurrentSourceVersion', function (event) {
 
     data.baseVersion = baseMatch != null && baseMatch[1] !== undefined ? baseMatch[1] : "";
     data.supplementaryVersion = supplementaryMatch != null && supplementaryMatch[1] !== undefined ? parseInt(supplementaryMatch[1]) : 0;
-    data.fullVersion = fullMatch != null && fullMatch[1] !== undefined ? fullMatch[1] : "";
+    data.fullVersion = fullMatch != null && fullMatch[1] !== undefined ? fullMatch[1] : data.baseVersion;
     data.fullVersion = data.fullVersion
       .replace('{base_version}', data.baseVersion)
       .replace('{supplementary_version}', data.supplementaryVersion.toString())

--- a/GUI/electron/src/preload.ts
+++ b/GUI/electron/src/preload.ts
@@ -50,7 +50,7 @@ electron.remote.getCurrentWindow().on('leave-html-full-screen', () => {
 
 //FUNCTIONS
 function dumpSettingsToFile(settingsObj) {
-  settingsObj["check_version"] = true;    
+  settingsObj["check_version"] = true;
   fs.writeFileSync(pythonSourcePath + "settings.sav", JSON.stringify(settingsObj, null, 4));
 }
 
@@ -83,17 +83,36 @@ function readSettingsFromFile() {
 
 //POST ROBOT
 post.on('getCurrentSourceVersion', function (event) {
+  type VersionData = {
+    baseVersion: string;
+    supplementaryVersion: number;
+    fullVersion: string;
+    branchUrl: string;
+  };
 
   let versionFilePath = pythonSourcePath + "version.py"; //Read version.py from the python source
+  let data: VersionData = { baseVersion : "", supplementaryVersion : 0, fullVersion : "", branchUrl : "" }
 
   if (fs.existsSync(versionFilePath)) {
-    let versionString = fs.readFileSync(versionFilePath, 'utf8');
-    versionString = versionString.substr(versionString.indexOf("'") + 1);
-   
-    return versionString.substr(0, versionString.indexOf("'"));
+    let versionFile = fs.readFileSync(versionFilePath, 'utf8');
+
+    let baseMatch = versionFile.match(/^[ \t]*__version__ = ['"](.+)['"]/m);
+    let supplementaryMatch = versionFile.match(/^[ \t]*supplementary_version = (\d+)$/m);
+    let fullMatch = versionFile.match(/^[ \t]*__version__ = f['"]*(.+)['"]/m);
+    let urlMatch = versionFile.match(/^[ \t]*branch_url = ['"](.+)['"]/m);
+
+    data.baseVersion = baseMatch != null && baseMatch[1] !== undefined ? baseMatch[1] : "";
+    data.supplementaryVersion = supplementaryMatch != null && supplementaryMatch[1] !== undefined ? parseInt(supplementaryMatch[1]) : 0;
+    data.fullVersion = fullMatch != null && fullMatch[1] !== undefined ? fullMatch[1] : "";
+    data.fullVersion = data.fullVersion
+      .replace('{base_version}', data.baseVersion)
+      .replace('{supplementary_version}', data.supplementaryVersion.toString())
+    data.branchUrl = urlMatch != null && urlMatch[1] !== undefined ? urlMatch[1] : "";
+
+    return data;
   }
   else {
-    return false;
+    return null;
   }
 });
 
@@ -291,7 +310,7 @@ post.on('generateSeed', function (event) {
     }
 
     if (err.short == "user_cancelled")
-      post.send(window, 'generateSeedCancelled'); 
+      post.send(window, 'generateSeedCancelled');
     else
       post.send(window, 'generateSeedError', err);
   });

--- a/GUI/src/app/@theme/components/footer/footer.component.ts
+++ b/GUI/src/app/@theme/components/footer/footer.component.ts
@@ -24,6 +24,7 @@ export class FooterComponent {
 
   localVersion: string = "";
   remoteVersion: string = "";
+  branchUrl: string = "";
   hasUpdate: boolean = false;
 
   constructor(public global: GUIGlobal, private dialogService: NbDialogService) { }
@@ -39,7 +40,8 @@ export class FooterComponent {
         }
         else if (eventObj.name == "local_version_checked") {
           this.localVersion = eventObj.version;
-        }      
+          this.branchUrl = eventObj.branchUrl;
+        }
       });
 
       if (this.global.getGlobalVar("appReady")) {
@@ -65,7 +67,7 @@ export class FooterComponent {
     }).onClose.subscribe(confirmed => {
 
       if (confirmed) {
-        let link = this.remoteVersion.includes("Release") ? "https://www.ootrandomizer.com/downloads" : "https://github.com/TestRunnerSRL/OoT-Randomizer/tree/Dev";
+        let link = this.remoteVersion.includes("Release") ? "https://www.ootrandomizer.com/downloads" : this.branchUrl;
         (<any>window).open(link, "_blank");
       }
     });

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -23,7 +23,7 @@ export class GUIGlobal {
   @HostBinding('class.indigo-pink') materialStyleIndigo: boolean = true;
 
   @Output() globalEmitter: EventEmitter<object> = new EventEmitter();
-  
+
   constructor(private http: HttpClient) {
     this.globalVars = new Map<string, any>([
       ["appReady", false],
@@ -370,7 +370,7 @@ export class GUIGlobal {
             adjustedUserPresets[presetName] = { settings: userPresets[presetName] };
         });
 
-        Object.assign(res.presets, adjustedUserPresets);       
+        Object.assign(res.presets, adjustedUserPresets);
       }
     }
 
@@ -534,29 +534,48 @@ export class GUIGlobal {
 
       var event = await post.send(window, 'getCurrentSourceVersion');
 
-      var res: string = event.data;
+      type VersionData = {
+        baseVersion: string;
+        supplementaryVersion: number;
+        fullVersion: string;
+        branchUrl: string;
+      };
+
+      var local: VersionData = event.data;
       var result = { hasUpdate: false, currentVersion: "", latestVersion: "" };
 
-      if (res && res.length > 0) {
+      if (local !== null) {
 
-        console.log("Local:", res);
-        result.currentVersion = res;
+        console.log("Local:", local);
+        result.currentVersion = local.fullVersion;
 
-        this.globalEmitter.emit({ name: "local_version_checked", version: res });
+        this.globalEmitter.emit({ name: "local_version_checked", version: local.fullVersion, branchUrl: local.branchUrl });
 
-        let branch = res.includes("Release") ? "release" : "Dev";
-        var remoteFile = await this.http.get("https://raw.githubusercontent.com/TestRunnerSRL/OoT-Randomizer/" + branch + "/version.py", { responseType: "text" }).toPromise();
+        let remote: VersionData = { baseVersion : "", supplementaryVersion : 0, fullVersion : "", branchUrl : "" }
+        let url = local.branchUrl.replace("https://github.com", "https://raw.githubusercontent.com").replace("tree/", "") + "/version.py";
+        console.log("URL: ", url)
+        var remoteFile = await this.http.get(url, { responseType: "text" }).toPromise();
 
-        let remoteVersion = remoteFile.substr(remoteFile.indexOf("'") + 1);
-        remoteVersion = remoteVersion.substr(0, remoteVersion.indexOf("'"));
+        let baseMatch = remoteFile.match(/^[ \t]*__version__ = ['"](.+)['"]/m);
+        let supplementaryMatch = remoteFile.match(/^[ \t]*supplementary_version = (\d+)$/m);
+        let fullMatch = remoteFile.match(/^[ \t]*__version__ = f['"]*(.+)['"]/m);
+        let urlMatch = remoteFile.match(/^[ \t]*branch_url = ['"](.+)['"]/m);
 
-        console.log("Remote:", remoteVersion);
-        result.latestVersion = remoteVersion;
+        remote.baseVersion = baseMatch != null && baseMatch[1] !== undefined ? baseMatch[1] : "";
+        remote.supplementaryVersion = supplementaryMatch != null && supplementaryMatch[1] !== undefined ? parseInt(supplementaryMatch[1]) : 0;
+        remote.fullVersion = fullMatch != null && fullMatch[1] !== undefined ? fullMatch[1] : "";
+        remote.fullVersion = remote.fullVersion
+          .replace('{base_version}', remote.baseVersion)
+          .replace('{supplementary_version}', remote.supplementaryVersion.toString())
+        remote.branchUrl = urlMatch != null && urlMatch[1] !== undefined ? urlMatch[1] : "";
+
+        console.log("Remote:", remote);
+        result.latestVersion = remote.fullVersion;
 
         //Compare versions
-        result.hasUpdate = this.isVersionNewer(remoteVersion, res);
+        result.hasUpdate = this.isVersionNewer(remote.baseVersion, local.baseVersion, remote.supplementaryVersion, local.supplementaryVersion);
 
-        return result;  
+        return result;
       }
       else {
         return result;
@@ -568,7 +587,7 @@ export class GUIGlobal {
     }
   }
 
-  isVersionNewer(newVersion: string, oldVersion: string) {
+  isVersionNewer(newVersion: string, oldVersion: string, newSubVersion: number = 0, oldSubVersion: number = 0) {
 
     //Strip away dev strings
     if (oldVersion.startsWith("dev") && oldVersion.includes("_"))
@@ -583,10 +602,14 @@ export class GUIGlobal {
     //Version is not newer if the new version doesn't satisfy the format
     if (newSplit.length < 3)
       return false;
+    else if (newSplit.length == 4)
+      newSubVersion = newSubVersion == 0 ? Number(newSplit[3]) : 0;
 
     //Version is newer if the old version doesn't satisfy the format
     if (oldSplit.length < 3)
       return true;
+    else if (oldSplit.length == 4)
+      oldSubVersion = oldSubVersion == 0 ? Number(oldSplit[3]) : 0;
 
     //Compare major.minor.revision
     if (Number(newSplit[0]) > Number(oldSplit[0])) {
@@ -599,6 +622,11 @@ export class GUIGlobal {
       else if (Number(newSplit[1]) == Number(oldSplit[1])) {
         if (Number(newSplit[2]) > Number(oldSplit[2])) {
           return true;
+        }
+        else if (Number(newSplit[2]) == Number(oldSplit[2])) {
+          if (newSubVersion > oldSubVersion) {
+            return true;
+          }
         }
       }
     }
@@ -637,7 +665,7 @@ export class GUIGlobal {
     }
     else if (typeof (settingValue) == "string") { //Try to cast it
 
-      if (Number(parseInt(settingValue)) != Number(settingValue)) { //Cast failed, not numeric    
+      if (Number(parseInt(settingValue)) != Number(settingValue)) { //Cast failed, not numeric
         error = true;
       }
       else {
@@ -778,7 +806,7 @@ export class GUIGlobal {
         section.settings.forEach(setting => {
 
           if (setting.name in cleanSettings) {
-            this.generator_settingsMap[setting.name] = setting.default; 
+            this.generator_settingsMap[setting.name] = setting.default;
           }
         });
       });
@@ -837,8 +865,8 @@ export class GUIGlobal {
 
             if (error) { //Input could not be recovered, abort
               invalidSettingsList.push(setting.text);
-            }       
-          }     
+            }
+          }
         });
       });
     });
@@ -1148,7 +1176,7 @@ export class GUIGlobal {
       fileReader.onload = function (event) {
 
         console.log("Read in file successfully");
-        resolve(event.target["result"]); 
+        resolve(event.target["result"]);
       };
 
       if (useArrayBuffer)
@@ -1212,7 +1240,7 @@ export class GUIGlobal {
       return plandoFileText;
     }
     catch (ex) {
-      switch (ex.error) {       
+      switch (ex.error) {
         case "file_read_error": {
           throw { error: `An error occurred during the loading of the ${settingText}! Please try to enter it again.` };
         }

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -563,7 +563,7 @@ export class GUIGlobal {
 
         remote.baseVersion = baseMatch != null && baseMatch[1] !== undefined ? baseMatch[1] : "";
         remote.supplementaryVersion = supplementaryMatch != null && supplementaryMatch[1] !== undefined ? parseInt(supplementaryMatch[1]) : 0;
-        remote.fullVersion = fullMatch != null && fullMatch[1] !== undefined ? fullMatch[1] : "";
+        remote.fullVersion = fullMatch != null && fullMatch[1] !== undefined ? fullMatch[1] : remote.baseVersion;
         remote.fullVersion = remote.fullVersion
           .replace('{base_version}', remote.baseVersion)
           .replace('{supplementary_version}', remote.supplementaryVersion.toString())

--- a/Rom.py
+++ b/Rom.py
@@ -55,8 +55,7 @@ class Rom(BigStream):
         self.original = self.copy()
 
         # Add version number to header.
-        self.write_bytes(0x35, get_version_bytes(base_version, branch_identifier, supplementary_version))
-        self.force_patch.extend([0x35, 0x36, 0x37, 0x38, 0x39])
+        self.write_version_bytes()
 
 
     def copy(self):
@@ -133,8 +132,7 @@ class Rom(BigStream):
         self.changed_dma = {}
         self.force_patch = []
         self.last_address = None
-        self.write_bytes(0x35, get_version_bytes(base_version, branch_identifier, supplementary_version))
-        self.force_patch.extend([0x35, 0x36, 0x37, 0x38, 0x39])
+        self.write_version_bytes()
 
 
     def sym(self, symbol_name):
@@ -151,6 +149,13 @@ class Rom(BigStream):
     def update_header(self):
         crc = calculate_crc(self)
         self.write_bytes(0x10, crc)
+
+
+    def write_version_bytes(self):
+        version_bytes = get_version_bytes(base_version, branch_identifier, supplementary_version)
+        self.write_bytes(0x19, version_bytes)
+        self.write_bytes(0x35, version_bytes[:3])
+        self.force_patch.extend([0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x35, 0x36, 0x37])
 
 
     def read_rom(self, file):

--- a/Rom.py
+++ b/Rom.py
@@ -11,7 +11,7 @@ import copy
 from Utils import is_bundled, subprocess_args, local_path, data_path, default_output_path, get_version_bytes
 from ntype import BigStream, uint32
 from crc import calculate_crc
-from version import __version__
+from version import base_version, branch_identifier, supplementary_version
 
 DMADATA_START = 0x7430
 
@@ -55,8 +55,8 @@ class Rom(BigStream):
         self.original = self.copy()
 
         # Add version number to header.
-        self.write_bytes(0x35, get_version_bytes(__version__))
-        self.force_patch.extend([0x35, 0x36, 0x37])
+        self.write_bytes(0x35, get_version_bytes(base_version, branch_identifier, supplementary_version))
+        self.force_patch.extend([0x35, 0x36, 0x37, 0x38, 0x39])
 
 
     def copy(self):
@@ -133,8 +133,8 @@ class Rom(BigStream):
         self.changed_dma = {}
         self.force_patch = []
         self.last_address = None
-        self.write_bytes(0x35, get_version_bytes(__version__))
-        self.force_patch.extend([0x35, 0x36, 0x37])
+        self.write_bytes(0x35, get_version_bytes(base_version, branch_identifier, supplementary_version))
+        self.force_patch.extend([0x35, 0x36, 0x37, 0x38, 0x39])
 
 
     def sym(self, symbol_name):

--- a/Utils.py
+++ b/Utils.py
@@ -6,7 +6,7 @@ import sys
 import urllib.request
 from urllib.error import URLError, HTTPError
 import re
-from version import __version__
+from version import __version__, base_version, supplementary_version, branch_url
 import random
 import itertools
 import bisect
@@ -84,10 +84,12 @@ def close_console():
         except Exception:
             pass
 
-def get_version_bytes(a):
-    version_bytes = [0x00, 0x00, 0x00]
+def get_version_bytes(a, b=0x00, c=0x00):
+    version_bytes = [0x00, 0x00, 0x00, b, c]
+
     if not a:
-        return version_bytes;
+        return version_bytes
+
     sa = a.replace('v', '').replace(' ', '.').split('.')
 
     for i in range(0,3):
@@ -124,12 +126,30 @@ class VersionError(Exception):
 def check_version(checked_version):
     if compare_version(checked_version, __version__) < 0:
         try:
-            with urllib.request.urlopen('https://raw.githubusercontent.com/TestRunnerSRL/OoT-Randomizer/Dev/version.py') as versionurl:
-                version = versionurl.read()
-                version = re.search(".__version__ = '(.+)'", str(version)).group(1)
+            with urllib.request.urlopen(f'{branch_url.replace("https://github.com", "https://raw.githubusercontent.com").replace("tree/", "")}/version.py') as versionurl:
+                version_file = versionurl.read().decode("utf-8")
 
-                if compare_version(version, __version__) > 0:
-                    raise VersionError("You are on version " + __version__ + ", and the latest is version " + version + ".")
+                base_match = re.search("""^[ \t]*__version__ = ['"](.+)['"]""", version_file, re.MULTILINE)
+                supplementary_match = re.search(r"^[ \t]*supplementary_version = (\d+)$", version_file, re.MULTILINE)
+                full_match = re.search("""^[ \t]*__version__ = f['"]*(.+)['"]""", version_file, re.MULTILINE)
+                url_match = re.search("""^[ \t]*branch_url = ['"](.+)['"]""", version_file, re.MULTILINE)
+
+                remote_base_version = base_match.group(1) if base_match else ""
+                remote_supplementary_version = int(supplementary_match.group(1)) if supplementary_match else 0
+                remote_full_version = full_match.group(1) if full_match else ""
+                remote_full_version = remote_full_version \
+                    .replace('{base_version}', remote_base_version) \
+                    .replace('{supplementary_version}', str(remote_supplementary_version))
+                remote_branch_url = url_match.group(1) if url_match else ""
+
+                upgrade_available = False
+                if compare_version(remote_base_version, base_version) > 0:
+                    upgrade_available = True
+                elif compare_version(remote_base_version, base_version) == 0 and remote_supplementary_version > supplementary_version:
+                    upgrade_available = True
+
+                if upgrade_available:
+                    raise VersionError("You are on version " + __version__ + ", and the latest is version " + remote_full_version + ".")
         except (URLError, HTTPError) as e:
             logger = logging.getLogger('')
             logger.warning("Could not fetch latest version: " + str(e))

--- a/Utils.py
+++ b/Utils.py
@@ -136,7 +136,7 @@ def check_version(checked_version):
 
                 remote_base_version = base_match.group(1) if base_match else ""
                 remote_supplementary_version = int(supplementary_match.group(1)) if supplementary_match else 0
-                remote_full_version = full_match.group(1) if full_match else ""
+                remote_full_version = full_match.group(1) if full_match else remote_base_version
                 remote_full_version = remote_full_version \
                     .replace('{base_version}', remote_base_version) \
                     .replace('{supplementary_version}', str(remote_supplementary_version))

--- a/version.py
+++ b/version.py
@@ -1,1 +1,17 @@
-__version__ = '6.2.195 f.LUM'
+__version__ = '6.2.195'
+
+# This is a supplementary version number for branches based off of main dev.
+supplementary_version = 0
+
+# Pick a unique identifier byte for your fork if you are intending to have a long-lasting branch.
+# This will be 0x00 for main releases and 0x01 for main dev.
+branch_identifier = 0x01
+
+# URL to your branch on GitHub.
+branch_url = 'https://github.com/TestRunnerSRL/OoT-Randomizer/tree/Dev'
+
+# This is named __version__ at the top for compatability with older versions trying to version check.
+base_version = __version__
+
+# And finally, the completed version string. This is what is displayed and used for salting seeds.
+__version__ = f'{base_version} f.LUM'


### PR DESCRIPTION
Reworks version checks to make it easier for branches to have their own individual version tracking. Version checks are performed using the branch URL specified, and now checks the supplementary version as well.

The main version bytes at 0x35-0x37 of the ROM are unchanged. A 5-byte set of version bytes are injected to 0x19-0x1D, with branch identifier as the 4th byte and supplementary version as the 5th byte.