### PR TITLE
introduce info icon for mobile users

### DIFF
--- a/GUI/src/app/@theme/layouts/GUI/gui.layout.scss
+++ b/GUI/src/app/@theme/layouts/GUI/gui.layout.scss
@@ -222,12 +222,6 @@
     }
   }
 
-  @include media-breakpoint-down(xs) {
-    .main-content {
-      padding: 0.75rem !important;
-    }
-  }
-
   @include media-breakpoint-down(sm) {
 
     nb-sidebar.menu-sidebar {

--- a/GUI/src/app/@theme/styles/styles.scss
+++ b/GUI/src/app/@theme/styles/styles.scss
@@ -100,7 +100,7 @@
       }
 
       nb-option, nb-option.selected {
-        color: nb-theme(color-basic-1000) !important;
+        color: nb-theme(color-basic-1000);
 
         &:hover {
           background-color: nb-theme(color-success-300) !important;
@@ -198,6 +198,12 @@
 
         &.selectXSmall {
           display: block;
+        }
+
+        &.select-colors {
+          display: inline-block;
+          max-width: 300px;
+          width: 72%;
         }
       }
 
@@ -439,6 +445,7 @@
           -webkit-user-select: none;
           -moz-user-select: none;
           user-select: none;
+          font-weight: 500;
 
           &:hover {
             background-color: nb-theme(color-info-500);

--- a/GUI/src/app/@theme/styles/theme.ootr-dark.scss
+++ b/GUI/src/app/@theme/styles/theme.ootr-dark.scss
@@ -119,6 +119,7 @@ $nb-themes: nb-register-theme(
       dropdown-border-radius: 12px,
       backdrop-popup: #232323,
       picker-font-weight: 600,
+      tooltip-src: url('data:image/svg+xml;utf8,<?xml version="1.0" ?><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g data-name="Layer 2"><g fill="rgb(170,170,170)" data-name="info"><rect width="24" height="24" transform="rotate(180 12 12)" opacity="0"/><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8z"/><circle cx="12" cy="8" r="1"/><path d="M12 10a1 1 0 0 0-1 1v5a1 1 0 0 0 2 0v-5a1 1 0 0 0-1-1z"/></g></g></svg>'),
     ),
     ootr-dark,
     default

--- a/GUI/src/app/@theme/styles/theme.ootr-default.scss
+++ b/GUI/src/app/@theme/styles/theme.ootr-default.scss
@@ -119,6 +119,7 @@ $nb-themes: nb-register-theme(
       dropdown-border-radius: 3px,
       backdrop-popup: black,
       picker-font-weight: 500,
+      tooltip-src: url('data:image/svg+xml;utf8,<?xml version="1.0" ?><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g data-name="Layer 2"><g fill="rgb(5, 47, 95)" data-name="info"><rect width="24" height="24" transform="rotate(180 12 12)" opacity="0"/><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8z"/><circle cx="12" cy="8" r="1"/><path d="M12 10a1 1 0 0 0-1 1v5a1 1 0 0 0 2 0v-5a1 1 0 0 0-1-1z"/></g></g></svg>'),
     ),
     ootr-default,
     default

--- a/GUI/src/app/pages/generator/generator.component.html
+++ b/GUI/src/app/pages/generator/generator.component.html
@@ -36,41 +36,99 @@
                           <span *ngIf="!section.is_colors || global.generator_settingsMap[setting.name] !== 'Custom Color' || global.generator_customColorMap[setting.name].length === 0" class="comboBoxLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name], 'oneLineComboBox': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)), 'oLCBLabelFirst': getColumnCount(refEl) > 2 && setting.no_line_break, 'oLCBLabelSecond': getColumnCount(refEl) > 2 && itemIndex > 0 && section.settings[itemIndex-1].no_line_break}">{{setting.text}}</span>
                           <!--Combobox with Custom Color Picker for Cosmetics-->
                           <ng-container *ngIf="section.is_colors">
-                            <div class="colorPickerContainer" [ngClass]="{'oneLineComboBox oLCBPicker': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break))}">
-                              <input #refColorPicker [(colorPicker)]="global.generator_customColorMap[setting.name]" [cpAlphaChannel]="disabled" [cpOutputFormat]="hex" [cpUseRootViewContainer]="true" [cpAddColorButton]="true" [cpPresetColors]="['#fff', '#000']" [cpMaxPresetColorsLength]="5"
+                            <div class="colorPickerContainer"
+                                 [ngClass]="{'oneLineComboBox oLCBPicker': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break))}">
+                              <input #refColorPicker [(colorPicker)]="global.generator_customColorMap[setting.name]"
+                                     [cpAlphaChannel]="disabled" [cpOutputFormat]="hex" [cpUseRootViewContainer]="true"
+                                     [cpAddColorButton]="true" [cpPresetColors]="['#fff', '#000']"
+                                     [cpMaxPresetColorsLength]="5"
                                      (colorPickerClose)="afterSettingChange(true)" />
                             </div>
-                            <nb-select class="selectXSmall" [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)) }" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [(selected)]="global.generator_settingsMap[setting.name]" (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event), refColorPicker)"
-                                       [nbPopover]="tooltipComponent" [nbPopoverContext]="{tooltip: setting.tooltip}" [nbPopoverTrigger]="setting.tooltip && setting.tooltip.length > 0 ? 'click' : 'noop'" nbPopoverPlacement="right" nbPopoverAdjustment="counterclockwise" size="xsmall">
-                              <nb-option *ngFor="let option of setting.options; index as optionIndex" [value]="option.name">{{option.text}}</nb-option>
-                            </nb-select>
+                              <nb-select class="selectXSmall"
+                                         [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)), 'select-colors' : getColumnCount(refEl) === 1}"
+                                         [disabled]="!global.generator_settingsVisibilityMap[setting.name]"
+                                         [(selected)]="global.generator_settingsMap[setting.name]"
+                                         (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event), refColorPicker)"
+                                         [nbPopover]="tooltipComponent"
+                                         [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                         [nbPopoverTrigger]="setting.tooltip?.length > 0 && getColumnCount(refEl) > 1 ? 'click' : 'noop'"
+                                         [nbPopoverPlacement]="'right'"
+                                         [nbPopoverAdjustment]="'horizontal'"
+                                         size="xsmall">
+                                <nb-option *ngFor="let option of setting.options; index as optionIndex"
+                                           [value]="option.name">{{option.text}}</nb-option>
+                              </nb-select>
+                              <img class="select-info info-icon-colors"
+                                   [ngClass]="{disabled: !setting.tooltip}"
+                                   *ngIf="getColumnCount(refEl) === 1"
+                                   [nbPopover]="tooltipComponent"
+                                   [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                   [nbPopoverTrigger]="setting.tooltip?.length > 0 ? 'hover' : 'noop'"
+                                   [nbPopoverPlacement]="'top'"
+                                   [nbPopoverAdjustment]="'vertical'" />
                           </ng-container>
                           <!--Normal Combobox-->
                           <ng-container *ngIf="!section.is_colors">
-                            <nb-select class="selectXSmall"
+                            <div class="select-wrapper">
+                              <nb-select class="selectXSmall"
+                                         [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && setting.no_line_break}"
+                                         [disabled]="!global.generator_settingsVisibilityMap[setting.name]"
+                                         [(selected)]="global.generator_settingsMap[setting.name]"
+                                         (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event))"
+                                         [nbPopover]="tooltipComponent"
+                                         [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                         [nbPopoverTrigger]="setting.tooltip?.length > 0 && getColumnCount(refEl) > 1 ? 'click' : 'noop'"
+                                         [nbPopoverPlacement]="'right'"
+                                         [nbPopoverAdjustment]="'horizontal'"
+                                         size="xsmall">
+                                <nb-option *ngFor="let option of setting.options; index as optionIndex"
+                                           [value]="option.name">{{option.text}}</nb-option>
+                              </nb-select>
+                              <img class="select-info"
+                                   [ngClass]="{disabled: !setting.tooltip}"
+                                   *ngIf="getColumnCount(refEl) === 1"
+                                   [nbPopover]="tooltipComponent"
+                                   [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                   [nbPopoverTrigger]="setting.tooltip?.length > 0 ? 'hover' : 'noop'"
+                                   [nbPopoverPlacement]="'top'"
+                                   [nbPopoverAdjustment]="'vertical'" />
+                            </div>
+                          </ng-container>
+                        </ng-container>
+                        <!--Multiple Select-->
+                        <ng-container *ngSwitchCase="'MultipleSelect'">
+                          <span class="comboBoxLabel" [ngClass]="{
+                                'disabled': !global.generator_settingsVisibilityMap[setting.name],
+                                'oneLineComboBox': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)),
+                                'oLCBLabelFirst': getColumnCount(refEl) > 2 && setting.no_line_break,
+                                'oLCBLabelSecond': getColumnCount(refEl) > 2 && itemIndex > 0 && section.settings[itemIndex-1].no_line_break
+                                }">
+                            {{setting.text}}
+                          </span>
+                          <div class="select-wrapper">
+                            <nb-select multiple placeholder="None" class="selectXSmall"
                                        [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && setting.no_line_break}"
                                        [disabled]="!global.generator_settingsVisibilityMap[setting.name]"
                                        [(selected)]="global.generator_settingsMap[setting.name]"
                                        (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event))"
                                        [nbPopover]="tooltipComponent"
                                        [nbPopoverContext]="{tooltip: setting.tooltip}"
-                                       [nbPopoverTrigger]="setting.tooltip?.length > 0 ? 'click' : 'noop'"
+                                       [nbPopoverTrigger]="setting.tooltip?.length > 0 && getColumnCount(refEl) > 1 ? 'click' : 'noop'"
                                        [nbPopoverPlacement]="'right'"
-                                       [nbPopoverAdjustment]="flipPreferredHintAxis ? 'counterclockwise' : 'horizontal'"
-                                       size="xsmall">
+                                       [nbPopoverAdjustment]="'horizontal'">
+                              <nb-select-label *ngIf="global.generator_settingsMap[setting.name].length !== setting.options.length && global.generator_settingsMap[setting.name].length > 2">Selected: {{global.generator_settingsMap[setting.name].length}}</nb-select-label>
+                              <nb-select-label *ngIf="global.generator_settingsMap[setting.name].length === setting.options.length">All</nb-select-label>
                               <nb-option *ngFor="let option of setting.options; index as optionIndex" [value]="option.name">{{option.text}}</nb-option>
                             </nb-select>
-                          </ng-container>
-                        </ng-container>
-                        <!--Multiple Select-->
-                        <ng-container *ngSwitchCase="'MultipleSelect'">
-                          <span class="comboBoxLabel" [ngClass]="{'disabled': !global.generator_settingsVisibilityMap[setting.name], 'oneLineComboBox': getColumnCount(refEl) > 2 && (setting.no_line_break || (itemIndex > 0 && section.settings[itemIndex-1].no_line_break)), 'oLCBLabelFirst': getColumnCount(refEl) > 2 && setting.no_line_break, 'oLCBLabelSecond': getColumnCount(refEl) > 2 && itemIndex > 0 && section.settings[itemIndex-1].no_line_break}">{{setting.text}}</span>
-                          <nb-select multiple placeholder="None" class="selectXSmall" [ngClass]="{'oneLineComboBox oLCBSelect': getColumnCount(refEl) > 2 && setting.no_line_break}" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" [(selected)]="global.generator_settingsMap[setting.name]" (selectedChange)="checkVisibility($event, setting, findOption(setting.options, $event))"
-                                     [nbPopover]="tooltipComponent" [nbPopoverContext]="{tooltip: setting.tooltip}" [nbPopoverTrigger]="setting.tooltip && setting.tooltip.length > 0 ? 'click' : 'noop'" nbPopoverPlacement="right" nbPopoverAdjustment="counterclockwise" size="xsmall">
-                            <nb-select-label *ngIf="global.generator_settingsMap[setting.name].length !== setting.options.length && global.generator_settingsMap[setting.name].length > 2">Selected: {{global.generator_settingsMap[setting.name].length}}</nb-select-label>
-                            <nb-select-label *ngIf="global.generator_settingsMap[setting.name].length === setting.options.length">All</nb-select-label>
-                            <nb-option *ngFor="let option of setting.options; index as optionIndex" [value]="option.name">{{option.text}}</nb-option>
-                          </nb-select>
+                            <img class="select-info"
+                                 [ngClass]="{disabled: !setting.tooltip}"
+                                 *ngIf="getColumnCount(refEl) === 1"
+                                 [nbPopover]="tooltipComponent"
+                                 [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                 [nbPopoverTrigger]="setting.tooltip?.length > 0 ? 'hover' : 'noop'"
+                                 [nbPopoverPlacement]="'top'"
+                                 [nbPopoverAdjustment]="'vertical'" />
+                          </div>
                         </ng-container>
                         <!--Scale-->
                         <ng-container *ngSwitchCase="'Scale'">
@@ -138,18 +196,29 @@
                           <button class="ioInputBrowseButton" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" nbButton status="info" size="small" (click)="browseForDirectory(setting)">Browse</button>
                         </ng-container>
                         <ng-container *ngSwitchCase="'Presetinput'">
-                          <nb-select #refPresetSelect
-                                     class="selectXSmall"
-                                     [disabled]="!global.generator_settingsVisibilityMap[setting.name]"
-                                     [(selected)]="global.generator_settingsMap[setting.name]"
-                                     [nbPopover]="tooltipComponent"
-                                     [nbPopoverContext]="{tooltip: setting.tooltip}"
-                                     [nbPopoverTrigger]="setting.tooltip?.length > 0 ? 'click' : 'noop'"
-                                     [nbPopoverPlacement]="'right'"
-                                     [nbPopoverAdjustment]="flipPreferredHintAxis ? 'counterclockwise' : 'horizontal'"
-                                     size="xsmall">
-                            <nb-option *ngFor="let presetKey of getPresetArray(); index as presetIndex" [value]="presetKey">{{presetKey}}</nb-option>
-                          </nb-select>
+                          <div class="select-wrapper">
+                            <nb-select #refPresetSelect
+                                       class="selectXSmall"
+                                       [disabled]="!global.generator_settingsVisibilityMap[setting.name]"
+                                       [(selected)]="global.generator_settingsMap[setting.name]"
+                                       [nbPopover]="tooltipComponent"
+                                       [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                       [nbPopoverTrigger]="setting.tooltip?.length > 0 && getColumnCount(refEl) > 1 ? 'click' : 'noop'"
+                                       [nbPopoverPlacement]="'start-top'"
+                                       [nbPopoverAdjustment]="'horizontal'"
+                                       size="xsmall">
+                              <nb-option *ngFor="let presetKey of getPresetArray(); index as presetIndex"
+                                         [value]="presetKey">{{presetKey}}</nb-option>
+                            </nb-select>
+                            <img class="select-info"
+                                 [ngClass]="{disabled: !setting.tooltip}"
+                                 *ngIf="getColumnCount(refEl) === 1"
+                                 [nbPopover]="tooltipComponent"
+                                 [nbPopoverContext]="{tooltip: setting.tooltip}"
+                                 [nbPopoverTrigger]="setting.tooltip?.length > 0 ? 'hover' : 'noop'"
+                                 [nbPopoverPlacement]="'top'"
+                                 [nbPopoverAdjustment]="'vertical'" />
+                          </div>
                           <button class="presetButton" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" nbButton status="info" size="small" (click)="loadPreset()">Load</button>
                           <button class="presetButton" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" nbButton status="info" size="small" (click)="savePreset(refPresetSelect)">Save</button>
                           <button class="presetButton" [disabled]="!global.generator_settingsVisibilityMap[setting.name]" nbButton status="info" size="small" (click)="deletePreset()">Remove</button>

--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -80,7 +80,6 @@
     }
   }
 
-
   .footerTabset {
     position: absolute;
     bottom: 0;
@@ -97,7 +96,7 @@
       padding: 1.25rem;
 
       @media (max-width: 680px) {
-        padding: 0.5rem;
+        padding: 1.25rem 0.5rem 0.5rem 0.5rem;
       }
     }
   }
@@ -262,6 +261,7 @@
 
   .comboBoxLabel {
     position: relative;
+    display: block;
     left: 10px;
 
     &.oneLineComboBox {
@@ -280,6 +280,36 @@
 
   .selectXSmall {
     max-width: 300px;
+  }
+
+  div.select-wrapper {
+    display: flex;
+
+    nb-select {
+      flex-grow: 1;
+    }
+  }
+
+  img.select-info {
+    content: "o";
+    width: 26px;
+    height: 26px;
+    padding: 13px;
+    font-size: 2em;
+    margin-left: 5px;
+    background-image: nb-theme(tooltip-src);
+    background-repeat: no-repeat;
+    background-position: center center;
+    cursor: pointer;
+
+    &.info-icon-colors {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    &.disabled {
+      opacity: 0;
+    }
   }
 
   p.numberTextInputLabel {
@@ -324,16 +354,16 @@
     overflow: hidden;
   }
 
-.scale {
-  position: relative;
-  top: -7px;
-  min-width: 100%;
-  pointer-events: none; //Reduces the clickable part to just the visible slider itself
+  .scale {
+    position: relative;
+    top: -7px;
+    min-width: 100%;
+    pointer-events: none; //Reduces the clickable part to just the visible slider itself
 
-  ::ng-deep .mat-slider-wrapper {
-    pointer-events: auto;
+    ::ng-deep .mat-slider-wrapper {
+      pointer-events: auto;
+    }
   }
-}
 
   .ioInputLabel {
     position: relative;

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -50,8 +50,6 @@ export class GeneratorComponent implements OnInit {
   repatchCosmeticsCheckboxTooltipPatch: string = "Replaces the cosmetic and sound settings generated in the patch file<br>with those selected on this page.";
   repatchCosmeticsCheckboxTooltipSeedPageWeb: string = "Replaces the cosmetic and sound settings generated in the seed<br>with those selected on this page.";
 
-  flipPreferredHintAxis: boolean = window.matchMedia('(max-width: 500px)').matches;
-
   constructor(private overlayContainer: OverlayContainer, private cd: ChangeDetectorRef, public global: GUIGlobal, private dialogService: NbDialogService) {
   }
 
@@ -1355,10 +1353,5 @@ export class GeneratorComponent implements OnInit {
         }
       }
     }
-  }
-
-  @HostListener('window:resize', ['$event'])
-  onResize(_: Event): void {
-    this.flipPreferredHintAxis = window.matchMedia('(max-width: 500px)').matches;
   }
 }

--- a/GUI/src/app/pages/generator/generator.module.ts
+++ b/GUI/src/app/pages/generator/generator.module.ts
@@ -62,6 +62,9 @@ import { GUITooltipComponent } from './guiTooltip/guiTooltip.component';
         GUITooltipComponent,
         GUIListboxComponent
     ],
+    providers: [
+      { provide: Window, useValue: window }
+    ],
     schemas: [
         CUSTOM_ELEMENTS_SCHEMA
     ]

--- a/GUI/src/app/pages/generator/guiTooltip/guiTooltip.component.ts
+++ b/GUI/src/app/pages/generator/guiTooltip/guiTooltip.component.ts
@@ -16,11 +16,14 @@ export class GUITooltipComponent implements AfterViewChecked {
   @Input()
   tooltip: string = '';
 
-  constructor(@Inject(DOCUMENT) private readonly document: Document) {
+  constructor(@Inject(DOCUMENT) private readonly document: Document,
+              private readonly window: Window,
+  ) {
   }
 
   ngAfterViewChecked(): void {
     this.preventHintPositioningOutsideTopBounds();
+    this.preventHintPositioningOutsideBottomBounds();
     this.preventHintOverlayingOnSelectOptions();
   }
 
@@ -29,7 +32,15 @@ export class GUITooltipComponent implements AfterViewChecked {
 
     Array.from(cdkOverlayPanes)
       .filter((e: HTMLElement) => e.offsetTop < 0)
-      .forEach((e: HTMLElement) => e.style.top = '0px');
+      .forEach((e: HTMLElement) => e.style.top = '16px');
+  }
+
+  private preventHintPositioningOutsideBottomBounds(): void {
+    const cdkOverlayPanes = this.document.getElementsByClassName('cdk-overlay-pane');
+
+    Array.from(cdkOverlayPanes)
+      .filter((e: HTMLElement) => this.calculateFeasibleHeight(e) < e.offsetHeight)
+      .forEach((e: HTMLElement) => e.style.maxHeight = `${this.calculateFeasibleHeight(e) }px`);
   }
 
   private preventHintOverlayingOnSelectOptions(): void {
@@ -37,5 +48,9 @@ export class GUITooltipComponent implements AfterViewChecked {
 
     Array.from(cdkOverlayBoxes)
       .forEach((e: HTMLElement, i: number) => i === cdkOverlayBoxes.length-1 ? e.style.zIndex = '999' : e.style.zIndex = '1000');
+  }
+
+  private calculateFeasibleHeight(element: HTMLElement): number {
+    return this.window.innerHeight - element.offsetTop;
   }
 }


### PR DESCRIPTION
After fixing various problems with the tooltips in general (https://github.com/TestRunnerSRL/OoT-Randomizer/pull/1757), this PR introduces an info icon next to dropdowns for narrow viewports to prevent hints from over/under-laying dropdown options.

**Before:**

![hint_mobile_old](https://user-images.githubusercontent.com/17959794/201167500-a543667d-7115-4386-98d3-607d7792416b.gif)

**After:**

![hint_mobile_new](https://user-images.githubusercontent.com/17959794/201167624-c39a7a1e-b49e-43e0-9100-b14407f4b7f2.gif)
