### PR TITLE
Enable Ocarina in Granny's Potion Shop, Bombchu Bowling and Shooting Gallery

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -852,6 +852,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_byte(0xB6D3D3, 0x00) # Gerudo Training Ground
     rom.write_byte(0xB6D42B, 0x00) # Inside Ganon's Castle
 
+    # Allow Ocarina in some places
+    rom.write_byte(0xB6D346, 0x11) # Granny's Potion Shop
+    rom.write_byte(0xB6D33A, 0x51) # Bombchu Bowling
+    rom.write_byte(0xB6D30A, 0x51) # Archery
+
     # Remove disruptive text from Gerudo Training Ground and early Shadow Temple (vanilla)
     Wonder_text = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, 0x27CE080,
                    0x27CE090, 0x2887070, 0x2887080, 0x2887090, 0x2897070, 0x28C7134, 0x28D91BC, 0x28A60F4, 0x28AE084,


### PR DESCRIPTION
This unlocks the restriction on Ocarina in 3 places : 
* Granny's Potion Shop
* Bombchu Bowling
* Shooting Gallery (both child and adult)

It's a very small quality of life change, but it always felt weird to have to walk out of the room to warp out.
To note that this allows to play Sun Song in all these rooms, but this shouldn't change anything logically.

Additional protection for Bowling/Gallery has been added to #1843 to ensure that dpad ocarina cannot be used while actually playing the minigames, which could cause some temp B bugs.

