### PR TITLE
Fix one hint per goal for fully pre-hinted goals

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -573,6 +573,25 @@ def get_goal_hint(spoiler, world, checked):
     goal = random.choice(location_reverse_map[location])
     goal.weight = 0
 
+    # Make sure this wasn't the last hintable location for other goals.
+    # If so, set weights to zero. This is important for one-hint-per-goal.
+    # Locations are unique per-category, so we don't have to check the others.
+    for other_goal in goals:
+        if zero_weights or other_goal.weight > 0:
+            goal_locations = list(filter(lambda location:
+                location[0].name not in checked
+                and location[0].name not in world.hint_exclusions
+                and location[0].name not in world.hint_type_overrides['goal']
+                and location[0].item.name not in world.item_hint_type_overrides['goal']
+                and location[0].item.name not in unHintableWothItems,
+                other_goal.required_locations))
+            if not goal_locations:
+                other_goal.weight = 0
+                # Replace randomly chosen goal with the goal that has all its locations
+                # hinted without being directly hinted itself.
+                if world.one_hint_per_goal:
+                    goal = other_goal
+
     location_text = HintArea.at(location).text(world.settings.clearer_hints)
     if world_id == world.id:
         player_text = "the"


### PR DESCRIPTION
When choosing a goal to hint with one-hint-per-goal activated, if a goal already has all of its locations hinted by previous hints, the category selection algorithm was getting caught on trying to hint the goal as it saw it had a non-zero weight. When goal hints were chosen category -> goal -> location, fully hinted goals had their weights set to zero during goal selection and automatically rerolled the category if necessary. After moving to category -> location -> goal, there is implicit filtering for the goal in the hintable locations list, but the goal weights were only updated for the goal selected to be hinted. This change adds a check after goal selection to make sure all fully-hinted goals accounting for the just-selected location no longer count for the one-hint-per-goal filter. If that filter is on, it will attempt to swap out for that goal to ensure it doesn't go completely unhinted in violation of that part of the design.

This should fix both Standard S6 and MW S3 bug reports on missing goal hints.