### PR TITLE
Allow Closed Forest in combination with boss room shuffle

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -471,9 +471,17 @@ def shuffle_random_entrances(worlds):
         if worlds[0].settings.shuffle_bosses == 'full':
             entrance_pools['Boss'] = world.get_shufflable_entrances(type='ChildBoss', only_primary=True)
             entrance_pools['Boss'] += world.get_shufflable_entrances(type='AdultBoss', only_primary=True)
+            if worlds[0].settings.open_forest == 'closed':
+                # Deku is forced vanilla below, so Queen Gohma must be vanilla to ensure she is reachable.
+                # This is already enforced by the fill algorithm in most cases, but this covers the odd settings combination where it isn't.
+                entrance_pools['Boss'].remove(world.get_entrance('Deku Tree Boss Door -> Queen Gohma Boss Room'))
         elif worlds[0].settings.shuffle_bosses == 'limited':
             entrance_pools['ChildBoss'] = world.get_shufflable_entrances(type='ChildBoss', only_primary=True)
             entrance_pools['AdultBoss'] = world.get_shufflable_entrances(type='AdultBoss', only_primary=True)
+            if worlds[0].settings.open_forest == 'closed':
+                # Deku is forced vanilla below, so Queen Gohma must be vanilla to ensure she is reachable.
+                # This is already enforced by the fill algorithm in most cases, but this covers the odd settings combination where it isn't.
+                entrance_pools['ChildBoss'].remove(world.get_entrance('Deku Tree Boss Door -> Queen Gohma Boss Room'))
 
         if worlds[0].shuffle_dungeon_entrances:
             entrance_pools['Dungeon'] = world.get_shufflable_entrances(type='Dungeon', only_primary=True)

--- a/World.py
+++ b/World.py
@@ -71,7 +71,7 @@ class World(object):
             settings.open_forest == 'closed'
             and (
                 self.shuffle_special_interior_entrances or settings.shuffle_overworld_entrances
-                or settings.warp_songs or settings.spawn_positions or (settings.shuffle_bosses != 'off')
+                or settings.warp_songs or settings.spawn_positions
             )
         ):
             self.settings.open_forest = 'closed_deku'


### PR DESCRIPTION
There's no reason to disallow this settings combination that I'm aware of. Dungeon ER is already compatible and simply forces the Deku entrance to be vanilla to prevent a forest escape via Spirit hands. This PR similarly forces the Queen Gohma entrance to be vanilla, but allows all other boss entrances to be shuffled normally.

In theory, it would be possible to shuffle these two entrances if both ER settings are enabled, and just enforce that Deku doesn't go to Spirit, which will force the ER algorithm to place Gohma inside the dungeon in the Deku entrance. This PR takes the conservative route to stay closer to the vanilla progression advertised by the Closed Forest setting, but that change could be made in a separate PR if desired.