### PR TITLE
Fix starting bombchu count

### DIFF
--- a/StartingItems.py
+++ b/StartingItems.py
@@ -27,7 +27,7 @@ inventory = dict(chain(
     _entry('dins_fire', 'Dins Fire', guitext="Din's Fire"),
     _entry('slingshot', available=3, ammo={'Deku Seeds': (30, 40, 50)}),
     _entry('ocarina', available=2),
-    _entry('bombchus', ammo={'Bombchus': (19,)}), # start with additional bombchus
+    _entry('bombchus', ammo={'Bombchus': (20,)}), # start with additional bombchus
     _entry('hookshot', 'Progressive Hookshot', available=2),
     _entry('ice_arrow', 'Ice Arrows'),
     _entry('farores_wind', 'Farores Wind', guitext="Farore's Wind"),


### PR DESCRIPTION
#1524 came with a known bug where `Bombchus` (i.e. the variable-amount pack for chus in logic) on skipped locations only gave 19 bombchus instead of 20. As of #1627, this bug also affects starting chus plando'd using the old syntax (`{"settings": {"starting_items": ["bombchus"]}}`). But since everything internally uses the new system now, there's an easy fix. Tested to make sure old-style plando, new-style plando, and skipped `Song from Impa` all work as expected, both with and without chus in logic.