### PR TITLE
Set Hylian Shield discount for each seed

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1525,6 +1525,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     patch_files(rom, mq_scenes)
 
+    # Set the hylian shield discount for the seed
+    possible_discounts = [0x0005, 0x000A, 0x000F, 0x0014, 0x0019, 0x001E, 0x0023, 0x0028]
+    set_discount = random.choice(possible_discounts)
+    rom.write_int16s(0xC0290C, [set_discount for i in range(8)])
+
     ### Load Shop File
     # Move shop actor file to free space
     shop_item_file = File({


### PR DESCRIPTION
The Hylian Shield discount you get in Bazaar after selling the Keaton Mask is currently chosen randomly between 8 values : 5, 10, 15, 20, 25, 30, 35 and 40.

This PR sets the 8 different shield discounts possibilities to a same unique value rolled once at the seed generation, so that all players have the same discount.

This sadly removes the niche strat of savescumming the buy to have a better discount.