### PR TITLE
Fix Enhanced Map/Compass on Glitched Logic

### DIFF
--- a/data/Glitched World/Deku Tree.json
+++ b/data/Glitched World/Deku Tree.json
@@ -22,7 +22,7 @@
         },
         "exits": {
             "Deku Tree Slingshot Room": "here(has_shield)",
-            "Deku Tree Boss Room": "here(has_fire_source_with_torch()) or can_shield
+            "Deku Tree Boss Door": "here(has_fire_source_with_torch()) or can_shield
                 or is_adult"
         }
     },
@@ -38,7 +38,15 @@
         }
     },
     {
-        "region_name": "Deku Tree Boss Room",
+        "region_name": "Deku Tree Boss Door",
+        "scene": "Deku Tree",
+        "dungeon": "Deku Tree",
+        "exits": {
+            "Queen Gohma Boss Room": "True"
+        }
+    },
+    {
+        "region_name": "Queen Gohma Boss Room",
         "dungeon": "Deku Tree",
         "events": {
             "Deku Tree Clear": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and

--- a/data/Glitched World/Dodongos Cavern.json
+++ b/data/Glitched World/Dodongos Cavern.json
@@ -63,8 +63,16 @@
                 or (can_live_dmg(0.5) and can_use(Hover_Boots)) or can_hover"
         },
         "exits": {
-            "King Dodongo Boss Room": "has_explosives",
+            "Dodongos Cavern Boss Door": "has_explosives",
             "Dodongos Cavern Lobby": "True"
+        }
+    },
+    {
+        "region_name": "Dodongos Cavern Boss Door",
+        "scene": "Dodongos Cavern",
+        "dungeon": "Dodongos Cavern",
+        "exits": {
+            "King Dodongo Boss Room": "True"
         }
     },
     {

--- a/data/Glitched World/Fire Temple.json
+++ b/data/Glitched World/Fire Temple.json
@@ -8,17 +8,12 @@
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and (can_use(Megaton_Hammer) or can_use(Hookshot) or has_explosives)",
             "Fire Temple Boss Key Chest": "(
                 ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Megaton_Hammer)) or (can_mega and can_use(Hookshot))",
-            "Fire Temple Volvagia Heart": "
-                (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer) and 
-                (Boss_Key_Fire_Temple or at('Fire Temple Flame Maze', True))",
-            "Volvagia": "
-                (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer) and 
-                (Boss_Key_Fire_Temple or at('Fire Temple Flame Maze', True))",
             "Fire Temple GS Boss Key Loop": "
                 ((Small_Key_Fire_Temple, 8) or not keysanity)"
         },
         "exits": {
-            "Fire Temple Big Lava Room":"(Small_Key_Fire_Temple, 2)"
+            "Fire Temple Big Lava Room":"(Small_Key_Fire_Temple, 2)",
+            "Fire Temple Boss Door": "True"
         }
     },
     {
@@ -91,6 +86,25 @@
                 ",
             "Fire Temple Megaton Hammer Chest": "has_explosives or
                 can_use(Megaton_Hammer)"
+        }
+    },
+    {
+        "region_name": "Fire Temple Boss Door",
+        "scene": "Fire Temple",
+        "dungeon": "Fire Temple",
+        "exits": {
+            "Volvagia Boss Room": "(Boss_Key_Fire_Temple or at('Fire Temple Flame Maze', True))"
+        }
+    },
+    {
+        "region_name": "Volvagia Boss Room",
+        "scene": "Fire Temple",
+        "dungeon": "Fire Temple",
+        "locations": {
+            "Fire Temple Volvagia Heart": "
+                (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer)",
+            "Volvagia": "
+                (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer)"
         }
     }
 ]

--- a/data/Glitched World/Forest Temple.json
+++ b/data/Glitched World/Forest Temple.json
@@ -19,7 +19,7 @@
             "Forest Temple Block Push Room": "(Small_Key_Forest_Temple, 1)",
             "Forest Temple Basement": "(Forest_Temple_Jo_and_Beth and Forest_Temple_Amy_and_Meg) or (can_use(Hover_Boots) and can_mega)",
             "Forest Temple Falling Room": "can_hover or (can_use(Hover_Boots) and Bombs and can_live_dmg(0.5))",
-            "Forest Temple Boss Room": "is_adult"
+            "Forest Temple Boss Door": "is_adult"
         }
     },
     {
@@ -37,7 +37,7 @@
                  ((can_use(Boomerang) or Nuts or Buy_Deku_Shield) and
                   (Sticks or Kokiri_Sword or can_use(Slingshot))))",
             "Forest Temple Outside Upper Ledge": "can_hover or (can_use(Hover_Boots) and has_explosives and can_live_dmg(0.5))",
-            "Forest Temple Boss Room": "is_child and can_live_dmg(0.5)"
+            "Forest Temple Boss Door": "is_child and can_live_dmg(0.5)"
         }
     },
     {
@@ -147,11 +147,19 @@
             "Forest Temple GS Basement": "can_use(Hookshot) or can_use(Boomerang) or can_hover"
         },
         "exits":{
-            "Forest Temple Boss Room": "Boss_Key_Forest_Temple"
+            "Forest Temple Boss Door": "Boss_Key_Forest_Temple"
         }
     },
     {
-        "region_name": "Forest Temple Boss Room",
+        "region_name": "Forest Temple Boss Door",
+        "scene": "Forest Temple",
+        "dungeon": "Forest Temple",
+        "exits": {
+            "Phantom Ganon Boss Room": "True"
+        }
+    },
+    {
+        "region_name": "Phantom Ganon Boss Room",
         "dungeon": "Forest Temple",
         "locations": {
             "Forest Temple Phantom Ganon Heart": "(can_use(Hookshot) or can_use(Bow)) or 

--- a/data/Glitched World/Jabu Jabus Belly.json
+++ b/data/Glitched World/Jabu Jabus Belly.json
@@ -31,11 +31,19 @@
         },
         "exits": {
             "Jabu Jabus Belly Main": "True",
-            "Jabu Jabus Belly Boss Area": "can_use(Boomerang) or can_use(Hover_Boots) or can_mega"
+            "Jabu Jabus Belly Boss Door": "can_use(Boomerang) or can_use(Hover_Boots) or can_mega"
         }
     },
     {
-        "region_name": "Jabu Jabus Belly Boss Area",
+        "region_name": "Jabu Jabus Belly Boss Door",
+        "scene": "Jabu Jabus Belly",
+        "dungeon": "Jabu Jabus Belly",
+        "exits": {
+            "Barinade Boss Room": "True"
+        }
+    },
+    {
+        "region_name": "Barinade Boss Room",
         "dungeon": "Jabu Jabus Belly",
         "locations": {
             "Jabu Jabus Belly Barinade Heart": "can_use(Boomerang) and (Sticks or Kokiri_Sword)",

--- a/data/Glitched World/Shadow Temple.json
+++ b/data/Glitched World/Shadow Temple.json
@@ -16,7 +16,7 @@
         "exits": {
             "Shadow Temple Entryway": "True",
             "Shadow Temple First Beamos": "can_use(Hover_Boots) or can_mega",
-            "Shadow Boss": "can_hover and has_explosives and can_use(Hover_Boots) and 
+            "Shadow Temple Boss Door": "can_hover and has_explosives and can_use(Hover_Boots) and
                 can_live_dmg(2.0)"
         }
     },
@@ -91,14 +91,22 @@
             "Shadow Temple GS Triple Giant Pot": "True"
         },
         "exits": {
-            "Shadow Boss": "(has_bombchus or can_use(Distant_Scarecrow) or Bow or 
+            "Shadow Temple Boss Door": "(has_bombchus or can_use(Distant_Scarecrow) or Bow or
                 (can_mega and can_use(Hover_Boots)) or can_hover) and 
                 (Boss_Key_Shadow_Temple or (has_explosives and is_adult)) and
                 (can_mega or can_use(Hover_Boots)) and (Small_Key_Shadow_Temple, 5)"
         }
     },
     {
-        "region_name": "Shadow Boss",
+        "region_name": "Shadow Temple Boss Door",
+        "scene": "Shadow Temple",
+        "dungeon": "Shadow Temple",
+        "exits": {
+            "Bongo Bongo Boss Room": "True"
+        }
+    },
+    {
+        "region_name": "Bongo Bongo Boss Room",
         "dungeon": "Shadow Temple",
         "locations": {
             "Shadow Temple Bongo Bongo Heart": "True",

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -94,7 +94,7 @@
                 can_hover or
                 can_use(Hookshot)) and has_explosives",
             "Child Spirit Temple Climb": "True",
-            "Spirit Temple Boss": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives",
+            "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives",
             "Early Adult Spirit Temple": "can_jumpslash or can_hover or can_use(Hookshot)"
         }
     },
@@ -156,12 +156,20 @@
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {
-            "Spirit Temple Boss": "can_use(Mirror_Shield)",
+            "Spirit Temple Boss Door": "can_use(Mirror_Shield)",
             "Spirit Temple Central Chamber": "can_use(Mirror_Shield) or can_use(Hookshot)"
         }
     },
     {
-        "region_name": "Spirit Temple Boss",
+        "region_name": "Spirit Temple Boss Door",
+        "scene": "Spirit Temple",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Twinrova Boss Room": "True"
+        }
+    },
+    {
+        "region_name": "Twinrova Boss Room",
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Twinrova Heart": "True",

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -5,7 +5,7 @@
         "locations": {},
         "exits": {
             "High Alcove": "is_adult or can_hover",
-            "Boss Area": "can_use(Longshot) or can_hover or (can_use(Hover_Boots) and (can_mega or Megaton_Hammer))",
+            "Water Temple Boss Door": "can_use(Longshot) or can_hover or (can_use(Hover_Boots) and (can_mega or Megaton_Hammer))",
             "Dark Link Area": "(at('High Alcove', can_play(Zeldas_Lullaby)) or 
                     (can_use(Hover_Boots) and (can_mega or Megaton_Hammer)))
                 and (Small_Key_Water_Temple, 4)",
@@ -29,7 +29,7 @@
             "Boss Key Area": "is_adult and 
                 (Small_Key_Water_Temple, 4)
                 and (can_use(Longshot) or can_hover or Hover_Boots)",
-            "Boss Area": "can_play(Zeldas_Lullaby) and can_use(Longshot)",
+            "Water Temple Boss Door": "can_play(Zeldas_Lullaby) and can_use(Longshot)",
             "Water Temple Lobby": "can_play(Zeldas_Lullaby)"
 
         }
@@ -161,7 +161,15 @@
         }
     },
     {
-        "region_name": "Boss Area",
+        "region_name": "Water Temple Boss Door",
+        "scene": "Water Temple",
+        "dungeon": "Water Temple",
+        "exits": {
+            "Morpha Boss Room": "True"
+        }
+    },
+    {
+        "region_name": "Morpha Boss Room",
         "dungeon": "Water Temple",
         "events": {
             "Water Temple Clear": "can_jumpslash and (can_hover or Boss_Key_Water_Temple)"


### PR DESCRIPTION
This renames boss regions in Glitched Logic so that the Enhanced Maps/Compass part of #1641 works on Glitched Logic.