### PR TITLE
Seed generator (solver) speedups: keep state items in a flat list

### DIFF
--- a/Goals.py
+++ b/Goals.py
@@ -126,7 +126,7 @@ class GoalCategory(object):
                 if goal.items:
                     if all(map(full_search.state_list[index].has_item_goal, goal.items)):
                         for i in goal.items:
-                            i['quantity'] = min(full_search.state_list[index].item_count(i['name']), i['quantity'])
+                            i['quantity'] = min(full_search.state_list[index].item_name_count(i['name']), i['quantity'])
 
 
 def replace_goal_names(worlds):

--- a/Item.py
+++ b/Item.py
@@ -189,7 +189,7 @@ def ItemFactory(items, world=None, event=False):
 
 def MakeEventItem(name, location, item=None):
     if item is None:
-        item = ItemFactory(name, location.world, event=True)
+        item = Item(name, location.world, event=True)
     location.world.push_item(location, item)
     location.locked = True
     if name not in item_table:

--- a/Item.py
+++ b/Item.py
@@ -1,4 +1,11 @@
+import re
+
 from ItemList import item_table
+from RulesCommon import allowed_globals
+
+_escape = re.compile(r'[\'()[\]-]')
+def escape_name(name):
+    return _escape.sub('', name.replace(' ', '_'))
 
 
 class ItemInfo(object):
@@ -8,6 +15,11 @@ class ItemInfo(object):
     medallions = set()
     stones = set()
     junk = {}
+
+    solver_ids = {}
+    bottle_ids = set()
+    medallion_ids = set()
+    stone_ids = set()
 
     def __init__(self, name='', event=False):
         if event:
@@ -32,15 +44,25 @@ class ItemInfo(object):
         self.junk = self.special.get('junk', None)
         self.trade = self.special.get('trade', False)
 
+        self.solver_id = None
+        if name and self.junk is None:
+            esc = escape_name(name)
+            if esc not in ItemInfo.solver_ids:
+                allowed_globals[esc] = ItemInfo.solver_ids[esc] = len(ItemInfo.solver_ids)
+            self.solver_id = ItemInfo.solver_ids[esc]
+
 
 for item_name in item_table:
     ItemInfo.items[item_name] = ItemInfo(item_name)
     if ItemInfo.items[item_name].bottle:
         ItemInfo.bottles.add(item_name)
+        ItemInfo.bottle_ids.add(ItemInfo.solver_ids[escape_name(item_name)])
     if ItemInfo.items[item_name].medallion:
         ItemInfo.medallions.add(item_name)
+        ItemInfo.medallion_ids.add(ItemInfo.solver_ids[escape_name(item_name)])
     if ItemInfo.items[item_name].stone:
         ItemInfo.stones.add(item_name)
+        ItemInfo.stone_ids.add(ItemInfo.solver_ids[escape_name(item_name)])
     if ItemInfo.items[item_name].junk is not None:
         ItemInfo.junk[item_name] = ItemInfo.items[item_name].junk
 
@@ -66,6 +88,10 @@ class Item(object):
         self.special = self.info.special
         self.index = self.info.index
         self.alias = self.info.alias
+
+        self.solver_id = self.info.solver_id
+        # Do not alias to junk--it has no solver id!
+        self.alias_id = ItemInfo.solver_ids[escape_name(self.alias[0])] if self.alias else None
 
 
     item_worlds_to_fix = {}

--- a/Item.py
+++ b/Item.py
@@ -1,11 +1,7 @@
 import re
 
 from ItemList import item_table
-from RulesCommon import allowed_globals
-
-_escape = re.compile(r'[\'()[\]-]')
-def escape_name(name):
-    return _escape.sub('', name.replace(' ', '_'))
+from RulesCommon import allowed_globals, escape_name
 
 
 class ItemInfo(object):

--- a/ItemList.py
+++ b/ItemList.py
@@ -165,6 +165,7 @@ item_table = {
     'Shadow Trial Clear':               ('Event',    True,  None, None),
     'Spirit Trial Clear':               ('Event',    True,  None, None),
     'Light Trial Clear':                ('Event',    True,  None, None),
+    'Epona':                            ('Event',    True,  None, None),
 
     'Deku Stick Drop':                  ('Drop',     True,  None, None),
     'Deku Nut Drop':                    ('Drop',     True,  None, None),

--- a/Location.py
+++ b/Location.py
@@ -69,7 +69,14 @@ class Location(object):
         if self.never:
             return
         self.access_rules.append(lambda_rule)
-        self.access_rule = lambda state, **kwargs: all(rule(state, **kwargs) for rule in self.access_rules)
+        self.access_rule = self._run_rules
+
+
+    def _run_rules(self, state, **kwargs):
+        for rule in self.access_rules:
+            if not rule(state, **kwargs):
+                return False
+        return True
 
 
     def set_rule(self, lambda_rule):

--- a/Main.py
+++ b/Main.py
@@ -810,9 +810,9 @@ def create_playthrough(spoiler):
         collected.clear()
     logger.info('Collected %d final spheres', len(collection_spheres))
 
-    if not search.can_beat_game():
-        logger.error("Didn't beat game after all!")
-        logger.debug('Missing these locations: %s', ', '.join(loc.name for loc in set(required_locations) - search._cache['visited_locations'] - internal_locations))
+    if not search.can_beat_game(False):
+        logger.error('Playthrough could not beat the game!')
+        # Add temporary debugging info or breakpoint here if this happens
 
     # Then we can finally output our playthrough
     spoiler.playthrough = OrderedDict((str(i), {location: location.item for location in sphere}) for i, sphere in enumerate(collection_spheres))

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -1,21 +1,21 @@
 import ast
 from collections import defaultdict
-from inspect import signature, _ParameterKind
 import logging
 import re
 
-from Item import ItemInfo, MakeEventItem
+from Item import ItemInfo, Item, MakeEventItem, escape_name
 from Location import Location
 from Region import TimeOfDay
+from RulesCommon import allowed_globals
 from State import State
 from Utils import data_path, read_logic_file
 
 
 escaped_items = {}
 for item in ItemInfo.items:
-    escaped_items[re.sub(r'[\'()[\]]', '', item.replace(' ', '_'))] = item
+    escaped_items[escape_name(item)] = item
 
-event_name = re.compile(r'\w+')
+event_name = re.compile(r'[A-Z]\w+')
 # All generated lambdas must accept these keyword args!
 # For evaluation at a certain age (required as all rules are evaluated at a specific age)
 # or at a certain spot (can be omitted in many cases)
@@ -26,7 +26,8 @@ kwarg_defaults = {
     'tod': TimeOfDay.NONE,
 }
 
-allowed_globals = {'TimeOfDay': TimeOfDay}
+special_globals = {'TimeOfDay': TimeOfDay}
+allowed_globals.update(special_globals)
 
 rule_aliases = {}
 nonaliases = set()
@@ -79,7 +80,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                     value=ast.Name(id='state', ctx=ast.Load()),
                     attr='has',
                     ctx=ast.Load()),
-                args=[ast.Str(escaped_items[node.id])],
+                args=[node],
                 keywords=[])
         elif node.id in self.world.__dict__:
             return ast.parse('%r' % self.world.__dict__[node.id], mode='eval').body
@@ -88,27 +89,33 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             return ast.parse('%r' % self.world.settings.__dict__[node.id], mode='eval').body
         elif node.id in State.__dict__:
             return self.make_call(node, node.id, [], [])
-        elif node.id in kwarg_defaults or node.id in allowed_globals:
+        elif node.id in kwarg_defaults or node.id in special_globals:
             return node
         elif event_name.match(node.id):
             self.events.add(node.id.replace('_', ' '))
+            # Ensure the item info is updated properly
+            Item(node.id, event=True)
             return ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id='state', ctx=ast.Load()),
                     attr='has',
                     ctx=ast.Load()),
-                args=[ast.Str(node.id.replace('_', ' '))],
+                args=[node],
                 keywords=[])
         else:
             raise Exception('Parse Error: invalid node name %s' % node.id, self.current_spot.name, ast.dump(node, False))
 
     def visit_Str(self, node):
+        esc = escape_name(node.s)
+        if esc not in ItemInfo.solver_ids:
+            self.events.add(esc.replace('_', ' '))
+            Item(esc, event=True)
         return ast.Call(
             func=ast.Attribute(
                 value=ast.Name(id='state', ctx=ast.Load()),
                 attr='has',
                 ctx=ast.Load()),
-            args=[ast.Str(node.s)],
+            args=[ast.Name(id=escape_name(node.s), ctx=ast.Load())],
             keywords=[])
 
     # python 3.8 compatibility: ast walking now uses visit_Constant for Constant subclasses
@@ -127,7 +134,8 @@ class Rule_AST_Transformer(ast.NodeTransformer):
 
         if not isinstance(item, (ast.Name, ast.Str)):
             raise Exception('Parse Error: first value must be an item. Got %s' % item.__class__.__name__, self.current_spot.name, ast.dump(node, False))
-        iname = item.id if isinstance(item, ast.Name) else item.s
+        if isinstance(item, ast.Str):
+            item = ast.Name(id=escape_name(item.s), ctx=ast.Load())
 
         if not (isinstance(count, ast.Name) or isinstance(count, ast.Num)):
             raise Exception('Parse Error: second value must be a number. Got %s' % item.__class__.__name__, self.current_spot.name, ast.dump(node, False))
@@ -136,18 +144,15 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             # Must be a settings constant
             count = ast.parse('%r' % self.world.settings.__dict__[count.id], mode='eval').body
 
-        if iname in escaped_items:
-            iname = escaped_items[iname]
-
-        if iname not in ItemInfo.items:
-            self.events.add(iname)
+        if item.id not in ItemInfo.solver_ids:
+            self.events.add(item.id.replace('_', ' '))
 
         return ast.Call(
             func=ast.Attribute(
                 value=ast.Name(id='state', ctx=ast.Load()),
                 attr='has',
                 ctx=ast.Load()),
-            args=[ast.Str(iname), count],
+            args=[item, count],
             keywords=[])
 
 
@@ -201,8 +206,10 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                 elif child.id in rule_aliases:
                     child = self.visit(child)
                 elif child.id in escaped_items:
+                    logging.getLogger('').debug(f'Call? {node.func.id} with {child.id}')
                     child = ast.Str(escaped_items[child.id])
                 else:
+                    logging.getLogger('').debug(f'Call? {node.func.id} with {child.id}')
                     child = ast.Str(child.id.replace('_', ' '))
             elif not isinstance(child, ast.Str):
                 child = self.visit(child)
@@ -289,9 +296,13 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         # if any is False(And)/True(Or), the whole node can be replaced with it
         for elt in list(node.values):
             if isinstance(elt, ast.Str):
-                items.add(elt.s)
-            elif isinstance(elt, ast.Name) and elt.id in nonaliases:
-                items.add(escaped_items[elt.id])
+                items.add(escape_name(elt.s))
+            elif (isinstance(elt, ast.Name) and elt.id not in rule_aliases
+                    and elt.id not in self.world.__dict__
+                    and elt.id not in self.world.settings.__dict__
+                    and elt.id not in dir(self)
+                    and elt.id not in State.__dict__):
+                items.add(elt.id)
             else:
                 # It's possible this returns a single item check,
                 # but it's already wrapped in a Call.
@@ -304,9 +315,11 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                         and elt.func.attr in ('has', groupable) and len(elt.args) == 1):
                     args = elt.args[0]
                     if isinstance(args, ast.Str):
-                        items.add(args.s)
+                        items.add(escape_name(args.s))
+                    elif isinstance(args, ast.Name):
+                        items.add(args.id)
                     else:
-                        items.update(it.s for it in args.elts)
+                        items.update(it.id for it in args.elts)
                 elif isinstance(elt, ast.BoolOp) and node.op.__class__ == elt.op.__class__:
                     new_values.extend(elt.values)
                 else:
@@ -323,7 +336,8 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                     value=ast.Name(id='state', ctx=ast.Load()),
                     attr='has_any_of' if early_return else 'has_all_of',
                     ctx=ast.Load()),
-                args=[ast.Tuple(elts=[ast.Str(i) for i in items], ctx=ast.Load())],
+                args=[ast.Tuple(elts=[ast.Name(id=i, ctx=ast.Load()) for i in items],
+                                ctx=ast.Load())],
                 keywords=[])] + new_values
         else:
             node.values = new_values
@@ -354,6 +368,8 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             return self.replaced_rules[target][rule]
 
         subrule_name = target + ' Subrule %d' % (1 + len(self.replaced_rules[target]))
+        # Ensure the item info is created
+        Item(subrule_name, event=True)
         # Save the info to be made into a rule later
         self.delayed_rules.append((target, node, subrule_name))
         # Replace the call with a reference to that item
@@ -362,7 +378,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                 value=ast.Name(id='state', ctx=ast.Load()),
                 attr='has',
                 ctx=ast.Load()),
-            args=[ast.Str(subrule_name)],
+            args=[ast.Name(id=escape_name(subrule_name), ctx=ast.Load())],
             keywords=[])
         # Cache the subrule for any others in this region
         # (and reserve the item name in the process)
@@ -401,6 +417,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
             # requires consistent iteration on dicts
             kwargs = [ast.arg(arg=k) for k in kwarg_defaults.keys()]
             kwd = list(map(ast.Constant, kwarg_defaults.values()))
+            name = f'<{self.current_spot and self.current_spot.name}: {rule_str}>'
             try:
                 self.rule_cache[rule_str] = eval(compile(
                     ast.fix_missing_locations(
@@ -412,8 +429,9 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                                 kwonlyargs=kwargs,
                                 kw_defaults=kwd),
                             body=body))),
-                    '<string>', 'eval'),
+                    name, 'eval'),
                     # globals/locals. if undefined, everything in the namespace *now* would be allowed
+                    # Intentionally modifiable so we can add the ItemInfo solver ids as we go
                     allowed_globals)
             except TypeError as e:
                 raise Exception('Parse Error: %s' % e, self.current_spot.name, ast.dump(body, False))
@@ -446,7 +464,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if self.world.ensure_tod_access:
             # tod has DAY or (tod == NONE and (ss or find a path from a provider))
             # parsing is better than constructing this expression by hand
-            return ast.parse("(tod & TimeOfDay.DAY) if tod else (state.has_all_of(('Ocarina', 'Suns Song')) or state.search.can_reach(spot.parent_region, age=age, tod=TimeOfDay.DAY))", mode='eval').body
+            return ast.parse("(tod & TimeOfDay.DAY) if tod else (state.has_all_of((Ocarina, Suns_Song)) or state.search.can_reach(spot.parent_region, age=age, tod=TimeOfDay.DAY))", mode='eval').body
         return ast.NameConstant(True)
 
     def at_dampe_time(self, node):
@@ -463,7 +481,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if self.world.ensure_tod_access:
             # tod has DAMPE or (tod == NONE and (ss or find a path from a provider))
             # parsing is better than constructing this expression by hand
-            return ast.parse("(tod & TimeOfDay.DAMPE) if tod else (state.has_all_of(('Ocarina', 'Suns Song')) or state.search.can_reach(spot.parent_region, age=age, tod=TimeOfDay.DAMPE))", mode='eval').body
+            return ast.parse("(tod & TimeOfDay.DAMPE) if tod else (state.has_all_of((Ocarina, Suns_Song)) or state.search.can_reach(spot.parent_region, age=age, tod=TimeOfDay.DAMPE))", mode='eval').body
         return ast.NameConstant(True)
 
 

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 import logging
 import re
 
-from Item import ItemInfo, Item, MakeEventItem, escape_name
+from Item import ItemInfo, Item, MakeEventItem
 from Location import Location
 from Region import TimeOfDay
-from RulesCommon import allowed_globals
+from RulesCommon import allowed_globals, escape_name
 from State import State
 from Utils import data_path, read_logic_file
 

--- a/RulesCommon.py
+++ b/RulesCommon.py
@@ -1,1 +1,12 @@
+import re
+
+# Variable names and values used by rule execution,
+# will be automatically filled by Items
 allowed_globals = {}
+
+
+_escape = re.compile(r'[\'()[\]-]')
+
+def escape_name(name):
+    return _escape.sub('', name.replace(' ', '_'))
+

--- a/RulesCommon.py
+++ b/RulesCommon.py
@@ -1,0 +1,1 @@
+allowed_globals = {}

--- a/Search.py
+++ b/Search.py
@@ -291,6 +291,8 @@ class Search(object):
     def iter_pseudo_starting_locations(self):
         for state in self.state_list:
             for location in state.world.distribution.skipped_locations:
+                # We need to use the locations in the current world
+                location = state.world.get_location(location.name)
                 self._cache['visited_locations'].add(location)
                 yield location
 

--- a/Search.py
+++ b/Search.py
@@ -108,8 +108,8 @@ class Search(object):
                     if exit.connected_region.provides_time and not regions[exit.world.get_region('Root')] & exit.connected_region.provides_time:
                         exit_queue.extend(failed)
                         failed = []
+                        regions[exit.world.get_region('Root')] |= exit.connected_region.provides_time
                     regions[exit.connected_region] = exit.connected_region.provides_time
-                    regions[exit.world.get_region('Root')] |= exit.connected_region.provides_time
                     exit_queue.extend(exit.connected_region.exits)
                 else:
                     failed.append(exit)

--- a/State.py
+++ b/State.py
@@ -2,7 +2,8 @@ from collections import Counter
 import copy
 import logging
 
-from Item import ItemInfo, escape_name
+from Item import ItemInfo
+from RulesCommon import escape_name
 
 Triforce_Piece = ItemInfo.solver_ids['Triforce_Piece']
 Triforce = ItemInfo.solver_ids['Triforce']

--- a/State.py
+++ b/State.py
@@ -1,13 +1,18 @@
 from collections import Counter
 import copy
+import logging
 
-from Item import ItemInfo
+from Item import ItemInfo, escape_name
 
+Triforce_Piece = ItemInfo.solver_ids['Triforce_Piece']
+Triforce = ItemInfo.solver_ids['Triforce']
+Rutos_Letter = ItemInfo.solver_ids['Rutos_Letter']
+Piece_of_Heart = ItemInfo.solver_ids['Piece_of_Heart']
 
 class State(object):
 
     def __init__(self, parent):
-        self.prog_items = Counter()
+        self.solv_items = [0] * len(ItemInfo.solver_ids)
         self.world = parent
         self.search = None
         self._won = self.won_triforce_hunt if self.world.settings.triforce_hunt else self.won_normal
@@ -17,7 +22,8 @@ class State(object):
         if not new_world:
             new_world = self.world
         new_state = State(new_world)
-        new_state.prog_items = copy.copy(self.prog_items)
+        for i, val in enumerate(self.solv_items):
+            new_state.solv_items[i] = val
         return new_state
 
 
@@ -33,36 +39,47 @@ class State(object):
 
 
     def won_triforce_hunt(self):
-        return self.has('Triforce Piece', self.world.settings.triforce_goal_per_world)
+        return self.has(Triforce_Piece, self.world.settings.triforce_goal_per_world)
 
 
     def won_normal(self):
-        return self.has('Triforce')
+        return self.has(Triforce)
 
 
     def has(self, item, count=1):
-        return self.prog_items[item] >= count
+        return self.solv_items[item] >= count
 
 
     def has_any_of(self, items):
-        return any(map(self.prog_items.__contains__, items))
+        for i in items:
+            if self.solv_items[i]: return True
+        return False
 
 
     def has_all_of(self, items):
-        return all(map(self.prog_items.__contains__, items))
+        for i in items:
+            if not self.solv_items[i]: return False
+        return True
 
 
     def count_of(self, items):
-        return len(list(filter(self.prog_items.__contains__, items)))
+        s = 0
+        for i in items:
+            s += self.solv_items[i]
+        return s
 
 
     def item_count(self, item):
-        return self.prog_items[item]
+        return self.solv_items[item]
+
+
+    def item_name_count(self, name):
+        return self.solv_items[ItemInfo.solver_ids[escape_name(name)]]
 
 
     def has_bottle(self, **kwargs):
         # Extra Ruto's Letter are automatically emptied
-        return self.has_any_of(ItemInfo.bottles) or self.has('Rutos Letter', 2)
+        return self.has_any_of(ItemInfo.bottle_ids) or self.has(Rutos_Letter, 2)
 
 
     def has_hearts(self, count):
@@ -73,30 +90,31 @@ class State(object):
     def heart_count(self):
         # Warning: This is limited by World.max_progressions so it currently only works if hearts are required for LACS, bridge, or Ganon bk
         return (
-            self.item_count('Piece of Heart') // 4 # aliases ensure Heart Container and Piece of Heart (Treasure Chest Game) are included in this
+            self.item_count(Piece_of_Heart) // 4 # aliases ensure Heart Container and Piece of Heart (Treasure Chest Game) are included in this
             + 3 # starting hearts
         )
 
     def has_medallions(self, count):
-        return self.count_of(ItemInfo.medallions) >= count
+        return self.count_of(ItemInfo.medallion_ids) >= count
 
 
     def has_stones(self, count):
-        return self.count_of(ItemInfo.stones) >= count
+        return self.count_of(ItemInfo.stone_ids) >= count
 
 
     def has_dungeon_rewards(self, count):
-        return (self.count_of(ItemInfo.medallions) + self.count_of(ItemInfo.stones)) >= count
+        return (self.count_of(ItemInfo.medallion_ids) + self.count_of(ItemInfo.stone_ids)) >= count
 
 
+    # TODO: Store the item's solver id in the goal
     def has_item_goal(self, item_goal):
-        return self.prog_items[item_goal['name']] >= item_goal['minimum']
+        return self.solv_items[ItemInfo.solver_ids[escape_name(item_goal['name'])]] >= item_goal['minimum']
 
 
     def has_full_item_goal(self, category, goal, item_goal):
         local_goal = self.world.goal_categories[category.name].get_goal(goal.name)
         per_world_max_quantity = local_goal.get_item(item_goal['name'])['quantity']
-        return self.prog_items[item_goal['name']] >= per_world_max_quantity
+        return self.solv_items[ItemInfo.solver_ids[escape_name(item_goal['name'])]] >= per_world_max_quantity
 
 
     def has_all_item_goals(self):
@@ -141,11 +159,12 @@ class State(object):
         if 'Small Key Ring' in item.name and self.world.settings.keyring_give_bk:
             dungeon_name = item.name[:-1].split(' (', 1)[1]
             if dungeon_name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
-                self.prog_items[f'Boss Key ({dungeon_name})'] = True
+                bk = f'Boss Key ({dungeon_name})'
+                self.solv_items[ItemInfo.solver_ids[escape_name(bk)]] = 1
         if item.alias:
-            self.prog_items[item.alias[0]] += item.alias[1]
+            self.solv_items[item.alias_id] += item.alias[1]
         if item.advancement:
-            self.prog_items[item.name] += 1
+            self.solv_items[item.solver_id] += 1
 
 
     # Be careful using this function. It will not uncollect any
@@ -154,15 +173,14 @@ class State(object):
         if 'Small Key Ring' in item.name and self.world.settings.keyring_give_bk:
             dungeon_name = item.name[:-1].split(' (', 1)[1]
             if dungeon_name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
-                self.prog_items[f'Boss Key ({dungeon_name})'] = False
-        if item.alias and self.prog_items[item.alias[0]] > 0:
-            self.prog_items[item.alias[0]] -= item.alias[1]
-            if self.prog_items[item.alias[0]] <= 0:
-                del self.prog_items[item.alias[0]]
-        if self.prog_items[item.name] > 0:
-            self.prog_items[item.name] -= 1
-            if self.prog_items[item.name] <= 0:
-                del self.prog_items[item.name]
+                bk = f'Boss Key ({dungeon_name})'
+                self.solv_items[ItemInfo.solver_ids[escape_name(bk)]] = 0
+        if item.alias and self.solv_items[item.alias_id] > 0:
+            self.solv_items[item.alias_id] -= item.alias[1]
+            if self.solv_items[item.alias_id] < 0:
+                self.solv_items[item.alias_id] = 0
+        if self.solv_items[item.solver_id] > 0:
+            self.solv_items[item.solver_id] -= 1
 
 
     def region_has_shortcuts(self, region_name):
@@ -176,4 +194,14 @@ class State(object):
     def __setstate__(self, state):
         self.__dict__.update(state)
 
+
+    def get_prog_items(self):
+        return {
+            **{item.name: self.solv_items[item.solver_id]
+                for item in ItemInfo.items.values()
+                if item.junk is None and self.solv_items[item.solver_id]},
+            **{event: self.solv_items[ItemInfo.solver_ids[event]]
+                for event in self.world.event_items
+                if self.solv_items[ItemInfo.solver_ids[event]]}
+        }
 

--- a/State.py
+++ b/State.py
@@ -13,12 +13,6 @@ class State(object):
         self._won = self.won_triforce_hunt if self.world.settings.triforce_hunt else self.won_normal
 
 
-    ## Ensure that this will always have a value
-    @property
-    def is_glitched(self):
-        return self.world.settings.logic_rules != 'glitchless'
-
-
     def copy(self, new_world=None):
         if not new_world:
             new_world = self.world


### PR DESCRIPTION
Quick summary: these give speedups in total around 10-15% on 3-world multiworld seeds, 3-15% on 1-world easy mode seeds.

Since we have a fixed list of progress items (including event items), it's a lot more time-efficient to encode them as an enum-like integer type and use them as indexes into a fixed-size list, than to use Counter--especially for "cache-miss" lookups of items we don't have in the dict.

This dict/list (was `prog_items` and is now `solv_items` for distinction) is internal-only and doesn't affect the spoiler output (but I did have to make sure we have an Epona item created, so I put that in the item list which will cause it to be in playthroughs now), so this looks reasonably self-contained. There's probably an easier way to make sure all items ever used are immediately created and added to the appropriate `solver_ids` map and to the rules globals in order to not break the generator in the future.

Included a few other small improvements and debugging messages.