### PR TITLE
fix: CSP with modern electron (update check and styling)

### DIFF
--- a/GUI/electron/src/main.ts
+++ b/GUI/electron/src/main.ts
@@ -239,7 +239,7 @@ function manageCSP() {
     callback({
       responseHeaders: {
         ...details.responseHeaders,
-        'Content-Security-Policy': ['default-src \'self\' *.gstatic.com; img-src \'self\' data: *; style-src \'self\' \'unsafe-inline\' *.googleapis.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' *.googleapis.com; connect-src \'self\' *.githubusercontent.com ws: localhost:4200*']
+        'Content-Security-Policy': ['default-src \'self\' https://*.gstatic.com/; img-src \'self\' data: *; style-src \'self\' \'unsafe-inline\' https://*.googleapis.com/; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' https://*.googleapis.com/; connect-src \'self\' https://*.githubusercontent.com/ ws: localhost:4200*']
       }
     })
   });


### PR DESCRIPTION
CSP was broken with modern electron, therefore, the update check was broken.

Also fixes a couple styling imports from being blocked by CSP.