### PR TITLE
Remove hack to keep the Well's water up as adult

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1059,7 +1059,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_int16(0xAC995A, 0x060C)
 
         # Tell the well water we are always a child.
-        rom.write_int32(0xDD5BF4, 0x00000000)
+        # rom.write_int32(0xDD5BF4, 0x00000000)
 
         # Make the Adult well blocking stone dissappear if the well has been drained by
         # checking the well drain event flag instead of links age. This actor doesn't need a


### PR DESCRIPTION
We believe this was an early attempt to keep adult out of the well, prior to the modern way of doing it by removing the stone when checking the storms flag, the code right below this rom write. A recent way to enter botw as adult was found that requires no items, but the water needs to be down like vanilla.  So reverting this change as it is no longer relevant to the randomizer and prevents a vanilla glitch from being performed.