### PR TITLE
Document interaction between Very Strong with Magic hint distro and All Goals Reachable

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2591,7 +2591,8 @@ setting_infos = [
             to beat the game, but otherwise behaves like 'Required Only'.
             Goal items are the items required for the rainbow bridge and/or Ganon's Boss Key, so for example if the bridge is
             set to 1 Medallion and Ganon's Boss Key to 1 Gold Skulltula Token, all 6 Medallions and all 100 Tokens will
-            be obtainable. In Triforce Hunt, this will instead guarantee that all Triforce Pieces can be obtained.
+            be obtainable. In Triforce Hunt, this will instead guarantee that all Triforce Pieces can be obtained. Hint
+            distributions that define custom goals or remove the default goals will affect item placement as well.
 
             'Required Only': Only items and locations required to beat the game will be guaranteed reachable.
         ''',

--- a/data/Hints/very_strong_magic.json
+++ b/data/Hints/very_strong_magic.json
@@ -1,7 +1,7 @@
 {
     "name":                  "very_strong_magic",
     "gui_name":              "Very Strong with Magic",
-    "description":           "Very Strong with Magic.",
+    "description":           "Like the Very Strong hint distribution, but a fixed goal hint with two copies for the Magic Meters is added. All other goals are removed.",
     "add_locations":         [],
     "remove_locations":      [],
     "add_items":             [],

--- a/data/Hints/very_strong_magic.json
+++ b/data/Hints/very_strong_magic.json
@@ -1,7 +1,7 @@
 {
     "name":                  "very_strong_magic",
     "gui_name":              "Very Strong with Magic",
-    "description":           "Like the Very Strong hint distribution, but a fixed goal hint with two copies for the Magic Meters is added. All other goals are removed.",
+    "description":           "Like the Very Strong hint distribution, but a fixed goal hint with two copies for a Magic Meter is added. All other goals are removed.",
     "add_locations":         [],
     "remove_locations":      [],
     "add_items":             [],


### PR DESCRIPTION
Hint distributions can change goal definitions, thus affecting item/entrance randomization in AGR. The `very_strong_magic` hint distro is unique in being a built-in distro that changes goals. This was poorly documented, so I've both updated the description for `very_strong_magic` so it actually says what it does, and added a sentence to the AGR description pointing out the interaction.