### PR TITLE
Better error message for conflicting settings in plando

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -6310,9 +6310,8 @@ def validate_settings(settings_dict):
 
 def validate_disabled_setting(settings_dict, setting, choice, other_setting):
     if other_setting in settings_dict:
-        disabled_default = get_setting_info(other_setting).disabled_default
-        if settings_dict[other_setting] != disabled_default:
-            raise ValueError(f'{other_setting!r} must be set to {disabled_default!r} since {setting!r} is set to {choice!r}')
+        if settings_dict[other_setting] != get_setting_info(other_setting).disabled_default:
+            raise ValueError(f'The {other_setting!r} setting cannot be used since {setting!r} is set to {choice!r}')
 
 class UnmappedSettingError(Exception):
     pass


### PR DESCRIPTION
Since #1562, this plando:

```json
{
    "settings": {
        "bridge": "vanilla",
        "bridge_medallions": 6
    }
}
```

produces this error message:

> ValueError: 'bridge_medallions' must be set to 0 since 'bridge' is set to 'vanilla'

This is misleading because `0` is not a valid option for `bridge_medallions`, and the actual fix is to remove `bridge_medallions` from the plando. This PR updates the error message accordingly:

> ValueError: The 'bridge_medallions' setting cannot be used since 'bridge' is set to 'vanilla'