### PR TITLE
Setting to shuffle the river exit in Gerudo Valley

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -315,6 +315,8 @@ entrance_shuffle_table = [
     ('Overworld',       ('ZD Behind King Zora -> Zoras Fountain',                           { 'index': 0x0225 }),
                         ('Zoras Fountain -> ZD Behind King Zora',                           { 'index': 0x01A1 })),
 
+    ('OverworldOneWay', ('GV Lower Stream -> Lake Hylia',                                   { 'index': 0x0219 })),
+
     ('OwlDrop',         ('LH Owl Flight -> Hyrule Field',                                   { 'index': 0x027E, 'addresses': [0xAC9F26] })),
     ('OwlDrop',         ('DMT Owl Flight -> Kak Impas Rooftop',                             { 'index': 0x0554, 'addresses': [0xAC9EF2] })),
 
@@ -407,9 +409,9 @@ _add_boss_entrances()
 # if shuffling warp songs (depending on other settings).
 # Table maps: short key -> ([target regions], [allowed types])
 priority_entrance_table = {
-    'Bolero': (['DMC Central Local'], ['OwlDrop', 'WarpSong']),
-    'Nocturne': (['Graveyard Warp Pad Region'], ['OwlDrop', 'Spawn', 'WarpSong']),
-    'Requiem': (['Desert Colossus', 'Desert Colossus From Spirit Lobby'], ['OwlDrop', 'Spawn', 'WarpSong']),
+    'Bolero': (['DMC Central Local'], ['OwlDrop', 'WarpSong', 'OverworldOneWay']),
+    'Nocturne': (['Graveyard Warp Pad Region'], ['OwlDrop', 'Spawn', 'WarpSong', 'OverworldOneWay']),
+    'Requiem': (['Desert Colossus', 'Desert Colossus From Spirit Lobby'], ['OwlDrop', 'Spawn', 'WarpSong', 'OverworldOneWay']),
 }
 
 
@@ -448,6 +450,9 @@ def shuffle_random_entrances(worlds):
         one_way_entrance_pools = OrderedDict()
         entrance_pools = OrderedDict()
         one_way_priorities = {}
+
+        if worlds[0].settings.shuffle_gerudo_valley_river_exit:
+            one_way_entrance_pools['OverworldOneWay'] = world.get_shufflable_entrances(type='OverworldOneWay')
 
         if worlds[0].settings.owl_drops:
             one_way_entrance_pools['OwlDrop'] = world.get_shufflable_entrances(type='OwlDrop')
@@ -507,16 +512,19 @@ def shuffle_random_entrances(worlds):
         one_way_target_entrance_pools = {}
         for pool_type, entrance_pool in one_way_entrance_pools.items():
             # One way entrances are extra entrances that will be connected to entrance positions from a selection of entrance pools
-            if pool_type == 'OwlDrop':
-                valid_target_types = ('WarpSong', 'OwlDrop', 'Overworld', 'Extra')
+            if pool_type == 'OverworldOneWay':
+                valid_target_types = ('Spawn', 'WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
+                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
+            elif pool_type == 'OwlDrop':
+                valid_target_types = ('WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Prelude of Light Warp -> Temple of Time'])
                 for target in one_way_target_entrance_pools[pool_type]:
                     target.set_rule(lambda state, age=None, **kwargs: age == 'child')
             elif pool_type == 'Spawn':
-                valid_target_types = ('Spawn', 'WarpSong', 'OwlDrop', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
+                valid_target_types = ('Spawn', 'WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
             elif pool_type == 'WarpSong':
-                valid_target_types = ('Spawn', 'WarpSong', 'OwlDrop', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
+                valid_target_types = ('Spawn', 'WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
             # Ensure that when trying to place the last entrance of a one way pool, we don't assume the rest of the targets are reachable
             for target in one_way_target_entrance_pools[pool_type]:
@@ -742,7 +750,7 @@ def place_one_way_priority_entrance(worlds, world, priority_name, allowed_region
                 continue
         # If not shuffling dungeons, Nocturne requires adult access.
         if not entrance.world.shuffle_dungeon_entrances and priority_name == 'Nocturne':
-            if entrance.type != 'WarpSong' and entrance.parent_region.name != 'Adult Spawn':
+            if entrance.type not in ('OverworldOneWay', 'WarpSong') and entrance.parent_region.name != 'Adult Spawn':
                 continue
         for target in one_way_target_entrance_pools[entrance.type]:
             if target.connected_region and target.connected_region.name in allowed_regions:
@@ -785,7 +793,7 @@ def check_entrances_compatibility(entrance, target, rollbacks=(), placed_one_way
         raise EntranceShuffleError('Self scene connections are forbidden')
 
     # One way entrances shouldn't lead to the same hint area as other already chosen one way entrances
-    if entrance.type in ('OwlDrop', 'Spawn', 'WarpSong'):
+    if entrance.type in ('OverworldOneWay', 'OwlDrop', 'Spawn', 'WarpSong'):
         try:
             hint_area = HintArea.at(target.connected_region)
         except HintAreaNotFound:
@@ -864,7 +872,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
                 raise EntranceShuffleError('Kak Impas House entrances are not in the same hint area')
 
     if (world.shuffle_special_interior_entrances or world.settings.shuffle_overworld_entrances or world.settings.spawn_positions) and \
-       (entrance_placed == None or entrance_placed.type in ['SpecialInterior', 'Overworld', 'Spawn', 'WarpSong', 'OwlDrop']):
+       (entrance_placed == None or entrance_placed.type in ('SpecialInterior', 'Overworld', 'OverworldOneWay', 'Spawn', 'WarpSong', 'OwlDrop')):
         # At least one valid starting region with all basic refills should be reachable without using any items at the beginning of the seed
         # Note this creates new empty states rather than reuse the worlds' states (which already have starting items)
         no_items_search = Search([State(w) for w in worlds])
@@ -888,7 +896,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
             raise EntranceShuffleError('Path to Temple of Time as child is not guaranteed')
 
     if (world.shuffle_interior_entrances or world.settings.shuffle_overworld_entrances) and \
-       (entrance_placed == None or entrance_placed.type in ['Interior', 'SpecialInterior', 'Overworld', 'Spawn', 'WarpSong', 'OwlDrop']):
+       (entrance_placed == None or entrance_placed.type in ('Interior', 'SpecialInterior', 'Overworld', 'OverworldOneWay', 'Spawn', 'WarpSong', 'OwlDrop')):
         # The Big Poe Shop should always be accessible as adult without the need to use any bottles
         # This is important to ensure that players can never lock their only bottles by filling them with Big Poes they can't sell
         # We can use starting items in this check as long as there are no exits requiring the use of a bottle without refills
@@ -923,7 +931,7 @@ def entrance_unreachable_as(entrance, age, already_checked=None):
     already_checked.append(entrance)
 
     # The following cases determine when we say an entrance is not safe to affirm unreachable as the given age
-    if entrance.type in ('WarpSong', 'Overworld'):
+    if entrance.type in ('WarpSong', 'OverworldOneWay', 'Overworld'):
         # Note that we consider all overworld entrances as potentially accessible as both ages, to be completely safe
         return False
     elif entrance.type == 'OwlDrop':
@@ -962,7 +970,7 @@ def get_entrance_replacing(region, entrance_name):
     try:
         return next(filter(lambda entrance: entrance.replaces and entrance.replaces.name == entrance_name and \
                                             entrance.parent_region and entrance.parent_region.name != 'Root Exits' and \
-                                            entrance.type not in ('OwlDrop', 'Spawn', 'WarpSong'), region.entrances))
+                                            entrance.type not in ('OverworldOneWay', 'OwlDrop', 'Spawn', 'WarpSong'), region.entrances))
     except StopIteration:
         return None
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2259,7 +2259,7 @@ setting_infos = [
                     'dungeon_shortcuts', 'trials_random', 'trials',
                     'starting_age', 'shuffle_interior_entrances',
                     'shuffle_grotto_entrances', 'shuffle_dungeon_entrances',
-                    'shuffle_bosses', 'shuffle_overworld_entrances', 'owl_drops', 'warp_songs', 'spawn_positions',
+                    'shuffle_bosses', 'shuffle_overworld_entrances', 'shuffle_gerudo_valley_river_exit', 'owl_drops', 'warp_songs', 'spawn_positions',
                     'triforce_hunt', 'triforce_count_per_world', 'triforce_goal_per_world', 'bombchus_in_logic', 'one_item_per_dungeon',
                     'shuffle_mapcompass', 'shuffle_smallkeys', 'shuffle_hideoutkeys', 'key_rings_choice', 'key_rings',
                     'shuffle_bosskeys', 'enhance_map_compass'
@@ -2295,7 +2295,7 @@ setting_infos = [
         disable        = {
             'glitchless': {'settings' : ['tricks_list_msg']},
             'glitched'  : {'settings' : ['allowed_tricks', 'shuffle_interior_entrances', 'shuffle_grotto_entrances',
-                                         'shuffle_dungeon_entrances', 'shuffle_overworld_entrances', 'owl_drops',
+                                         'shuffle_dungeon_entrances', 'shuffle_overworld_entrances', 'shuffle_gerudo_valley_river_exit', 'owl_drops',
                                          'warp_songs', 'spawn_positions', 'mq_dungeons_mode', 'mq_dungeons_specific',
                                          'mq_dungeons_count', 'shuffle_bosses', 'dungeon_shortcuts', 'deadly_bonks', 
                                          'shuffle_freestanding_items', 'shuffle_pots', 'shuffle_crates', 'shuffle_beehives']},
@@ -3657,11 +3657,26 @@ setting_infos = [
             Some entrances are kept unshuffled to avoid issues:
             - Hyrule Castle Courtyard and Garden entrances
             - Both Market Back Alley entrances
-            - Gerudo Valley to Lake Hylia
 
-            Just like when shuffling interior entrances, shuffling overworld 
-            entrances disables trade timers and trade items never revert, 
+            The entrance from Gerudo Valley to Lake Hylia is a one-way
+            entrance and has its own setting below.
+
+            Just like when shuffling interior entrances, shuffling overworld
+            entrances disables trade timers and trade items never revert,
             even when dying or loading a save.
+        ''',
+        default        = False,
+        shared         = True,
+        gui_params     = {
+            'randomize_key': 'randomize_settings',
+        },
+    ),
+    Checkbutton(
+        name           = 'shuffle_gerudo_valley_river_exit',
+        gui_text       = 'Shuffle Gerudo Valley River Exit',
+        gui_tooltip    = '''\
+            Randomize where the the one-way entrance
+            down the river in Gerudo Valley leads to.
         ''',
         default        = False,
         shared         = True,

--- a/World.py
+++ b/World.py
@@ -60,7 +60,7 @@ class World(object):
 
         self.entrance_shuffle = (
             self.shuffle_interior_entrances or settings.shuffle_grotto_entrances or self.shuffle_dungeon_entrances
-            or settings.shuffle_overworld_entrances or settings.owl_drops or settings.warp_songs
+            or settings.shuffle_overworld_entrances or settings.shuffle_gerudo_valley_river_exit or settings.owl_drops or settings.warp_songs
             or settings.spawn_positions or (settings.shuffle_bosses != 'off')
         )
 

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -169,6 +169,7 @@
             "shuffle_dungeon_entrances",
             "shuffle_bosses",
             "shuffle_overworld_entrances",
+            "shuffle_gerudo_valley_river_exit",
             "owl_drops",
             "warp_songs",
             "spawn_positions",


### PR DESCRIPTION
This adds a toggle to shuffle the exit down the river in Gerudo Valley as a one-way entrance, behaving like an owl drop but for both ages. The exit's vanilla target entrance at Lake Hylia also becomes a valid target for all one-way entrance types regardless of the setting, which is consistent with how other types of entrances are handled.

I propose this as an alternative to the current behavior on @Roman971's branch, where this entrance is included in the pool of overworld entrances if entrances are decoupled. Decoupled seems like a fairly unpopular setting even among ER players (for example, it's excluded from the RSL weights, and there was a tournament with a “full entrance randomizer” theme that didn't use the setting), so this setting removes the requirement to use decoupled in order to shuffle this exit.

This PR also includes a minor fix to how hint areas are calculated: The algorithm will now prefer regular entrance types over spawns, owl drops, warp songs, and the new `OverworldOneWay` type, which ensures that a region without its own hint area that's reachable via both a one-way and a regular entrance will be considered part of the hint area of the regular entrance.