### PR TITLE
Store settings versioning names to avoid breaking plandomizers when renaming a setting

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -20,7 +20,7 @@ from version import __version__
 from Utils import random_choices
 from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
 import StartingItems
-from SettingsList import build_close_match, validate_settings
+from SettingsList import build_close_match, validate_settings, settings_versioning
 
 
 class InvalidFileException(Exception):
@@ -1087,6 +1087,10 @@ class Distribution(object):
 
         self.settings.__dict__.update(update_dict['_settings'])
         if 'settings' in self.src_dict:
+            for setting in self.src_dict['settings']:
+                for setting_version in settings_versioning:
+                    if setting == setting_version.old_name:
+                        self.src_dict['settings'][setting_version.new_name] = self.src_dict['settings'].pop(setting_version.old_name)
             validate_settings(self.src_dict['settings'])
             self.src_dict['_settings'] = self.src_dict['settings']
             del self.src_dict['settings']

--- a/Settings.py
+++ b/Settings.py
@@ -12,7 +12,7 @@ import textwrap
 
 from version import __version__
 from Utils import random_choices, local_path, data_path
-from SettingsList import setting_infos, get_setting_info, validate_settings
+from SettingsList import setting_infos, get_setting_info, validate_settings, settings_versioning
 from Plandomizer import Distribution
 import StartingItems
 
@@ -318,6 +318,11 @@ class Settings:
 
     # add the settings as fields, and calculate information based on them
     def __init__(self, settings_dict, strict=False):
+        # Update old setting names with the most recent ones
+        for setting in settings_dict:
+                for setting_version in settings_versioning:
+                    if setting == setting_version.old_name:
+                        settings_dict[setting_version.new_name] = settings_dict.pop(setting_version.old_name)
         if settings_dict.get('compress_rom', None):
             # Old compress_rom setting is set, so set the individual output settings using it.
             settings_dict['create_patch_file'] = settings_dict['compress_rom'] == 'Patch' or settings_dict.get('create_patch_file', False)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -20,6 +20,20 @@ import Sounds as sfx
 import StartingItems
 from Utils import data_path
 
+# Old/New name of a setting
+class Setting_Info_Versioning():
+
+    def __init__(self, old_name, new_name):
+        self.old_name = old_name # old name of the setting
+        self.new_name = new_name # old name of the setting
+
+settings_versioning = [
+    Setting_Info_Versioning(
+        old_name       = '',
+        new_name       = '',
+    )
+]
+
 # holds the info for a single setting
 class Setting_Info():
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -25,7 +25,7 @@ class Setting_Info_Versioning():
 
     def __init__(self, old_name, new_name):
         self.old_name = old_name # old name of the setting
-        self.new_name = new_name # old name of the setting
+        self.new_name = new_name # new name of the setting
 
 settings_versioning = [
     Setting_Info_Versioning(


### PR DESCRIPTION
This adds a settings_versioning table in SettingsList.py, which purpose is to update settings names, either in the __init___ of the Settings class, or in loading of settings in Plandomizer.Py

By adding a new Setting_Info_Versioning entry in the table with the previous name used by the setting and the new one after a rename, this enables plandomizers to use the old name without breaking.

I've tested this in my current Traps branch (see https://github.com/GSKirox/OoT-Randomizer/tree/Traps), and plandos using the old setting name work fine, and all Unit Tests also pass.