### PR TITLE
Randomize spoiler log playthrough

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -716,6 +716,7 @@ def create_playthrough(spoiler):
         # Otherwise, an item we collect could influence later item collection in the same sphere
         collected = list(search.iter_reachable_locations(item_locations))
         if not collected: break
+        random.shuffle(collected)
         # Gather the new entrances before collecting items.
         collection_spheres.append(collected)
         accessed_entrances = set(filter(search.spot_access, remaining_entrances))
@@ -734,6 +735,7 @@ def create_playthrough(spoiler):
     # like bow and slingshot appear as early as possible rather than as late as possible.
     required_locations = []
     for sphere in reversed(collection_spheres):
+        random.shuffle(sphere)
         for location in sphere:
             # we remove the item at location and check if the game is still beatable in case the item could be required
             old_item = location.item
@@ -763,6 +765,7 @@ def create_playthrough(spoiler):
     # Reduce each entrance sphere in reverse order, by checking if the game is beatable when we disconnect the entrance.
     required_entrances = []
     for sphere in reversed(entrance_spheres):
+        random.shuffle(sphere)
         for entrance in sphere:
             # we disconnect the entrance and check if the game is still beatable
             old_connected_region = entrance.disconnect()

--- a/Main.py
+++ b/Main.py
@@ -765,6 +765,7 @@ def create_playthrough(spoiler):
     # Reduce each entrance sphere in reverse order, by checking if the game is beatable when we disconnect the entrance.
     required_entrances = []
     for sphere in reversed(entrance_spheres):
+        sphere = list(sphere)
         random.shuffle(sphere)
         for entrance in sphere:
             # we disconnect the entrance and check if the game is still beatable

--- a/Main.py
+++ b/Main.py
@@ -720,7 +720,7 @@ def create_playthrough(spoiler):
         # Gather the new entrances before collecting items.
         collection_spheres.append(collected)
         accessed_entrances = set(filter(search.spot_access, remaining_entrances))
-        entrance_spheres.append(accessed_entrances)
+        entrance_spheres.append(list(accessed_entrances))
         remaining_entrances -= accessed_entrances
         for location in collected:
             # Collect the item for the state world it is for
@@ -765,7 +765,6 @@ def create_playthrough(spoiler):
     # Reduce each entrance sphere in reverse order, by checking if the game is beatable when we disconnect the entrance.
     required_entrances = []
     for sphere in reversed(entrance_spheres):
-        sphere = list(sphere)
         random.shuffle(sphere)
         for entrance in sphere:
             # we disconnect the entrance and check if the game is still beatable


### PR DESCRIPTION
The playthrough algorithm currently has a bias based on the order in which regions and locations are defined, which should really be an implementation detail. This means that some routes will never be used despite being equal in sphere count to others, which could hide bugs. It also means that in some situations, it may be very slightly beneficial for runners to learn or reference the location definition order, e.g. for misc. item hints like the hookshot hint in Dampé's diary.

This PR removes that bias by shuffling each sphere before iterating through it.