### PR TITLE
Fix swapped flags for DC single/double eye switch pots

### DIFF
--- a/LocationList.py
+++ b/LocationList.py
@@ -842,10 +842,10 @@ location_table = OrderedDict([
    #("Dodongos Cavern Last Block Pot 4",                             ("Pot",          0x01,  0x21, None,                            'Rupee (1)',                             ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
     ("Dodongos Cavern Blade Room Pot 1",                             ("Pot",          0x01,  (9,0,15), None,                        'Recovery Heart',                        ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
     ("Dodongos Cavern Blade Room Pot 2",                             ("Pot",          0x01,  (9,0,16), None,                        'Recovery Heart',                        ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
-    ("Dodongos Cavern Single Eye Switch Room Pot 1",                 ("Pot",          0x01,  (12,0,6), None,                        'Recovery Heart',                        ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
-    ("Dodongos Cavern Single Eye Switch Room Pot 2",                 ("Pot",          0x01,  (12,0,7), None,                        'Rupees (5)',                            ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
-    ("Dodongos Cavern Double Eye Switch Room Pot 1",                 ("Pot",          0x01,  (10,0,7), None,                        'Recovery Heart',                        ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
-    ("Dodongos Cavern Double Eye Switch Room Pot 2",                 ("Pot",          0x01,  (10,0,8), None,                        'Rupees (5)',                            ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
+    ("Dodongos Cavern Single Eye Switch Room Pot 1",                 ("Pot",          0x01,  (10,0,7), None,                        'Recovery Heart',                        ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
+    ("Dodongos Cavern Single Eye Switch Room Pot 2",                 ("Pot",          0x01,  (10,0,8), None,                        'Rupees (5)',                            ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
+    ("Dodongos Cavern Double Eye Switch Room Pot 1",                 ("Pot",          0x01,  (12,0,6), None,                        'Recovery Heart',                        ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
+    ("Dodongos Cavern Double Eye Switch Room Pot 2",                 ("Pot",          0x01,  (12,0,7), None,                        'Rupees (5)',                            ("Dodongo's Cavern", "Vanilla Dungeons", "Pots",))),
 
     # Dodongo's Cavern MQ
     ("Dodongos Cavern MQ Map Chest",                                 ("Chest",        0x01,  0x00, None,                            'Map (Dodongos Cavern)',                 ("Dodongo's Cavern MQ", "Master Quest", "Chests",))),


### PR DESCRIPTION
The addresses for the DC Single Eye Switch and Double Eye Switch pots are switched with each other; in the current code, the Single Eye Switch pots are found in the room with two eye switches, which is in the same logical region as the bomb bag chest. This means that it is possible to be logically expected to reach the Single Eye Switch pots, but their contents are unreachable because they're located elsewhere.

This PR fixes this.