### PR TITLE
Don't count dungeons with rewards on altar as already hinted

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -473,7 +473,9 @@ def get_checked_areas(world, checked):
             location = world.get_location(check)
         except Exception:
             return check
-        return HintArea.at(location)
+        # Don't consider dungeons as already hinted from the reward hint on the Temple of Time altar
+        if location.type != 'Boss': #TODO or shuffled dungeon rewards
+            return HintArea.at(location)
 
     return set(get_area_from_name(check) for check in checked)
 


### PR DESCRIPTION
Fixes the issue described here: <https://discord.com/channels/274180765816848384/438698093354156032/1027371049215594526>

tl;dr: Hint areas with an already hinted location can't be hinted barren. An exception is made for always hints but not for altar hints, so dungeons currently can't be hinted barren. Making altar hints work like always hints would only fix this until dungeon rewards become major items (which is planned for dungeon reward shuffle), so instead this is fixed by specifically making the “already hinted” check for barren hints ignore boss locations.