### PR TITLE
Frogs 2 Misc Hint

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -215,6 +215,7 @@ conditional_always = {
     'Kak 30 Gold Skulltula Reward': lambda world: tokens_required_by_settings(world) < 30 and '30_skulltulas' not in world.settings.misc_hints,
     'Kak 40 Gold Skulltula Reward': lambda world: tokens_required_by_settings(world) < 40 and '40_skulltulas' not in world.settings.misc_hints,
     'Kak 50 Gold Skulltula Reward': lambda world: tokens_required_by_settings(world) < 50 and '50_skulltulas' not in world.settings.misc_hints,
+    'ZR Frogs Ocarina Game':        lambda world: 'frogs2' not in world.settings.misc_hints,
 }
 
 # Entrance hints required under certain settings
@@ -447,7 +448,7 @@ hintTable = {
     'Deku Seeds (30)':                                          (["catapult ammo", "lots-o-seeds"], "Deku Seeds (30 pieces)", 'item'),
     'Gold Skulltula Token':                                     (["proof of destruction", "an arachnid chip", "spider remains", "one percent of a curse"], "a Gold Skulltula Token", 'item'),
 
-    'ZR Frogs Ocarina Game':                                       (["an #amphibian feast# yields", "the #croaking choir's magnum opus# awards", "the #froggy finale# yields"], "the final reward from the #Frogs of Zora's River# is", 'always'),
+    'ZR Frogs Ocarina Game':                                       (["an #amphibian feast# yields", "the #croaking choir's magnum opus# awards", "the #froggy finale# yields"], "the final reward from the #Frogs of Zora's River# is", ['overworld', 'sometimes']),
     'KF Links House Cow':                                          ("the #bovine bounty of a horseback hustle# gifts", "#Malon's obstacle course# leads to", 'always'),
 
     'Song from Ocarina of Time':                                   ("the #Ocarina of Time# teaches", None, ['song', 'sometimes']),
@@ -1766,6 +1767,13 @@ misc_location_hint_table = {
         'item_location': 'Kak 50 Gold Skulltula Reward',
         'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x4150 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
+    },
+    'frogs2': {
+        'id': 0x022E,
+        'hint_location': 'ZR Frogs Ocarina Minigame Hint',
+        'item_location': 'ZR Frogs Ocarina Game',
+        'location_text': "Some frogs holding \x05\x42{item}\x05\x40 are looking at you from underwater...",
+        'location_fallback': "Some frogs are looking at you from underwater...",
     },
 }
 

--- a/LocationList.py
+++ b/LocationList.py
@@ -2028,6 +2028,7 @@ location_table = OrderedDict([
     ("30 Skulltulas Reward Hint",                                    ("Hint",         None,  None, None,                            None,                                    None)),
     ("40 Skulltulas Reward Hint",                                    ("Hint",         None,  None, None,                            None,                                    None)),
     ("50 Skulltulas Reward Hint",                                    ("Hint",         None,  None, None,                            None,                                    None)),
+    ("ZR Frogs Ocarina Minigame Hint",                               ("Hint",         None,  None, None,                            None,                                    None)),
     ("Ganondorf Hint",                                               ("Hint",         None,  None, None,                            None,                                    None)),
 ])
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4833,6 +4833,7 @@ setting_infos = [
             '30_skulltulas':  'House of Skulltula: 30',
             '40_skulltulas':  'House of Skulltula: 40',
             '50_skulltulas':  'House of Skulltula: 50',
+            'frogs2':         'Frogs Ocarina Game',
         },
         gui_tooltip    = '''\
             This setting adds some hints at locations
@@ -4867,6 +4868,11 @@ setting_infos = [
             Talking to a cursed House of Skulltula
             resident will tell you the reward they will
             give you for removing their curse.
+
+            Placing yourself on the log at Zora River
+            where you play the songs for the frogs will
+            tell you what the reward is for playing all 
+            six non warp songs.
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs'],

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4833,6 +4833,7 @@ setting_infos = [
             '30_skulltulas':  'House of Skulltula: 30',
             '40_skulltulas':  'House of Skulltula: 40',
             '50_skulltulas':  'House of Skulltula: 50',
+            'frogs2':         'Frogs 2',
         },
         gui_tooltip    = '''\
             This setting adds some hints at locations
@@ -4867,6 +4868,11 @@ setting_infos = [
             Talking to a cursed House of Skulltula
             resident will tell you the reward they will
             give you for removing their curse.
+
+            Placing yourself on the log at Zora River
+            where you play the songs for the frogs will
+            tell you what the reward is for playing all 
+            six non warp songs to the frogs.
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs'],

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1024,7 +1024,8 @@
             "ZR GS Near Raised Grottos": "is_adult and (Progressive_Hookshot or can_hover) and at_night",
             "ZR GS Above Bridge": "can_use(Hookshot) and at_night",
             "ZR Near Grottos Gossip Stone": "True",
-            "ZR Near Domain Gossip Stone": "True"
+            "ZR Near Domain Gossip Stone": "True",
+            "ZR Frogs Ocarina Minigame Hint": "True"
         },
         "exits": {
             "ZR Front": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2181,7 +2181,8 @@
             "Butterfly Fairy": "can_use(Sticks) and has_bottle",
             "Bug Shrub": "
                 (is_child or here(can_plant_bean) or Hover_Boots or logic_zora_river_lower) and
-                can_cut_shrubs and has_bottle"
+                can_cut_shrubs and has_bottle",
+            "ZR Frogs Ocarina Minigame Hint": "True"
         },
         "exits": {
             "ZR Front": "True",


### PR DESCRIPTION
Following recent discussions for settings for future tournaments, some racers expressed an interest in having a fixed Frogs Ocarina Game hint, like the recent Skull House hints.

This adds a new hint in the textbox popping up when Link jumps on the log : 

https://user-images.githubusercontent.com/65768236/211411824-c68db4c0-44a0-4f8b-9532-2f33ac9694cf.mp4


This textbox only appears the first time in the area, but you can always reload the area and come back to read the hint again.