### PR TITLE
Account for melting red ice walls being permanent

### DIFF
--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -25,7 +25,7 @@
         },
         "exits": {
             "Ice Cavern Map Room": "is_adult",
-            "Ice Cavern Behind Ice Walls": "Blue_Fire"
+            "Ice Cavern Behind Ice Walls": "here(Blue_Fire)"
         }
     },
     {


### PR DESCRIPTION
This puts melting the red ice walls in vanilla Ice Cavern using blue fire arrows and then coming back as child to collect the skulltulas and red rupees with boomerang into logic. I checked all instances of the `Blue_Fire` logic helper and this seems to be the only case where this is relevant.