### PR TITLE
Shields and Chus in big chests Setting

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1896,7 +1896,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     SILVER_CHEST = 13
     SKULL_CHEST_SMALL = 14
     SKULL_CHEST_BIG =  15
-    if world.settings.bombchus_in_logic:
+    if world.settings.bombchus_in_logic or world.settings.minor_items_as_major_chest:
         bombchu_ids = [0x6A, 0x03, 0x6B]
         for i in bombchu_ids:
             item = read_rom_item(rom, i)
@@ -1912,6 +1912,15 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             item = read_rom_item(rom, i)
             item['chest_type'] = GILDED_CHEST
             write_rom_item(rom, i, item)
+    if world.settings.minor_items_as_major_chest:
+        # Deku
+        item = read_rom_item(rom, 0x29)
+        item['chest_type'] = GILDED_CHEST
+        write_rom_item(rom, 0x29, item)
+        # Hylian
+        item = read_rom_item(rom, 0x2A)
+        item['chest_type'] = GILDED_CHEST
+        write_rom_item(rom, 0x2A, item)
 
     # Update chest type appearance
     if world.settings.correct_chest_appearances == 'textures':

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4394,6 +4394,25 @@ setting_infos = [
             smaller version of the fancy chest.
         ''',
         shared         = True,
+        disable        = {
+            'off' : {'settings' : ['minor_items_as_major_chest']},
+        },
+    ),
+    Checkbutton(
+        name           = 'minor_items_as_major_chest',
+        gui_text       = 'Minor Items in Big/Gold chests',
+        gui_tooltip    = '''\
+            Chests with Hylian Shield, Deku Shield
+            or Bombchus (regardless of the Bombchus
+            In Logic setting), will appear in
+            Big and/or Gold chests, depending on the 
+            Chest Appearance Matches Contents setting.
+        ''',
+        shared         = True,
+        disabled_default = False,
+        gui_params       = {
+            "hide_when_disabled" : True
+        },
     ),
     Checkbutton(
         name           = 'invisible_chests',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -361,6 +361,7 @@
           "settings": [
             "ocarina_songs",
             "correct_chest_appearances",
+            "minor_items_as_major_chest",
             "invisible_chests",
             "clearer_hints",
             "hints",


### PR DESCRIPTION
Added a setting for Shields and Chus to be unconditionally in gold or big chests depending on the CSMC setting above it.  Will disappear if the CSMC setting is 'off'.  Does not affect if the item is considered major or not, it will simply appear in a big/gold chest.