### PR TITLE
Add dynamic setting update routine for GUI

### DIFF
--- a/GUI/electron/src/modules/generator.js
+++ b/GUI/electron/src/modules/generator.js
@@ -347,6 +347,49 @@ function parseSettings(pythonPath, randoPath) {
   });
 }
 
+function getUpdatedDynamicSetting(pythonPath, scriptPath, settingName) {
+  return new Promise(function (resolve, reject) {
+
+    let output = "";
+    let error = false;
+
+    let args = ['--setting', settingName];
+
+    //console.log("Get dynamic setting now with spawn!");
+
+    let settingsToJSONPY = spawn(pythonPath + ' ' + '"' + scriptPath + '"', args, { shell: true }).on('error', err => {
+      console.error("[getUpdatedDynamicSetting] Error spawning process:", err);
+      reject(err);
+    });
+
+    settingsToJSONPY.stdout.on('data', data => {
+      output = output + data.toString();
+      error = false;
+    });
+    settingsToJSONPY.stderr.on('data', data => {
+      output = output + data.toString();
+      error = true;
+    });
+
+    promiseFromChildProcess(settingsToJSONPY).then(function () {
+
+      //console.log("Get dynamic setting DONE!");
+
+      if (error) {
+        console.error('[getUpdatedDynamicSetting] settingsToJSONPY error: ' + output);
+        reject(output);
+      }
+      else {
+        resolve(output.replace(/\r?\n|\r/g, "\r\n"));
+      }
+
+    }).catch(err => {
+      console.error('[getUpdatedDynamicSetting] settingsToJSONPY promise rejected: ' + err);
+      reject(err);
+    });
+  });
+}
+
 module.exports = new EventEmitter();
 
 module.exports.getSettings = getSettings;
@@ -354,3 +397,4 @@ module.exports.parseSettings = parseSettings;
 module.exports.romBuilding = romBuilding;
 module.exports.cancelRomBuilding = cancelRomBuilding;
 module.exports.testPythonPath = testPythonPath;
+module.exports.getUpdatedDynamicSetting = getUpdatedDynamicSetting;

--- a/GUI/electron/src/preload.ts
+++ b/GUI/electron/src/preload.ts
@@ -18,6 +18,7 @@ console.log("Platform:", platform);
 var pythonPath = commander.python ? '"' + commander.python + '"' : platform == "win32" ? "py" : "python3";
 var pythonSourcePath = path.normalize(remote.app.isPackaged ? remote.app.getAppPath() + "/python/" : remote.app.getAppPath() + "/../");
 var pythonGeneratorPath = pythonSourcePath + "OoTRandomizer.py";
+var pythonSettingsToJsonPath = pythonSourcePath + "SettingsToJson.py";
 
 console.log("Python Executable Path:", pythonPath);
 console.log("Python Source Path:", pythonGeneratorPath);
@@ -251,6 +252,23 @@ post.on('convertSettingsToString', function (event) {
 
   return true;
 });
+
+post.on('updateDynamicSetting', function (event) {
+  let data = event.data;
+
+  if (!data || typeof (data) != "string" || data.length < 1)
+    return false;
+
+  //console.log("get settings from string", data);
+
+  generator.getUpdatedDynamicSetting(pythonPath, pythonSettingsToJsonPath, data).then(res => {
+    //console.log('[Preload] Success');
+      post.send(window, 'updateDynamicSettingSuccess', res);
+      
+  }).catch((err) => {
+      post.send(window, 'updateDynamicSettingError', err);
+  })
+})
 
 post.on('convertStringToSettings', function (event) {
 

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -535,6 +535,9 @@ export class GUIGlobal implements OnDestroy {
           if (setting.dynamic) {
             let dynamicSetting = await this.updateDynamicSetting(setting.name)
 
+            if (!dynamicSetting)
+              continue;
+
             let isCosmetic = (tab.name in guiSettings.cosmeticsObj);
                     
             guiSettings.settingsObj[tab.name].sections[section.name].settings[setting.name] = dynamicSetting;

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -535,28 +535,28 @@ export class GUIGlobal implements OnDestroy {
           if (setting.dynamic) {
             let dynamicSetting = await this.updateDynamicSetting(setting.name)
 
-            if (!dynamicSetting)
-              continue;
+            if (dynamicSetting) {
 
-            let parsedSetting = JSON.parse(dynamicSetting);
+              let parsedSetting = JSON.parse(dynamicSetting);
 
-            let isCosmetic = (tab.name in guiSettings.cosmeticsObj);
-                   
-            guiSettings.settingsObj[tab.name].sections[section.name].settings[setting.name] = parsedSetting.object;
-            
-            guiSettings.settingsArray[tabIndex].sections[sectionIndex].settings[settingIndex] = parsedSetting.array;
-
-            if (isCosmetic) {
-              guiSettings.cosmeticsObj[tab.name].sections[section.name].settings[setting.name] = parsedSetting.object;
-
-              let cosmeticTabIndex = guiSettings.cosmeticsArray.findIndex(elem => elem.name == tab.name);
-
-              if (cosmeticTabIndex != -1) {
-
-                //Note: This follows the assumption that sections and settings are structured identically between settings and cosmetics arrays.
-                guiSettings.cosmeticsArray[cosmeticTabIndex].sections[sectionIndex].settings[settingIndex] = parsedSetting.array;
-              }
-            }  
+              let isCosmetic = (tab.name in guiSettings.cosmeticsObj);
+                     
+              guiSettings.settingsObj[tab.name].sections[section.name].settings[setting.name] = parsedSetting.object;
+              
+              guiSettings.settingsArray[tabIndex].sections[sectionIndex].settings[settingIndex] = parsedSetting.array;
+  
+              if (isCosmetic) {
+                guiSettings.cosmeticsObj[tab.name].sections[section.name].settings[setting.name] = parsedSetting.object;
+  
+                let cosmeticTabIndex = guiSettings.cosmeticsArray.findIndex(elem => elem.name == tab.name);
+  
+                if (cosmeticTabIndex != -1) {
+  
+                  //Note: This follows the assumption that sections and settings are structured identically between settings and cosmetics arrays.
+                  guiSettings.cosmeticsArray[cosmeticTabIndex].sections[sectionIndex].settings[settingIndex] = parsedSetting.array;
+                }
+              }  
+            }
           }
         };
       }

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -538,20 +538,22 @@ export class GUIGlobal implements OnDestroy {
             if (!dynamicSetting)
               continue;
 
+            let parsedSetting = JSON.parse(dynamicSetting);
+
             let isCosmetic = (tab.name in guiSettings.cosmeticsObj);
                     
-            guiSettings.settingsObj[tab.name].sections[section.name].settings[setting.name] = dynamicSetting;
-            guiSettings.settingsArray[tabIndex].sections[sectionIndex].settings[settingIndex] = dynamicSetting;
+            guiSettings.settingsObj[tab.name].sections[section.name].settings[setting.name] = parsedSetting;
+            guiSettings.settingsArray[tabIndex].sections[sectionIndex].settings[settingIndex] = parsedSetting;
 
             if (isCosmetic) {
-              guiSettings.cosmeticsObj[tab.name].sections[section.name].settings[setting.name] = dynamicSetting;
+              guiSettings.cosmeticsObj[tab.name].sections[section.name].settings[setting.name] = parsedSetting;
 
               let cosmeticTabIndex = guiSettings.cosmeticsArray.findIndex(elem => elem.name == tab.name);
 
               if (cosmeticTabIndex != -1) {
 
                 //Note: This follows the assumption that sections and settings are structured identically between settings and cosmetics arrays.
-                guiSettings.cosmeticsArray[cosmeticTabIndex].sections[sectionIndex].settings[settingIndex] = dynamicSetting;
+                guiSettings.cosmeticsArray[cosmeticTabIndex].sections[sectionIndex].settings[settingIndex] = parsedSetting;
               }
             }  
           }

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4743,6 +4743,9 @@ setting_infos = [
         default        = 'balanced',
         choices        = HintDistList(),
         gui_tooltip    = HintDistTips(),
+        gui_params     = {
+            "dynamic": True,
+        },
         shared         = True,
         disable        = {
             '!bingo' : {'settings' : ['bingosync_url']},
@@ -5161,6 +5164,7 @@ setting_infos = [
         default        = 'Default',
         gui_params     = {
             "hide_when_disabled": True,
+            "dynamic": True,
         }
     ),
     Setting_Info('model_adult_filepicker', str, "Adult Link Model", "Fileinput", False, {},
@@ -5197,6 +5201,7 @@ setting_infos = [
         default        = 'Default',
         gui_params     = {
             "hide_when_disabled": True,
+            "dynamic": True,
         }
     ),
     Setting_Info('model_child_filepicker', str, "Child Link Model", "Fileinput", False, {},
@@ -6100,6 +6105,7 @@ setting_infos = [
         ''',
         gui_params     = {
             "hide_when_disabled": True,
+            "dynamic": True,
         }
     ),
     Combobox(
@@ -6114,6 +6120,7 @@ setting_infos = [
         ''',
         gui_params     = {
             "hide_when_disabled": True,
+            "dynamic": True,
         }
     ),
     Setting_Info(

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -271,7 +271,7 @@ def CreateJSON(path, web_version=False):
         json.dump(settingOutputJson, f)
 
 
-def GetSettingOptions(setting_key, web_version):
+def GetSettingDetails(setting_key, web_version):
     setting = GetSettingJson(setting_key, web_version)
 
     print(json.dumps(setting))
@@ -285,7 +285,7 @@ def settingToJsonMain():
         arg_index = args.index('--setting') + 1
         if len(args) < arg_index:
             raise Exception("Usage: SettingsToJson.py --setting <setting_key>")
-        return GetSettingOptions(args[arg_index], web_version)
+        return GetSettingDetails(args[arg_index], web_version)
 
     CreateJSON(data_path('generated/settings_list.json'), web_version)
 

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -272,9 +272,11 @@ def CreateJSON(path, web_version=False):
 
 
 def GetSettingDetails(setting_key, web_version):
-    setting = GetSettingJson(setting_key, web_version)
+    settingJsonObj = GetSettingJson(setting_key, web_version, as_array=False)
+    settingJsonArr = GetSettingJson(setting_key, web_version, as_array=True)
 
-    print(json.dumps(setting))
+    settingOutput = { "object": settingJsonObj, "array": settingJsonArr }
+    print(json.dumps(settingOutput))
 
 
 def settingToJsonMain():

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -9,7 +9,7 @@ import copy
 
 tab_keys     = ['text', 'app_type', 'footer']
 section_keys = ['text', 'app_type', 'is_colors', 'is_sfx', 'col_span', 'row_span', 'subheader']
-setting_keys = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function', 'option_remove']
+setting_keys = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function', 'option_remove', 'dynamic']
 types_with_options = ['Checkbutton', 'Radiobutton', 'Combobox', 'SearchBox', 'MultipleSelect']
 
 
@@ -270,9 +270,23 @@ def CreateJSON(path, web_version=False):
     with open(path, 'w') as f:
         json.dump(settingOutputJson, f)
 
- 
+
+def GetSettingOptions(setting_key, web_version):
+    setting = GetSettingJson(setting_key, web_version)
+
+    print(json.dumps(setting))
+
+
 def settingToJsonMain():
-    web_version = '--web' in sys.argv
+    args = sys.argv[1:]
+    web_version = '--web' in args
+
+    if '--setting' in args:
+        arg_index = args.index('--setting') + 1
+        if len(args) < arg_index:
+            raise Exception("Usage: SettingsToJson.py --setting <setting_key>")
+        return GetSettingOptions(args[arg_index], web_version)
+
     CreateJSON(data_path('generated/settings_list.json'), web_version)
 
 


### PR DESCRIPTION
In release mode / bundled mode, the start procedure does not perform any update to _data/generated/settings_list.json_.
For release, it is instead fixed in place.

This however meant that all settings that rely on custom user data to be input, like

- Custom Music
- Custom Models
- Voices
- Hint_Distributions

could not be user adjusted in the bundled release version. 
Since several features with this concept in mind were added during 7.0 dev, this needs to be handled.

This PR adds a electron preload routine to call SettingsToJson.py with the --setting flag (which was added together with @Cuphat ) to output the setting definition of a setting (provided as argument) in both object and array format.
Settings that need this dynamic option list creation are flagged with the gui_param **dynamic**.

On boot, the GUI queries the electron framework through post-robot for any setting with this parameter, which spawns a python process to return the settings definition. 

This increases the GUI boot time slightly, but allows for clean refreshing of dynamic settings in any execution state.

As a bonus, this can be used to add a feature to refresh these settings at runtime from the GUI via a button. 

Preparations were made to handle this case in web mode, should it ever be needed.