### PR TITLE
Fix error allowing hinted WoTH ZL

### DIFF
--- a/data/Hints/tournament_test_woth.json
+++ b/data/Hints/tournament_test_woth.json
@@ -16,7 +16,7 @@
     ],
     "add_items":             [],
     "remove_items":          [
-        { "item": "Zeldas Lullaby", "types": ["goal"] }
+        { "item": "Zeldas Lullaby", "types": ["woth"] }
     ],
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,


### PR DESCRIPTION
When creating this distribution I forgot to change the item type for ZL, allowing it to be hinted as WoTH, which is unintended. I've changed the value indicated from "goal" to "woth" to fix that behavior.