### PR TITLE
Move disable battle music to sfx main section 2: The Movening

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -5849,6 +5849,19 @@ setting_infos = [
             }
         }
     ),
+    Checkbutton(
+        name           = 'disable_battle_music',
+        gui_text       = 'Disable Battle Music',
+        shared         = False,
+        cosmetic       = True,
+        gui_tooltip    = '''\
+            Disable standard battle music.
+	        This prevents background music from being
+	        interrupted by the battle theme when being
+	        near enemies.
+        ''',
+        default        = False,
+    ),
     Combobox(
         name           = 'background_music',
         gui_text       = 'Background Music',
@@ -5874,19 +5887,6 @@ setting_infos = [
             ],
             'web:option_remove': ['random_custom_only'],
         },
-    ),
-    Checkbutton(
-        name           = 'disable_battle_music',
-        gui_text       = 'Disable Battle Music',
-        shared         = False,
-        cosmetic       = True,
-        gui_tooltip    = '''\
-            Disable standard battle music.
-	        This prevents background music from being
-	        interrupted by the battle theme when being
-	        near enemies.
-        ''',
-        default        = False,
     ),
     Combobox(
         name           = 'fanfares',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -480,9 +480,10 @@
           "name": "sfx_main_section",
           "is_sfx": true,
           "col_span": 4,
-          "row_span": [2,1,1],
+          "row_span": [2,1,2],
           "settings": [
-            "randomize_all_sfx"
+            "randomize_all_sfx",
+            "disable_battle_music"
           ]
         },
         {
@@ -493,7 +494,6 @@
           "row_span": [6,6,11],
           "settings": [
             "background_music",
-            "disable_battle_music",
             "fanfares",
             "ocarina_fanfares",
             "sfx_low_hp",


### PR DESCRIPTION
#1656 Seems to have been inadvertently reverted at some point, likely during the GUI upgrades, so this is just reverting the reversion.