### PR TITLE
Ignore empty / non-existent bgm -> bgm_group mappings

### DIFF
--- a/Music.py
+++ b/Music.py
@@ -464,6 +464,8 @@ def randomize_music(rom, settings, log):
                             source = music_mapping[target] = group.pop()
                             if source in sequences_alias:
                                 break
+                            
+                    log.errors.append(f"Warning: Group '{source}' linked to '{target}' does not have a valid custom sequence. Ignoring!")
                 else:
                     break
                     

--- a/Music.py
+++ b/Music.py
@@ -440,7 +440,8 @@ def randomize_music(rom, settings, log):
             del music_mapping[target]
             continue
 
-        source = group = group_name = None
+        source = mapping
+        group = group_name = None
         if isinstance(mapping, list):
             # Try to find a valid source in the defined list
             while len(mapping) > 0:

--- a/Music.py
+++ b/Music.py
@@ -426,7 +426,7 @@ def randomize_music(rom, settings, log):
     ff_groups_full = {n: [ns for ns in s if ns in fanfare_sequences] for n, s in itertools.chain(fanfare_groups.items(), plando_groups.items())}
     bgm_groups = {n: s.copy() for n, s in bgm_groups_full.items()}
     ff_groups = {n: s.copy() for n, s in ff_groups_full.items()}
-    for target, source in music_mapping.copy().items():
+    for target, mapping in music_mapping.copy().items():
         if target in bgm_ids:
             groups_full_alias = bgm_groups_full
             groups_alias = bgm_groups
@@ -440,25 +440,51 @@ def randomize_music(rom, settings, log):
             del music_mapping[target]
             continue
 
-        if isinstance(source, list):
-            random.shuffle(source)
-            source = music_mapping[target] = source.pop()
+        source = group = group_name = None
+        if isinstance(mapping, list):
+            # Try to find a valid source in the defined list
+            while len(mapping) > 0:
+                random.shuffle(mapping)
+                source = music_mapping[target] = mapping.pop()
+                
+                if source.startswith('#'):
+                    group_name = source[1:]
+                    group = groups_alias.get(group_name, None)
 
-        group = group_name = None
-        if source.startswith('#'):
+                    # Check if group exists.
+                    if group is not None:
+                        # Check if we need to refill this group from the source dictionary.
+                        if not group:
+                            groups_alias[group_name] = groups_full_alias.get(group_name, []).copy()
+                            group = groups_alias[group_name]
+
+                        if group:
+                            random.shuffle(group)
+                            source = music_mapping[target] = group.pop()
+                            if source in sequences_alias:
+                                break
+                else:
+                    break
+                    
+            if len(mapping) == 0 and source not in sequences_alias:
+                del music_mapping[target]
+                log.errors.append(f"Target Sequence '{target}' does not have a valid 'bgm_groups' entry.")
+                continue
+                
+        elif mapping.startswith('#'):
             group_name = source[1:]
             group = groups_alias.get(group_name, None)
 
-        # Check if group exists.
-        if group is not None:
-            # Check if we need to refill this group from the source dictionary.
-            if not group:
-                groups_alias[group_name] = groups_full_alias.get(group_name, []).copy()
-                group = groups_alias[group_name]
+            # Check if group exists.
+            if group is not None:
+                # Check if we need to refill this group from the source dictionary.
+                if not group:
+                    groups_alias[group_name] = groups_full_alias.get(group_name, []).copy()
+                    group = groups_alias[group_name]
 
-            if group:
-                random.shuffle(group)
-                source = music_mapping[target] = group.pop()
+                if group:
+                    random.shuffle(group)
+                    source = music_mapping[target] = group.pop()
 
         # Check if mapped sequence exists.
         if source not in sequences_alias:


### PR DESCRIPTION
Empty / non-existent bgm -> bgm_group mappings should not cause the bgm_groups routine to fail, for e.g. you have the below definitions:

```json
{
  "bgm":              {
    "Hyrule Field":         ["#Overworld", "#Outdoors", "#Fields", "#HyruleField"]
    ...
    "Market":               ["#Overworld", "#Outdoors", "#Town", "#Market"],
    ...
    "Shop":                 ["#Overworld", "#Indoors", "#Shop"],
    ...
  },

  "bgm_groups":            {
    "favorites": [],
    "exclude":   [],
    "groups":                {
      "Overworld":          ["Hyrule Field", "Lost Woods", "Gerudo Valley", "Market", "Kakariko Child", "Kakariko Adult", "Lon Lon Ranch", "Kokiri Forest", "Goron City", "Zoras Domain", "Castle Courtyard", "Horse Race", "Mini-game", "Shooting Gallery", "Fairy Fountain", "Temple of Time", "Chamber of the Sages", "House", "Shop", "Potion Shop", "Windmill Hut"],
    }
  }
}
```

The bgm_group mapping routine would skip to the next track if it randomly picked either the "Outdoors", "Fields" or "HyruleField" when trying to map Hyrule Field. What my change aims to do is to instead always try to make use of any group mapping that is defined and actually has a valid sequence mapped to it.

The reason you might want this behaviour is if you are wanting to allow .meta files in your data/Music to make use of "Outdoors", "Fields" or "HyruleField". Even if no sequence currently exists for those groups yet, they _could_ eventually.

With my change, if there's no .meta files that are found to be a part of the other bgm_groups, the Overworld list will be shuffled and selected from randomly while the others will be ignored. If there is no group that has a valid sequence in the bgm mapping, then and only then will it log an error to the Cosmetics log.