### PR TITLE
Cosmetic Plando: Music Groups, Favorites, Excludes

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -43,8 +43,7 @@ def patch_music(rom, settings, log, symbols):
     # patch music
     if settings.background_music != 'normal' or settings.fanfares != 'normal' or log.src_dict.get('bgm', {}):
         music.restore_music(rom)
-        log.bgm, errors = music.randomize_music(rom, settings, log.src_dict.get('bgm', {}))
-        log.errors.extend(errors)
+        music.randomize_music(rom, settings, log)
     else:
         music.restore_music(rom)
     # Remove battle music
@@ -1010,6 +1009,7 @@ class CosmeticsLog(object):
         self.misc_colors = {}
         self.sfx = {}
         self.bgm = {}
+        self.bgm_groups = {}
 
         self.src_dict = {}
         self.errors = []
@@ -1035,6 +1035,12 @@ class CosmeticsLog(object):
             else:
                 logging.getLogger('').warning("Cosmetic Plandomizer enabled, but no file provided.")
                 self.settings.enable_cosmetic_file = False
+
+        self.bgm_groups['favorites'] = CollapseList(self.src_dict.get('bgm_groups', {}).get('favorites', []).copy())
+        self.bgm_groups['exclude'] = CollapseList(self.src_dict.get('bgm_groups', {}).get('exclude', []).copy())
+        self.bgm_groups['groups'] = AlignedDict(self.src_dict.get('bgm_groups', {}).get('groups', {}).copy(), 1)
+        for key, value in self.bgm_groups['groups'].items():
+            self.bgm_groups['groups'][key] = CollapseList(value.copy())
 
         if self.src_dict.get('settings', {}):
             valid_settings = []
@@ -1062,11 +1068,12 @@ class CosmeticsLog(object):
             'ui_colors': self.ui_colors,
             'misc_colors': self.misc_colors,
             'sfx': self.sfx,
+            'bgm_groups': self.bgm_groups,
             'bgm': self.bgm,
         }
 
         if (not self.settings.enable_cosmetic_file):
-            del self_dict[':enable_cosmetic_file'] # Done this way for ordering purposes.
+            del self_dict[':enable_cosmetic_file']  # Done this way for ordering purposes.
         if (not self.errors):
             del self_dict[':errors']
 

--- a/Rom.py
+++ b/Rom.py
@@ -170,6 +170,13 @@ class Rom(BigStream):
         self.force_patch.extend([0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x35, 0x36, 0x37])
 
 
+    def read_version_bytes(self):
+        version_bytes = self.read_bytes(0x19, 5)
+        if version_bytes[0] == 0:
+            version_bytes = self.read_bytes(0x35, 3)
+        return version_bytes
+
+
     def read_rom(self, file):
         # "Reads rom into bytearray"
         try:

--- a/Rom.py
+++ b/Rom.py
@@ -172,8 +172,10 @@ class Rom(BigStream):
 
     def read_version_bytes(self):
         version_bytes = self.read_bytes(0x19, 5)
-        if version_bytes[0] == 0:
-            version_bytes = self.read_bytes(0x35, 3)
+        secondary_version_bytes = self.read_bytes(0x35, 3)
+        for i in range(3):
+            if secondary_version_bytes[i] != version_bytes[i]:
+                return secondary_version_bytes
         return version_bytes
 
 


### PR DESCRIPTION
Adds `bgm_groups` to cosmetic logs containing the following:

`favorites`: A list of sequence names that will be prioritized and will always be included unless there are more favorite sequences than tracks to shuffle them to.

`exclude`: A list of sequences that will be excluded. When randomizing music during patch file generation, these could still be included unless the number of target tracks is reduced somehow (such as assigning one sequence to multiple tracks or disabling tracks).

`groups`: A dictionary containing a name and a list of sequences. Inside of `bgm`, you can now substitute the name of a group (preceeded by a `#`, i.e. `#group_name`) and a random sequence from the list will be chosen. Once a sequence is chosen, it is removed from the list and won't be chosen again. If all sequences on the list are exhausted, the list will be refilled and the process continues.

Groups are can also be created by the .meta files for custom sequences. These will be parsed from line 4 of the .meta file. Use a comma to separate multiple groups. 

This is a draft with minimal testing, but I hope anyone interested will give it a whirl and let me know if it breaks.