### PR TITLE
Add tooltips for model settings on web

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -5197,8 +5197,23 @@ setting_infos = [
             "dynamic": True,
         }
     ),
-    Setting_Info('model_adult_filepicker', str, "Adult Link Model", "Fileinput", False, {},
-        gui_params = {
+    Setting_Info(
+        name        = 'model_adult_filepicker',
+        type        = str,
+        gui_text    = "Adult Link Model",
+        gui_type    = "Fileinput",
+        shared      = False,
+        choices     = {},
+        gui_tooltip = '''\
+            Link's model will be replaced by the model selected.
+            Cosmetics options might not be applied when a
+            custom model is in use.
+            Caution: Any changes to Link's skeleton have the potential
+            to affect gameplay in significant ways and so are disallowed
+            for all recorded Racetime races. A note will appear at the top
+            of the pause screen if this is the case.
+        ''',
+        gui_params  = {
             "file_types": [
                 {
                   "name": "Z64 Model Files",
@@ -5210,7 +5225,8 @@ setting_infos = [
                 }
             ],
             "hide_when_disabled": True,
-    }),
+        }
+    ),
     Combobox(
         name           = 'model_child',
         gui_text       = 'Child Link Model',
@@ -5234,8 +5250,23 @@ setting_infos = [
             "dynamic": True,
         }
     ),
-    Setting_Info('model_child_filepicker', str, "Child Link Model", "Fileinput", False, {},
-        gui_params = {
+    Setting_Info(
+        name        = 'model_child_filepicker',
+        type        = str,
+        gui_text    = "Child Link Model",
+        gui_type    = "Fileinput",
+        shared      = False,
+        choices     = {},
+        gui_tooltip = '''\
+            Link's model will be replaced by the model selected.
+            Cosmetics options might not be applied when a
+            custom model is in use.
+            Caution: Any changes to Link's skeleton have the potential
+            to affect gameplay in significant ways and so are disallowed
+            for all recorded Racetime races. A note will appear at the top
+            of the pause screen if this is the case.
+        ''',
+        gui_params  = {
             "file_types": [
                 {
                   "name": "Z64 Model Files",
@@ -5247,7 +5278,8 @@ setting_infos = [
                 }
             ],
             "hide_when_disabled": True,
-    }),
+        }
+    ),
     Setting_Info(
         name           = 'model_unavailable_msg',
         type           = str,


### PR DESCRIPTION
The website uses `Fileinput`s for loading custom Link models, and the tooltips shown on the Electron app's `Combobox`es were missing from them. This PR copies them over, except for the part about adding models to the right directory which doesn't apply there.