### PR TITLE
Revert spirit logic regression

### DIFF
--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -24,29 +24,12 @@
         "region_name": "Child Spirit Temple",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Child Bridge Chest": "
-                (Boomerang or Slingshot or (has_bombchus and logic_spirit_child_bombchu)) and
-                (Sticks or has_explosives or
-                    ((Nuts or Boomerang) and (Kokiri_Sword or Slingshot)))",
-            "Deku Shield Pot": "
-                fix_broken_drops and
-                (Boomerang or Slingshot or (has_bombchus and logic_spirit_child_bombchu)) and
-                (Sticks or has_explosives or
-                    ((Nuts or Boomerang) and (Kokiri_Sword or Slingshot)))",
-            "Spirit Temple Child Early Torches Chest": "
-                (Boomerang or Slingshot or (has_bombchus and logic_spirit_child_bombchu)) and
-                (Sticks or has_explosives or
-                    ((Nuts or Boomerang) and (Kokiri_Sword or Slingshot))) and
-                (Sticks or can_use(Dins_Fire))",
+            "Spirit Temple Child Bridge Chest": "True",
+            "Spirit Temple Child Early Torches Chest": "Sticks or can_use(Dins_Fire)",
             "Spirit Temple Child Bridge Flying Pot": "True",
             "Spirit Temple Child Anubis Pot": "True",
-            "Spirit Temple GS Metal Fence": "
-                (Boomerang or Slingshot or (has_bombchus and logic_spirit_child_bombchu)) and
-                (Sticks or has_explosives or
-                    ((Nuts or Boomerang) and (Kokiri_Sword or Slingshot)))"
-        },
-        "exits": {
-            "Child Spirit Before Locked Door": "True"
+            "Spirit Temple GS Metal Fence": "True",
+            "Deku Shield Pot": "fix_broken_drops"
         }
     },
     {


### PR DESCRIPTION
I added a region for the child spirit loop to avoid duplication with killing the Armos and knocking down the bridge. This seems to have been reverted when fix broken drops was merged into pots. By luck I don't believe the improper merge caused any actual bugs.

(Warning: I didn't test these changes to even make sure there was no syntax error.)