### PR TITLE
Fix logic for bonk damage options

### DIFF
--- a/data/World/Bosses.json
+++ b/data/World/Bosses.json
@@ -45,11 +45,11 @@
             "Dodongos Cavern King Dodongo Heart": "
                 ((can_use(Megaton_Hammer) and logic_dc_hammer_floor) or
                     has_explosives or king_dodongo_shortcuts) and
-                (((Bombs or Progressive_Strength_Upgrade) and can_jumpslash) or deadly_bonks)",
+                (((Bombs or Progressive_Strength_Upgrade) and can_jumpslash) or deadly_bonks == 'ohko')",
             "King Dodongo": "
                 ((can_use(Megaton_Hammer) and logic_dc_hammer_floor) or
                     has_explosives or king_dodongo_shortcuts) and
-                (((Bombs or Progressive_Strength_Upgrade) and can_jumpslash) or deadly_bonks)",
+                (((Bombs or Progressive_Strength_Upgrade) and can_jumpslash) or deadly_bonks == 'ohko')",
             "Fairy Pot": "has_bottle"
         },
         "exits": {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -430,7 +430,7 @@
                 (logic_lab_diving and Iron_Boots and can_use(Hookshot))",
             "LH GS Lab Crate": "
                 Iron_Boots and can_use(Hookshot) and
-                ((not deadly_bonks) or Fairy or (can_use(Nayrus_Love) and shuffle_interior_entrances == 'off'))"
+                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_interior_entrances == 'off'))"
         },
         "exits": {
             "Lake Hylia": "True"


### PR DESCRIPTION
When #1619 updated the logic to account for bonk damage being changed from a toggle to a dropdown, these 3 locations were missed. As a result, the logic always expected you to kill King Dodongo with nothing and the lab crate always logically assumed one bonk KO.