### PR TITLE
Python: Type Hints, Misc Cleanup, Drop Python 3.6/3.7 Support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   test_minimum_python:
     name: Unit Tests - Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CI.py
+++ b/CI.py
@@ -1,20 +1,22 @@
 # This script is called by GitHub Actions, see .github/workflows/python.yml
 # To fix code style errors, run: python3 ./CI.py --fix --no_unit_tests
 
+import argparse
 import json
-import sys
-from io import StringIO
-import unittest
 import os.path
 import pathlib
-import argparse
+import sys
+import unittest
+from io import StringIO
+from typing import NoReturn
+
 
 import Unittest as Tests
 from SettingsList import logic_tricks, validate_settings
 from Utils import data_path
 
 
-def error(msg, can_fix):
+def error(msg: str, can_fix: bool) -> None:
     if not hasattr(error, "count"):
         error.count = 0
     print(msg, file=sys.stderr)
@@ -25,7 +27,7 @@ def error(msg, can_fix):
         error.cannot_fix = True
 
 
-def run_unit_tests():
+def run_unit_tests() -> None:
     # Run Unit Tests
     stream = StringIO()
     runner = unittest.TextTestRunner(stream=stream)
@@ -38,7 +40,7 @@ def run_unit_tests():
         error('Unit Tests had an error, see output above.', False)
 
 
-def check_presets_formatting(fix_errors=False):
+def check_presets_formatting(fix_errors: bool = False) -> None:
     # Check the code style of presets_default.json
     with open(data_path('presets_default.json'), encoding='utf-8') as f:
         presets = json.load(f)
@@ -59,7 +61,8 @@ def check_presets_formatting(fix_errors=False):
                 json.dump(presets, file, indent=4)
                 print(file=file)
 
-def check_hell_mode_tricks(fix_errors=False):
+
+def check_hell_mode_tricks(fix_errors: bool = False) -> None:
     # Check for tricks missing from Hell Mode preset.
     with open(data_path('presets_default.json'), encoding='utf-8') as f:
         presets = json.load(f)
@@ -79,11 +82,11 @@ def check_hell_mode_tricks(fix_errors=False):
             print(file=file)
 
 
-def check_code_style(fix_errors=False):
+def check_code_style(fix_errors: bool = False) -> None:
     # Check for code style errors
     repo_dir = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
 
-    def check_file_format(path):
+    def check_file_format(path: pathlib.Path):
         fixed = ''
         with path.open(encoding='utf-8', newline='') as file:
             path = path.relative_to(repo_dir)
@@ -129,7 +132,7 @@ def check_code_style(fix_errors=False):
     check_file_format(repo_dir / 'data' / 'presets_default.json')
 
 
-def run_ci_checks():
+def run_ci_checks() -> NoReturn:
     parser = argparse.ArgumentParser()
     parser.add_argument('--no_unit_tests', help="Skip unit tests", action='store_true')
     parser.add_argument('--only_unit_tests', help="Only run unit tests", action='store_true')
@@ -147,7 +150,7 @@ def run_ci_checks():
     exit_ci(args.fix)
 
 
-def exit_ci(fix_errors=False):
+def exit_ci(fix_errors: bool = False) -> NoReturn:
     if hasattr(error, "count") and error.count:
         print(f'CI failed with {error.count} errors.', file=sys.stderr)
         if fix_errors:

--- a/Colors.py
+++ b/Colors.py
@@ -208,7 +208,7 @@ b_button_colors: Dict[str, Color] = {
 }
 
 #                        C Button                 Pause Menu C Cursor      Pause Menu C Icon        C Note
-c_button_colors: Dict[str, Color] = {
+c_button_colors: Dict[str, Tuple[Color, Color, Color, Color]] = {
     "N64 Blue":         (Color(0x5A, 0x5A, 0xFF), Color(0x00, 0x32, 0xFF), Color(0x00, 0x64, 0xFF), Color(0x50, 0x96, 0xFF)),
     "N64 Green":        (Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00)),
     "N64 Red":          (Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00)),
@@ -378,7 +378,7 @@ def relative_luminance(color: List[int]) -> float:
     return color_ratios[0] * 0.299 + color_ratios[1] * 0.587 + color_ratios[2] * 0.114
 
 
-def lum_color_ratio(val: int) -> float:
+def lum_color_ratio(val: float) -> float:
     val /= 255
     if val <= 0.03928:
         return val / 12.92

--- a/Colors.py
+++ b/Colors.py
@@ -1,10 +1,11 @@
-from collections import namedtuple
 import random
 import re
+from collections import namedtuple
+from typing import Dict, Tuple, List
 
 Color = namedtuple('Color', '  R     G     B')
 
-tunic_colors = {
+tunic_colors: Dict[str, Color] = {
     "Kokiri Green":      Color(0x1E, 0x69, 0x1B),
     "Goron Red":         Color(0x64, 0x14, 0x00),
     "Zora Blue":         Color(0x00, 0x3C, 0x64),
@@ -38,7 +39,8 @@ tunic_colors = {
     "Lumen":             Color(0x50, 0x8C, 0xF0),
 }
 
-NaviColors = {          # Inner Core Color         Outer Glow Color
+#                        Inner Core Color         Outer Glow Color
+NaviColors: Dict[str, Tuple[Color, Color]] = {
     "Rainbow":           (Color(0x00, 0x00, 0x00), Color(0x00, 0x00, 0x00)),
     "Gold":              (Color(0xFE, 0xCC, 0x3C), Color(0xFE, 0xC0, 0x07)),
     "White":             (Color(0xFF, 0xFF, 0xFF), Color(0x00, 0x00, 0xFF)),
@@ -61,7 +63,7 @@ NaviColors = {          # Inner Core Color         Outer Glow Color
     "Phantom Zelda":     (Color(0x97, 0x7A, 0x6C), Color(0x6F, 0x46, 0x67)),
 }
 
-sword_trail_colors = {
+sword_trail_colors: Dict[str, Color] = {
     "Rainbow":           Color(0x00, 0x00, 0x00),
     "White":             Color(0xFF, 0xFF, 0xFF),
     "Red":               Color(0xFF, 0x00, 0x00),
@@ -75,7 +77,7 @@ sword_trail_colors = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-bombchu_trail_colors = {
+bombchu_trail_colors: Dict[str, Color] = {
     "Rainbow":           Color(0x00, 0x00, 0x00),
     "Red":               Color(0xFA, 0x00, 0x00),
     "Green":             Color(0x00, 0xFF, 0x00),
@@ -88,7 +90,7 @@ bombchu_trail_colors = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-boomerang_trail_colors = {
+boomerang_trail_colors: Dict[str, Color] = {
     "Rainbow":           Color(0x00, 0x00, 0x00),
     "Yellow":            Color(0xFF, 0xFF, 0x64),
     "Red":               Color(0xFF, 0x00, 0x00),
@@ -102,7 +104,7 @@ boomerang_trail_colors = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-gauntlet_colors = {
+gauntlet_colors: Dict[str, Color] = {
     "Silver":            Color(0xFF, 0xFF, 0xFF),
     "Gold":              Color(0xFE, 0xCF, 0x0F),
     "Black":             Color(0x00, 0x00, 0x06),
@@ -118,7 +120,7 @@ gauntlet_colors = {
     "Purple":            Color(0x80, 0x00, 0x80),
 }
 
-shield_frame_colors = {
+shield_frame_colors: Dict[str, Color] = {
     "Red":               Color(0xD7, 0x00, 0x00),
     "Green":             Color(0x00, 0xFF, 0x00),
     "Blue":              Color(0x00, 0x40, 0xD8),
@@ -131,14 +133,14 @@ shield_frame_colors = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-heart_colors = {
+heart_colors: Dict[str, Color] = {
     "Red":          Color(0xFF, 0x46, 0x32),
     "Green":        Color(0x46, 0xC8, 0x32),
     "Blue":         Color(0x32, 0x46, 0xFF),
     "Yellow":       Color(0xFF, 0xE0, 0x00),
 }
 
-magic_colors = {
+magic_colors: Dict[str, Color] = {
     "Green":             Color(0x00, 0xC8, 0x00),
     "Red":               Color(0xC8, 0x00, 0x00),
     "Blue":              Color(0x00, 0x30, 0xFF),
@@ -150,7 +152,7 @@ magic_colors = {
 
 #                        A Button                 Text Cursor              Shop Cursor              Save/Death Cursor
 #                        Pause Menu A Cursor      Pause Menu A Icon        A Note
-a_button_colors = {
+a_button_colors: Dict[str, Tuple[Color, Color, Color, Color, Color, Color, Color]] = {
     "N64 Blue":         (Color(0x5A, 0x5A, 0xFF), Color(0x00, 0x50, 0xC8), Color(0x00, 0x50, 0xFF), Color(0x64, 0x64, 0xFF),
                          Color(0x00, 0x32, 0xFF), Color(0x00, 0x64, 0xFF), Color(0x50, 0x96, 0xFF)),
     "N64 Green":        (Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x64, 0x96, 0x64),
@@ -186,7 +188,7 @@ a_button_colors = {
 }
 
 #                       B Button
-b_button_colors = {
+b_button_colors: Dict[str, Color] = {
     "N64 Blue":         Color(0x5A, 0x5A, 0xFF),
     "N64 Green":        Color(0x00, 0x96, 0x00),
     "N64 Red":          Color(0xC8, 0x00, 0x00),
@@ -206,7 +208,7 @@ b_button_colors = {
 }
 
 #                        C Button                 Pause Menu C Cursor      Pause Menu C Icon        C Note
-c_button_colors = {
+c_button_colors: Dict[str, Color] = {
     "N64 Blue":         (Color(0x5A, 0x5A, 0xFF), Color(0x00, 0x32, 0xFF), Color(0x00, 0x64, 0xFF), Color(0x50, 0x96, 0xFF)),
     "N64 Green":        (Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00)),
     "N64 Red":          (Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00)),
@@ -226,7 +228,7 @@ c_button_colors = {
 }
 
 #                       Start Button
-start_button_colors = {
+start_button_colors: Dict[str, Color] = {
     "N64 Blue":         Color(0x5A, 0x5A, 0xFF),
     "N64 Green":        Color(0x00, 0x96, 0x00),
     "N64 Red":          Color(0xC8, 0x00, 0x00),
@@ -245,138 +247,138 @@ start_button_colors = {
     "Orange":           Color(0xFF, 0x80, 0x00),
 }
 
-meta_color_choices = ["Random Choice", "Completely Random", "Custom Color"]
+meta_color_choices: List[str] = ["Random Choice", "Completely Random", "Custom Color"]
 
 
-def get_tunic_colors():
+def get_tunic_colors() -> List[str]:
     return list(tunic_colors.keys())
 
 
-def get_tunic_color_options():
+def get_tunic_color_options() -> List[str]:
     return meta_color_choices + ["Rainbow"] + get_tunic_colors()
 
 
-def get_navi_colors():
+def get_navi_colors() -> List[str]:
     return list(NaviColors.keys())
 
 
-def get_navi_color_options(outer=False):
+def get_navi_color_options(outer: bool = False) -> List[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_navi_colors()
     else:
         return meta_color_choices + get_navi_colors()
 
 
-def get_sword_trail_colors():
+def get_sword_trail_colors() -> List[str]:
     return list(sword_trail_colors.keys())
 
 
-def get_sword_trail_color_options(outer=False):
+def get_sword_trail_color_options(outer: bool = False) -> List[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_sword_trail_colors()
     else:
         return meta_color_choices + get_sword_trail_colors()
 
 
-def get_bombchu_trail_colors():
+def get_bombchu_trail_colors() -> List[str]:
     return list(bombchu_trail_colors.keys())
 
 
-def get_bombchu_trail_color_options(outer=False):
+def get_bombchu_trail_color_options(outer: bool = False) -> List[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_bombchu_trail_colors()
     else:
         return meta_color_choices + get_bombchu_trail_colors()
 
 
-def get_boomerang_trail_colors():
+def get_boomerang_trail_colors() -> List[str]:
     return list(boomerang_trail_colors.keys())
 
 
-def get_boomerang_trail_color_options(outer=False):
+def get_boomerang_trail_color_options(outer: bool = False) -> List[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_boomerang_trail_colors()
     else:
         return meta_color_choices + get_boomerang_trail_colors()
 
 
-def get_gauntlet_colors():
+def get_gauntlet_colors() -> List[str]:
     return list(gauntlet_colors.keys())
 
 
-def get_gauntlet_color_options():
+def get_gauntlet_color_options() -> List[str]:
     return meta_color_choices + get_gauntlet_colors()
 
 
-def get_shield_frame_colors():
+def get_shield_frame_colors() -> List[str]:
     return list(shield_frame_colors.keys())
 
 
-def get_shield_frame_color_options():
+def get_shield_frame_color_options() -> List[str]:
     return meta_color_choices + get_shield_frame_colors()
 
 
-def get_heart_colors():
+def get_heart_colors() -> List[str]:
     return list(heart_colors.keys())
 
 
-def get_heart_color_options():
+def get_heart_color_options() -> List[str]:
     return meta_color_choices + get_heart_colors()
 
 
-def get_magic_colors():
+def get_magic_colors() -> List[str]:
     return list(magic_colors.keys())
 
 
-def get_magic_color_options():
+def get_magic_color_options() -> List[str]:
     return meta_color_choices + get_magic_colors()
 
 
-def get_a_button_colors():
+def get_a_button_colors() -> List[str]:
     return list(a_button_colors.keys())
 
 
-def get_a_button_color_options():
+def get_a_button_color_options() -> List[str]:
     return meta_color_choices + get_a_button_colors()
 
 
-def get_b_button_colors():
+def get_b_button_colors() -> List[str]:
     return list(b_button_colors.keys())
 
 
-def get_b_button_color_options():
+def get_b_button_color_options() -> List[str]:
     return meta_color_choices + get_b_button_colors()
 
 
-def get_c_button_colors():
+def get_c_button_colors() -> List[str]:
     return list(c_button_colors.keys())
 
 
-def get_c_button_color_options():
+def get_c_button_color_options() -> List[str]:
     return meta_color_choices + get_c_button_colors()
 
 
-def get_start_button_colors():
+def get_start_button_colors() -> List[str]:
     return list(start_button_colors.keys())
 
 
-def get_start_button_color_options():
+def get_start_button_color_options() -> List[str]:
     return meta_color_choices + get_start_button_colors()
 
 
-def contrast_ratio(color1, color2):
+def contrast_ratio(color1: List[int], color2: List[int]) -> float:
     # Based on accessibility standards (WCAG 2.0)
     lum1 = relative_luminance(color1)
     lum2 = relative_luminance(color2)
     return (max(lum1, lum2) + 0.05) / (min(lum1, lum2) + 0.05)
 
 
-def relative_luminance(color):
+def relative_luminance(color: List[int]) -> float:
     color_ratios = list(map(lum_color_ratio, color))
     return color_ratios[0] * 0.299 + color_ratios[1] * 0.587 + color_ratios[2] * 0.114
 
 
-def lum_color_ratio(val):
+def lum_color_ratio(val: int) -> float:
     val /= 255
     if val <= 0.03928:
         return val / 12.92
@@ -384,14 +386,17 @@ def lum_color_ratio(val):
         return pow((val + 0.055) / 1.055, 2.4)
 
 
-def generate_random_color():
+def generate_random_color() -> List[int]:
     return [random.getrandbits(8), random.getrandbits(8), random.getrandbits(8)]
 
 
-def hex_to_color(option):
+def hex_to_color(option: str) -> List[int]:
+    if not hasattr(hex_to_color, "regex"):
+        hex_to_color.regex = re.compile(r'^(?:[0-9a-fA-F]{3}){1,2}$')
+
     # build color from hex code
     option = option[1:] if option[0] == "#" else option
-    if not re.search(r'^(?:[0-9a-fA-F]{3}){1,2}$', option):
+    if not hex_to_color.regex.search(option):
         raise Exception(f"Invalid color value provided: {option}")
     if len(option) > 3:
         return list(int(option[i:i + 2], 16) for i in (0, 2, 4))
@@ -399,5 +404,5 @@ def hex_to_color(option):
         return list(int(f'{option[i]}{option[i]}', 16) for i in (0, 1, 2))
 
 
-def color_to_hex(color):
+def color_to_hex(color: List[int]) -> str:
     return '#' + ''.join(['{:02X}'.format(c) for c in color])

--- a/Colors.py
+++ b/Colors.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
 import random
 import re
 from collections import namedtuple
-from typing import Dict, Tuple, List
 
 Color = namedtuple('Color', '  R     G     B')
 
-tunic_colors: Dict[str, Color] = {
+tunic_colors: dict[str, Color] = {
     "Kokiri Green":      Color(0x1E, 0x69, 0x1B),
     "Goron Red":         Color(0x64, 0x14, 0x00),
     "Zora Blue":         Color(0x00, 0x3C, 0x64),
@@ -40,7 +40,7 @@ tunic_colors: Dict[str, Color] = {
 }
 
 #                        Inner Core Color         Outer Glow Color
-NaviColors: Dict[str, Tuple[Color, Color]] = {
+NaviColors: dict[str, tuple[Color, Color]] = {
     "Rainbow":           (Color(0x00, 0x00, 0x00), Color(0x00, 0x00, 0x00)),
     "Gold":              (Color(0xFE, 0xCC, 0x3C), Color(0xFE, 0xC0, 0x07)),
     "White":             (Color(0xFF, 0xFF, 0xFF), Color(0x00, 0x00, 0xFF)),
@@ -63,7 +63,7 @@ NaviColors: Dict[str, Tuple[Color, Color]] = {
     "Phantom Zelda":     (Color(0x97, 0x7A, 0x6C), Color(0x6F, 0x46, 0x67)),
 }
 
-sword_trail_colors: Dict[str, Color] = {
+sword_trail_colors: dict[str, Color] = {
     "Rainbow":           Color(0x00, 0x00, 0x00),
     "White":             Color(0xFF, 0xFF, 0xFF),
     "Red":               Color(0xFF, 0x00, 0x00),
@@ -77,7 +77,7 @@ sword_trail_colors: Dict[str, Color] = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-bombchu_trail_colors: Dict[str, Color] = {
+bombchu_trail_colors: dict[str, Color] = {
     "Rainbow":           Color(0x00, 0x00, 0x00),
     "Red":               Color(0xFA, 0x00, 0x00),
     "Green":             Color(0x00, 0xFF, 0x00),
@@ -90,7 +90,7 @@ bombchu_trail_colors: Dict[str, Color] = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-boomerang_trail_colors: Dict[str, Color] = {
+boomerang_trail_colors: dict[str, Color] = {
     "Rainbow":           Color(0x00, 0x00, 0x00),
     "Yellow":            Color(0xFF, 0xFF, 0x64),
     "Red":               Color(0xFF, 0x00, 0x00),
@@ -104,7 +104,7 @@ boomerang_trail_colors: Dict[str, Color] = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-gauntlet_colors: Dict[str, Color] = {
+gauntlet_colors: dict[str, Color] = {
     "Silver":            Color(0xFF, 0xFF, 0xFF),
     "Gold":              Color(0xFE, 0xCF, 0x0F),
     "Black":             Color(0x00, 0x00, 0x06),
@@ -120,7 +120,7 @@ gauntlet_colors: Dict[str, Color] = {
     "Purple":            Color(0x80, 0x00, 0x80),
 }
 
-shield_frame_colors: Dict[str, Color] = {
+shield_frame_colors: dict[str, Color] = {
     "Red":               Color(0xD7, 0x00, 0x00),
     "Green":             Color(0x00, 0xFF, 0x00),
     "Blue":              Color(0x00, 0x40, 0xD8),
@@ -133,14 +133,14 @@ shield_frame_colors: Dict[str, Color] = {
     "Pink":              Color(0xFF, 0x69, 0xB4),
 }
 
-heart_colors: Dict[str, Color] = {
+heart_colors: dict[str, Color] = {
     "Red":          Color(0xFF, 0x46, 0x32),
     "Green":        Color(0x46, 0xC8, 0x32),
     "Blue":         Color(0x32, 0x46, 0xFF),
     "Yellow":       Color(0xFF, 0xE0, 0x00),
 }
 
-magic_colors: Dict[str, Color] = {
+magic_colors: dict[str, Color] = {
     "Green":             Color(0x00, 0xC8, 0x00),
     "Red":               Color(0xC8, 0x00, 0x00),
     "Blue":              Color(0x00, 0x30, 0xFF),
@@ -152,7 +152,7 @@ magic_colors: Dict[str, Color] = {
 
 #                        A Button                 Text Cursor              Shop Cursor              Save/Death Cursor
 #                        Pause Menu A Cursor      Pause Menu A Icon        A Note
-a_button_colors: Dict[str, Tuple[Color, Color, Color, Color, Color, Color, Color]] = {
+a_button_colors: dict[str, tuple[Color, Color, Color, Color, Color, Color, Color]] = {
     "N64 Blue":         (Color(0x5A, 0x5A, 0xFF), Color(0x00, 0x50, 0xC8), Color(0x00, 0x50, 0xFF), Color(0x64, 0x64, 0xFF),
                          Color(0x00, 0x32, 0xFF), Color(0x00, 0x64, 0xFF), Color(0x50, 0x96, 0xFF)),
     "N64 Green":        (Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x64, 0x96, 0x64),
@@ -188,7 +188,7 @@ a_button_colors: Dict[str, Tuple[Color, Color, Color, Color, Color, Color, Color
 }
 
 #                       B Button
-b_button_colors: Dict[str, Color] = {
+b_button_colors: dict[str, Color] = {
     "N64 Blue":         Color(0x5A, 0x5A, 0xFF),
     "N64 Green":        Color(0x00, 0x96, 0x00),
     "N64 Red":          Color(0xC8, 0x00, 0x00),
@@ -208,7 +208,7 @@ b_button_colors: Dict[str, Color] = {
 }
 
 #                        C Button                 Pause Menu C Cursor      Pause Menu C Icon        C Note
-c_button_colors: Dict[str, Tuple[Color, Color, Color, Color]] = {
+c_button_colors: dict[str, tuple[Color, Color, Color, Color]] = {
     "N64 Blue":         (Color(0x5A, 0x5A, 0xFF), Color(0x00, 0x32, 0xFF), Color(0x00, 0x64, 0xFF), Color(0x50, 0x96, 0xFF)),
     "N64 Green":        (Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00), Color(0x00, 0x96, 0x00)),
     "N64 Red":          (Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00), Color(0xC8, 0x00, 0x00)),
@@ -228,7 +228,7 @@ c_button_colors: Dict[str, Tuple[Color, Color, Color, Color]] = {
 }
 
 #                       Start Button
-start_button_colors: Dict[str, Color] = {
+start_button_colors: dict[str, Color] = {
     "N64 Blue":         Color(0x5A, 0x5A, 0xFF),
     "N64 Green":        Color(0x00, 0x96, 0x00),
     "N64 Red":          Color(0xC8, 0x00, 0x00),
@@ -247,133 +247,133 @@ start_button_colors: Dict[str, Color] = {
     "Orange":           Color(0xFF, 0x80, 0x00),
 }
 
-meta_color_choices: List[str] = ["Random Choice", "Completely Random", "Custom Color"]
+meta_color_choices: list[str] = ["Random Choice", "Completely Random", "Custom Color"]
 
 
-def get_tunic_colors() -> List[str]:
+def get_tunic_colors() -> list[str]:
     return list(tunic_colors.keys())
 
 
-def get_tunic_color_options() -> List[str]:
+def get_tunic_color_options() -> list[str]:
     return meta_color_choices + ["Rainbow"] + get_tunic_colors()
 
 
-def get_navi_colors() -> List[str]:
+def get_navi_colors() -> list[str]:
     return list(NaviColors.keys())
 
 
-def get_navi_color_options(outer: bool = False) -> List[str]:
+def get_navi_color_options(outer: bool = False) -> list[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_navi_colors()
     else:
         return meta_color_choices + get_navi_colors()
 
 
-def get_sword_trail_colors() -> List[str]:
+def get_sword_trail_colors() -> list[str]:
     return list(sword_trail_colors.keys())
 
 
-def get_sword_trail_color_options(outer: bool = False) -> List[str]:
+def get_sword_trail_color_options(outer: bool = False) -> list[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_sword_trail_colors()
     else:
         return meta_color_choices + get_sword_trail_colors()
 
 
-def get_bombchu_trail_colors() -> List[str]:
+def get_bombchu_trail_colors() -> list[str]:
     return list(bombchu_trail_colors.keys())
 
 
-def get_bombchu_trail_color_options(outer: bool = False) -> List[str]:
+def get_bombchu_trail_color_options(outer: bool = False) -> list[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_bombchu_trail_colors()
     else:
         return meta_color_choices + get_bombchu_trail_colors()
 
 
-def get_boomerang_trail_colors() -> List[str]:
+def get_boomerang_trail_colors() -> list[str]:
     return list(boomerang_trail_colors.keys())
 
 
-def get_boomerang_trail_color_options(outer: bool = False) -> List[str]:
+def get_boomerang_trail_color_options(outer: bool = False) -> list[str]:
     if outer:
         return ["[Same as Inner]"] + meta_color_choices + get_boomerang_trail_colors()
     else:
         return meta_color_choices + get_boomerang_trail_colors()
 
 
-def get_gauntlet_colors() -> List[str]:
+def get_gauntlet_colors() -> list[str]:
     return list(gauntlet_colors.keys())
 
 
-def get_gauntlet_color_options() -> List[str]:
+def get_gauntlet_color_options() -> list[str]:
     return meta_color_choices + get_gauntlet_colors()
 
 
-def get_shield_frame_colors() -> List[str]:
+def get_shield_frame_colors() -> list[str]:
     return list(shield_frame_colors.keys())
 
 
-def get_shield_frame_color_options() -> List[str]:
+def get_shield_frame_color_options() -> list[str]:
     return meta_color_choices + get_shield_frame_colors()
 
 
-def get_heart_colors() -> List[str]:
+def get_heart_colors() -> list[str]:
     return list(heart_colors.keys())
 
 
-def get_heart_color_options() -> List[str]:
+def get_heart_color_options() -> list[str]:
     return meta_color_choices + get_heart_colors()
 
 
-def get_magic_colors() -> List[str]:
+def get_magic_colors() -> list[str]:
     return list(magic_colors.keys())
 
 
-def get_magic_color_options() -> List[str]:
+def get_magic_color_options() -> list[str]:
     return meta_color_choices + get_magic_colors()
 
 
-def get_a_button_colors() -> List[str]:
+def get_a_button_colors() -> list[str]:
     return list(a_button_colors.keys())
 
 
-def get_a_button_color_options() -> List[str]:
+def get_a_button_color_options() -> list[str]:
     return meta_color_choices + get_a_button_colors()
 
 
-def get_b_button_colors() -> List[str]:
+def get_b_button_colors() -> list[str]:
     return list(b_button_colors.keys())
 
 
-def get_b_button_color_options() -> List[str]:
+def get_b_button_color_options() -> list[str]:
     return meta_color_choices + get_b_button_colors()
 
 
-def get_c_button_colors() -> List[str]:
+def get_c_button_colors() -> list[str]:
     return list(c_button_colors.keys())
 
 
-def get_c_button_color_options() -> List[str]:
+def get_c_button_color_options() -> list[str]:
     return meta_color_choices + get_c_button_colors()
 
 
-def get_start_button_colors() -> List[str]:
+def get_start_button_colors() -> list[str]:
     return list(start_button_colors.keys())
 
 
-def get_start_button_color_options() -> List[str]:
+def get_start_button_color_options() -> list[str]:
     return meta_color_choices + get_start_button_colors()
 
 
-def contrast_ratio(color1: List[int], color2: List[int]) -> float:
+def contrast_ratio(color1: list[int], color2: list[int]) -> float:
     # Based on accessibility standards (WCAG 2.0)
     lum1 = relative_luminance(color1)
     lum2 = relative_luminance(color2)
     return (max(lum1, lum2) + 0.05) / (min(lum1, lum2) + 0.05)
 
 
-def relative_luminance(color: List[int]) -> float:
+def relative_luminance(color: list[int]) -> float:
     color_ratios = list(map(lum_color_ratio, color))
     return color_ratios[0] * 0.299 + color_ratios[1] * 0.587 + color_ratios[2] * 0.114
 
@@ -386,11 +386,11 @@ def lum_color_ratio(val: float) -> float:
         return pow((val + 0.055) / 1.055, 2.4)
 
 
-def generate_random_color() -> List[int]:
+def generate_random_color() -> list[int]:
     return [random.getrandbits(8), random.getrandbits(8), random.getrandbits(8)]
 
 
-def hex_to_color(option: str) -> List[int]:
+def hex_to_color(option: str) -> list[int]:
     if not hasattr(hex_to_color, "regex"):
         hex_to_color.regex = re.compile(r'^(?:[0-9a-fA-F]{3}){1,2}$')
 
@@ -404,5 +404,5 @@ def hex_to_color(option: str) -> List[int]:
         return list(int(f'{option[i]}{option[i]}', 16) for i in (0, 1, 2))
 
 
-def color_to_hex(color: List[int]) -> str:
+def color_to_hex(color: list[int]) -> str:
     return '#' + ''.join(['{:02X}'.format(c) for c in color])

--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -584,10 +584,10 @@ def patch_heart_colors(rom, settings, log, symbols):
         else:
             color = hex_to_color(heart_option)
             heart_option = 'Custom'
-        rom.write_int16s(symbol, color) # symbol for ingame HUD
-        rom.write_int16s(file_select_address, color) # file select normal hearts
+        rom.write_int16s(symbol, color)  # symbol for ingame HUD
+        rom.write_int16s(file_select_address, color)  # file select normal hearts
         if heart_option != 'Red':
-            rom.write_int16s(file_select_address + 6, color) # file select DD hearts
+            rom.write_int16s(file_select_address + 6, color)  # file select DD hearts
         else:
             original_dd_color = rom.original.read_bytes(file_select_address + 6, 6)
             rom.write_bytes(file_select_address + 6, original_dd_color)

--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -1,19 +1,25 @@
-from version import __version__
-from Utils import data_path
-from Colors import *
-import random
-import logging
-import Music as music
-import Sounds as sfx
-import IconManip as icon
-from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
-from Plandomizer import InvalidFileException
 import json
-from itertools import chain
+import logging
 import os
+import random
+from itertools import chain
+from typing import TYPE_CHECKING, Dict, List, Tuple, Optional, Union, Iterable, Callable, Any
+
+import Colors
+import IconManip
+import Music
+import Sounds
+from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict
+from Plandomizer import InvalidFileException
+from Utils import data_path
+from version import __version__
+
+if TYPE_CHECKING:
+    from Rom import Rom
+    from Settings import Settings
 
 
-def patch_targeting(rom, settings, log, symbols):
+def patch_targeting(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Set default targeting option to Hold
     if settings.default_targeting == 'hold':
         rom.write_byte(0xB71E6D, 0x01)
@@ -21,7 +27,7 @@ def patch_targeting(rom, settings, log, symbols):
         rom.write_byte(0xB71E6D, 0x00)
 
 
-def patch_dpad(rom, settings, log, symbols):
+def patch_dpad(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Display D-Pad HUD
     if settings.display_dpad:
         rom.write_byte(symbols['CFG_DISPLAY_DPAD'], 0x01)
@@ -30,7 +36,7 @@ def patch_dpad(rom, settings, log, symbols):
     log.display_dpad = settings.display_dpad
 
 
-def patch_dpad_info(rom, settings, log, symbols):
+def patch_dpad_info(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Display D-Pad HUD in pause menu for either dungeon info or equips
     if settings.dpad_dungeon_menu:
         rom.write_byte(symbols['CFG_DPAD_DUNGEON_INFO_ENABLE'], 0x01)
@@ -39,19 +45,19 @@ def patch_dpad_info(rom, settings, log, symbols):
     log.dpad_dungeon_menu = settings.dpad_dungeon_menu
 
 
-def patch_music(rom, settings, log, symbols):
+def patch_music(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch music
     if settings.background_music != 'normal' or settings.fanfares != 'normal' or log.src_dict.get('bgm', {}):
-        music.restore_music(rom)
-        music.randomize_music(rom, settings, log)
+        Music.restore_music(rom)
+        Music.randomize_music(rom, settings, log)
     else:
-        music.restore_music(rom)
+        Music.restore_music(rom)
     # Remove battle music
     if settings.disable_battle_music:
         rom.write_byte(0xBE447F, 0x00)
 
 
-def patch_model_colors(rom, color, model_addresses):
+def patch_model_colors(rom: "Rom", color: Optional[List[int]], model_addresses: Tuple[List[int], List[int], List[int]]) -> None:
     main_addresses, dark_addresses, light_addresses = model_addresses
 
     if color is None:
@@ -72,7 +78,7 @@ def patch_model_colors(rom, color, model_addresses):
         rom.write_bytes(address, lightened_color)
 
 
-def patch_tunic_icon(rom, tunic, color, rainbow=False):
+def patch_tunic_icon(rom: "Rom", tunic: str, color: Optional[List[int]], rainbow: bool = False) -> None:
     # patch tunic icon colors
     icon_locations = {
         'Kokiri Tunic': 0x007FE000,
@@ -81,14 +87,14 @@ def patch_tunic_icon(rom, tunic, color, rainbow=False):
     }
 
     if color is not None:
-        tunic_icon = icon.generate_rainbow_tunic_icon() if rainbow else icon.generate_tunic_icon(color)
+        tunic_icon = IconManip.generate_rainbow_tunic_icon() if rainbow else IconManip.generate_tunic_icon(color)
     else:
         tunic_icon = rom.original.read_bytes(icon_locations[tunic], 0x1000)
 
     rom.write_bytes(icon_locations[tunic], tunic_icon)
 
 
-def patch_tunic_colors(rom, settings, log, symbols):
+def patch_tunic_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Need to check for the existence of the CFG_TUNIC_COLORS symbol.
     # This was added with rainbow tunic but custom tunic colors should still support older patch versions.
     tunic_address = symbols.get('CFG_TUNIC_COLORS', 0x00B6DA38) # Use new tunic color ROM address. Fall back to vanilla tunic color ROM address.
@@ -98,11 +104,11 @@ def patch_tunic_colors(rom, settings, log, symbols):
         ('Zora Tunic',   'zora_color',   tunic_address+6),
     ]
 
-    tunic_color_list = get_tunic_colors()
+    tunic_color_list = Colors.get_tunic_colors()
     rainbow_error = None
 
     for tunic, tunic_setting, address in tunics:
-        tunic_option = settings.settings_dict[tunic_setting]
+        tunic_option = getattr(settings, tunic_setting)
 
         # Handle Plando
         if log.src_dict.get('equipment_colors', {}).get(tunic, {}).get('color', '') and log.src_dict['equipment_colors'][tunic][':option'] != 'Rainbow':
@@ -130,15 +136,15 @@ def patch_tunic_colors(rom, settings, log, symbols):
 
         # handle completely random
         if tunic_option == 'Completely Random':
-            color = generate_random_color()
+            color = Colors.generate_random_color()
         # grab the color from the list
-        elif tunic_option in tunic_colors:
-            color = list(tunic_colors[tunic_option])
+        elif tunic_option in Colors.tunic_colors:
+            color = list(Colors.tunic_colors[tunic_option])
         elif tunic_option == 'Rainbow':
-            color = list(Color(0x00, 0x00, 0x00))
+            color = list(Colors.Color(0x00, 0x00, 0x00))
         # build color from hex code
         else:
-            color = hex_to_color(tunic_option)
+            color = Colors.hex_to_color(tunic_option)
             tunic_option = 'Custom'
 
         rom.write_bytes(address, color)
@@ -151,14 +157,14 @@ def patch_tunic_colors(rom, settings, log, symbols):
 
         log.equipment_colors[tunic] = CollapseDict({
             ':option': tunic_option,
-            'color': color_to_hex(color),
+            'color': Colors.color_to_hex(color),
         })
 
         if rainbow_error:
             log.errors.append(rainbow_error)
 
 
-def patch_navi_colors(rom, settings, log, symbols):
+def patch_navi_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch navi colors
     navi = [
         # colors for Navi
@@ -177,12 +183,12 @@ def patch_navi_colors(rom, settings, log, symbols):
             symbols.get('CFG_RAINBOW_NAVI_PROP_INNER_ENABLED', None), symbols.get('CFG_RAINBOW_NAVI_PROP_OUTER_ENABLED', None)),
     ]
 
-    navi_color_list = get_navi_colors()
+    navi_color_list = Colors.get_navi_colors()
     rainbow_error = None
 
     for navi_action, navi_setting, navi_addresses, rainbow_inner_symbol, rainbow_outer_symbol in navi:
-        navi_option_inner = settings.settings_dict[navi_setting+'_inner']
-        navi_option_outer = settings.settings_dict[navi_setting+'_outer']
+        navi_option_inner = getattr(settings, f'{navi_setting}_inner')
+        navi_option_outer = getattr(settings, f'{navi_setting}_outer')
         plando_colors = log.src_dict.get('misc_colors', {}).get(navi_action, {}).get('colors', [])
 
         # choose a random choice for the whole group
@@ -207,7 +213,7 @@ def patch_navi_colors(rom, settings, log, symbols):
 
                 # Plando
                 if len(plando_colors) > address_index and plando_colors[address_index].get(navi_part, ''):
-                    color = hex_to_color(plando_colors[address_index][navi_part])
+                    color = Colors.hex_to_color(plando_colors[address_index][navi_part])
 
                 # set rainbow option
                 if rainbow_symbol is not None and option == 'Rainbow':
@@ -221,15 +227,15 @@ def patch_navi_colors(rom, settings, log, symbols):
 
                 # completely random is random for every subgroup
                 if color is None and option == 'Completely Random':
-                    color = generate_random_color()
+                    color = Colors.generate_random_color()
 
                 # grab the color from the list
-                if color is None and option in NaviColors:
-                    color = list(NaviColors[option][index])
+                if color is None and option in Colors.NaviColors:
+                    color = list(Colors.NaviColors[option][index])
 
                 # build color from hex code
                 if color is None:
-                    color = hex_to_color(option)
+                    color = Colors.hex_to_color(option)
                     option = 'Custom'
 
                 # Check color validity
@@ -255,7 +261,7 @@ def patch_navi_colors(rom, settings, log, symbols):
                 log.misc_colors[navi_action]['colors'].append(address_colors_str)
                 for part, color in address_colors.items():
                     if log.misc_colors[navi_action][f':option_{part}'] != "Rainbow" or rainbow_error:
-                        address_colors_str[part] = color_to_hex(color)
+                        address_colors_str[part] = Colors.color_to_hex(color)
         else:
             del log.misc_colors[navi_action]['colors']
 
@@ -263,7 +269,7 @@ def patch_navi_colors(rom, settings, log, symbols):
         log.errors.append(rainbow_error)
 
 
-def patch_sword_trails(rom, settings, log, symbols):
+def patch_sword_trails(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch sword trail duration
     rom.write_byte(0x00BEFF8C, settings.sword_trail_duration)
 
@@ -274,12 +280,12 @@ def patch_sword_trails(rom, settings, log, symbols):
             symbols.get('CFG_RAINBOW_SWORD_INNER_ENABLED', None), symbols.get('CFG_RAINBOW_SWORD_OUTER_ENABLED', None)),
     ]
 
-    sword_trail_color_list = get_sword_trail_colors()
+    sword_trail_color_list = Colors.get_sword_trail_colors()
     rainbow_error = None
 
     for trail_name, trail_setting, trail_addresses, rainbow_inner_symbol, rainbow_outer_symbol in sword_trails:
-        option_inner = settings.settings_dict[trail_setting+'_inner']
-        option_outer = settings.settings_dict[trail_setting+'_outer']
+        option_inner = getattr(settings, f'{trail_setting}_inner')
+        option_outer = getattr(settings, f'{trail_setting}_outer')
         plando_colors = log.src_dict.get('misc_colors', {}).get(trail_name, {}).get('colors', [])
 
         # handle random choice
@@ -305,7 +311,7 @@ def patch_sword_trails(rom, settings, log, symbols):
 
                 # Plando
                 if len(plando_colors) > address_index and plando_colors[address_index].get(trail_part, ''):
-                    color = hex_to_color(plando_colors[address_index][trail_part])
+                    color = Colors.hex_to_color(plando_colors[address_index][trail_part])
 
                 # set rainbow option
                 if rainbow_symbol is not None and option == 'Rainbow':
@@ -319,15 +325,15 @@ def patch_sword_trails(rom, settings, log, symbols):
 
                 # completely random is random for every subgroup
                 if color is None and option == 'Completely Random':
-                    color = generate_random_color()
+                    color = Colors.generate_random_color()
 
                 # grab the color from the list
-                if color is None and option in sword_trail_colors:
-                    color = list(sword_trail_colors[option])
+                if color is None and option in Colors.sword_trail_colors:
+                    color = list(Colors.sword_trail_colors[option])
 
                 # build color from hex code
                 if color is None:
-                    color = hex_to_color(option)
+                    color = Colors.hex_to_color(option)
                     option = 'Custom'
 
                 # Check color validity
@@ -359,7 +365,7 @@ def patch_sword_trails(rom, settings, log, symbols):
                 log.misc_colors[trail_name]['colors'].append(address_colors_str)
                 for part, color in address_colors.items():
                     if log.misc_colors[trail_name][f':option_{part}'] != "Rainbow" or rainbow_error:
-                        address_colors_str[part] = color_to_hex(color)
+                        address_colors_str[part] = Colors.color_to_hex(color)
         else:
             del log.misc_colors[trail_name]['colors']
 
@@ -367,10 +373,10 @@ def patch_sword_trails(rom, settings, log, symbols):
         log.errors.append(rainbow_error)
 
 
-def patch_bombchu_trails(rom, settings, log, symbols):
+def patch_bombchu_trails(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch bombchu trail colors
     bombchu_trails = [
-        ('Bombchu Trail', 'bombchu_trail_color', get_bombchu_trail_colors(), bombchu_trail_colors,
+        ('Bombchu Trail', 'bombchu_trail_color', Colors.get_bombchu_trail_colors(), Colors.bombchu_trail_colors,
             (symbols['CFG_BOMBCHU_TRAIL_INNER_COLOR'], symbols['CFG_BOMBCHU_TRAIL_OUTER_COLOR'],
              symbols['CFG_RAINBOW_BOMBCHU_TRAIL_INNER_ENABLED'], symbols['CFG_RAINBOW_BOMBCHU_TRAIL_OUTER_ENABLED'])),
     ]
@@ -378,10 +384,10 @@ def patch_bombchu_trails(rom, settings, log, symbols):
     patch_trails(rom, settings, log, bombchu_trails)
 
 
-def patch_boomerang_trails(rom, settings, log, symbols):
+def patch_boomerang_trails(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch boomerang trail colors
     boomerang_trails = [
-        ('Boomerang Trail', 'boomerang_trail_color', get_boomerang_trail_colors(), boomerang_trail_colors,
+        ('Boomerang Trail', 'boomerang_trail_color', Colors.get_boomerang_trail_colors(), Colors.boomerang_trail_colors,
             (symbols['CFG_BOOM_TRAIL_INNER_COLOR'], symbols['CFG_BOOM_TRAIL_OUTER_COLOR'],
              symbols['CFG_RAINBOW_BOOM_TRAIL_INNER_ENABLED'], symbols['CFG_RAINBOW_BOOM_TRAIL_OUTER_ENABLED'])),
     ]
@@ -389,11 +395,11 @@ def patch_boomerang_trails(rom, settings, log, symbols):
     patch_trails(rom, settings, log, boomerang_trails)
 
 
-def patch_trails(rom, settings, log, trails):
+def patch_trails(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', trails) -> None:
     for trail_name, trail_setting, trail_color_list, trail_color_dict, trail_symbols in trails:
         color_inner_symbol, color_outer_symbol, rainbow_inner_symbol, rainbow_outer_symbol = trail_symbols
-        option_inner = settings.settings_dict[trail_setting+'_inner']
-        option_outer = settings.settings_dict[trail_setting+'_outer']
+        option_inner = getattr(settings, f'{trail_setting}_inner')
+        option_outer = getattr(settings, f'{trail_setting}_outer')
         plando_colors = log.src_dict.get('misc_colors', {}).get(trail_name, {}).get('colors', [])
 
         # handle random choice
@@ -416,7 +422,7 @@ def patch_trails(rom, settings, log, trails):
 
             # Plando
             if len(plando_colors) > 0 and plando_colors[0].get(trail_part, ''):
-                color = hex_to_color(plando_colors[0][trail_part])
+                color = Colors.hex_to_color(plando_colors[0][trail_part])
 
             # set rainbow option
             if option == 'Rainbow':
@@ -432,10 +438,10 @@ def patch_trails(rom, settings, log, trails):
                     fixed_dark_color = [0, 0, 0]
                     color = [0, 0, 0]
                     # Avoid colors which have a low contrast so the bombchu ticking is still visible
-                    while contrast_ratio(color, fixed_dark_color) <= 4:
-                        color = generate_random_color()
+                    while Colors.contrast_ratio(color, fixed_dark_color) <= 4:
+                        color = Colors.generate_random_color()
                 else:
-                    color = generate_random_color()
+                    color = Colors.generate_random_color()
 
             # grab the color from the list
             if color is None and option in trail_color_dict:
@@ -443,7 +449,7 @@ def patch_trails(rom, settings, log, trails):
 
             # build color from hex code
             if color is None:
-                color = hex_to_color(option)
+                color = Colors.hex_to_color(option)
                 option = 'Custom'
 
             option_dict[trail_part] = option
@@ -463,12 +469,12 @@ def patch_trails(rom, settings, log, trails):
             log.misc_colors[trail_name]['colors'].append(colors_str)
             for part, color in colors.items():
                 if log.misc_colors[trail_name][f':option_{part}'] != "Rainbow":
-                    colors_str[part] = color_to_hex(color)
+                    colors_str[part] = Colors.color_to_hex(color)
         else:
             del log.misc_colors[trail_name]['colors']
 
 
-def patch_gauntlet_colors(rom, settings, log, symbols):
+def patch_gauntlet_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch gauntlet colors
     gauntlets = [
         ('Silver Gauntlets', 'silver_gauntlets_color', 0x00B6DA44,
@@ -476,10 +482,10 @@ def patch_gauntlet_colors(rom, settings, log, symbols):
         ('Gold Gauntlets', 'golden_gauntlets_color',  0x00B6DA47,
             ([0x173B4EC], [0x173B4F4, 0x173B52C, 0x173B534], [])), # GI Model DList colors
     ]
-    gauntlet_color_list = get_gauntlet_colors()
+    gauntlet_color_list = Colors.get_gauntlet_colors()
 
     for gauntlet, gauntlet_setting, address, model_addresses in gauntlets:
-        gauntlet_option = settings.settings_dict[gauntlet_setting]
+        gauntlet_option = getattr(settings, gauntlet_setting)
 
         # Handle Plando
         if log.src_dict.get('equipment_colors', {}).get(gauntlet, {}).get('color', ''):
@@ -490,13 +496,13 @@ def patch_gauntlet_colors(rom, settings, log, symbols):
             gauntlet_option = random.choice(gauntlet_color_list)
         # handle completely random
         if gauntlet_option == 'Completely Random':
-            color = generate_random_color()
+            color = Colors.generate_random_color()
         # grab the color from the list
-        elif gauntlet_option in gauntlet_colors:
-            color = list(gauntlet_colors[gauntlet_option])
+        elif gauntlet_option in Colors.gauntlet_colors:
+            color = list(Colors.gauntlet_colors[gauntlet_option])
         # build color from hex code
         else:
-            color = hex_to_color(gauntlet_option)
+            color = Colors.hex_to_color(gauntlet_option)
             gauntlet_option = 'Custom'
         rom.write_bytes(address, color)
         if settings.correct_model_colors:
@@ -505,20 +511,21 @@ def patch_gauntlet_colors(rom, settings, log, symbols):
             patch_model_colors(rom, None, model_addresses)
         log.equipment_colors[gauntlet] = CollapseDict({
             ':option': gauntlet_option,
-            'color': color_to_hex(color),
+            'color': Colors.color_to_hex(color),
         })
 
-def patch_shield_frame_colors(rom, settings, log, symbols):
+
+def patch_shield_frame_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch shield frame colors
     shield_frames = [
         ('Mirror Shield Frame', 'mirror_shield_frame_color',
             [0xFA7274, 0xFA776C, 0xFAA27C, 0xFAC564, 0xFAC984, 0xFAEDD4],
             ([0x1616FCC], [0x1616FD4], [])),
     ]
-    shield_frame_color_list = get_shield_frame_colors()
+    shield_frame_color_list = Colors.get_shield_frame_colors()
 
     for shield_frame, shield_frame_setting, addresses, model_addresses in shield_frames:
-        shield_frame_option = settings.settings_dict[shield_frame_setting]
+        shield_frame_option = getattr(settings, shield_frame_setting)
 
         # Handle Plando
         if log.src_dict.get('equipment_colors', {}).get(shield_frame, {}).get('color', ''):
@@ -531,11 +538,11 @@ def patch_shield_frame_colors(rom, settings, log, symbols):
         if shield_frame_option == 'Completely Random':
             color = [random.getrandbits(8), random.getrandbits(8), random.getrandbits(8)]
         # grab the color from the list
-        elif shield_frame_option in shield_frame_colors:
-            color = list(shield_frame_colors[shield_frame_option])
+        elif shield_frame_option in Colors.shield_frame_colors:
+            color = list(Colors.shield_frame_colors[shield_frame_option])
         # build color from hex code
         else:
-            color = hex_to_color(shield_frame_option)
+            color = Colors.hex_to_color(shield_frame_option)
             shield_frame_option = 'Custom'
         for address in addresses:
             rom.write_bytes(address, color)
@@ -546,11 +553,11 @@ def patch_shield_frame_colors(rom, settings, log, symbols):
 
         log.equipment_colors[shield_frame] = CollapseDict({
             ':option': shield_frame_option,
-            'color': color_to_hex(color),
+            'color': Colors.color_to_hex(color),
         })
 
 
-def patch_heart_colors(rom, settings, log, symbols):
+def patch_heart_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch heart colors
     hearts = [
         ('Heart Color', 'heart_color', symbols['CFG_HEART_COLOR'], 0xBB0994,
@@ -559,10 +566,10 @@ def patch_heart_colors(rom, settings, log, symbols):
               0x14B706C, 0x14B707C, 0x14B708C, 0x14B709C, 0x14B70AC, 0x14B70BC, 0x14B70CC, 0x16092A4],
              [0x16092FC, 0x1609394])), # GI Model and Potion DList colors
     ]
-    heart_color_list = get_heart_colors()
+    heart_color_list = Colors.get_heart_colors()
 
     for heart, heart_setting, symbol, file_select_address, model_addresses in hearts:
-        heart_option = settings.settings_dict[heart_setting]
+        heart_option = getattr(settings, heart_setting)
 
         # Handle Plando
         if log.src_dict.get('ui_colors', {}).get(heart, {}).get('color', ''):
@@ -573,13 +580,13 @@ def patch_heart_colors(rom, settings, log, symbols):
             heart_option = random.choice(heart_color_list)
         # handle completely random
         if heart_option == 'Completely Random':
-            color = generate_random_color()
+            color = Colors.generate_random_color()
         # grab the color from the list
-        elif heart_option in heart_colors:
-            color = list(heart_colors[heart_option])
+        elif heart_option in Colors.heart_colors:
+            color = list(Colors.heart_colors[heart_option])
         # build color from hex code
         else:
-            color = hex_to_color(heart_option)
+            color = Colors.hex_to_color(heart_option)
             heart_option = 'Custom'
         rom.write_int16s(symbol, color)  # symbol for ingame HUD
         rom.write_int16s(file_select_address, color)  # file select normal hearts
@@ -590,16 +597,17 @@ def patch_heart_colors(rom, settings, log, symbols):
             rom.write_bytes(file_select_address + 6, original_dd_color)
         if settings.correct_model_colors and heart_option != 'Red':
             patch_model_colors(rom, color, model_addresses) # heart model colors
-            icon.patch_overworld_icon(rom, color, 0xF43D80) # Overworld Heart Icon
+            IconManip.patch_overworld_icon(rom, color, 0xF43D80)  # Overworld Heart Icon
         else:
             patch_model_colors(rom, None, model_addresses)
-            icon.patch_overworld_icon(rom, None, 0xF43D80)
+            IconManip.patch_overworld_icon(rom, None, 0xF43D80)
         log.ui_colors[heart] = CollapseDict({
             ':option': heart_option,
-            'color': color_to_hex(color),
+            'color': Colors.color_to_hex(color),
         })
 
-def patch_magic_colors(rom, settings, log, symbols):
+
+def patch_magic_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # patch magic colors
     magic = [
         ('Magic Meter Color', 'magic_color', symbols["CFG_MAGIC_COLOR"],
@@ -607,10 +615,10 @@ def patch_magic_colors(rom, settings, log, symbols):
              [0x154C65C, 0x154CFBC, 0x1609284],
              [0x16092DC, 0x160933C])), # GI Model and Potion DList colors
     ]
-    magic_color_list = get_magic_colors()
+    magic_color_list = Colors.get_magic_colors()
 
     for magic_color, magic_setting, symbol, model_addresses in magic:
-        magic_option = settings.settings_dict[magic_setting]
+        magic_option = getattr(settings, magic_setting)
 
         # Handle Plando
         if log.src_dict.get('ui_colors', {}).get(magic_color, {}).get('color', ''):
@@ -620,29 +628,30 @@ def patch_magic_colors(rom, settings, log, symbols):
            magic_option = random.choice(magic_color_list)
 
         if magic_option == 'Completely Random':
-            color = generate_random_color()
-        elif magic_option in magic_colors:
-            color = list(magic_colors[magic_option])
+            color = Colors.generate_random_color()
+        elif magic_option in Colors.magic_colors:
+            color = list(Colors.magic_colors[magic_option])
         else:
-            color = hex_to_color(magic_option)
+            color = Colors.hex_to_color(magic_option)
             magic_option = 'Custom'
         rom.write_int16s(symbol, color)
         if magic_option != 'Green' and settings.correct_model_colors:
             patch_model_colors(rom, color, model_addresses)
-            icon.patch_overworld_icon(rom, color, 0xF45650, data_path('icons/magicSmallExtras.raw')) # Overworld Small Pot
-            icon.patch_overworld_icon(rom, color, 0xF47650, data_path('icons/magicLargeExtras.raw')) # Overworld Big Pot
+            IconManip.patch_overworld_icon(rom, color, 0xF45650, data_path('icons/magicSmallExtras.raw'))  # Overworld Small Pot
+            IconManip.patch_overworld_icon(rom, color, 0xF47650, data_path('icons/magicLargeExtras.raw'))  # Overworld Big Pot
         else:
             patch_model_colors(rom, None, model_addresses)
-            icon.patch_overworld_icon(rom, None, 0xF45650)
-            icon.patch_overworld_icon(rom, None, 0xF47650)
+            IconManip.patch_overworld_icon(rom, None, 0xF45650)
+            IconManip.patch_overworld_icon(rom, None, 0xF47650)
         log.ui_colors[magic_color] = CollapseDict({
             ':option': magic_option,
-            'color': color_to_hex(color),
+            'color': Colors.color_to_hex(color),
         })
 
-def patch_button_colors(rom, settings, log, symbols):
+
+def patch_button_colors(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     buttons = [
-        ('A Button Color', 'a_button_color', a_button_colors,
+        ('A Button Color', 'a_button_color', Colors.a_button_colors,
             [('A Button Color', symbols['CFG_A_BUTTON_COLOR'],
                 None),
              ('Text Cursor Color', symbols['CFG_TEXT_CURSOR_COLOR'],
@@ -658,11 +667,11 @@ def patch_button_colors(rom, settings, log, symbols):
              ('A Note Color', symbols['CFG_A_NOTE_COLOR'], # For Textbox Song Display
                 [(0xBB299A, 0xBB299B, 0xBB299E), (0xBB2C8E, 0xBB2C8F, 0xBB2C92), (0xBB2F8A, 0xBB2F8B, 0xBB2F96)]), # Pause Menu Song Display
             ]),
-        ('B Button Color', 'b_button_color', b_button_colors,
+        ('B Button Color', 'b_button_color', Colors.b_button_colors,
             [('B Button Color', symbols['CFG_B_BUTTON_COLOR'],
                 None),
             ]),
-        ('C Button Color', 'c_button_color', c_button_colors,
+        ('C Button Color', 'c_button_color', Colors.c_button_colors,
             [('C Button Color', symbols['CFG_C_BUTTON_COLOR'],
                 None),
              ('Pause Menu C Cursor Color', None,
@@ -672,14 +681,14 @@ def patch_button_colors(rom, settings, log, symbols):
              ('C Note Color', symbols['CFG_C_NOTE_COLOR'], # For Textbox Song Display
                 [(0xBB2996, 0xBB2997, 0xBB29A2), (0xBB2C8A, 0xBB2C8B, 0xBB2C96), (0xBB2F86, 0xBB2F87, 0xBB2F9A)]), # Pause Menu Song Display
             ]),
-        ('Start Button Color', 'start_button_color', start_button_colors,
+        ('Start Button Color', 'start_button_color', Colors.start_button_colors,
             [('Start Button Color', None,
                 [(0xAE9EC6, 0xAE9EC7, 0xAE9EDA)]),
             ]),
     ]
 
     for button, button_setting, button_colors, patches in buttons:
-        button_option = settings.settings_dict[button_setting]
+        button_option = getattr(settings, button_setting)
         color_set = None
         colors = {}
         log_dict = CollapseDict({':option': button_option, 'colors': {}})
@@ -696,22 +705,22 @@ def patch_button_colors(rom, settings, log, symbols):
             fixed_font_color = [10, 10, 10]
             color = [0, 0, 0]
             # Avoid colors which have a low contrast with the font inside buttons (eg. the A letter)
-            while contrast_ratio(color, fixed_font_color) <= 3:
-                color = generate_random_color()
+            while Colors.contrast_ratio(color, fixed_font_color) <= 3:
+                color = Colors.generate_random_color()
         # grab the color from the list
         elif button_option in button_colors:
             color_set = [button_colors[button_option]] if isinstance(button_colors[button_option][0], int) else list(button_colors[button_option])
             color = color_set[0]
         # build color from hex code
         else:
-            color = hex_to_color(button_option)
+            color = Colors.hex_to_color(button_option)
             button_option = 'Custom'
         log_dict[':option'] = button_option
 
         # apply all button color patches
         for i, (patch, symbol, byte_addresses) in enumerate(patches):
             if plando_colors.get(patch, ''):
-                colors[patch] = hex_to_color(plando_colors[patch])
+                colors[patch] = Colors.hex_to_color(plando_colors[patch])
             elif color_set is not None and len(color_set) > i and color_set[i]:
                 colors[patch] = color_set[i]
             else:
@@ -726,39 +735,39 @@ def patch_button_colors(rom, settings, log, symbols):
                     rom.write_byte(g_addr, colors[patch][1])
                     rom.write_byte(b_addr, colors[patch][2])
 
-            log_dict['colors'][patch] = color_to_hex(colors[patch])
+            log_dict['colors'][patch] = Colors.color_to_hex(colors[patch])
 
 
-def patch_sfx(rom, settings, log, symbols):
+def patch_sfx(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Configurable Sound Effects
     sfx_config = [
-          ('sfx_navi_overworld', sfx.SoundHooks.NAVI_OVERWORLD),
-          ('sfx_navi_enemy',     sfx.SoundHooks.NAVI_ENEMY),
-          ('sfx_low_hp',         sfx.SoundHooks.HP_LOW),
-          ('sfx_menu_cursor',    sfx.SoundHooks.MENU_CURSOR),
-          ('sfx_menu_select',    sfx.SoundHooks.MENU_SELECT),
-          ('sfx_nightfall',      sfx.SoundHooks.NIGHTFALL),
-          ('sfx_horse_neigh',    sfx.SoundHooks.HORSE_NEIGH),
-          ('sfx_hover_boots',    sfx.SoundHooks.BOOTS_HOVER),
-          ('sfx_iron_boots',     sfx.SoundHooks.BOOTS_IRON),
-          ('sfx_silver_rupee',   sfx.SoundHooks.SILVER_RUPEE),
-          ('sfx_boomerang_throw',sfx.SoundHooks.BOOMERANG_THROW),
-          ('sfx_hookshot_chain', sfx.SoundHooks.HOOKSHOT_CHAIN),
-          ('sfx_arrow_shot',     sfx.SoundHooks.ARROW_SHOT),
-          ('sfx_slingshot_shot', sfx.SoundHooks.SLINGSHOT_SHOT),
-          ('sfx_magic_arrow_shot', sfx.SoundHooks.MAGIC_ARROW_SHOT),
-          ('sfx_bombchu_move',   sfx.SoundHooks.BOMBCHU_MOVE),
-          ('sfx_get_small_item', sfx.SoundHooks.GET_SMALL_ITEM),
-          ('sfx_explosion',      sfx.SoundHooks.EXPLOSION),
-          ('sfx_daybreak',       sfx.SoundHooks.DAYBREAK),
-          ('sfx_cucco',          sfx.SoundHooks.CUCCO),
+          ('sfx_navi_overworld',   Sounds.SoundHooks.NAVI_OVERWORLD),
+          ('sfx_navi_enemy',       Sounds.SoundHooks.NAVI_ENEMY),
+          ('sfx_low_hp',           Sounds.SoundHooks.HP_LOW),
+          ('sfx_menu_cursor',      Sounds.SoundHooks.MENU_CURSOR),
+          ('sfx_menu_select',      Sounds.SoundHooks.MENU_SELECT),
+          ('sfx_nightfall',        Sounds.SoundHooks.NIGHTFALL),
+          ('sfx_horse_neigh',      Sounds.SoundHooks.HORSE_NEIGH),
+          ('sfx_hover_boots',      Sounds.SoundHooks.BOOTS_HOVER),
+          ('sfx_iron_boots',       Sounds.SoundHooks.BOOTS_IRON),
+          ('sfx_silver_rupee',     Sounds.SoundHooks.SILVER_RUPEE),
+          ('sfx_boomerang_throw',  Sounds.SoundHooks.BOOMERANG_THROW),
+          ('sfx_hookshot_chain',   Sounds.SoundHooks.HOOKSHOT_CHAIN),
+          ('sfx_arrow_shot',       Sounds.SoundHooks.ARROW_SHOT),
+          ('sfx_slingshot_shot',   Sounds.SoundHooks.SLINGSHOT_SHOT),
+          ('sfx_magic_arrow_shot', Sounds.SoundHooks.MAGIC_ARROW_SHOT),
+          ('sfx_bombchu_move',     Sounds.SoundHooks.BOMBCHU_MOVE),
+          ('sfx_get_small_item',   Sounds.SoundHooks.GET_SMALL_ITEM),
+          ('sfx_explosion',        Sounds.SoundHooks.EXPLOSION),
+          ('sfx_daybreak',         Sounds.SoundHooks.DAYBREAK),
+          ('sfx_cucco',            Sounds.SoundHooks.CUCCO),
     ]
-    sound_dict = sfx.get_patch_dict()
-    sounds_keyword_label = {sound.value.keyword: sound.value.label for sound in sfx.Sounds}
-    sounds_label_keyword = {sound.value.label: sound.value.keyword for sound in sfx.Sounds}
+    sound_dict = Sounds.get_patch_dict()
+    sounds_keyword_label = {sound.value.keyword: sound.value.label for sound in Sounds.Sounds}
+    sounds_label_keyword = {sound.value.label: sound.value.keyword for sound in Sounds.Sounds}
 
     for setting, hook in sfx_config:
-        selection = settings.settings_dict[setting]
+        selection = getattr(settings, setting)
 
         # Handle Plando
         if log.src_dict.get('sfx', {}).get(hook.value.name, ''):
@@ -768,17 +777,18 @@ def patch_sfx(rom, settings, log, symbols):
             elif selection_label in sounds_label_keyword:
                 selection = sounds_label_keyword[selection_label]
 
+        sound_id = 0
         if selection == 'default':
             for loc in hook.value.locations:
                 sound_id = rom.original.read_int16(loc)
                 rom.write_int16(loc, sound_id)
         else:
             if selection == 'random-choice':
-                selection = random.choice(sfx.get_hook_pool(hook)).value.keyword
+                selection = random.choice(Sounds.get_hook_pool(hook)).value.keyword
             elif selection == 'random-ear-safe':
-                selection = random.choice(sfx.get_hook_pool(hook, "TRUE")).value.keyword
+                selection = random.choice(Sounds.get_hook_pool(hook, True)).value.keyword
             elif selection == 'completely-random':
-                selection = random.choice(sfx.standard).value.keyword
+                selection = random.choice(Sounds.standard).value.keyword
             sound_id  = sound_dict[selection]
             if hook.value.sfx_flag and sound_id > 0x7FF:
                 sound_id -= 0x800
@@ -794,7 +804,7 @@ def patch_sfx(rom, settings, log, symbols):
             rom.write_int16(symbols['GET_ITEM_SEQ_ID'], sound_id)
 
 
-def patch_instrument(rom, settings, log, symbols):
+def patch_instrument(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Player Instrument
     instruments = {
            #'none':            0x00,
@@ -820,7 +830,7 @@ def patch_instrument(rom, settings, log, symbols):
     log.sfx['Ocarina'] = ocarina_options[choice]
 
 
-def read_default_voice_data(rom):
+def read_default_voice_data(rom: "Rom") -> Dict[str, Dict[str, int]]:
     audiobank = 0xD390
     audiotable = 0x79470
     soundbank = audiobank + rom.read_int32(audiobank + 0x4)
@@ -841,7 +851,7 @@ def read_default_voice_data(rom):
     return soundbank_entries
 
 
-def patch_silent_voice(rom, sfxidlist, soundbank_entries, log):
+def patch_silent_voice(rom: "Rom", sfxidlist: Iterable[int], soundbank_entries: Dict[str, Dict[str, int]], log: 'CosmeticsLog') -> None:
     binsfxfilename = os.path.join(data_path('Voices'), 'SilentVoiceSFX.bin')
     if not os.path.isfile(binsfxfilename):
         log.errors.append(f"Could not find silent voice sfx at {binsfxfilename}. Skipping voice patching")
@@ -859,7 +869,7 @@ def patch_silent_voice(rom, sfxidlist, soundbank_entries, log):
         rom.write_bytes(soundbank_entries[sfxid]["romoffset"], injectme)
 
 
-def apply_voice_patch(rom, voice_path, soundbank_entries):
+def apply_voice_patch(rom: "Rom", voice_path: str, soundbank_entries: Dict[str, Dict[str, int]]) -> None:
     if not os.path.exists(voice_path):
         return
 
@@ -875,7 +885,7 @@ def apply_voice_patch(rom, voice_path, soundbank_entries):
             rom.write_bytes(soundbank_entries[sfxid]["romoffset"], binsfx)
 
 
-def patch_voices(rom, settings, log, symbols):
+def patch_voices(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
     # Reset the audiotable back to default to prepare patching voices and read data
     rom.write_bytes(0x00079470, rom.original.read_bytes(0x00079470, 0x460AD0))
 
@@ -886,8 +896,8 @@ def patch_voices(rom, settings, log, symbols):
 
     soundbank_entries = read_default_voice_data(rom)
     voice_ages = (
-        ('Child', settings.sfx_link_child, sfx.get_voice_sfx_choices(0, False), chain([0x14, 0x87], range(0x1C, 0x36+1), range(0x3E, 0x4C+1))),
-        ('Adult', settings.sfx_link_adult, sfx.get_voice_sfx_choices(1, False), chain([0x37, 0x38, 0x3C, 0x3D, 0x86], range(0x00, 0x13+1), range(0x15, 0x1B+1), range(0x4D, 0x58+1)))
+        ('Child', settings.sfx_link_child, Sounds.get_voice_sfx_choices(0, False), chain([0x14, 0x87], range(0x1C, 0x36+1), range(0x3E, 0x4C+1))),
+        ('Adult', settings.sfx_link_adult, Sounds.get_voice_sfx_choices(1, False), chain([0x37, 0x38, 0x3C, 0x3D, 0x86], range(0x00, 0x13+1), range(0x15, 0x1B+1), range(0x4D, 0x58+1)))
     )
 
     for name, voice_setting, choices, silence_sfx_ids in voice_ages:
@@ -938,13 +948,13 @@ def patch_music_changes(rom, settings, log, symbols):
     log.slowdown_music_when_lowhp = settings.slowdown_music_when_lowhp
 
 
-legacy_cosmetic_data_headers = [
+legacy_cosmetic_data_headers: List[int] = [
     0x03481000,
     0x03480810,
 ]
 
-patch_sets = {}
-global_patch_sets = [
+patch_sets: Dict[int, Dict[str, Any]] = {}
+global_patch_sets: List[Callable[["Rom", "Settings", 'CosmeticsLog', Dict[str, int]], type(None)]] = [
     patch_targeting,
     patch_music,
     patch_tunic_colors,
@@ -1091,7 +1101,8 @@ patch_sets[0x1F073FDC] = {
     }
 }
 
-def patch_cosmetics(settings, rom):
+
+def patch_cosmetics(settings: "Settings", rom: "Rom") -> 'CosmeticsLog':
     # re-seed for aesthetic effects. They shouldn't be affected by the generation seed
     random.seed()
     settings.resolve_random_settings(cosmetic=True)
@@ -1103,7 +1114,7 @@ def patch_cosmetics(settings, rom):
     cosmetic_version = None
     versioned_patch_set = None
     cosmetic_context = rom.read_int32(rom.sym('RANDO_CONTEXT') + 4)
-    if cosmetic_context >= 0x80000000 and cosmetic_context <= 0x80F7FFFC:
+    if 0x80000000 <= cosmetic_context <= 0x80F7FFFC:
         cosmetic_context = (cosmetic_context - 0x80400000) + 0x3480000 # convert from RAM to ROM address
         cosmetic_version = rom.read_int32(cosmetic_context)
         versioned_patch_set = patch_sets.get(cosmetic_version)
@@ -1146,20 +1157,19 @@ def patch_cosmetics(settings, rom):
     return log
 
 
-class CosmeticsLog(object):
+class CosmeticsLog:
+    def __init__(self, settings: "Settings") -> None:
+        self.settings: "Settings" = settings
 
-    def __init__(self, settings):
-        self.settings = settings
+        self.equipment_colors: Dict[str, dict] = {}
+        self.ui_colors: Dict[str, dict] = {}
+        self.misc_colors: Dict[str, dict] = {}
+        self.sfx: Dict[str, str] = {}
+        self.bgm: Dict[str, str] = {}
+        self.bgm_groups: Dict[str, Union[list, dict]] = {}
 
-        self.equipment_colors = {}
-        self.ui_colors = {}
-        self.misc_colors = {}
-        self.sfx = {}
-        self.bgm = {}
-        self.bgm_groups = {}
-
-        self.src_dict = {}
-        self.errors = []
+        self.src_dict: dict = {}
+        self.errors: List[str] = []
 
         if self.settings.enable_cosmetic_file:
             if self.settings.cosmetic_file:
@@ -1171,7 +1181,7 @@ class CosmeticsLog(object):
                 except json.decoder.JSONDecodeError as e:
                     raise InvalidFileException(f"Invalid Cosmetic Plandomizer File. Make sure the file is a valid JSON file. Failure reason: {str(e)}") from None
                 except FileNotFoundError:
-                    message = "Cosmetic Plandomizer file not found at %s" % (self.settings.cosmetic_file)
+                    message = "Cosmetic Plandomizer file not found at %s" % self.settings.cosmetic_file
                     logging.getLogger('').warning(message)
                     self.errors.append(message)
                     self.settings.enable_cosmetic_file = False
@@ -1204,8 +1214,7 @@ class CosmeticsLog(object):
             if self.src_dict['settings'].get('randomize_all_sfx', False):
                 settings.resolve_random_settings(cosmetic=True, randomize_key='randomize_all_sfx')
 
-
-    def to_json(self):
+    def to_json(self) -> dict:
         self_dict = {
             ':version': __version__,
             ':enable_cosmetic_file': True,
@@ -1219,19 +1228,17 @@ class CosmeticsLog(object):
             'bgm': self.bgm,
         }
 
-        if (not self.settings.enable_cosmetic_file):
+        if not self.settings.enable_cosmetic_file:
             del self_dict[':enable_cosmetic_file']  # Done this way for ordering purposes.
-        if (not self.errors):
+        if not self.errors:
             del self_dict[':errors']
 
         return self_dict
 
-
-    def to_str(self):
+    def to_str(self) -> str:
         return dump_obj(self.to_json(), ensure_ascii=False)
 
-
-    def to_file(self, filename):
-        json = self.to_str()
+    def to_file(self, filename: str) -> None:
+        json_str = self.to_str()
         with open(filename, 'w') as outfile:
-            outfile.write(json)
+            outfile.write(json_str)

--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -933,7 +933,8 @@ def patch_voices(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: dict[
         # Write the setting to the log
         log.sfx[log_key] = voice_setting
 
-def patch_music_changes(rom, settings, log, symbols):
+
+def patch_music_changes(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: dict[str, int]) -> None:
     # Music tempo changes
     if settings.speedup_music_for_last_triforce_piece:
         rom.write_byte(symbols['CFG_SPEEDUP_MUSIC_FOR_LAST_TRIFORCE_PIECE'], 0x01)

--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -33,7 +33,6 @@ def patch_dpad(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: D
         rom.write_byte(symbols['CFG_DISPLAY_DPAD'], 0x01)
     else:
         rom.write_byte(symbols['CFG_DISPLAY_DPAD'], 0x00)
-    log.display_dpad = settings.display_dpad
 
 
 def patch_dpad_info(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
@@ -42,7 +41,6 @@ def patch_dpad_info(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbo
         rom.write_byte(symbols['CFG_DPAD_DUNGEON_INFO_ENABLE'], 0x01)
     else:
         rom.write_byte(symbols['CFG_DPAD_DUNGEON_INFO_ENABLE'], 0x00)
-    log.dpad_dungeon_menu = settings.dpad_dungeon_menu
 
 
 def patch_music(rom: "Rom", settings: "Settings", log: 'CosmeticsLog', symbols: Dict[str, int]) -> None:
@@ -954,7 +952,7 @@ legacy_cosmetic_data_headers: List[int] = [
 ]
 
 patch_sets: Dict[int, Dict[str, Any]] = {}
-global_patch_sets: List[Callable[["Rom", "Settings", 'CosmeticsLog', Dict[str, int]], type(None)]] = [
+global_patch_sets: List[Callable[["Rom", "Settings", 'CosmeticsLog', Dict[str, int]], None]] = [
     patch_targeting,
     patch_music,
     patch_tunic_colors,

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -1,30 +1,30 @@
-from typing import TYPE_CHECKING, List
-
-from Hints import HintArea
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from Hints import HintArea
     from Item import Item
     from Region import Region
     from World import World
 
 
 class Dungeon:
-    def __init__(self, world: "World", name: str, hint: HintArea) -> None:
-        self.world: "World" = world
+    def __init__(self, world: World, name: str, hint: HintArea) -> None:
+        self.world: World = world
         self.name: str = name
         self.hint: HintArea = hint
-        self.regions: "List[Region]" = []
-        self.boss_key: "List[Item]" = []
-        self.small_keys: "List[Item]" = []
-        self.dungeon_items: "List[Item]" = []
-        self.silver_rupees: "List[Item]" = []
+        self.regions: list[Region] = []
+        self.boss_key: list[Item] = []
+        self.small_keys: list[Item] = []
+        self.dungeon_items: list[Item] = []
+        self.silver_rupees: list[Item] = []
 
         for region in world.regions:
             if region.dungeon == self.name:
                 region.dungeon = self
                 self.regions.append(region)
 
-    def copy(self, new_world: "World") -> 'Dungeon':
+    def copy(self, new_world: World) -> Dungeon:
         new_dungeon = Dungeon(new_world, self.name, self.hint)
 
         new_dungeon.boss_key = [item.copy(new_world) for item in self.boss_key]
@@ -35,17 +35,17 @@ class Dungeon:
         return new_dungeon
 
     @property
-    def keys(self) -> "List[Item]":
+    def keys(self) -> list[Item]:
         return self.small_keys + self.boss_key
 
     @property
-    def all_items(self) -> "List[Item]":
+    def all_items(self) -> list[Item]:
         return self.dungeon_items + self.keys + self.silver_rupees
 
     def item_name(self, text: str) -> str:
         return f"{text} ({self.name})"
 
-    def is_dungeon_item(self, item: "Item") -> bool:
+    def is_dungeon_item(self, item: Item) -> bool:
         return item.name in [dungeon_item.name for dungeon_item in self.all_items]
 
     def __str__(self) -> str:

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Optional, Any
 
 if TYPE_CHECKING:
@@ -43,6 +44,26 @@ class Dungeon:
         return new_dungeon
 
     @property
+    def shuffle_mapcompass(self) -> str:
+        return self.world.settings.shuffle_mapcompass
+
+    @property
+    def shuffle_smallkeys(self) -> str:
+        return self.world.settings.shuffle_smallkeys
+
+    @property
+    def shuffle_bosskeys(self) -> str:
+        return self.world.settings.shuffle_bosskeys if self.name != 'Ganons Castle' else self.world.settings.shuffle_ganon_bosskey
+
+    @property
+    def shuffle_silver_rupees(self) -> str:
+        return self.world.settings.shuffle_silver_rupees
+
+    @property
+    def empty(self) -> bool:
+        return self.world.empty_dungeons[self.name].empty
+
+    @property
     def keys(self) -> list[Item]:
         return self.small_keys + self.boss_key
 
@@ -63,6 +84,29 @@ class Dungeon:
 
     def is_dungeon_item(self, item: Item) -> bool:
         return item.name in [dungeon_item.name for dungeon_item in self.all_items]
+
+    def get_restricted_dungeon_items(self) -> Iterator[Item]:
+        if self.shuffle_mapcompass == 'dungeon' or (self.empty and self.shuffle_mapcompass in ['any_dungeon', 'overworld', 'keysanity', 'regional']):
+            yield from self.dungeon_items
+        if self.shuffle_smallkeys == 'dungeon' or (self.empty and self.shuffle_smallkeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']):
+            yield from self.small_keys
+        if self.shuffle_bosskeys == 'dungeon' or (self.empty and self.shuffle_bosskeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']):
+            yield from self.boss_key
+        if self.shuffle_silver_rupees == 'dungeon' or (self.empty and self.shuffle_silver_rupees in ['any_dungeon', 'overworld', 'anywhere', 'regional']):
+            yield from self.silver_rupees
+
+    # get a list of items that don't have to be in their proper dungeon
+    def get_unrestricted_dungeon_items(self) -> Iterator[Item]:
+        if self.empty:
+            return
+        if self.shuffle_mapcompass in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
+            yield from self.dungeon_items
+        if self.shuffle_smallkeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
+            yield from self.small_keys
+        if self.shuffle_bosskeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
+            yield from self.boss_key
+        if self.shuffle_silver_rupees in ['any_dungeon', 'overworld', 'anywhere', 'regional']:
+            yield from self.silver_rupees
 
     def __str__(self) -> str:
         return str(self.__unicode__())

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Any
 
 if TYPE_CHECKING:
     from Hints import HintArea
@@ -9,28 +9,36 @@ if TYPE_CHECKING:
 
 
 class Dungeon:
-    def __init__(self, world: World, name: str, hint: HintArea) -> None:
+    def __init__(self, world: World, name: str, hint: HintArea, regions: Optional[list[Region]] = None) -> None:
         self.world: World = world
         self.name: str = name
         self.hint: HintArea = hint
-        self.regions: list[Region] = []
+        self.regions: list[Region] = regions if regions is not None else []
         self.boss_key: list[Item] = []
         self.small_keys: list[Item] = []
         self.dungeon_items: list[Item] = []
         self.silver_rupees: list[Item] = []
 
-        for region in world.regions:
-            if region.dungeon == self.name:
+        if regions is None:
+            for region in world.regions:
+                if region.dungeon_name != self.name:
+                    continue
                 region.dungeon = self
                 self.regions.append(region)
 
-    def copy(self, new_world: World) -> Dungeon:
-        new_dungeon = Dungeon(new_world, self.name, self.hint)
+    def copy(self, *, copy_dict: Optional[dict[int, Any]] = None) -> Dungeon:
+        copy_dict = {} if copy_dict is None else copy_dict
+        if (new_dungeon := copy_dict.get(id(self), None)) and isinstance(new_dungeon, Dungeon):
+            return new_dungeon
 
-        new_dungeon.boss_key = [item.copy(new_world) for item in self.boss_key]
-        new_dungeon.small_keys = [item.copy(new_world) for item in self.small_keys]
-        new_dungeon.dungeon_items = [item.copy(new_world) for item in self.dungeon_items]
-        new_dungeon.silver_rupees = [item.copy(new_world) for item in self.silver_rupees]
+        new_dungeon = Dungeon(world=self.world.copy(copy_dict=copy_dict), name=self.name, hint=self.hint, regions=[])
+        copy_dict[id(self)] = new_dungeon
+
+        new_dungeon.regions = [region.copy(copy_dict=copy_dict) for region in self.regions]
+        new_dungeon.boss_key = [item.copy(copy_dict=copy_dict) for item in self.boss_key]
+        new_dungeon.small_keys = [item.copy(copy_dict=copy_dict) for item in self.small_keys]
+        new_dungeon.dungeon_items = [item.copy(copy_dict=copy_dict) for item in self.dungeon_items]
+        new_dungeon.silver_rupees = [item.copy(copy_dict=copy_dict) for item in self.silver_rupees]
 
         return new_dungeon
 

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -45,6 +45,14 @@ class Dungeon:
     def item_name(self, text: str) -> str:
         return f"{text} ({self.name})"
 
+    def get_silver_rupee_names(self) -> set[str]:
+        from Item import ItemInfo
+        return {name for name, item in ItemInfo.items.items() if item.type == 'SilverRupee' and self.name in name}
+
+    def get_item_names(self) -> set[str]:
+        return (self.get_silver_rupee_names() |
+                {self.item_name(name) for name in ["Map", "Compass", "Small Key", "Boss Key", "Small Key Ring"]})
+
     def is_dungeon_item(self, item: Item) -> bool:
         return item.name in [dungeon_item.name for dungeon_item in self.all_items]
 

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -1,27 +1,30 @@
-import os
+from typing import TYPE_CHECKING, List
 
 from Hints import HintArea
-from Utils import data_path
+
+if TYPE_CHECKING:
+    from Item import Item
+    from Region import Region
+    from World import World
 
 
 class Dungeon:
-    def __init__(self, world, name, hint):
-        self.world = world
-        self.name = name
-        self.hint = hint
-        self.regions = []
-        self.boss_key = []
-        self.small_keys = []
-        self.dungeon_items = []
-        self.silver_rupees = []
+    def __init__(self, world: "World", name: str, hint: HintArea) -> None:
+        self.world: "World" = world
+        self.name: str = name
+        self.hint: HintArea = hint
+        self.regions: "List[Region]" = []
+        self.boss_key: "List[Item]" = []
+        self.small_keys: "List[Item]" = []
+        self.dungeon_items: "List[Item]" = []
+        self.silver_rupees: "List[Item]" = []
 
         for region in world.regions:
             if region.dungeon == self.name:
                 region.dungeon = self
                 self.regions.append(region)
 
-
-    def copy(self, new_world):
+    def copy(self, new_world: "World") -> 'Dungeon':
         new_dungeon = Dungeon(new_world, self.name, self.hint)
 
         new_dungeon.boss_key = [item.copy(new_world) for item in self.boss_key]
@@ -31,50 +34,22 @@ class Dungeon:
 
         return new_dungeon
 
-
     @property
-    def keys(self):
+    def keys(self) -> "List[Item]":
         return self.small_keys + self.boss_key
 
-
     @property
-    def all_items(self):
+    def all_items(self) -> "List[Item]":
         return self.dungeon_items + self.keys + self.silver_rupees
 
-
-    def item_name(self, text):
+    def item_name(self, text: str) -> str:
         return f"{text} ({self.name})"
 
-
-    def is_dungeon_item(self, item):
+    def is_dungeon_item(self, item: "Item") -> bool:
         return item.name in [dungeon_item.name for dungeon_item in self.all_items]
 
-
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.__unicode__())
 
-
-    def __unicode__(self):
+    def __unicode__(self) -> str:
         return '%s' % self.name
-
-
-def create_dungeons(world):
-    savewarps_to_connect = []
-    for hint_area in HintArea:
-        if hint_area.is_dungeon:
-            name = hint_area.dungeon_name
-
-            if world.settings.logic_rules == 'glitched':
-                if not world.dungeon_mq[name]:
-                    dungeon_json = os.path.join(data_path('Glitched World'), name + '.json')
-                else:
-                    dungeon_json = os.path.join(data_path('Glitched World'), name + ' MQ.json')
-            else:
-                if not world.dungeon_mq[name]:
-                    dungeon_json = os.path.join(data_path('World'), name + '.json')
-                else:
-                    dungeon_json = os.path.join(data_path('World'), name + ' MQ.json')
-
-            savewarps_to_connect += world.load_regions_from_json(dungeon_json)
-            world.dungeons.append(Dungeon(world, name, hint_area))
-    return savewarps_to_connect

--- a/Entrance.py
+++ b/Entrance.py
@@ -26,14 +26,24 @@ class Entrance:
         self.never: bool = False
         self.rule_string: Optional[str] = None
 
-    def copy(self, new_region: Region) -> Entrance:
-        new_entrance = Entrance(self.name, new_region)
-        new_entrance.connected_region = self.connected_region.name  # TODO: Revamp World/Region copying such that this is not a type error.
+    def copy(self, *, copy_dict: Optional[dict[int, Any]] = None) -> Entrance:
+        copy_dict = {} if copy_dict is None else copy_dict
+        if (new_entrance := copy_dict.get(id(self), None)) and isinstance(new_entrance, Entrance):
+            return new_entrance
+
+        new_entrance = Entrance(self.name, self.parent_region.copy(copy_dict=copy_dict) if self.parent_region else None)
+        copy_dict[id(self)] = new_entrance
+
+        if self.connected_region is not None:
+            new_entrance.connected_region = self.connected_region.copy(copy_dict=copy_dict)
         new_entrance.access_rule = self.access_rule
         new_entrance.access_rules = list(self.access_rules)
-        new_entrance.reverse = self.reverse
-        new_entrance.replaces = self.replaces
-        new_entrance.assumed = self.assumed
+        if self.reverse:
+            new_entrance.reverse = self.reverse.copy(copy_dict=copy_dict)
+        if self.replaces:
+            new_entrance.replaces = self.replaces.copy(copy_dict=copy_dict)
+        if self.assumed:
+            new_entrance.assumed = self.assumed.copy(copy_dict=copy_dict)
         new_entrance.type = self.type
         new_entrance.shuffled = self.shuffled
         new_entrance.data = self.data

--- a/Entrance.py
+++ b/Entrance.py
@@ -1,32 +1,32 @@
-from typing import TYPE_CHECKING, List, Optional, Dict, Any
-
-from RulesCommon import AccessRule
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Any
 
 if TYPE_CHECKING:
     from Region import Region
+    from RulesCommon import AccessRule
     from World import World
 
 
 class Entrance:
-    def __init__(self, name: str = '', parent: "Optional[Region]" = None) -> None:
+    def __init__(self, name: str = '', parent: Optional[Region] = None) -> None:
         self.name: str = name
-        self.parent_region: "Optional[Region]" = parent
-        self.world: "Optional[World]" = parent.world if parent is not None else None
-        self.connected_region: "Optional[Region]" = None
+        self.parent_region: Optional[Region] = parent
+        self.world: Optional[World] = parent.world if parent is not None else None
+        self.connected_region: Optional[Region] = None
         self.access_rule: AccessRule = lambda state, **kwargs: True
-        self.access_rules: List[AccessRule] = []
-        self.reverse: 'Optional[Entrance]' = None
-        self.replaces: 'Optional[Entrance]' = None
-        self.assumed: 'Optional[Entrance]' = None
+        self.access_rules: list[AccessRule] = []
+        self.reverse: Optional[Entrance] = None
+        self.replaces: Optional[Entrance] = None
+        self.assumed: Optional[Entrance] = None
         self.type: Optional[str] = None
         self.shuffled: bool = False
-        self.data: Optional[Dict[str, Any]] = None
+        self.data: Optional[dict[str, Any]] = None
         self.primary: bool = False
         self.always: bool = False
         self.never: bool = False
         self.rule_string: Optional[str] = None
 
-    def copy(self, new_region: "Region") -> 'Entrance':
+    def copy(self, new_region: Region) -> Entrance:
         new_entrance = Entrance(self.name, new_region)
         new_entrance.connected_region = self.connected_region.name  # TODO: Revamp World/Region copying such that this is not a type error.
         new_entrance.access_rule = self.access_rule
@@ -57,11 +57,11 @@ class Entrance:
         self.access_rule = lambda_rule
         self.access_rules = [lambda_rule]
 
-    def connect(self, region: "Region") -> None:
+    def connect(self, region: Region) -> None:
         self.connected_region = region
         region.entrances.append(self)
 
-    def disconnect(self) -> "Optional[Region]":
+    def disconnect(self) -> Optional[Region]:
         if self.connected_region is None:
             raise Exception(f"`disconnect()` called without a valid `connected_region` for entrance {self.name}.")
         self.connected_region.entrances.remove(self)
@@ -69,11 +69,11 @@ class Entrance:
         self.connected_region = None
         return previously_connected
 
-    def bind_two_way(self, other_entrance: 'Entrance') -> None:
+    def bind_two_way(self, other_entrance: Entrance) -> None:
         self.reverse = other_entrance
         other_entrance.reverse = self
 
-    def get_new_target(self) -> 'Entrance':
+    def get_new_target(self) -> Entrance:
         if self.world is None:
             raise Exception(f"`get_new_target()` called without a valid `world` for entrance {self.name}.")
         if self.connected_region is None:
@@ -85,7 +85,7 @@ class Entrance:
         root.exits.append(target_entrance)
         return target_entrance
 
-    def assume_reachable(self) -> 'Entrance':
+    def assume_reachable(self) -> Entrance:
         if self.assumed is None:
             self.assumed = self.get_new_target()
             self.disconnect()

--- a/Entrance.py
+++ b/Entrance.py
@@ -1,27 +1,32 @@
-from Region import TimeOfDay
+from typing import TYPE_CHECKING, List, Optional, Callable, Dict, Any
+
+from RulesCommon import AccessRule
+
+if TYPE_CHECKING:
+    from Region import Region
+    from World import World
 
 
-class Entrance(object):
+class Entrance:
+    def __init__(self, name: str = '', parent: "Optional[Region]" = None) -> None:
+        self.name: str = name
+        self.parent_region: "Optional[Region]" = parent
+        self.world: "World" = parent.world
+        self.connected_region: "Optional[Region]" = None
+        self.access_rule: AccessRule = lambda state, **kwargs: True
+        self.access_rules: List[AccessRule] = []
+        self.reverse: 'Optional[Entrance]' = None
+        self.replaces: 'Optional[Entrance]' = None
+        self.assumed: 'Optional[Entrance]' = None
+        self.type: Optional[str] = None
+        self.shuffled: bool = False
+        self.data: Optional[Dict[str, Any]] = None
+        self.primary: bool = False
+        self.always: bool = False
+        self.never: bool = False
+        self.rule_string: Optional[str] = None
 
-    def __init__(self, name='', parent=None):
-        self.name = name
-        self.parent_region = parent
-        self.world = parent.world
-        self.connected_region = None
-        self.access_rule = lambda state, **kwargs: True
-        self.access_rules = []
-        self.reverse = None
-        self.replaces = None
-        self.assumed = None
-        self.type = None
-        self.shuffled = False
-        self.data = None
-        self.primary = False
-        self.always = False
-        self.never = False
-
-
-    def copy(self, new_region):
+    def copy(self, new_region: "Region") -> 'Entrance':
         new_entrance = Entrance(self.name, new_region)
         new_entrance.connected_region = self.connected_region.name
         new_entrance.access_rule = self.access_rule
@@ -38,8 +43,7 @@ class Entrance(object):
 
         return new_entrance
 
-
-    def add_rule(self, lambda_rule):
+    def add_rule(self, lambda_rule: AccessRule) -> None:
         if self.always:
             self.set_rule(lambda_rule)
             self.always = False
@@ -49,30 +53,25 @@ class Entrance(object):
         self.access_rules.append(lambda_rule)
         self.access_rule = lambda state, **kwargs: all(rule(state, **kwargs) for rule in self.access_rules)
 
-
-    def set_rule(self, lambda_rule):
+    def set_rule(self, lambda_rule: AccessRule) -> None:
         self.access_rule = lambda_rule
         self.access_rules = [lambda_rule]
 
-
-    def connect(self, region):
+    def connect(self, region: "Region") -> None:
         self.connected_region = region
         region.entrances.append(self)
 
-
-    def disconnect(self):
+    def disconnect(self) -> "Optional[Region]":
         self.connected_region.entrances.remove(self)
         previously_connected = self.connected_region
         self.connected_region = None
         return previously_connected
 
-
-    def bind_two_way(self, other_entrance):
+    def bind_two_way(self, other_entrance: 'Entrance') -> None:
         self.reverse = other_entrance
         other_entrance.reverse = self
 
-
-    def get_new_target(self):
+    def get_new_target(self) -> 'Entrance':
         root = self.world.get_region('Root Exits')
         target_entrance = Entrance('Root -> ' + self.connected_region.name, root)
         target_entrance.connect(self.connected_region)
@@ -80,18 +79,14 @@ class Entrance(object):
         root.exits.append(target_entrance)
         return target_entrance
 
-
-    def assume_reachable(self):
-        if self.assumed == None:
+    def assume_reachable(self) -> 'Entrance':
+        if self.assumed is None:
             self.assumed = self.get_new_target()
             self.disconnect()
         return self.assumed
 
-
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.__unicode__())
 
-
-    def __unicode__(self):
+    def __unicode__(self) -> str:
         return '%s' % self.name
-

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -1,18 +1,26 @@
 import random
 import logging
-from itertools import chain
-from Fill import ShuffleError
 from collections import OrderedDict
+from itertools import chain
+from typing import TYPE_CHECKING, List, Iterable, Container, Tuple, Dict, Optional
+
+from Fill import ShuffleError
 from Search import Search
-from Region import TimeOfDay
+from Region import Region, TimeOfDay
 from Rules import set_entrances_based_rules
 from State import State
 from Item import ItemFactory
 from Hints import HintArea, HintAreaNotFound
 from HintList import misc_item_hint_table
 
+if TYPE_CHECKING:
+    from Entrance import Entrance
+    from Location import Location
+    from Item import Item
+    from World import World
 
-def set_all_entrances_data(world):
+
+def set_all_entrances_data(world: "World") -> None:
     for type, forward_entry, *return_entry in entrance_shuffle_table:
         forward_entrance = world.get_entrance(forward_entry[0])
         forward_entrance.data = forward_entry[1]
@@ -30,11 +38,11 @@ def set_all_entrances_data(world):
                 return_entrance.data['index'] = 0x7FFF
 
 
-def assume_entrance_pool(entrance_pool):
+def assume_entrance_pool(entrance_pool: "List[Entrance]") -> "List[Entrance]":
     assumed_pool = []
     for entrance in entrance_pool:
         assumed_forward = entrance.assume_reachable()
-        if entrance.reverse != None:
+        if entrance.reverse is not None:
             assumed_return = entrance.reverse.assume_reachable()
             if (entrance.type in ('Dungeon', 'Grotto', 'Grave') and entrance.reverse.name != 'Spirit Temple Lobby -> Desert Colossus From Spirit Lobby') or \
                (entrance.type == 'Interior' and entrance.world.shuffle_special_interior_entrances):
@@ -45,8 +53,8 @@ def assume_entrance_pool(entrance_pool):
     return assumed_pool
 
 
-def build_one_way_targets(world, types_to_include, exclude=(), target_region_names=()):
-    one_way_entrances = []
+def build_one_way_targets(world: "World", types_to_include: Iterable[str], exclude: Container[str] = (), target_region_names: Container[str] = ()) -> "List[Entrance]":
+    one_way_entrances: "List[Entrance]" = []
     for pool_type in types_to_include:
         one_way_entrances += world.get_shufflable_entrances(type=pool_type)
     valid_one_way_entrances = list(filter(lambda entrance: entrance.name not in exclude, one_way_entrances))
@@ -408,7 +416,7 @@ class EntranceShuffleError(ShuffleError):
 
 
 # Set entrances of all worlds, first initializing them to their default regions, then potentially shuffling part of them
-def set_entrances(worlds, savewarps_to_connect):
+def set_entrances(worlds: "List[World]", savewarps_to_connect: "List[Tuple[Entrance, str]]") -> None:
     for world in worlds:
         world.initialize_entrances()
 
@@ -428,8 +436,7 @@ def set_entrances(worlds, savewarps_to_connect):
 
 
 # Shuffles entrances that need to be shuffled in all worlds
-def shuffle_random_entrances(worlds):
-
+def shuffle_random_entrances(worlds: "List[World]") -> None:
     # Store all locations reachable before shuffling to differentiate which locations were already unreachable from those we made unreachable
     complete_itempool = [item for world in worlds for item in world.get_itempool_with_dungeon_items()]
     max_search = Search.max_explore([world.state for world in worlds], complete_itempool)
@@ -555,7 +562,8 @@ def shuffle_random_entrances(worlds):
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
             # Ensure that when trying to place the last entrance of a one way pool, we don't assume the rest of the targets are reachable
             for target in one_way_target_entrance_pools[pool_type]:
-                target.add_rule((lambda entrances=entrance_pool: (lambda state, **kwargs: any(entrance.connected_region == None for entrance in entrances)))())
+                target.add_rule((lambda entrances=entrance_pool: (lambda state, **kwargs: any(
+                    entrance.connected_region is None for entrance in entrances)))())
         # Disconnect all one way entrances at this point (they need to be connected during all of the above process)
         for entrance in chain.from_iterable(one_way_entrance_pools.values()):
             entrance.disconnect()
@@ -565,7 +573,7 @@ def shuffle_random_entrances(worlds):
             target_entrance_pools[pool_type] = assume_entrance_pool(entrance_pool)
 
         # Set entrances defined in the distribution
-        world.distribution.set_shuffled_entrances(worlds, dict(chain(one_way_entrance_pools.items(), entrance_pools.items())), dict(chain(one_way_target_entrance_pools.items(), target_entrance_pools.items())), locations_to_ensure_reachable, complete_itempool)
+        world.distribution.set_shuffled_entrances(worlds, {**one_way_entrance_pools, **entrance_pools}, {**one_way_target_entrance_pools, **target_entrance_pools}, locations_to_ensure_reachable, complete_itempool)
 
         # Check placed one way entrances and trim.
         # The placed entrances are already pointing at their new regions.
@@ -592,7 +600,6 @@ def shuffle_random_entrances(worlds):
         for remaining_target in chain.from_iterable(one_way_target_entrance_pools.values()):
             if remaining_target.replaces in replaced_entrances:
                 delete_target_entrance(remaining_target)
-
 
         # Shuffle all entrances among the pools to shuffle
         for pool_type, entrance_pool in one_way_entrance_pools.items():
@@ -659,14 +666,14 @@ def shuffle_random_entrances(worlds):
     # Check that all shuffled entrances are properly connected to a region
     for world in worlds:
         for entrance in world.get_shuffled_entrances():
-            if entrance.connected_region == None:
+            if entrance.connected_region is None:
                 logging.getLogger('').error('%s was shuffled but still isn\'t connected to any region [World %d]', entrance, world.id)
-            if entrance.replaces == None:
+            if entrance.replaces is None:
                 logging.getLogger('').error('%s was shuffled but still doesn\'t replace any entrance [World %d]', entrance, world.id)
-    if len(world.get_region('Root Exits').exits) > 8:
-        for exit in world.get_region('Root Exits').exits:
-            logging.getLogger('').error('Root Exit: %s, Connected Region: %s', exit, exit.connected_region)
-        raise RuntimeError('Something went wrong, Root has too many entrances left after shuffling entrances [World %d]' % world.id)
+        if len(world.get_region('Root Exits').exits) > 8:
+            for exit in world.get_region('Root Exits').exits:
+                logging.getLogger('').error('Root Exit: %s, Connected Region: %s', exit, exit.connected_region)
+            raise RuntimeError('Something went wrong, Root has too many entrances left after shuffling entrances [World %d]' % world.id)
 
     # Check for game beatability in all worlds
     if not max_search.can_beat_game(False):
@@ -680,7 +687,10 @@ def shuffle_random_entrances(worlds):
             raise EntranceShuffleError('Worlds are not valid after shuffling entrances, Reason: %s' % error)
 
 
-def shuffle_one_way_priority_entrances(worlds, world, one_way_priorities, one_way_entrance_pools, one_way_target_entrance_pools, locations_to_ensure_reachable, complete_itempool, retry_count=2):
+def shuffle_one_way_priority_entrances(worlds: "List[World]", world: "World", one_way_priorities: Dict[str, Tuple[List[str], List[str]]],
+                                       one_way_entrance_pools: "Dict[str, List[Entrance]]", one_way_target_entrance_pools: "Dict[str, List[Entrance]]",
+                                       locations_to_ensure_reachable: "Iterable[Location]", complete_itempool: "List[Item]",
+                                       retry_count: int = 2) -> "List[Tuple[Entrance, Entrance]]":
     while retry_count:
         retry_count -= 1
         rollbacks = []
@@ -706,9 +716,13 @@ def shuffle_one_way_priority_entrances(worlds, world, one_way_priorities, one_wa
         raise EntranceShuffleError('Entrance placement attempt count exceeded for world %d. Some entrances in the Plandomizer File may have to be changed to create a valid seed. Reach out to Support on Discord for help.' % world.id)
     raise EntranceShuffleError('Entrance placement attempt count exceeded for world %d. Retry a few times or reach out to Support on Discord for help.' % world.id)
 
-# Shuffle all entrances within a provided pool
-def shuffle_entrance_pool(world, worlds, entrance_pool, target_entrances, locations_to_ensure_reachable, check_all=False, retry_count=20, placed_one_way_entrances=()):
 
+# Shuffle all entrances within a provided pool
+def shuffle_entrance_pool(world: "World", worlds: "List[World]", entrance_pool: "List[Entrance]", target_entrances: "List[Entrance]",
+                          locations_to_ensure_reachable: "Iterable[Location]", check_all: bool = False, retry_count: int = 20,
+                          placed_one_way_entrances: "Optional[List[Tuple[Entrance, Entrance]]]" = None) -> "List[Tuple[Entrance, Entrance]]":
+    if placed_one_way_entrances is None:
+        placed_one_way_entrances = []
     # Split entrances between those that have requirements (restrictive) and those that do not (soft). These are primarily age or time of day requirements.
     restrictive_entrances, soft_entrances = split_entrances_by_requirements(worlds, entrance_pool, target_entrances)
 
@@ -749,8 +763,7 @@ def shuffle_entrance_pool(world, worlds, entrance_pool, target_entrances, locati
 
 
 # Split entrances based on their requirements to figure out how each entrance should be handled when shuffling them
-def split_entrances_by_requirements(worlds, entrances_to_split, assumed_entrances):
-
+def split_entrances_by_requirements(worlds: "List[World]", entrances_to_split: "List[Entrance]", assumed_entrances: "List[Entrance]") -> "Tuple[List[Entrance], List[Entrance]]":
     # First, disconnect all root assumed entrances and save which regions they were originally connected to, so we can reconnect them later
     original_connected_regions = {}
     entrances_to_disconnect = set(assumed_entrances).union(entrance.reverse for entrance in assumed_entrances if entrance.reverse)
@@ -784,7 +797,10 @@ def split_entrances_by_requirements(worlds, entrances_to_split, assumed_entrance
     return restrictive_entrances, soft_entrances
 
 
-def replace_entrance(worlds, entrance, target, rollbacks, locations_to_ensure_reachable, itempool, placed_one_way_entrances=()):
+def replace_entrance(worlds: "List[World]", entrance: "Entrance", target: "Entrance", rollbacks: "List[Tuple[Entrance, Entrance]]",
+                     locations_to_ensure_reachable: "Iterable[Location]", itempool: "List[Item]", placed_one_way_entrances: "Optional[List[Tuple[Entrance, Entrance]]]" = None) -> bool:
+    if placed_one_way_entrances is None:
+        placed_one_way_entrances = []
     try:
         check_entrances_compatibility(entrance, target, rollbacks, placed_one_way_entrances)
         change_connections(entrance, target)
@@ -803,7 +819,9 @@ def replace_entrance(worlds, entrance, target, rollbacks, locations_to_ensure_re
 # Connect one random entrance from entrance pools to one random target in the respective target pool.
 # Entrance chosen will have one of the allowed types.
 # Target chosen will lead to one of the allowed regions.
-def place_one_way_priority_entrance(worlds, world, priority_name, allowed_regions, allowed_types, rollbacks, locations_to_ensure_reachable, complete_itempool, one_way_entrance_pools, one_way_target_entrance_pools):
+def place_one_way_priority_entrance(worlds: "List[World]", world: "World", priority_name: str, allowed_regions: Container[str], allowed_types: Iterable[str],
+                                    rollbacks: "List[Tuple[Entrance, Entrance]]", locations_to_ensure_reachable: "Iterable[Location]", complete_itempool: "List[Item]",
+                                    one_way_entrance_pools: "Dict[str, List[Entrance]]", one_way_target_entrance_pools: "Dict[str, List[Entrance]]") -> None:
     # Combine the entrances for allowed types in one list.
     # Shuffle this list.
     # Pick the first one not already set, not adult spawn, that has a valid target entrance.
@@ -832,8 +850,10 @@ def place_one_way_priority_entrance(worlds, world, priority_name, allowed_region
 
 # Shuffle entrances by placing them instead of entrances in the provided target entrances list
 # While shuffling entrances, the algorithm will ensure worlds are still valid based on multiple criterias
-def shuffle_entrances(worlds, entrances, target_entrances, rollbacks, locations_to_ensure_reachable=(), placed_one_way_entrances=()):
-
+def shuffle_entrances(worlds: "List[World]", entrances: "List[Entrance]", target_entrances: "List[Entrance]", rollbacks: "List[Tuple[Entrance, Entrance]]",
+                      locations_to_ensure_reachable: "Iterable[Location]" = (), placed_one_way_entrances: "Optional[List[Tuple[Entrance, Entrance]]]" = None) -> None:
+    if placed_one_way_entrances is None:
+        placed_one_way_entrances = []
     # Retrieve all items in the itempool, all worlds included
     complete_itempool = [item for world in worlds for item in world.get_itempool_with_dungeon_items()]
 
@@ -841,23 +861,26 @@ def shuffle_entrances(worlds, entrances, target_entrances, rollbacks, locations_
 
     # Place all entrances in the pool, validating worlds during every placement
     for entrance in entrances:
-        if entrance.connected_region != None:
+        if entrance.connected_region is not None:
             continue
         random.shuffle(target_entrances)
 
         for target in target_entrances:
-            if target.connected_region == None:
+            if target.connected_region is None:
                 continue
 
             if replace_entrance(worlds, entrance, target, rollbacks, locations_to_ensure_reachable, complete_itempool, placed_one_way_entrances=placed_one_way_entrances):
                 break
 
-        if entrance.connected_region == None:
+        if entrance.connected_region is None:
             raise EntranceShuffleError('No more valid entrances to replace with %s in world %d' % (entrance, entrance.world.id))
 
 
 # Check and validate that an entrance is compatible to replace a specific target
-def check_entrances_compatibility(entrance, target, rollbacks=(), placed_one_way_entrances=()):
+def check_entrances_compatibility(entrance: "Entrance", target: "Entrance", rollbacks: "List[Tuple[Entrance, Entrance]]" = (),
+                                  placed_one_way_entrances: "Optional[List[Tuple[Entrance, Entrance]]]" = None) -> None:
+    if placed_one_way_entrances is None:
+        placed_one_way_entrances = []
     # An entrance shouldn't be connected to its own scene, so we fail in that situation
     if entrance.parent_region.get_scene() and entrance.parent_region.get_scene() == target.connected_region.get_scene():
         raise EntranceShuffleError('Self scene connections are forbidden')
@@ -880,8 +903,10 @@ def check_entrances_compatibility(entrance, target, rollbacks=(), placed_one_way
 
 
 # Validate the provided worlds' structures, raising an error if it's not valid based on our criterias
-def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable, itempool, placed_one_way_entrances=()):
-
+def validate_world(world: "World", worlds: "List[World]", entrance_placed: "Optional[Entrance]", locations_to_ensure_reachable: "Iterable[Location]",
+                   itempool: "List[Item]", placed_one_way_entrances: "Optional[List[Tuple[Entrance, Entrance]]]" = None) -> None:
+    if placed_one_way_entrances is None:
+        placed_one_way_entrances = []
     # For various reasons, we don't want the player to end up through certain entrances as the wrong age
     # This means we need to hard check that none of the relevant entrances are ever reachable as that age
     # This is mostly relevant when shuffling special interiors (such as windmill or kak potion shop)
@@ -930,7 +955,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
         world.shuffle_interior_entrances and (
             (world.dungeon_rewards_hinted and world.mixed_pools_bosses) or #TODO also enable if boss reward shuffle is on
             any(hint_type in world.settings.misc_hints for hint_type in misc_item_hint_table) or world.settings.hints != 'none'
-        ) and (entrance_placed == None or entrance_placed.type in ['Interior', 'SpecialInterior'])
+        ) and (entrance_placed is None or entrance_placed.type in ['Interior', 'SpecialInterior'])
     ):
         # Ensure Kak Potion Shop entrances are in the same hint area so there is no ambiguity as to which entrance is used for hints
         potion_front_entrance = get_entrance_replacing(world.get_region('Kak Potion Shop Front'), 'Kakariko Village -> Kak Potion Shop Front')
@@ -998,8 +1023,8 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
 
 
 # Returns whether or not we can affirm the entrance can never be accessed as the given age
-def entrance_unreachable_as(entrance, age, already_checked=None):
-    if already_checked == None:
+def entrance_unreachable_as(entrance: "Entrance", age: str, already_checked: "Optional[List[Entrance]]" = None) -> bool:
+    if already_checked is None:
         already_checked = []
 
     already_checked.append(entrance)
@@ -1027,7 +1052,7 @@ def entrance_unreachable_as(entrance, age, already_checked=None):
 
 
 # Returns whether two entrances are in the same hint area
-def same_hint_area(first, second):
+def same_hint_area(first: HintArea, second: HintArea) -> bool:
     try:
         return HintArea.at(first) == HintArea.at(second)
     except HintAreaNotFound:
@@ -1035,7 +1060,7 @@ def same_hint_area(first, second):
 
 
 # Shorthand function to find an entrance with the requested name leading to a specific region
-def get_entrance_replacing(region, entrance_name):
+def get_entrance_replacing(region: Region, entrance_name: str) -> "Optional[Entrance]":
     original_entrance = region.world.get_entrance(entrance_name)
 
     if not original_entrance.shuffled:
@@ -1050,7 +1075,7 @@ def get_entrance_replacing(region, entrance_name):
 
 
 # Change connections between an entrance and a target assumed entrance, in order to test the connections afterwards if necessary
-def change_connections(entrance, target_entrance):
+def change_connections(entrance: "Entrance", target_entrance: "Entrance") -> None:
     entrance.connect(target_entrance.disconnect())
     entrance.replaces = target_entrance.replaces
     if entrance.reverse:
@@ -1059,7 +1084,7 @@ def change_connections(entrance, target_entrance):
 
 
 # Restore connections between an entrance and a target assumed entrance
-def restore_connections(entrance, target_entrance):
+def restore_connections(entrance: "Entrance", target_entrance: "Entrance") -> None:
     target_entrance.connect(entrance.disconnect())
     entrance.replaces = None
     if entrance.reverse:
@@ -1068,7 +1093,7 @@ def restore_connections(entrance, target_entrance):
 
 
 # Confirm the replacement of a target entrance by a new entrance, logging the new connections and completely deleting the target entrances
-def confirm_replacement(entrance, target_entrance):
+def confirm_replacement(entrance: "Entrance", target_entrance: "Entrance") -> None:
     delete_target_entrance(target_entrance)
     logging.getLogger('').debug('Connected %s To %s [World %d]', entrance, entrance.connected_region, entrance.world.id)
     if entrance.reverse:
@@ -1078,9 +1103,9 @@ def confirm_replacement(entrance, target_entrance):
 
 
 # Delete an assumed target entrance, by disconnecting it if needed and removing it from its parent region
-def delete_target_entrance(target_entrance):
-    if target_entrance.connected_region != None:
+def delete_target_entrance(target_entrance: "Entrance") -> None:
+    if target_entrance.connected_region is not None:
         target_entrance.disconnect()
-    if target_entrance.parent_region != None:
+    if target_entrance.parent_region is not None:
         target_entrance.parent_region.exits.remove(target_entrance)
         target_entrance.parent_region = None

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -45,7 +45,7 @@ def assume_entrance_pool(entrance_pool: "List[Entrance]") -> "List[Entrance]":
         if entrance.reverse is not None:
             assumed_return = entrance.reverse.assume_reachable()
             if (entrance.type in ('Dungeon', 'Grotto', 'Grave') and entrance.reverse.name != 'Spirit Temple Lobby -> Desert Colossus From Spirit Lobby') or \
-               (entrance.type == 'Interior' and entrance.world.shuffle_special_interior_entrances):
+               (entrance.type == 'Interior' and entrance.world and entrance.world.shuffle_special_interior_entrances):
                 # In most cases, Dungeon, Grotto/Grave and Simple Interior exits shouldn't be assumed able to give access to their parent region
                 assumed_return.set_rule(lambda state, **kwargs: False)
             assumed_forward.bind_two_way(assumed_return)
@@ -444,6 +444,7 @@ def shuffle_random_entrances(worlds: "List[World]") -> None:
     non_drop_locations = [location for world in worlds for location in world.get_locations() if location.type not in ('Drop', 'Event')]
     max_search.visit_locations(non_drop_locations)
     locations_to_ensure_reachable = list(filter(max_search.visited, non_drop_locations))
+    placed_one_way_entrances = None
 
     # Shuffle all entrances within their own worlds
     for world in worlds:

--- a/Fill.py
+++ b/Fill.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 import random
 import logging
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from Hints import HintArea
 from Item import Item, ItemFactory, ItemInfo
@@ -26,7 +27,7 @@ class FillError(ShuffleError):
 
 
 # Places all items into the world
-def distribute_items_restrictive(worlds: "List[World]", fill_locations: Optional[List[Location]] = None) -> None:
+def distribute_items_restrictive(worlds: list[World], fill_locations: Optional[list[Location]] = None) -> None:
     if worlds[0].settings.shuffle_song_items == 'song':
         song_location_names = location_groups['Song']
     elif worlds[0].settings.shuffle_song_items == 'dungeon':
@@ -237,7 +238,7 @@ def distribute_items_restrictive(worlds: "List[World]", fill_locations: Optional
 
 # Places restricted dungeon items into the worlds. To ensure there is room for them.
 # they are placed first, so it will assume all other items are reachable
-def fill_dungeons_restrictive(worlds: "List[World]", search: Search, shuffled_locations: List[Location], dungeon_items: List[Item], itempool: List[Item]) -> None:
+def fill_dungeons_restrictive(worlds: list[World], search: Search, shuffled_locations: list[Location], dungeon_items: list[Item], itempool: list[Item]) -> None:
     # List of states with all non-key items
     base_search = search.copy()
     base_search.collect_all(itempool)
@@ -259,7 +260,7 @@ def fill_dungeons_restrictive(worlds: "List[World]", search: Search, shuffled_lo
 # Places items into dungeon locations. This is used when there should be exactly
 # one progression item per dungeon. This should be run before all the progression
 # items are places to ensure there is space to place them.
-def fill_dungeon_unique_item(worlds: "List[World]", search: Search, fill_locations: List[Location], itempool: List[Item]) -> None:
+def fill_dungeon_unique_item(worlds: list[World], search: Search, fill_locations: list[Location], itempool: list[Item]) -> None:
     # We should make sure that we don't count event items, shop items,
     # token items, or dungeon items as a major item. itempool at this
     # point should only be able to have tokens of those restrictions
@@ -333,8 +334,8 @@ def fill_dungeon_unique_item(worlds: "List[World]", search: Search, fill_locatio
 
 
 # Places items restricting placement to the recipient player's own world
-def fill_ownworld_restrictive(worlds: "List[World]", search: Search, locations: List[Location], ownpool: List[Item],
-                              itempool: List[Item], description: str = "Unknown", attempts: int = 15) -> None:
+def fill_ownworld_restrictive(worlds: list[World], search: Search, locations: list[Location], ownpool: list[Item],
+                              itempool: list[Item], description: str = "Unknown", attempts: int = 15) -> None:
     # look for preplaced items
     placed_prizes = [loc.item.name for loc in locations if loc.item is not None]
     unplaced_prizes = [item for item in ownpool if item.name not in placed_prizes]
@@ -390,9 +391,9 @@ def fill_ownworld_restrictive(worlds: "List[World]", search: Search, locations: 
 # every item. Raises an error if specified count of items are not placed.
 #
 # This function will modify the location and itempool arguments. placed items and
-# filled locations will be removed. If this returns and error, then the state of
+# filled locations will be removed. If this returns an error, then the state of
 # those two lists cannot be guaranteed.
-def fill_restrictive(worlds: "List[World]", base_search: Search, locations: List[Location], itempool: List[Item], count: int = -1) -> None:
+def fill_restrictive(worlds: list[World], base_search: Search, locations: list[Location], itempool: list[Item], count: int = -1) -> None:
     unplaced_items = []
 
     # don't run over this search, just keep it as an item collection
@@ -507,7 +508,7 @@ def fill_restrictive(worlds: "List[World]", base_search: Search, locations: List
 # This places items in the itempool into the locations
 # It does not check for reachability, only that the item is
 # allowed in the location
-def fill_restrictive_fast(worlds: "List[World]", locations: List[Location], itempool: List[Item]) -> None:
+def fill_restrictive_fast(worlds: list[World], locations: list[Location], itempool: list[Item]) -> None:
     while itempool and locations:
         item_to_place = itempool.pop()
         random.shuffle(locations)
@@ -535,7 +536,7 @@ def fill_restrictive_fast(worlds: "List[World]", locations: List[Location], item
 # this places item in item_pool completely randomly into
 # fill_locations. There is no checks for validity since
 # there should be none for these remaining items
-def fast_fill(locations: List[Location], itempool: List[Item]) -> None:
+def fast_fill(locations: list[Location], itempool: list[Item]) -> None:
     random.shuffle(locations)
     while itempool and locations:
         spot_to_fill = locations.pop()

--- a/Fill.py
+++ b/Fill.py
@@ -21,7 +21,7 @@ class FillError(ShuffleError):
 
 
 # Places all items into the world
-def distribute_items_restrictive(window, worlds, fill_locations=None):
+def distribute_items_restrictive(worlds, fill_locations=None):
     if worlds[0].settings.shuffle_song_items == 'song':
         song_location_names = location_groups['Song']
     elif worlds[0].settings.shuffle_song_items == 'dungeon':
@@ -57,9 +57,6 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
                 and not location.type.startswith('Hint')]
     world_states = [world.state for world in worlds]
 
-    window.locationcount = len(fill_locations) + len(song_locations) + len(shop_locations)
-    window.fillcount = 0
-
     # Generate the itempools
     shopitempool = [item for world in worlds for item in world.itempool if item.type == 'Shop']
     songitempool = [item for world in worlds for item in world.itempool if item.type == 'Song']
@@ -79,7 +76,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
 
     cloakable_locations = shop_locations + song_locations + fill_locations
     all_models = shopitempool + dungeon_items + songitempool + itempool
-    worlds[0].settings.distribution.fill(window, worlds, [shop_locations, song_locations, fill_locations], [shopitempool, dungeon_items, songitempool, progitempool, prioitempool, restitempool])
+    worlds[0].settings.distribution.fill(worlds, [shop_locations, song_locations, fill_locations], [shopitempool, dungeon_items, songitempool, progitempool, prioitempool, restitempool])
     itempool = progitempool + prioitempool + restitempool
 
     # set ice traps to have the appearance of other random items in the item pool
@@ -121,10 +118,10 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # set of locations that they can be placed in, so placing them first will
     # reduce the odds of creating unbeatable seeds. This also avoids needing
     # to create item rules for every location for whether they are a shop item
-    # or not. This shouldn't have much affect on item bias.
+    # or not. This shouldn't have much effect on item bias.
     if shop_locations:
         logger.info('Placing shop items.')
-        fill_ownworld_restrictive(window, worlds, search, shop_locations, shopitempool, itempool + songitempool + dungeon_items, "shop")
+        fill_ownworld_restrictive(worlds, search, shop_locations, shopitempool, itempool + songitempool + dungeon_items, "shop")
     # Update the shop item access rules
     for world in worlds:
         set_shop_rules(world)
@@ -137,7 +134,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # placement, but will leave as is for now
     if dungeon_items:
         logger.info('Placing dungeon items.')
-        fill_dungeons_restrictive(window, worlds, search, fill_locations, dungeon_items, itempool + songitempool)
+        fill_dungeons_restrictive(worlds, search, fill_locations, dungeon_items, itempool + songitempool)
         search.collect_locations()
 
 
@@ -159,12 +156,12 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
                     restdungeon.append(item)
                 else:
                     restother.append(item)
-            fast_fill(window, empty_locations, restother)
+            fast_fill(empty_locations, restother)
             restitempool = restdungeon + restother
             random.shuffle(restitempool)
         else:
             # We don't have to worry about this if dungeon items stay in their own dungeons
-            fast_fill(window, empty_locations, restitempool)
+            fast_fill(empty_locations, restitempool)
 
 
     # places the songs into the world
@@ -175,7 +172,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # the song locations only.
     if worlds[0].settings.shuffle_song_items != 'any':
         logger.info('Placing song items.')
-        fill_ownworld_restrictive(window, worlds, search, song_locations, songitempool, progitempool, "song")
+        fill_ownworld_restrictive(worlds, search, song_locations, songitempool, progitempool, "song")
         search.collect_locations()
         fill_locations += [location for location in song_locations if location.item is None]
 
@@ -183,14 +180,14 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # placed to ensure there is a spot available for them
     if worlds[0].settings.one_item_per_dungeon:
         logger.info('Placing one major item per dungeon.')
-        fill_dungeon_unique_item(window, worlds, search, fill_locations, progitempool)
+        fill_dungeon_unique_item(worlds, search, fill_locations, progitempool)
         search.collect_locations()
 
     # Place all progression items. This will include keys in keysanity.
     # Items in this group will check for reachability and will be placed
     # such that the game is guaranteed beatable.
     logger.info('Placing progression items.')
-    fill_restrictive(window, worlds, search, fill_locations, progitempool)
+    fill_restrictive(worlds, search, fill_locations, progitempool)
     search.collect_locations()
 
     # Place all priority items.
@@ -198,13 +195,13 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
     # placed in the location, not checking reachability. This is important
     # for things like Ice Traps that can't be found at some locations
     logger.info('Placing priority items.')
-    fill_restrictive_fast(window, worlds, fill_locations, prioitempool)
+    fill_restrictive_fast(worlds, fill_locations, prioitempool)
 
     # Place the rest of the items.
     # No restrictions at all. Places them completely randomly. Since they
     # cannot affect the beatability, we don't need to check them
     logger.info('Placing the rest of the items.')
-    fast_fill(window, fill_locations, restitempool)
+    fast_fill(fill_locations, restitempool)
 
     # Log unplaced item/location warnings
     for item in progitempool + prioitempool + restitempool:
@@ -237,7 +234,7 @@ def distribute_items_restrictive(window, worlds, fill_locations=None):
 
 # Places restricted dungeon items into the worlds. To ensure there is room for them.
 # they are placed first so it will assume all other items are reachable
-def fill_dungeons_restrictive(window, worlds, search, shuffled_locations, dungeon_items, itempool):
+def fill_dungeons_restrictive(worlds, search, shuffled_locations, dungeon_items, itempool):
     # List of states with all non-key items
     base_search = search.copy()
     base_search.collect_all(itempool)
@@ -253,13 +250,13 @@ def fill_dungeons_restrictive(window, worlds, search, shuffled_locations, dungeo
     dungeon_items.sort(key=lambda item: sort_order.get(item.type, 1))
 
     # place dungeon items
-    fill_restrictive(window, worlds, base_search, shuffled_locations, dungeon_items)
+    fill_restrictive(worlds, base_search, shuffled_locations, dungeon_items)
 
 
 # Places items into dungeon locations. This is used when there should be exactly
 # one progression item per dungeon. This should be ran before all the progression
 # items are places to ensure there is space to place them.
-def fill_dungeon_unique_item(window, worlds, search, fill_locations, itempool):
+def fill_dungeon_unique_item(worlds, search, fill_locations, itempool):
     # We should make sure that we don't count event items, shop items,
     # token items, or dungeon items as a major item. itempool at this
     # point should only be able to have tokens of those restrictions
@@ -310,7 +307,7 @@ def fill_dungeon_unique_item(window, worlds, search, fill_locations, itempool):
                 major_items.append(item)
 
         # place 1 item into the dungeon
-        fill_restrictive(window, worlds, base_search, dungeon_locations, major_items, 1)
+        fill_restrictive(worlds, base_search, dungeon_locations, major_items, 1)
 
         # update the location and item pool, removing any placed items and filled locations
         # the fact that you can remove items from a list you're iterating over is python magic
@@ -333,7 +330,7 @@ def fill_dungeon_unique_item(window, worlds, search, fill_locations, itempool):
 
 
 # Places items restricting placement to the recipient player's own world
-def fill_ownworld_restrictive(window, worlds, search, locations, ownpool, itempool, description="Unknown", attempts=15):
+def fill_ownworld_restrictive(worlds, search, locations, ownpool, itempool, description="Unknown", attempts=15):
     # get the locations for each world
 
     # look for preplaced items
@@ -360,7 +357,7 @@ def fill_ownworld_restrictive(window, worlds, search, locations, ownpool, itempo
                 prizepool = list(prizepool_dict[world.id])
                 prize_locs = list(prize_locs_dict[world.id])
                 random.shuffle(prizepool)
-                fill_restrictive(window, worlds, base_search, prize_locs, prizepool)
+                fill_restrictive(worlds, base_search, prize_locs, prizepool)
 
                 logger.info("Placed %s items for world %s.", description, (world.id+1))
             except FillError as e:
@@ -375,7 +372,6 @@ def fill_ownworld_restrictive(window, worlds, search, locations, ownpool, itempo
             break
         else:
             raise FillError('Unable to place %s items in world %d' % (description, (world.id+1)))
-
 
 
 # Places items in the itempool into locations.
@@ -394,7 +390,7 @@ def fill_ownworld_restrictive(window, worlds, search, locations, ownpool, itempo
 # This function will modify the location and itempool arguments. placed items and
 # filled locations will be removed. If this returns and error, then the state of
 # those two lists cannot be guaranteed.
-def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1):
+def fill_restrictive(worlds, base_search, locations, itempool, count=-1):
     unplaced_items = []
 
     # don't run over this search, just keep it as an item collection
@@ -493,8 +489,6 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
         # Place the item in the world and continue
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)
         locations.remove(spot_to_fill)
-        window.fillcount += 1
-        window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))
 
         # decrement count
         count -= 1
@@ -511,7 +505,7 @@ def fill_restrictive(window, worlds, base_search, locations, itempool, count=-1)
 # This places items in the itempool into the locations
 # It does not check for reachability, only that the item is
 # allowed in the location
-def fill_restrictive_fast(window, worlds, locations, itempool):
+def fill_restrictive_fast(worlds, locations, itempool):
     while itempool and locations:
         item_to_place = itempool.pop()
         random.shuffle(locations)
@@ -534,18 +528,14 @@ def fill_restrictive_fast(window, worlds, locations, itempool):
         # Place the item in the world and continue
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)
         locations.remove(spot_to_fill)
-        window.fillcount += 1
-        window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))
 
 
 # this places item in item_pool completely randomly into
 # fill_locations. There is no checks for validity since
 # there should be none for these remaining items
-def fast_fill(window, locations, itempool):
+def fast_fill(locations, itempool):
     random.shuffle(locations)
     while itempool and locations:
         spot_to_fill = locations.pop()
         item_to_place = itempool.pop()
         spot_to_fill.world.push_item(spot_to_fill, item_to_place)
-        window.fillcount += 1
-        window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))

--- a/Goals.py
+++ b/Goals.py
@@ -37,7 +37,7 @@ validColors: list[str] = [
 
 class Goal:
     def __init__(self, world: World, name: str, hint_text: str | dict[str, str], color: str, items: Optional[list[dict[str, Any]]] = None,
-                 locations=None, lock_locations=None, lock_entrances: list[str] = None, required_locations=None, create_empty: bool = False) -> None:
+                 locations=None, lock_locations=None, lock_entrances: Optional[list[str]] = None, required_locations=None, create_empty: bool = False) -> None:
         # early exit if goal initialized incorrectly
         if not items and not locations and not create_empty:
             raise Exception('Invalid goal: no items or destinations set')
@@ -51,7 +51,7 @@ class Goal:
         self.items: list[GoalItem] = items or []
         self.locations = locations  # Unused?
         self.lock_locations = lock_locations  # Unused?
-        self.lock_entrances: list[str] = lock_entrances
+        self.lock_entrances: list[str] = lock_entrances or []
         self.required_locations: list[tuple[Location, int, int, list[int]]] = required_locations or []
         self.weight: int = 0
         self.category: Optional[GoalCategory] = None

--- a/Gui.py
+++ b/Gui.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
-if sys.version_info < (3, 7, 0):
-    print("OoT Randomizer requires Python version 3.7 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
+if sys.version_info < (3, 8):
+    print("OoT Randomizer requires Python version 3.8 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
     # raw_input was renamed to input in 3.0, handle both 2.x and 3.x by trying the rename for 2.x
     try:
         input = raw_input

--- a/Gui.py
+++ b/Gui.py
@@ -14,7 +14,7 @@ import subprocess
 import shutil
 import webbrowser
 from Utils import local_path, data_path, compare_version, VersionError
-from SettingsToJson import CreateJSON
+from SettingsToJson import create_settings_list_json
 
 
 def gui_main():
@@ -28,7 +28,7 @@ def gui_main():
 
     web_version = '--web' in sys.argv
     if '--skip-settingslist' not in sys.argv:
-        CreateJSON(data_path('generated/settings_list.json'), web_version)
+        create_settings_list_json(data_path('generated/settings_list.json'), web_version)
 
     if web_version:
         args = ["node", "run.js", "web"]

--- a/Gui.py
+++ b/Gui.py
@@ -10,14 +10,15 @@ if sys.version_info < (3, 6, 0):
     input("Press enter to exit...")
     sys.exit(1)
 
-import subprocess
 import shutil
+import subprocess
 import webbrowser
-from Utils import local_path, data_path, compare_version, VersionError
+
 from SettingsToJson import create_settings_list_json
+from Utils import local_path, data_path, compare_version, VersionError
 
 
-def gui_main():
+def gui_main() -> None:
     try:
         version_check("Node", "14.15.0", "https://nodejs.org/en/download/")
         version_check("NPM", "6.12.0", "https://nodejs.org/en/download/")
@@ -37,18 +38,18 @@ def gui_main():
     subprocess.run(args, shell=False, cwd=local_path("GUI"), check=True)
 
 
-def version_check(name, version, URL):
+def version_check(name: str, version: str, url: str) -> None:
     try:
         process = subprocess.Popen([shutil.which(name.lower()), "--version"], stdout=subprocess.PIPE)
     except Exception as ex:
-        raise VersionError('{name} is not installed. Please install {name} {version} or later'.format(name=name, version=version), URL)
+        raise VersionError('{name} is not installed. Please install {name} {version} or later'.format(name=name, version=version), url)
 
     while True:
         line = str(process.stdout.readline().strip(), 'UTF-8')
         if line == '':
             break
         if compare_version(line, version) < 0:
-            raise VersionError('{name} {version} or later is required but you are using {line}'.format(name=name, version=version, line=line), URL)
+            raise VersionError('{name} {version} or later is required but you are using {line}'.format(name=name, version=version, line=line), url)
         print('Using {name} {line}'.format(name=name, line=line))
 
 

--- a/Gui.py
+++ b/Gui.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
-if sys.version_info < (3, 6, 0):
-    print("OoT Randomizer requires Python version 3.6 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
+if sys.version_info < (3, 7, 0):
+    print("OoT Randomizer requires Python version 3.7 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
     # raw_input was renamed to input in 3.0, handle both 2.x and 3.x by trying the rename for 2.x
     try:
         input = raw_input

--- a/Gui.py
+++ b/Gui.py
@@ -1,28 +1,23 @@
 #!/usr/bin/env python3
-import os
 import sys
-
-min_python_version = [3,6,0]
-for i,v in enumerate(min_python_version):
-    if sys.version_info[i] < v:
-        print("Randomizer requires at least version 3.6 and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
-        # raw_input was renamed to input in 3.0, handle both 2.x and 3.x by trying the rename for 2.x
-        try:
-            input = raw_input
-        except NameError:
-            pass
-        input("Press enter to exit...")
-        sys.exit(1)
-    if sys.version_info[i] > v:
-        break
+if sys.version_info < (3, 6, 0):
+    print("OoT Randomizer requires Python version 3.6 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
+    # raw_input was renamed to input in 3.0, handle both 2.x and 3.x by trying the rename for 2.x
+    try:
+        input = raw_input
+    except NameError:
+        pass
+    input("Press enter to exit...")
+    sys.exit(1)
 
 import subprocess
 import shutil
 import webbrowser
-from Utils import local_path, data_path, check_python_version, compare_version, VersionError
+from Utils import local_path, data_path, compare_version, VersionError
 from SettingsToJson import CreateJSON
 
-def guiMain():
+
+def gui_main():
     try:
         version_check("Node", "14.15.0", "https://nodejs.org/en/download/")
         version_check("NPM", "6.12.0", "https://nodejs.org/en/download/")
@@ -39,7 +34,8 @@ def guiMain():
         args = ["node", "run.js", "web"]
     else:
         args = ["node", "run.js", "release", "python", sys.executable]
-    subprocess.run(args,shell=False,cwd=local_path("GUI"),check=True)
+    subprocess.run(args, shell=False, cwd=local_path("GUI"), check=True)
+
 
 def version_check(name, version, URL):
     try:
@@ -55,5 +51,6 @@ def version_check(name, version, URL):
             raise VersionError('{name} {version} or later is required but you are using {line}'.format(name=name, version=version, line=line), URL)
         print('Using {name} {line}'.format(name=name, line=line))
 
+
 if __name__ == '__main__':
-    guiMain()
+    gui_main()

--- a/HintList.py
+++ b/HintList.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 class Hint:
-    def __init__(self, name: str, text: Union[str, List[str]], hint_type: Union[str, List[str]], choice: int = None) -> None:
+    def __init__(self, name: str, text: Union[str, List[str]], hint_type: Union[str, List[str]], choice: Optional[int] = None) -> None:
         self.name: str = name
         self.type: List[str] = [hint_type] if not isinstance(hint_type, list) else hint_type
 
@@ -290,7 +290,7 @@ conditional_sometimes: "Dict[str, Callable[[World], bool]]" = {
 #   \u00A9      Down arrow
 #   \u00AA      Joystick
 
-hintTable: Dict[str, Tuple[List[str], Optional[str], Union[str, List[str]]]] = {
+hintTable: Dict[str, Tuple[Union[List[str], str], Optional[str], Union[str, List[str]]]] = {
     'Kokiri Emerald':                                           (["a tree's farewell", "the Spiritual Stone of the Forest"], "the Kokiri Emerald", 'item'),
     'Goron Ruby':                                               (["the Gorons' hidden treasure", "the Spiritual Stone of Fire"], "the Goron Ruby", 'item'),
     'Zora Sapphire':                                            (["an engagement ring", "the Spiritual Stone of Water"], "the Zora Sapphire", 'item'),

--- a/HintList.py
+++ b/HintList.py
@@ -20,11 +20,8 @@ import random
 #       ZF      Zora's Fountain
 #       ZR      Zora's River
 
-class Hint(object):
-    name = ""
-    text = ""
-    type = []
 
+class Hint(object):
     def __init__(self, name, text, type, choice=None):
         self.name = name
         self.type = [type] if not isinstance(type, list) else type
@@ -37,13 +34,12 @@ class Hint(object):
             else:
                 self.text = text[choice]
 
-class Multi(object):
-    name = ""
-    locations = []
 
+class Multi(object):
     def __init__(self, name, locations):
         self.name = name
         self.locations = locations
+
 
 def getHint(name, clearer_hint=False):
     textOptions, clearText, type = hintTable[name]
@@ -54,9 +50,11 @@ def getHint(name, clearer_hint=False):
     else:
         return Hint(name, textOptions, type)
 
+
 def getMulti(name):
     locations = multiTable[name]
     return Multi(name, locations)
+
 
 def getHintGroup(group, world):
     ret = []
@@ -122,6 +120,7 @@ def getRequiredHints(world):
             ret.append(hint)
     return ret
 
+
 # Get the multi hints containing the list of locations for a possible hint upgrade.
 def getUpgradeHintList(world, locations):
     ret = []
@@ -154,6 +153,7 @@ def getUpgradeHintList(world, locations):
                 if accepted_type:
                     ret.append(hint)
     return ret
+
 
 # Helpers for conditional always hints
 def stones_required_by_settings(world):

--- a/HintList.py
+++ b/HintList.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 import random
-from typing import TYPE_CHECKING, Union, List, Dict, Callable, Tuple, Optional, Any, Collection
+from collections.abc import Callable, Collection
+from typing import TYPE_CHECKING, Optional, Any
 
 if TYPE_CHECKING:
     from World import World
@@ -26,9 +28,9 @@ if TYPE_CHECKING:
 
 
 class Hint:
-    def __init__(self, name: str, text: Union[str, List[str]], hint_type: Union[str, List[str]], choice: Optional[int] = None) -> None:
+    def __init__(self, name: str, text: str | list[str], hint_type: str | list[str], choice: Optional[int] = None) -> None:
         self.name: str = name
-        self.type: List[str] = [hint_type] if not isinstance(hint_type, list) else hint_type
+        self.type: list[str] = [hint_type] if not isinstance(hint_type, list) else hint_type
 
         self.text: str
         if isinstance(text, str):
@@ -41,9 +43,9 @@ class Hint:
 
 
 class Multi:
-    def __init__(self, name: str, locations: List[str]) -> None:
+    def __init__(self, name: str, locations: list[str]) -> None:
         self.name: str = name
-        self.locations: List[str] = locations
+        self.locations: list[str] = locations
 
 
 def get_hint(name: str, clearer_hint: bool = False) -> Hint:
@@ -61,7 +63,7 @@ def get_multi(name: str) -> Multi:
     return Multi(name, locations)
 
 
-def get_hint_group(group: str, world: "World") -> List[Hint]:
+def get_hint_group(group: str, world: World) -> list[Hint]:
     ret = []
     for name in hintTable:
 
@@ -117,7 +119,7 @@ def get_hint_group(group: str, world: "World") -> List[Hint]:
     return ret
 
 
-def get_required_hints(world: "World") -> List[Hint]:
+def get_required_hints(world: World) -> list[Hint]:
     ret = []
     for name in hintTable:
         hint = get_hint(name)
@@ -127,7 +129,7 @@ def get_required_hints(world: "World") -> List[Hint]:
 
 
 # Get the multi hints containing the list of locations for a possible hint upgrade.
-def get_upgrade_hint_list(world: "World", locations: List[str]) -> List[Hint]:
+def get_upgrade_hint_list(world: World, locations: list[str]) -> list[Hint]:
     ret = []
     for name in multiTable:
         if name not in hint_exclusions(world):
@@ -162,7 +164,7 @@ def get_upgrade_hint_list(world: "World", locations: List[str]) -> List[Hint]:
 
 # Helpers for conditional always hints
 # TODO: Make these properties of World or Settings.
-def stones_required_by_settings(world: "World") -> int:
+def stones_required_by_settings(world: World) -> int:
     stones = 0
     if world.settings.bridge == 'stones' and not world.shuffle_special_dungeon_entrances:
         stones = max(stones, world.settings.bridge_stones)
@@ -180,7 +182,7 @@ def stones_required_by_settings(world: "World") -> int:
     return stones
 
 
-def medallions_required_by_settings(world: "World") -> int:
+def medallions_required_by_settings(world: World) -> int:
     medallions = 0
     if world.settings.bridge == 'medallions' and not world.shuffle_special_dungeon_entrances:
         medallions = max(medallions, world.settings.bridge_medallions)
@@ -198,7 +200,7 @@ def medallions_required_by_settings(world: "World") -> int:
     return medallions
 
 
-def tokens_required_by_settings(world: "World") -> int:
+def tokens_required_by_settings(world: World) -> int:
     tokens = 0
     if world.settings.bridge == 'tokens' and not world.shuffle_special_dungeon_entrances:
         tokens = max(tokens, world.settings.bridge_tokens)
@@ -211,7 +213,7 @@ def tokens_required_by_settings(world: "World") -> int:
 
 
 # Hints required under certain settings
-conditional_always: "Dict[str, Callable[[World], bool]]" = {
+conditional_always: dict[str, Callable[[World], bool]] = {
     'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3,
     'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest,
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
@@ -226,7 +228,7 @@ conditional_always: "Dict[str, Callable[[World], bool]]" = {
 }
 
 # Entrance hints required under certain settings
-conditional_entrance_always: "Dict[str, Callable[[World], bool]]" = {
+conditional_entrance_always: dict[str, Callable[[World], bool]] = {
     'Ganons Castle Grounds -> Ganons Castle Lobby': lambda world: (world.settings.bridge != 'open'
         and (world.settings.bridge != 'stones' or world.settings.bridge_stones > 1)
         and (world.settings.bridge != 'medallions' or world.settings.bridge_medallions > 1)
@@ -236,14 +238,14 @@ conditional_entrance_always: "Dict[str, Callable[[World], bool]]" = {
 }
 
 # Dual hints required under certain settings
-conditional_dual_always: "Dict[str, Callable[[World], bool]]" = {
+conditional_dual_always: dict[str, Callable[[World], bool]] = {
     'HF Ocarina of Time Retrieval': lambda world: stones_required_by_settings(world) < 2,
     'Deku Theater Rewards':         lambda world: not world.settings.complete_mask_quest,
     'ZR Frogs Rewards':             lambda world: not world.settings.shuffle_frog_song_rupees and 'frogs2' not in world.settings.misc_hints,
 }
 
 # Some sometimes, dual, and entrance hints should only be enabled under certain settings
-conditional_sometimes: "Dict[str, Callable[[World], bool]]" = {
+conditional_sometimes: dict[str, Callable[[World], bool]] = {
     # Conditional sometimes hints
     'HC Great Fairy Reward':                    lambda world: world.settings.shuffle_interior_entrances == 'off',
     'OGC Great Fairy Reward':                   lambda world: world.settings.shuffle_interior_entrances == 'off',
@@ -290,7 +292,7 @@ conditional_sometimes: "Dict[str, Callable[[World], bool]]" = {
 #   \u00A9      Down arrow
 #   \u00AA      Joystick
 
-hintTable: Dict[str, Tuple[Union[List[str], str], Optional[str], Union[str, List[str]]]] = {
+hintTable: dict[str, tuple[list[str] | str, Optional[str], str | list[str]]] = {
     'Kokiri Emerald':                                           (["a tree's farewell", "the Spiritual Stone of the Forest"], "the Kokiri Emerald", 'item'),
     'Goron Ruby':                                               (["the Gorons' hidden treasure", "the Spiritual Stone of Fire"], "the Goron Ruby", 'item'),
     'Zora Sapphire':                                            (["an engagement ring", "the Spiritual Stone of Water"], "the Zora Sapphire", 'item'),
@@ -1723,7 +1725,7 @@ hintTable: Dict[str, Tuple[Union[List[str], str], Optional[str], Union[str, List
 
 # Table containing the groups of locations for the multi hints (dual, etc.)
 # The is used in order to add the locations to the checked list
-multiTable: Dict[str, List[str]] = {
+multiTable: dict[str, list[str]] = {
     'Deku Theater Rewards':                                     ['Deku Theater Skull Mask', 'Deku Theater Mask of Truth'],
     'HF Ocarina of Time Retrieval':                             ['HF Ocarina of Time Item', 'Song from Ocarina of Time'],
     'HF Valley Grotto':                                         ['HF Cow Grotto Cow', 'HF GS Cow Grotto'],
@@ -1772,7 +1774,7 @@ multiTable: Dict[str, List[str]] = {
 }
 
 # TODO: Make these a type of some sort instead of a dict.
-misc_item_hint_table: Dict[str, Dict[str, Any]] = {
+misc_item_hint_table: dict[str, dict[str, Any]] = {
     'dampe_diary': {
         'id': 0x5003,
         'hint_location': 'Dampe Diary Hint',
@@ -1801,7 +1803,7 @@ misc_item_hint_table: Dict[str, Dict[str, Any]] = {
     },
 }
 
-misc_location_hint_table: Dict[str, Dict[str, Any]] = {
+misc_location_hint_table: dict[str, dict[str, Any]] = {
     '10_skulltulas': {
         'id': 0x9004,
         'hint_location': '10 Skulltulas Reward Hint',
@@ -1849,7 +1851,7 @@ misc_location_hint_table: Dict[str, Dict[str, Any]] = {
 # Separate table for goal names to avoid duplicates in the hint table.
 # Link's Pocket will always be an empty goal, but it's included here to
 # prevent key errors during the dungeon reward lookup.
-goalTable: Dict[str, Tuple[str, str, str]] = {
+goalTable: dict[str, tuple[str, str, str]] = {
     'Queen Gohma':                                              ("path to the #Spider#", "path to #Queen Gohma#", "Green"),
     'King Dodongo':                                             ("path to the #Dinosaur#", "path to #King Dodongo#", "Red"),
     'Barinade':                                                 ("path to the #Tentacle#", "path to #Barinade#", "Blue"),
@@ -1863,8 +1865,8 @@ goalTable: Dict[str, Tuple[str, str, str]] = {
 
 
 # This specifies which hints will never appear due to either having known or known useless contents or due to the locations not existing.
-def hint_exclusions(world: "World", clear_cache: bool = False) -> List[str]:
-    exclusions: Dict[int, List[str]] = hint_exclusions.exclusions
+def hint_exclusions(world: World, clear_cache: bool = False) -> list[str]:
+    exclusions: dict[int, list[str]] = hint_exclusions.exclusions
 
     if not clear_cache and world.id in exclusions:
         return exclusions[world.id]
@@ -1913,7 +1915,7 @@ def hint_exclusions(world: "World", clear_cache: bool = False) -> List[str]:
 hint_exclusions.exclusions = {}
 
 
-def name_is_location(name: str, hint_type: Union[str, Collection[str]], world: "World") -> bool:
+def name_is_location(name: str, hint_type: str | Collection[str], world: World) -> bool:
     if isinstance(hint_type, (list, tuple)):
         for htype in hint_type:
             if htype in ['sometimes', 'song', 'overworld', 'dungeon', 'always', 'exclude'] and name not in hint_exclusions(

--- a/HintList.py
+++ b/HintList.py
@@ -1,4 +1,8 @@
 import random
+from typing import TYPE_CHECKING, Union, List, Dict, Callable, Tuple, Optional, Any, Collection
+
+if TYPE_CHECKING:
+    from World import World
 
 #   Abbreviations
 #       DMC     Death Mountain Crater
@@ -21,46 +25,47 @@ import random
 #       ZR      Zora's River
 
 
-class Hint(object):
-    def __init__(self, name, text, type, choice=None):
-        self.name = name
-        self.type = [type] if not isinstance(type, list) else type
+class Hint:
+    def __init__(self, name: str, text: Union[str, List[str]], hint_type: Union[str, List[str]], choice: int = None) -> None:
+        self.name: str = name
+        self.type: List[str] = [hint_type] if not isinstance(hint_type, list) else hint_type
 
+        self.text: str
         if isinstance(text, str):
             self.text = text
         else:
-            if choice == None:
+            if choice is None:
                 self.text = random.choice(text)
             else:
                 self.text = text[choice]
 
 
-class Multi(object):
-    def __init__(self, name, locations):
-        self.name = name
-        self.locations = locations
+class Multi:
+    def __init__(self, name: str, locations: List[str]) -> None:
+        self.name: str = name
+        self.locations: List[str] = locations
 
 
-def getHint(name, clearer_hint=False):
-    textOptions, clearText, type = hintTable[name]
+def get_hint(name: str, clearer_hint: bool = False) -> Hint:
+    text_options, clear_text, hint_type = hintTable[name]
     if clearer_hint:
-        if clearText == None:
-            return Hint(name, textOptions, type, 0)
-        return Hint(name, clearText, type)
+        if clear_text is None:
+            return Hint(name, text_options, hint_type, 0)
+        return Hint(name, clear_text, hint_type)
     else:
-        return Hint(name, textOptions, type)
+        return Hint(name, text_options, hint_type)
 
 
-def getMulti(name):
+def get_multi(name: str) -> Multi:
     locations = multiTable[name]
     return Multi(name, locations)
 
 
-def getHintGroup(group, world):
+def get_hint_group(group: str, world: "World") -> List[Hint]:
     ret = []
     for name in hintTable:
 
-        hint = getHint(name, world.settings.clearer_hints)
+        hint = get_hint(name, world.settings.clearer_hints)
 
         if hint.name in world.always_hints and group == 'always':
             hint.type = 'always'
@@ -81,7 +86,7 @@ def getHintGroup(group, world):
             if hint.name in world.added_hint_types[group]:
                 hint.type = group
                 type_append = True
-            if nameIsLocation(name, hint.type, world):
+            if name_is_location(name, hint.type, world):
                 location = world.get_location(name)
                 for i in world.item_added_hint_types[group]:
                     if i == location.item.name:
@@ -95,39 +100,39 @@ def getHintGroup(group, world):
             if name in world.hint_type_overrides[group]:
                 type_override = True
         if group in world.item_hint_type_overrides:
-            if nameIsLocation(name, hint.type, world):
+            if name_is_location(name, hint.type, world):
                 location = world.get_location(name)
                 if location.item.name in world.item_hint_type_overrides[group]:
                     type_override = True
             elif name in multiTable.keys():
-                multi = getMulti(name)
+                multi = get_multi(name)
                 for locationName in multi.locations:
-                    if locationName not in hintExclusions(world):
+                    if locationName not in hint_exclusions(world):
                         location = world.get_location(locationName)
                         if location.item.name in world.item_hint_type_overrides[group]:
                             type_override = True
 
-        if group in hint.type and (name not in hintExclusions(world)) and not type_override and (conditional_keep or type_append):
+        if group in hint.type and (name not in hint_exclusions(world)) and not type_override and (conditional_keep or type_append):
             ret.append(hint)
     return ret
 
 
-def getRequiredHints(world):
+def get_required_hints(world: "World") -> List[Hint]:
     ret = []
     for name in hintTable:
-        hint = getHint(name)
+        hint = get_hint(name)
         if 'always' in hint.type or hint.name in conditional_always and conditional_always[hint.name](world):
             ret.append(hint)
     return ret
 
 
 # Get the multi hints containing the list of locations for a possible hint upgrade.
-def getUpgradeHintList(world, locations):
+def get_upgrade_hint_list(world: "World", locations: List[str]) -> List[Hint]:
     ret = []
     for name in multiTable:
-        if name not in hintExclusions(world):
-            hint = getHint(name, world.settings.clearer_hints)
-            multi = getMulti(name)
+        if name not in hint_exclusions(world):
+            hint = get_hint(name, world.settings.clearer_hints)
+            multi = get_multi(name)
 
             if len(locations) < len(multi.locations) and all(location in multi.locations for location in locations) and (hint.name not in conditional_sometimes.keys() or conditional_sometimes[hint.name](world)):
                 accepted_type = False
@@ -139,7 +144,7 @@ def getUpgradeHintList(world, locations):
                             type_override = True
                     if hint_type in world.item_hint_type_overrides:
                         for locationName in multi.locations:
-                            if locationName not in hintExclusions(world):
+                            if locationName not in hint_exclusions(world):
                                 location = world.get_location(locationName)
                                 if location.item.name in world.item_hint_type_overrides[hint_type]:
                                     type_override = True
@@ -156,7 +161,8 @@ def getUpgradeHintList(world, locations):
 
 
 # Helpers for conditional always hints
-def stones_required_by_settings(world):
+# TODO: Make these properties of World or Settings.
+def stones_required_by_settings(world: "World") -> int:
     stones = 0
     if world.settings.bridge == 'stones' and not world.shuffle_special_dungeon_entrances:
         stones = max(stones, world.settings.bridge_stones)
@@ -174,7 +180,7 @@ def stones_required_by_settings(world):
     return stones
 
 
-def medallions_required_by_settings(world):
+def medallions_required_by_settings(world: "World") -> int:
     medallions = 0
     if world.settings.bridge == 'medallions' and not world.shuffle_special_dungeon_entrances:
         medallions = max(medallions, world.settings.bridge_medallions)
@@ -192,7 +198,7 @@ def medallions_required_by_settings(world):
     return medallions
 
 
-def tokens_required_by_settings(world):
+def tokens_required_by_settings(world: "World") -> int:
     tokens = 0
     if world.settings.bridge == 'tokens' and not world.shuffle_special_dungeon_entrances:
         tokens = max(tokens, world.settings.bridge_tokens)
@@ -205,7 +211,7 @@ def tokens_required_by_settings(world):
 
 
 # Hints required under certain settings
-conditional_always = {
+conditional_always: "Dict[str, Callable[[World], bool]]" = {
     'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3,
     'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest,
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
@@ -220,7 +226,7 @@ conditional_always = {
 }
 
 # Entrance hints required under certain settings
-conditional_entrance_always = {
+conditional_entrance_always: "Dict[str, Callable[[World], bool]]" = {
     'Ganons Castle Grounds -> Ganons Castle Lobby': lambda world: (world.settings.bridge != 'open'
         and (world.settings.bridge != 'stones' or world.settings.bridge_stones > 1)
         and (world.settings.bridge != 'medallions' or world.settings.bridge_medallions > 1)
@@ -230,14 +236,14 @@ conditional_entrance_always = {
 }
 
 # Dual hints required under certain settings
-conditional_dual_always = {
+conditional_dual_always: "Dict[str, Callable[[World], bool]]" = {
     'HF Ocarina of Time Retrieval': lambda world: stones_required_by_settings(world) < 2,
     'Deku Theater Rewards':         lambda world: not world.settings.complete_mask_quest,
     'ZR Frogs Rewards':             lambda world: not world.settings.shuffle_frog_song_rupees and 'frogs2' not in world.settings.misc_hints,
 }
 
 # Some sometimes, dual, and entrance hints should only be enabled under certain settings
-conditional_sometimes = {
+conditional_sometimes: "Dict[str, Callable[[World], bool]]" = {
     # Conditional sometimes hints
     'HC Great Fairy Reward':                    lambda world: world.settings.shuffle_interior_entrances == 'off',
     'OGC Great Fairy Reward':                   lambda world: world.settings.shuffle_interior_entrances == 'off',
@@ -284,7 +290,7 @@ conditional_sometimes = {
 #   \u00A9      Down arrow
 #   \u00AA      Joystick
 
-hintTable = {
+hintTable: Dict[str, Tuple[List[str], Optional[str], Union[str, List[str]]]] = {
     'Kokiri Emerald':                                           (["a tree's farewell", "the Spiritual Stone of the Forest"], "the Kokiri Emerald", 'item'),
     'Goron Ruby':                                               (["the Gorons' hidden treasure", "the Spiritual Stone of Fire"], "the Goron Ruby", 'item'),
     'Zora Sapphire':                                            (["an engagement ring", "the Spiritual Stone of Water"], "the Zora Sapphire", 'item'),
@@ -1429,7 +1435,7 @@ hintTable = {
     'ZD Storms Grotto':                                         ("a small #Fairy Fountain#", None, 'region'),
     'GF Storms Grotto':                                         ("a small #Fairy Fountain#", None, 'region'),
 
-    # Junk hints must satisfy all of the following conditions:
+    # Junk hints must satisfy all the following conditions:
     # - They aren't inappropriate.
     # - They aren't absurdly long copy pastas.
     # - They aren't quotes or references that are simply not funny when out-of-context.
@@ -1717,7 +1723,7 @@ hintTable = {
 
 # Table containing the groups of locations for the multi hints (dual, etc.)
 # The is used in order to add the locations to the checked list
-multiTable = {
+multiTable: Dict[str, List[str]] = {
     'Deku Theater Rewards':                                     ['Deku Theater Skull Mask', 'Deku Theater Mask of Truth'],
     'HF Ocarina of Time Retrieval':                             ['HF Ocarina of Time Item', 'Song from Ocarina of Time'],
     'HF Valley Grotto':                                         ['HF Cow Grotto Cow', 'HF GS Cow Grotto'],
@@ -1765,7 +1771,8 @@ multiTable = {
     'Ganons Castle Spirit Trial Chests':                        ['Ganons Castle Spirit Trial Crystal Switch Chest', 'Ganons Castle Spirit Trial Invisible Chest'],
 }
 
-misc_item_hint_table = {
+# TODO: Make these a type of some sort instead of a dict.
+misc_item_hint_table: Dict[str, Dict[str, Any]] = {
     'dampe_diary': {
         'id': 0x5003,
         'hint_location': 'Dampe Diary Hint',
@@ -1794,7 +1801,7 @@ misc_item_hint_table = {
     },
 }
 
-misc_location_hint_table = {
+misc_location_hint_table: Dict[str, Dict[str, Any]] = {
     '10_skulltulas': {
         'id': 0x9004,
         'hint_location': '10 Skulltulas Reward Hint',
@@ -1842,7 +1849,7 @@ misc_location_hint_table = {
 # Separate table for goal names to avoid duplicates in the hint table.
 # Link's Pocket will always be an empty goal, but it's included here to
 # prevent key errors during the dungeon reward lookup.
-goalTable = {
+goalTable: Dict[str, Tuple[str, str, str]] = {
     'Queen Gohma':                                              ("path to the #Spider#", "path to #Queen Gohma#", "Green"),
     'King Dodongo':                                             ("path to the #Dinosaur#", "path to #King Dodongo#", "Red"),
     'Barinade':                                                 ("path to the #Tentacle#", "path to #Barinade#", "Blue"),
@@ -1856,23 +1863,25 @@ goalTable = {
 
 
 # This specifies which hints will never appear due to either having known or known useless contents or due to the locations not existing.
-def hintExclusions(world, clear_cache=False):
-    if not clear_cache and world.id in hintExclusions.exclusions:
-        return hintExclusions.exclusions[world.id]
+def hint_exclusions(world: "World", clear_cache: bool = False) -> List[str]:
+    exclusions: Dict[int, List[str]] = hint_exclusions.exclusions
 
-    hintExclusions.exclusions[world.id] = []
-    hintExclusions.exclusions[world.id].extend(world.settings.disabled_locations)
+    if not clear_cache and world.id in exclusions:
+        return exclusions[world.id]
+
+    exclusions[world.id] = []
+    exclusions[world.id].extend(world.settings.disabled_locations)
 
     for location in world.get_locations():
         if location.locked:
-            hintExclusions.exclusions[world.id].append(location.name)
+            exclusions[world.id].append(location.name)
 
     world_location_names = [
         location.name for location in world.get_locations()]
 
     location_hints = []
     for name in hintTable:
-        hint = getHint(name, world.settings.clearer_hints)
+        hint = get_hint(name, world.settings.clearer_hints)
         if any(item in hint.type for item in
                 ['always',
                  'dual_always',
@@ -1888,31 +1897,33 @@ def hintExclusions(world, clear_cache=False):
         if any(item in hint.type for item in
                 ['dual',
                  'dual_always']):
-            multi = getMulti(hint.name)
+            multi = get_multi(hint.name)
             exclude_hint = False
             for location in multi.locations:
                 if location not in world_location_names or world.get_location(location).locked:
                     exclude_hint = True
             if exclude_hint:
-                hintExclusions.exclusions[world.id].append(hint.name)
+                exclusions[world.id].append(hint.name)
         else:
-            if hint.name not in world_location_names and hint.name not in hintExclusions.exclusions[world.id]:
-                hintExclusions.exclusions[world.id].append(hint.name)
-    return hintExclusions.exclusions[world.id]
+            if hint.name not in world_location_names and hint.name not in exclusions[world.id]:
+                exclusions[world.id].append(hint.name)
+    return exclusions[world.id]
 
 
-hintExclusions.exclusions = {}
+hint_exclusions.exclusions = {}
 
 
-def nameIsLocation(name, hint_type, world):
+def name_is_location(name: str, hint_type: Union[str, Collection[str]], world: "World") -> bool:
     if isinstance(hint_type, (list, tuple)):
         for htype in hint_type:
-            if htype in ['sometimes', 'song', 'overworld', 'dungeon', 'always', 'exclude'] and name not in hintExclusions(world):
+            if htype in ['sometimes', 'song', 'overworld', 'dungeon', 'always', 'exclude'] and name not in hint_exclusions(
+                    world):
                 return True
-    elif hint_type in ['sometimes', 'song', 'overworld', 'dungeon', 'always', 'exclude'] and name not in hintExclusions(world):
+    elif hint_type in ['sometimes', 'song', 'overworld', 'dungeon', 'always', 'exclude'] and name not in hint_exclusions(
+            world):
         return True
     return False
 
 
-def clearHintExclusionCache():
-    hintExclusions.exclusions.clear()
+def clear_hint_exclusion_cache() -> None:
+    hint_exclusions.exclusions.clear()

--- a/Hints.py
+++ b/Hints.py
@@ -14,14 +14,14 @@ from Messages import COLOR_MAP, update_message_by_id
 from Region import Region
 from Search import Search
 from TextBox import line_wrap
-from Utils import random_choices, data_path
+from Utils import data_path
 
 
-bingoBottlesForHints = (
-    "Bottle", "Bottle with Red Potion","Bottle with Green Potion", "Bottle with Blue Potion",
+bingoBottlesForHints = {
+    "Bottle", "Bottle with Red Potion", "Bottle with Green Potion", "Bottle with Blue Potion",
     "Bottle with Fairy", "Bottle with Fish", "Bottle with Blue Fire", "Bottle with Bugs",
     "Bottle with Big Poe", "Bottle with Poe",
-)
+}
 
 defaultHintDists = [
     'balanced.json',
@@ -42,7 +42,8 @@ defaultHintDists = [
     'weekly.json',
 ]
 
-unHintableWothItems = ['Triforce Piece', 'Gold Skulltula Token', 'Piece of Heart', 'Piece of Heart (Treasure Chest Game)', 'Heart Container']
+unHintableWothItems = {'Triforce Piece', 'Gold Skulltula Token', 'Piece of Heart', 'Piece of Heart (Treasure Chest Game)', 'Heart Container'}
+
 
 class RegionRestriction(Enum):
     NONE = 0,
@@ -50,14 +51,14 @@ class RegionRestriction(Enum):
     OVERWORLD = 2,
 
 
-class GossipStone():
+class GossipStone:
     def __init__(self, name, location):
         self.name = name
         self.location = location
         self.reachable = True
 
 
-class GossipText():
+class GossipText:
     def __init__(self, text, colors=None, hinted_locations=None, hinted_items=None, prefix="They say that "):
         text = prefix + text
         text = text[:1].upper() + text[1:]
@@ -66,13 +67,12 @@ class GossipText():
         self.hinted_locations = hinted_locations
         self.hinted_items = hinted_items
 
-
     def to_json(self):
         return {'text': self.text, 'colors': self.colors, 'hinted_locations': self.hinted_locations, 'hinted_items': self.hinted_items}
 
-
     def __str__(self):
         return get_raw_text(line_wrap(colorText(self)))
+
 
 #   Abbreviations
 #       DMC     Death Mountain Crater
@@ -137,6 +137,7 @@ gossipLocations = {
 gossipLocations_reversemap = {
     stone.name : stone_id for stone_id, stone in gossipLocations.items()
 }
+
 
 def getItemGenericName(item):
     if item.unshuffled_dungeon_item:
@@ -245,7 +246,7 @@ def add_hint(spoiler, world, groups, gossip_text, count, locations=[], force_rea
 
 
 def can_reach_hint(worlds, hint_location, location):
-    if location == None:
+    if location is None:
         return True
 
     old_item = location.item
@@ -499,7 +500,8 @@ def get_woth_hint(spoiler, world, checked):
         world.woth_dungeon += 1
     location_text = hint_area.text(world.settings.clearer_hints)
 
-    return (GossipText('%s is on the way of the hero.' % location_text, ['Light Blue'], [location.name], [location.item.name]), [location])
+    return GossipText('%s is on the way of the hero.' % location_text, ['Light Blue'], [location.name], [location.item.name]), [location]
+
 
 def get_checked_areas(world, checked):
     def get_area_from_name(check):
@@ -512,6 +514,7 @@ def get_checked_areas(world, checked):
             return HintArea.at(location)
 
     return set(get_area_from_name(check) for check in checked)
+
 
 def get_goal_category(spoiler, world, goal_categories):
     cat_sizes = []
@@ -546,6 +549,7 @@ def get_goal_category(spoiler, world, goal_categories):
             goal_category = goal_categories[random.choices(cat_names, weights=cat_sizes)[0]]
 
     return goal_category
+
 
 def get_goal_hint(spoiler, world, checked):
     goal_category = get_goal_category(spoiler, world, world.goal_categories)
@@ -637,7 +641,7 @@ def get_goal_hint(spoiler, world, checked):
         player_text = "Player %s's" % (world_id + 1)
         goal_text = spoiler.goal_categories[world_id][goal_category.name].get_goal(goal.name).hint_text
 
-    return (GossipText('%s is on %s %s.' % (location_text, player_text, goal_text), ['Light Blue', goal.color], [location.name], [location.item.name]), [location])
+    return GossipText('%s is on %s %s.' % (location_text, player_text, goal_text), ['Light Blue', goal.color], [location.name], [location.item.name]), [location]
 
 
 def get_barren_hint(spoiler, world, checked, allChecked):
@@ -690,13 +694,13 @@ def get_barren_hint(spoiler, world, checked, allChecked):
 
     area_weights = [world.empty_areas[area]['weight'] for area in areas]
 
-    area = random_choices(areas, weights=area_weights)[0]
+    area = random.choices(areas, weights=area_weights)[0]
     if world.empty_areas[area]['dungeon']:
         world.barren_dungeon += 1
 
     checked.add(area)
 
-    return (GossipText("plundering %s is a foolish choice." % area.text(world.settings.clearer_hints), ['Pink']), None)
+    return GossipText("plundering %s is a foolish choice." % area.text(world.settings.clearer_hints), ['Pink']), None
 
 
 def is_not_checked(locations, checked):
@@ -725,10 +729,10 @@ def get_good_item_hint(spoiler, world, checked):
     hint_area = HintArea.at(location)
     if hint_area.is_dungeon:
         location_text = hint_area.text(world.settings.clearer_hints)
-        return (GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location])
+        return GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location]
     else:
         location_text = hint_area.text(world.settings.clearer_hints, preposition=True)
-        return (GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location])
+        return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
 
 def get_specific_item_hint(spoiler, world, checked):
@@ -780,18 +784,18 @@ def get_specific_item_hint(spoiler, world, checked):
         hint_area = HintArea.at(location)
         if world.hint_dist_user.get('vague_named_items', False):
             location_text = hint_area.text(world.settings.clearer_hints)
-            return (GossipText('%s may be on the hero\'s path.' % (location_text), ['Green'], [location.name], [location.item.name]), [location])
+            return GossipText('%s may be on the hero\'s path.' % location_text, ['Green'], [location.name], [location.item.name]), [location]
         elif hint_area.is_dungeon:
             location_text = hint_area.text(world.settings.clearer_hints)
-            return (GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location])
+            return GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location]
         else:
             location_text = hint_area.text(world.settings.clearer_hints, preposition=True)
-            return (GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location])
+            return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
     else:
         while True:
-            #This operation is likely to be costly (especially for large multiworlds), so cache the result for later
-            #named_item_locations: Filtered locations from all worlds that may contain named-items
+            # This operation is likely to be costly (especially for large multiworlds), so cache the result for later
+            # named_item_locations: Filtered locations from all worlds that may contain named-items
             try:
                 named_item_locations = spoiler._cached_named_item_locations
                 always_locations = spoiler._cached_always_locations
@@ -813,7 +817,6 @@ def get_specific_item_hint(spoiler, world, checked):
                         always_item = location.item.name
                     always_locations.append((always_item, location.item.world.id))
                 spoiler._cached_always_locations = always_locations
-
 
             itemname = world.named_item_pool.pop(0)
             if itemname == "Bottle" and world.settings.hint_dist == "bingo":
@@ -862,13 +865,13 @@ def get_specific_item_hint(spoiler, world, checked):
         hint_area = HintArea.at(location)
         if world.hint_dist_user.get('vague_named_items', False):
             location_text = hint_area.text(world.settings.clearer_hints, world=location.world.id + 1)
-            return (GossipText('%s may be on the hero\'s path.' % (location_text), ['Green'], [location.name], [location.item.name]), [location])
+            return GossipText('%s may be on the hero\'s path.' % location_text, ['Green'], [location.name], [location.item.name]), [location]
         elif hint_area.is_dungeon:
             location_text = hint_area.text(world.settings.clearer_hints, world=location.world.id + 1)
-            return (GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location])
+            return GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location]
         else:
             location_text = hint_area.text(world.settings.clearer_hints, preposition=True, world=location.world.id + 1)
-            return (GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location])
+            return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
 
 def get_random_location_hint(spoiler, world, checked):
@@ -891,10 +894,10 @@ def get_random_location_hint(spoiler, world, checked):
     hint_area = HintArea.at(location)
     if hint_area.is_dungeon:
         location_text = hint_area.text(world.settings.clearer_hints)
-        return (GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location])
+        return GossipText('%s hoards #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location]
     else:
         location_text = hint_area.text(world.settings.clearer_hints, preposition=True)
-        return (GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location])
+        return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
 
 def get_specific_hint(spoiler, world, checked, type):
@@ -922,7 +925,6 @@ def get_specific_hint(spoiler, world, checked, type):
             if multi:
                 return get_specific_multi_hint(spoiler, world, checked, hint)
 
-
     location = world.get_location(hint.name)
     checked.add(location.name)
 
@@ -934,7 +936,7 @@ def get_specific_hint(spoiler, world, checked, type):
         location_text = '#%s#' % location_text
     item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
 
-    return (GossipText('%s #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location])
+    return GossipText('%s #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location]
 
 
 def get_sometimes_hint(spoiler, world, checked):
@@ -951,6 +953,7 @@ def get_overworld_hint(spoiler, world, checked):
 
 def get_dungeon_hint(spoiler, world, checked):
     return get_specific_hint(spoiler, world, checked, 'dungeon')
+
 
 def get_random_multi_hint(spoiler, world, checked, type):
     hint_group = getHintGroup(type, world)
@@ -976,6 +979,7 @@ def get_random_multi_hint(spoiler, world, checked, type):
                     multi = getMulti(hint.name)
 
     return get_specific_multi_hint(spoiler, world, checked, hint)
+
 
 def get_specific_multi_hint(spoiler, world, checked, hint):
     multi = getMulti(hint.name)
@@ -1003,10 +1007,12 @@ def get_specific_multi_hint(spoiler, world, checked, hint):
 
     items = [location.item for location in locations]
     text_segments = [multi_text] + [getHint(getItemGenericName(item), world.settings.clearer_hints).text for item in items]
-    return (GossipText(gossip_string % tuple(text_segments), colors, [location.name for location in locations], [item.name for item in items]), locations)
+    return GossipText(gossip_string % tuple(text_segments), colors, [location.name for location in locations], [item.name for item in items]), locations
+
 
 def get_dual_hint(spoiler, world, checked):
     return get_random_multi_hint(spoiler, world, checked, 'dual')
+
 
 def get_entrance_hint(spoiler, world, checked):
     if not world.entrance_shuffle:
@@ -1041,7 +1047,7 @@ def get_entrance_hint(spoiler, world, checked):
     if '#' not in region_text:
         region_text = '#%s#' % region_text
 
-    return (GossipText('%s %s.' % (entrance_text, region_text), ['Green', 'Light Blue']), None)
+    return GossipText('%s %s.' % (entrance_text, region_text), ['Green', 'Light Blue']), None
 
 
 def get_junk_hint(spoiler, world, checked):
@@ -1053,7 +1059,7 @@ def get_junk_hint(spoiler, world, checked):
     hint = random.choice(hints)
     checked.add(hint.name)
 
-    return (GossipText(hint.text, prefix=''), None)
+    return GossipText(hint.text, prefix=''), None
 
 def get_important_check_hint(spoiler, world, checked):
     top_level_locations = []
@@ -1097,7 +1103,7 @@ def get_important_check_hint(spoiler, world, checked):
     else:
         numcolor = 'Green'
 
-    return (GossipText('#%s# has #%d# major item%s.' % (hintLoc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None)
+    return GossipText('#%s# has #%d# major item%s.' % (hintLoc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None
 
 
 hint_func = {
@@ -1503,7 +1509,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
                                 p = p * (((hint_counts.get(w2_type, 0) / w2_prob) + 1) / ((hint_counts.get(w1_type, 0) / w1_prob) + 1))
                     weighted_hint_prob.append(p)
 
-                hint_type = random_choices(hint_types, weights=weighted_hint_prob)[0]
+                hint_type = random.choices(hint_types, weights=weighted_hint_prob)[0]
                 copies = hint_dist[hint_type][1]
             except IndexError:
                 raise Exception('Not enough valid hints to fill gossip stone locations.')
@@ -1515,7 +1521,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             hint = hint_func[hint_type](spoiler, world, allCheckedLocations)
             checkedLocations.update(allCheckedLocations - checkedAlwaysLocations)
 
-        if hint == None:
+        if hint is None:
             index = hint_types.index(hint_type)
             hint_prob[index] = 0
             # Zero out the probability in the base distribution in case the probability list is modified

--- a/Hints.py
+++ b/Hints.py
@@ -1,29 +1,42 @@
+import itertools
+import json
 import logging
 import os
 import random
-from collections import OrderedDict, defaultdict
 import urllib.request
-from urllib.error import URLError, HTTPError
-import json
+from collections import OrderedDict, defaultdict
 from enum import Enum
-import itertools
+from typing import TYPE_CHECKING, Set, List, Optional, Dict, Union, MutableSet, Tuple, Callable, Iterable
+from urllib.error import URLError, HTTPError
 
-from HintList import getHint, getMulti, getHintGroup, getUpgradeHintList, hintExclusions, misc_item_hint_table, misc_location_hint_table
-from Item import Item, MakeEventItem
-from Messages import COLOR_MAP, update_message_by_id
+from HintList import Hint, get_hint, get_multi, get_hint_group, get_upgrade_hint_list, hint_exclusions, \
+    misc_item_hint_table, misc_location_hint_table
+from Item import Item, make_event_item
+from Messages import Message, COLOR_MAP, update_message_by_id
 from Region import Region
 from Search import Search
 from TextBox import line_wrap
-from Utils import data_path
+from Utils import TypeAlias, data_path
 
+if TYPE_CHECKING:
+    from Entrance import Entrance
+    from Goals import GoalCategory
+    from Location import Location
+    from Spoiler import Spoiler
+    from World import World
 
-bingoBottlesForHints = {
+Spot: TypeAlias = "Union[Entrance, Location, Region]"
+HintReturn: TypeAlias = "Optional[Tuple[GossipText, Optional[List[Location]]]]"
+HintFunc: TypeAlias = "Callable[[Spoiler, World, MutableSet[str]], HintReturn]"
+BarrenFunc: TypeAlias = "Callable[[Spoiler, World, MutableSet[str], MutableSet[str]], HintReturn]"
+
+bingoBottlesForHints: Set[str] = {
     "Bottle", "Bottle with Red Potion", "Bottle with Green Potion", "Bottle with Blue Potion",
     "Bottle with Fairy", "Bottle with Fish", "Bottle with Blue Fire", "Bottle with Bugs",
     "Bottle with Big Poe", "Bottle with Poe",
 }
 
-defaultHintDists = [
+defaultHintDists: List[str] = [
     'balanced.json',
     'bingo.json',
     'chaos.json',
@@ -42,7 +55,7 @@ defaultHintDists = [
     'weekly.json',
 ]
 
-unHintableWothItems = {'Triforce Piece', 'Gold Skulltula Token', 'Piece of Heart', 'Piece of Heart (Treasure Chest Game)', 'Heart Container'}
+unHintableWothItems: Set[str] = {'Triforce Piece', 'Gold Skulltula Token', 'Piece of Heart', 'Piece of Heart (Treasure Chest Game)', 'Heart Container'}
 
 
 class RegionRestriction(Enum):
@@ -52,26 +65,27 @@ class RegionRestriction(Enum):
 
 
 class GossipStone:
-    def __init__(self, name, location):
-        self.name = name
-        self.location = location
-        self.reachable = True
+    def __init__(self, name: str, location: str) -> None:
+        self.name: str = name
+        self.location: str = location
+        self.reachable: bool = True
 
 
 class GossipText:
-    def __init__(self, text, colors=None, hinted_locations=None, hinted_items=None, prefix="They say that "):
+    def __init__(self, text: str, colors: Optional[List[str]] = None, hinted_locations: Optional[List[str]] = None,
+                 hinted_items: Optional[List[str]] = None, prefix: str = "They say that ") -> None:
         text = prefix + text
         text = text[:1].upper() + text[1:]
-        self.text = text
-        self.colors = colors
-        self.hinted_locations = hinted_locations
-        self.hinted_items = hinted_items
+        self.text: str = text
+        self.colors: Optional[List[str]] = colors
+        self.hinted_locations: Optional[List[str]] = hinted_locations
+        self.hinted_items: Optional[List[str]] = hinted_items
 
-    def to_json(self):
+    def to_json(self) -> dict:
         return {'text': self.text, 'colors': self.colors, 'hinted_locations': self.hinted_locations, 'hinted_items': self.hinted_items}
 
-    def __str__(self):
-        return get_raw_text(line_wrap(colorText(self)))
+    def __str__(self) -> str:
+        return get_raw_text(line_wrap(color_text(self)))
 
 
 #   Abbreviations
@@ -90,7 +104,7 @@ class GossipText:
 #       ZF      Zora's Fountain
 #       ZR      Zora's River
 
-gossipLocations = {
+gossipLocations: Dict[int, GossipStone] = {
     0x0405: GossipStone('DMC (Bombable Wall)',              'DMC Gossip Stone'),
     0x0404: GossipStone('DMT (Biggoron)',                   'DMT Gossip Stone'),
     0x041A: GossipStone('Colossus (Spirit Temple)',         'Colossus Gossip Stone'),
@@ -134,19 +148,19 @@ gossipLocations = {
     0x044A: GossipStone('DMC (Upper Grotto)',               'DMC Upper Grotto Gossip Stone'),
 }
 
-gossipLocations_reversemap = {
-    stone.name : stone_id for stone_id, stone in gossipLocations.items()
+gossipLocations_reversemap: Dict[str, int] = {
+    stone.name: stone_id for stone_id, stone in gossipLocations.items()
 }
 
 
-def getItemGenericName(item):
+def get_item_generic_name(item: Item) -> str:
     if item.unshuffled_dungeon_item:
         return item.type
     else:
         return item.name
 
 
-def is_restricted_dungeon_item(item):
+def is_restricted_dungeon_item(item: Item) -> bool:
     return (
         ((item.map or item.compass) and item.world.settings.shuffle_mapcompass == 'dungeon') or
         (item.type == 'SmallKey' and item.world.settings.shuffle_smallkeys == 'dungeon') or
@@ -156,7 +170,8 @@ def is_restricted_dungeon_item(item):
     )
 
 
-def add_hint(spoiler, world, groups, gossip_text, count, locations=[], force_reachable=False):
+def add_hint(spoiler: "Spoiler", world: "World", groups: List[List[int]], gossip_text: GossipText, count: int,
+             locations: "Optional[List[Location]]" = None, force_reachable: bool = False) -> bool:
     random.shuffle(groups)
     skipped_groups = []
     duplicates = []
@@ -188,9 +203,9 @@ def add_hint(spoiler, world, groups, gossip_text, count, locations=[], force_rea
                         for i, stone_name in enumerate(stone_names):
                             # place the same event item in each location in the group
                             if event_item is None:
-                                event_item = MakeEventItem(stone_name, stone_locations[i], event_item)
+                                event_item = make_event_item(stone_name, stone_locations[i], event_item)
                             else:
-                                MakeEventItem(stone_name, stone_locations[i], event_item)
+                                make_event_item(stone_name, stone_locations[i], event_item)
 
                         # This mostly guarantees that we don't lock the player out of an item hint
                         # by establishing a (hint -> item) -> hint -> item -> (first hint) loop
@@ -245,7 +260,7 @@ def add_hint(spoiler, world, groups, gossip_text, count, locations=[], force_rea
     return success
 
 
-def can_reach_hint(worlds, hint_location, location):
+def can_reach_hint(worlds: "List[World]", hint_location: "Location", location: "Location") -> bool:
     if location is None:
         return True
 
@@ -258,19 +273,19 @@ def can_reach_hint(worlds, hint_location, location):
             and (hint_location.type != 'HintStone' or search.state_list[location.world.id].guarantee_hint()))
 
 
-def writeGossipStoneHints(spoiler, world, messages):
+def write_gossip_stone_hints(spoiler: "Spoiler", world: "World", messages: List[Message]) -> None:
     for id, gossip_text in spoiler.hints[world.id].items():
         update_message_by_id(messages, id, str(gossip_text), 0x23)
 
 
-def filterTrailingSpace(text):
+def filter_trailing_space(text: str) -> str:
     if text.endswith('& '):
         return text[:-1]
     else:
         return text
 
 
-hintPrefixes = [
+hintPrefixes: List[str] = [
     'a few ',
     'some ',
     'plenty of ',
@@ -280,8 +295,9 @@ hintPrefixes = [
     '',
 ]
 
-def getSimpleHintNoPrefix(item):
-    hint = getHint(item.name, True).text
+
+def get_simple_hint_no_prefix(item: Item) -> Hint:
+    hint = get_hint(item.name, True).text
 
     for prefix in hintPrefixes:
         if hint.startswith(prefix):
@@ -292,24 +308,24 @@ def getSimpleHintNoPrefix(item):
     return hint
 
 
-def colorText(gossip_text):
+def color_text(gossip_text: GossipText) -> str:
     text = gossip_text.text
     colors = list(gossip_text.colors) if gossip_text.colors is not None else []
     color = 'White'
 
     while '#' in text:
-        splitText = text.split('#', 2)
+        split_text = text.split('#', 2)
         if len(colors) > 0:
             color = colors.pop(0)
 
         for prefix in hintPrefixes:
-            if splitText[1].startswith(prefix):
-                splitText[0] += splitText[1][:len(prefix)]
-                splitText[1] = splitText[1][len(prefix):]
+            if split_text[1].startswith(prefix):
+                split_text[0] += split_text[1][:len(prefix)]
+                split_text[1] = split_text[1][len(prefix):]
                 break
 
-        splitText[1] = '\x05' + COLOR_MAP[color] + splitText[1] + '\x05\x40'
-        text = ''.join(splitText)
+        split_text[1] = '\x05' + COLOR_MAP[color] + split_text[1] + '\x05\x40'
+        text = ''.join(split_text)
 
     return text
 
@@ -363,7 +379,7 @@ class HintArea(Enum):
     # Performs a breadth first search to find the closest hint area from a given spot (region, location, or entrance).
     # May fail to find a hint if the given spot is only accessible from the root and not from any other region with a hint area
     @staticmethod
-    def at(spot, use_alt_hint=False):
+    def at(spot: Spot, use_alt_hint: bool = False) -> 'HintArea':
         if isinstance(spot, Region):
             original_parent = spot
         else:
@@ -400,50 +416,50 @@ class HintArea(Enum):
         raise HintAreaNotFound('No hint area could be found for %s [World %d]' % (spot, spot.world.id))
 
     @classmethod
-    def for_dungeon(cls, dungeon_name: str):
+    def for_dungeon(cls, dungeon_name: str) -> 'Optional[HintArea]':
         if '(' in dungeon_name and ')' in dungeon_name:
             # A dungeon item name was passed in - get the name of the dungeon from it.
             dungeon_name = dungeon_name[dungeon_name.index('(') + 1:dungeon_name.index(')')]
 
         if dungeon_name == "Thieves Hideout":
             # Special case for Thieves' Hideout since it's not considered a dungeon
-            return HintArea.THIEVES_HIDEOUT
+            return cls.THIEVES_HIDEOUT
 
         if dungeon_name == "Treasure Chest Game":
             # Special case for Treasure Chest Game keys: treat them as part of the market hint area regardless of where the treasure box shop actually is.
-            return HintArea.MARKET
+            return cls.MARKET
 
         for hint_area in cls:
             if hint_area.dungeon_name is not None and hint_area.dungeon_name in dungeon_name:
                 return hint_area
         return None
 
-    def preposition(self, clearer_hints):
+    def preposition(self, clearer_hints: bool) -> str:
         return self.value[1 if clearer_hints else 0]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value[2]
 
     # used for dungeon reward locations in the pause menu
     @property
-    def short_name(self):
+    def short_name(self) -> str:
         return self.value[3]
 
     # Hint areas are further grouped into colored sections of the map by association with the medallions.
     # These colors are used to generate the text boxes for shuffled warp songs.
     @property
-    def color(self):
+    def color(self) -> str:
         return self.value[4]
 
     @property
-    def dungeon_name(self):
+    def dungeon_name(self) -> Optional[str]:
         return self.value[5]
 
     @property
-    def is_dungeon(self):
+    def is_dungeon(self) -> bool:
         return self.dungeon_name is not None
 
-    def is_dungeon_item(self, item):
+    def is_dungeon_item(self, item: Item) -> bool:
         for dungeon in item.world.dungeons:
             if dungeon.name == self.dungeon_name:
                 return dungeon.is_dungeon_item(item)
@@ -451,9 +467,9 @@ class HintArea(Enum):
 
     # Formats the hint text for this area with proper grammar.
     # Dungeons are hinted differently depending on the clearer_hints setting.
-    def text(self, clearer_hints, preposition=False, world=None):
+    def text(self, clearer_hints: bool, preposition: bool = False, world: "Optional[World]" = None) -> str:
         if self.is_dungeon:
-            text = getHint(self.dungeon_name, clearer_hints).text
+            text = get_hint(self.dungeon_name, clearer_hints).text
         else:
             text = str(self)
         prefix, suffix = text.replace('#', '').split(' ', 1)
@@ -478,7 +494,7 @@ class HintArea(Enum):
         return text
 
 
-def get_woth_hint(spoiler, world, checked):
+def get_woth_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     locations = spoiler.required_locations[world.id]
     locations = list(filter(lambda location:
         location.name not in checked
@@ -503,20 +519,20 @@ def get_woth_hint(spoiler, world, checked):
     return GossipText('%s is on the way of the hero.' % location_text, ['Light Blue'], [location.name], [location.item.name]), [location]
 
 
-def get_checked_areas(world, checked):
-    def get_area_from_name(check):
+def get_checked_areas(world: "World", checked: MutableSet[str]) -> Set[Union[HintArea, str]]:
+    def get_area_from_name(check: str) -> Union[HintArea, str]:
         try:
             location = world.get_location(check)
         except Exception:
             return check
         # Don't consider dungeons as already hinted from the reward hint on the Temple of Time altar
-        if location.type != 'Boss': #TODO or shuffled dungeon rewards
+        if location.type != 'Boss':  # TODO or shuffled dungeon rewards
             return HintArea.at(location)
 
     return set(get_area_from_name(check) for check in checked)
 
 
-def get_goal_category(spoiler, world, goal_categories):
+def get_goal_category(spoiler: "Spoiler", world: "World", goal_categories: "Dict[str, GoalCategory]") -> "GoalCategory":
     cat_sizes = []
     cat_names = []
     zero_weights = True
@@ -551,7 +567,7 @@ def get_goal_category(spoiler, world, goal_categories):
     return goal_category
 
 
-def get_goal_hint(spoiler, world, checked):
+def get_goal_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     goal_category = get_goal_category(spoiler, world, world.goal_categories)
 
     # check if no goals were generated (and thus no categories available)
@@ -560,12 +576,13 @@ def get_goal_hint(spoiler, world, checked):
 
     goals = goal_category.goals
     category_locations = []
+    zero_weights = True
+    location_reverse_map = defaultdict(list)
 
     # Collect unhinted locations for the category across all category goals.
     # If all locations for all goals in the category are hinted, try remaining goal categories
     # If all locations for all goal categories are hinted, return no hint.
     while not category_locations:
-
         # Filter hinted goals until every goal in the category has been hinted.
         weights = []
         zero_weights = True
@@ -644,19 +661,19 @@ def get_goal_hint(spoiler, world, checked):
     return GossipText('%s is on %s %s.' % (location_text, player_text, goal_text), ['Light Blue', goal.color], [location.name], [location.item.name]), [location]
 
 
-def get_barren_hint(spoiler, world, checked, allChecked):
+def get_barren_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str], all_checked: MutableSet[str]) -> HintReturn:
     if not hasattr(world, 'get_barren_hint_prev'):
         world.get_barren_hint_prev = RegionRestriction.NONE
 
     checked_areas = get_checked_areas(world, checked)
     areas = list(filter(lambda area:
         area not in checked_areas
-        and area not in world.hint_type_overrides['barren']
+        and str(area) not in world.hint_type_overrides['barren']
         and not (world.barren_dungeon >= world.hint_dist_user['dungeons_barren_limit'] and world.empty_areas[area]['dungeon'])
         and any(
-            location.name not in allChecked
+            location.name not in all_checked
             and location.name not in world.hint_exclusions
-            and location.name not in hintExclusions(world)
+            and location.name not in hint_exclusions(world)
             and HintArea.at(location) == area
             for location in world.get_locations()
         ),
@@ -703,11 +720,11 @@ def get_barren_hint(spoiler, world, checked, allChecked):
     return GossipText("plundering %s is a foolish choice." % area.text(world.settings.clearer_hints), ['Pink']), None
 
 
-def is_not_checked(locations, checked):
+def is_not_checked(locations: "Iterable[Location]", checked: MutableSet[Union[HintArea, str]]) -> bool:
     return not any(location.name in checked or HintArea.at(location) in checked for location in locations)
 
 
-def get_good_item_hint(spoiler, world, checked):
+def get_good_item_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     locations = list(filter(lambda location:
         is_not_checked([location], checked)
         and ((location.item.majoritem
@@ -725,7 +742,7 @@ def get_good_item_hint(spoiler, world, checked):
     location = random.choice(locations)
     checked.add(location.name)
 
-    item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
+    item_text = get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text
     hint_area = HintArea.at(location)
     if hint_area.is_dungeon:
         location_text = hint_area.text(world.settings.clearer_hints)
@@ -735,7 +752,7 @@ def get_good_item_hint(spoiler, world, checked):
         return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
 
-def get_specific_item_hint(spoiler, world, checked):
+def get_specific_item_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     if len(world.named_item_pool) == 0:
         logger = logging.getLogger('')
         logger.info("Named item hint requested, but pool is empty.")
@@ -779,7 +796,7 @@ def get_specific_item_hint(spoiler, world, checked):
 
         location = random.choice(locations)
         checked.add(location.name)
-        item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
+        item_text = get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text
 
         hint_area = HintArea.at(location)
         if world.hint_dist_user.get('vague_named_items', False):
@@ -807,7 +824,7 @@ def get_specific_item_hint(spoiler, world, checked):
                 named_item_locations = [location for w in worlds for location in w.get_filled_locations() if (location.item.name in all_named_items)]
                 spoiler._cached_named_item_locations = named_item_locations
 
-                always_hints = [(hint, w.id) for w in worlds for hint in getHintGroup('always', w)]
+                always_hints = [(hint, w.id) for w in worlds for hint in get_hint_group('always', w)]
                 always_locations = []
                 for hint, id  in always_hints:
                     location = worlds[id].get_location(hint.name)
@@ -860,7 +877,7 @@ def get_specific_item_hint(spoiler, world, checked):
 
         location = random.choice(locations)
         checked.add(location.name)
-        item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
+        item_text = get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text
 
         hint_area = HintArea.at(location)
         if world.hint_dist_user.get('vague_named_items', False):
@@ -874,7 +891,7 @@ def get_specific_item_hint(spoiler, world, checked):
             return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
 
-def get_random_location_hint(spoiler, world, checked):
+def get_random_location_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     locations = list(filter(lambda location:
         is_not_checked([location], checked)
         and location.item.type not in ('Drop', 'Event', 'Shop', 'DungeonReward')
@@ -889,7 +906,7 @@ def get_random_location_hint(spoiler, world, checked):
 
     location = random.choice(locations)
     checked.add(location.name)
-    item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
+    item_text = get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text
 
     hint_area = HintArea.at(location)
     if hint_area.is_dungeon:
@@ -900,27 +917,28 @@ def get_random_location_hint(spoiler, world, checked):
         return GossipText('#%s# can be found %s.' % (item_text, location_text), ['Green', 'Red'], [location.name], [location.item.name]), [location]
 
 
-def get_specific_hint(spoiler, world, checked, type):
-    hintGroup = getHintGroup(type, world)
-    hintGroup = list(filter(lambda hint: is_not_checked([world.get_location(hint.name)], checked), hintGroup))
-    if not hintGroup:
+def get_specific_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str], hint_type: str) -> HintReturn:
+    hint_group = get_hint_group(hint_type, world)
+    hint_group = list(filter(lambda hint: is_not_checked([world.get_location(hint.name)], checked), hint_group))
+    if not hint_group:
         return None
 
-    hint = random.choice(hintGroup)
+    hint = random.choice(hint_group)
 
     if world.hint_dist_user['upgrade_hints'] in ['on', 'limited']:
-        upgrade_list = getUpgradeHintList(world, [hint.name])
-        upgrade_list = list(filter(lambda upgrade: is_not_checked([world.get_location(location) for location in getMulti(upgrade.name).locations], checked), upgrade_list))
+        upgrade_list = get_upgrade_hint_list(world, [hint.name])
+        upgrade_list = list(filter(lambda upgrade: is_not_checked([world.get_location(location) for location in get_multi(
+            upgrade.name).locations], checked), upgrade_list))
 
         if upgrade_list is not None:
             multi = None
 
             for upgrade in upgrade_list:
-                upgrade_multi = getMulti(upgrade.name)
+                upgrade_multi = get_multi(upgrade.name)
 
                 if not multi or len(multi.locations) < len(upgrade_multi.locations):
                     hint = upgrade
-                    multi = getMulti(hint.name)
+                    multi = get_multi(hint.name)
 
             if multi:
                 return get_specific_multi_hint(spoiler, world, checked, hint)
@@ -934,30 +952,31 @@ def get_specific_hint(spoiler, world, checked, type):
         location_text = hint.text
     if '#' not in location_text:
         location_text = '#%s#' % location_text
-    item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
+    item_text = get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text
 
     return GossipText('%s #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), [location]
 
 
-def get_sometimes_hint(spoiler, world, checked):
+def get_sometimes_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     return get_specific_hint(spoiler, world, checked, 'sometimes')
 
 
-def get_song_hint(spoiler, world, checked):
+def get_song_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     return get_specific_hint(spoiler, world, checked, 'song')
 
 
-def get_overworld_hint(spoiler, world, checked):
+def get_overworld_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     return get_specific_hint(spoiler, world, checked, 'overworld')
 
 
-def get_dungeon_hint(spoiler, world, checked):
+def get_dungeon_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     return get_specific_hint(spoiler, world, checked, 'dungeon')
 
 
-def get_random_multi_hint(spoiler, world, checked, type):
-    hint_group = getHintGroup(type, world)
-    multi_hints = list(filter(lambda hint: is_not_checked([world.get_location(location) for location in getMulti(hint.name).locations], checked), hint_group))
+def get_random_multi_hint(spoiler: "Spoiler", world: "World", checked: "MutableSet", hint_type: str) -> HintReturn:
+    hint_group = get_hint_group(hint_type, world)
+    multi_hints = list(filter(lambda hint: is_not_checked([world.get_location(location) for location in get_multi(
+        hint.name).locations], checked), hint_group))
 
     if not multi_hints:
         return None
@@ -965,24 +984,25 @@ def get_random_multi_hint(spoiler, world, checked, type):
     hint = random.choice(multi_hints)
 
     if world.hint_dist_user['upgrade_hints'] in ['on', 'limited']:
-        multi = getMulti(hint.name)
+        multi = get_multi(hint.name)
 
-        upgrade_list = getUpgradeHintList(world, multi.locations)
-        upgrade_list = list(filter(lambda upgrade: is_not_checked([world.get_location(location) for location in getMulti(upgrade.name).locations], checked), upgrade_list))
+        upgrade_list = get_upgrade_hint_list(world, multi.locations)
+        upgrade_list = list(filter(lambda upgrade: is_not_checked([world.get_location(location) for location in get_multi(
+            upgrade.name).locations], checked), upgrade_list))
 
         if upgrade_list:
             for upgrade in upgrade_list:
-                upgrade_multi = getMulti(upgrade.name)
+                upgrade_multi = get_multi(upgrade.name)
 
                 if len(multi.locations) < len(upgrade_multi.locations):
                     hint = upgrade
-                    multi = getMulti(hint.name)
+                    multi = get_multi(hint.name)
 
     return get_specific_multi_hint(spoiler, world, checked, hint)
 
 
-def get_specific_multi_hint(spoiler, world, checked, hint):
-    multi = getMulti(hint.name)
+def get_specific_multi_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str], hint: Hint) -> HintReturn:
+    multi = get_multi(hint.name)
     locations = [world.get_location(location) for location in multi.locations]
 
     for location in locations:
@@ -1006,22 +1026,22 @@ def get_specific_multi_hint(spoiler, world, checked, hint):
             gossip_string = gossip_string + '#%s# '
 
     items = [location.item for location in locations]
-    text_segments = [multi_text] + [getHint(getItemGenericName(item), world.settings.clearer_hints).text for item in items]
+    text_segments = [multi_text] + [get_hint(get_item_generic_name(item), world.settings.clearer_hints).text for item in items]
     return GossipText(gossip_string % tuple(text_segments), colors, [location.name for location in locations], [item.name for item in items]), locations
 
 
-def get_dual_hint(spoiler, world, checked):
+def get_dual_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     return get_random_multi_hint(spoiler, world, checked, 'dual')
 
 
-def get_entrance_hint(spoiler, world, checked):
+def get_entrance_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     if not world.entrance_shuffle:
         return None
 
-    entrance_hints = list(filter(lambda hint: hint.name not in checked, getHintGroup('entrance', world)))
+    entrance_hints = list(filter(lambda hint: hint.name not in checked, get_hint_group('entrance', world)))
     shuffled_entrance_hints = list(filter(lambda entrance_hint: world.get_entrance(entrance_hint.name).shuffled, entrance_hints))
 
-    regions_with_hint = [hint.name for hint in getHintGroup('region', world)]
+    regions_with_hint = [hint.name for hint in get_hint_group('region', world)]
     valid_entrance_hints = list(filter(lambda entrance_hint:
                                        (world.get_entrance(entrance_hint.name).connected_region.name in regions_with_hint or
                                         world.get_entrance(entrance_hint.name).connected_region.dungeon), shuffled_entrance_hints))
@@ -1040,9 +1060,9 @@ def get_entrance_hint(spoiler, world, checked):
 
     connected_region = entrance.connected_region
     if connected_region.dungeon:
-        region_text = getHint(connected_region.dungeon.name, world.settings.clearer_hints).text
+        region_text = get_hint(connected_region.dungeon.name, world.settings.clearer_hints).text
     else:
-        region_text = getHint(connected_region.name, world.settings.clearer_hints).text
+        region_text = get_hint(connected_region.name, world.settings.clearer_hints).text
 
     if '#' not in region_text:
         region_text = '#%s#' % region_text
@@ -1050,8 +1070,8 @@ def get_entrance_hint(spoiler, world, checked):
     return GossipText('%s %s.' % (entrance_text, region_text), ['Green', 'Light Blue']), None
 
 
-def get_junk_hint(spoiler, world, checked):
-    hints = getHintGroup('junk', world)
+def get_junk_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
+    hints = get_hint_group('junk', world)
     hints = list(filter(lambda hint: hint.name not in checked, hints))
     if not hints:
         return None
@@ -1061,7 +1081,7 @@ def get_junk_hint(spoiler, world, checked):
 
     return GossipText(hint.text, prefix=''), None
 
-def get_important_check_hint(spoiler, world, checked):
+def get_important_check_hint(spoiler: "Spoiler", world: "World", checked: MutableSet[str]) -> HintReturn:
     top_level_locations = []
     for location in world.get_filled_locations():
         if (HintArea.at(location).text(world.settings.clearer_hints) not in top_level_locations
@@ -1106,7 +1126,7 @@ def get_important_check_hint(spoiler, world, checked):
     return GossipText('#%s# has #%d# major item%s.' % (hintLoc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None
 
 
-hint_func = {
+hint_func: "Dict[str, Union[HintFunc, BarrenFunc]]" = {
     'trial':            lambda spoiler, world, checked: None,
     'always':           lambda spoiler, world, checked: None,
     'dual_always':      lambda spoiler, world, checked: None,
@@ -1127,7 +1147,7 @@ hint_func = {
     'important_check':  get_important_check_hint
 }
 
-hint_dist_keys = {
+hint_dist_keys: Set[str] = {
     'trial',
     'always',
     'dual_always',
@@ -1148,51 +1168,51 @@ hint_dist_keys = {
 }
 
 
-def buildBingoHintList(boardURL):
+def build_bingo_hint_list(board_url: str) -> List[str]:
     try:
-        if len(boardURL) > 256:
-            raise URLError(f"URL too large {len(boardURL)}")
-        with urllib.request.urlopen(boardURL + "/board") as board:
+        if len(board_url) > 256:
+            raise URLError(f"URL too large {len(board_url)}")
+        with urllib.request.urlopen(board_url + "/board") as board:
             if board.length and 0 < board.length < 4096:
-                goalList = board.read()
+                goal_list = board.read()
             else:
-                raise HTTPError(f"Board of invalid size {board.length}")
+                raise URLError(f"Board of invalid size {board.length}")
     except (URLError, HTTPError) as e:
         logger = logging.getLogger('')
         logger.info(f"Could not retrieve board info. Using default bingo hints instead: {e}")
         with open(data_path('Bingo/generic_bingo_hints.json'), 'r') as bingoFile:
-            genericBingo = json.load(bingoFile)
-        return genericBingo['settings']['item_hints']
+            generic_bingo = json.load(bingoFile)
+        return generic_bingo['settings']['item_hints']
 
     # Goal list returned from Bingosync is a sequential list of all of the goals on the bingo board, starting at top-left and moving to the right.
     # Each goal is a dictionary with attributes for name, slot, and colours. The only one we use is the name
-    goalList = [goal['name'] for goal in json.loads(goalList)]
+    goal_list = [goal['name'] for goal in json.loads(goal_list)]
     with open(data_path('Bingo/bingo_goals.json'), 'r') as bingoFile:
-        goalHintRequirements = json.load(bingoFile)
+        goal_hint_requirements = json.load(bingoFile)
 
-    hintsToAdd = {}
-    for goal in goalList:
+    hints_to_add = {}
+    for goal in goal_list:
         # Using 'get' here ensures some level of forward compatibility, where new goals added to randomiser bingo won't
         # cause the generator to crash (though those hints won't have item hints for them)
-        requirements = goalHintRequirements.get(goal,{})
+        requirements = goal_hint_requirements.get(goal, {})
         if len(requirements) != 0:
             for item in requirements:
-                hintsToAdd[item] = max(hintsToAdd.get(item, 0), requirements[item]['count'])
+                hints_to_add[item] = max(hints_to_add.get(item, 0), requirements[item]['count'])
 
     # Items to be hinted need to be included in the item_hints list once for each instance you want hinted
     # (e.g. if you want all three strength upgrades to be hintes it needs to be in the list three times)
     hints = []
-    for key, value in hintsToAdd.items():
+    for key, value in hints_to_add.items():
         for _ in range(value):
             hints.append(key)
 
-    #Since there's no way to verify if the Bingosync URL is actually for OoTR, this exception catches that case
+    # Since there's no way to verify if the Bingosync URL is actually for OoTR, this exception catches that case
     if len(hints) == 0:
         raise Exception('No item hints found for goals on Bingosync card. Verify Bingosync URL is correct, or leave field blank for generic bingo hints.')
     return hints
 
 
-def alwaysNamedItem(world, locations):
+def always_named_item(world: "World", locations: "Iterable[Location]"):
     for location in locations:
         if location.item.name in bingoBottlesForHints and world.settings.hint_dist == 'bingo':
             always_item = 'Bottle'
@@ -1202,39 +1222,38 @@ def alwaysNamedItem(world, locations):
             world.named_item_pool.remove(always_item)
 
 
-def buildGossipHints(spoiler, worlds):
-    checkedLocations = dict()
+def build_gossip_hints(spoiler: "Spoiler", worlds: "List[World]") -> None:
+    checked_locations = dict()
     # Add misc. item hint locations to "checked" locations if the respective hint is reachable without the hinted item.
     for world in worlds:
         for location in world.hinted_dungeon_reward_locations.values():
             if 'altar' in world.settings.misc_hints and not world.settings.enhance_map_compass and can_reach_hint(worlds, world.get_location('ToT Child Altar Hint' if location.item.info.stone else 'ToT Adult Altar Hint'), location):
                 item_world = location.world
-                if item_world.id not in checkedLocations:
-                    checkedLocations[item_world.id] = set()
-                checkedLocations[item_world.id].add(location.name)
+                if item_world.id not in checked_locations:
+                    checked_locations[item_world.id] = set()
+                checked_locations[item_world.id].add(location.name)
         for hint_type, location in world.misc_hint_item_locations.items():
             if hint_type in world.settings.misc_hints and can_reach_hint(worlds, world.get_location(misc_item_hint_table[hint_type]['hint_location']), location):
                 item_world = location.world
-                if item_world.id not in checkedLocations:
-                    checkedLocations[item_world.id] = set()
-                checkedLocations[item_world.id].add(location.name)
+                if item_world.id not in checked_locations:
+                    checked_locations[item_world.id] = set()
+                checked_locations[item_world.id].add(location.name)
         for hint_type in world.misc_hint_location_items.keys():
             location = world.get_location(misc_location_hint_table[hint_type]['item_location'])
             if hint_type in world.settings.misc_hints and can_reach_hint(worlds, world.get_location(misc_location_hint_table[hint_type]['hint_location']), location):
                 item_world = location.world
-                if item_world.id not in checkedLocations:
-                    checkedLocations[item_world.id] = set()
-                checkedLocations[item_world.id].add(location.name)
+                if item_world.id not in checked_locations:
+                    checked_locations[item_world.id] = set()
+                checked_locations[item_world.id].add(location.name)
 
     # Build all the hints.
     for world in worlds:
         world.update_useless_areas(spoiler)
-        buildWorldGossipHints(spoiler, world, checkedLocations.pop(world.id, None))
+        build_world_gossip_hints(spoiler, world, checked_locations.pop(world.id, None))
 
 
 # builds out general hints based on location and whether an item is required or not
-def buildWorldGossipHints(spoiler, world, checkedLocations=None):
-
+def build_world_gossip_hints(spoiler: "Spoiler", world: "World", checked_locations: Optional[MutableSet[str]] = None) -> None:
     world.barren_dungeon = 0
     world.woth_dungeon = 0
 
@@ -1244,16 +1263,16 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             search.spot_access(world.get_location(stone.location))
             and search.state_list[world.id].guarantee_hint())
 
-    if checkedLocations is None:
-        checkedLocations = set()
-    checkedAlwaysLocations = set()
+    if checked_locations is None:
+        checked_locations = set()
+    checked_always_locations = set()
 
-    stoneIDs = list(gossipLocations.keys())
+    stone_ids = list(gossipLocations.keys())
 
-    world.distribution.configure_gossip(spoiler, stoneIDs)
+    world.distribution.configure_gossip(spoiler, stone_ids)
 
     # If all gossip stones already have plando'd hints, do not roll any more
-    if len(stoneIDs) == 0:
+    if len(stone_ids) == 0:
         return
 
     if 'disabled' in world.hint_dist_user:
@@ -1262,12 +1281,12 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
                 stone_id = gossipLocations_reversemap[stone_name]
             except KeyError:
                 raise ValueError(f'Gossip stone location "{stone_name}" is not valid')
-            if stone_id in stoneIDs:
-                stoneIDs.remove(stone_id)
-                (gossip_text, _) = get_junk_hint(spoiler, world, checkedLocations)
+            if stone_id in stone_ids:
+                stone_ids.remove(stone_id)
+                (gossip_text, _) = get_junk_hint(spoiler, world, checked_locations)
                 spoiler.hints[world.id][stone_id] = gossip_text
 
-    stoneGroups = []
+    stone_groups = []
     if 'groups' in world.hint_dist_user:
         for group_names in world.hint_dist_user['groups']:
             group = []
@@ -1277,27 +1296,27 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
                 except KeyError:
                     raise ValueError(f'Gossip stone location "{stone_name}" is not valid')
 
-                if stone_id in stoneIDs:
-                    stoneIDs.remove(stone_id)
+                if stone_id in stone_ids:
+                    stone_ids.remove(stone_id)
                     group.append(stone_id)
             if len(group) != 0:
-                stoneGroups.append(group)
+                stone_groups.append(group)
     # put the remaining locations into singleton groups
-    stoneGroups.extend([[id] for id in stoneIDs])
+    stone_groups.extend([[id] for id in stone_ids])
 
-    random.shuffle(stoneGroups)
+    random.shuffle(stone_groups)
 
     # Create list of items for which we want hints. If Bingosync URL is supplied, include items specific to that bingo.
     # If not (or if the URL is invalid), use generic bingo hints
     if world.settings.hint_dist == "bingo":
         with open(data_path('Bingo/generic_bingo_hints.json'), 'r') as bingoFile:
-            bingoDefaults = json.load(bingoFile)
+            bingo_defaults = json.load(bingoFile)
         if world.settings.bingosync_url and world.settings.bingosync_url.startswith("https://bingosync.com/"): # Verify that user actually entered a bingosync URL
             logger = logging.getLogger('')
             logger.info("Got Bingosync URL. Building board-specific goals.")
-            world.item_hints = buildBingoHintList(world.settings.bingosync_url)
+            world.item_hints = build_bingo_hint_list(world.settings.bingosync_url)
         else:
-            world.item_hints = bingoDefaults['settings']['item_hints']
+            world.item_hints = bingo_defaults['settings']['item_hints']
 
         if world.settings.tokensanity in ("overworld", "all") and "Suns Song" not in world.item_hints:
             world.item_hints.append("Suns Song")
@@ -1305,11 +1324,10 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
         if world.settings.shopsanity != "off" and "Progressive Wallet" not in world.item_hints:
             world.item_hints.append("Progressive Wallet")
 
-
-    #Removes items from item_hints list if they are included in starting gear.
-    #This method ensures that the right number of copies are removed, e.g.
-    #if you start with one strength and hints call for two, you still get
-    #one hint for strength. This also handles items from Skip Child Zelda.
+    # Removes items from item_hints list if they are included in starting gear.
+    # This method ensures that the right number of copies are removed, e.g.
+    # if you start with one strength and hints call for two, you still get
+    # one hint for strength. This also handles items from Skip Child Zelda.
     for itemname, record in world.distribution.effective_starting_items.items():
         for _ in range(record.count):
             if itemname in world.item_hints:
@@ -1317,13 +1335,12 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
     world.named_item_pool = list(world.item_hints)
 
-    #Make sure the total number of hints won't pass 40. If so, we limit the always and trial hints
+    # Make sure the total number of hints won't pass 40. If so, we limit the always and trial hints
     if world.settings.hint_dist == "bingo":
-        numTrialHints = [0,1,2,3,2,1,0]
-        if (2*len(world.item_hints) + 2*len(getHintGroup('always', world)) + 2*numTrialHints[world.settings.trials] > 40) and (world.hint_dist_user['named_items_required']):
+        num_trial_hints = [0, 1, 2, 3, 2, 1, 0]
+        if (2 * len(world.item_hints) + 2 * len(get_hint_group('always', world)) + 2 * num_trial_hints[world.settings.trials] > 40) and (world.hint_dist_user['named_items_required']):
             world.hint_dist_user['distribution']['always']['copies'] = 1
             world.hint_dist_user['distribution']['trial']['copies'] = 1
-
 
     # Load hint distro from distribution file or pre-defined settings
     #
@@ -1362,82 +1379,84 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
     # Add required dual location hints, only if hint copies > 0
     if 'dual_always' in hint_dist and hint_dist['dual_always'][1] > 0:
-        alwaysDuals = getHintGroup('dual_always', world)
-        for hint in alwaysDuals:
-            multi = getMulti(hint.name)
-            firstLocation = world.get_location(multi.locations[0])
-            secondLocation = world.get_location(multi.locations[1])
-            checkedAlwaysLocations.add(firstLocation.name)
-            checkedAlwaysLocations.add(secondLocation.name)
+        always_duals = get_hint_group('dual_always', world)
+        for hint in always_duals:
+            multi = get_multi(hint.name)
+            first_location = world.get_location(multi.locations[0])
+            second_location = world.get_location(multi.locations[1])
+            checked_always_locations.add(first_location.name)
+            checked_always_locations.add(second_location.name)
 
-            alwaysNamedItem(world, [firstLocation, secondLocation])
+            always_named_item(world, [first_location, second_location])
 
             if hint.name in world.hint_text_overrides:
                 location_text = world.hint_text_overrides[hint.name]
             else:
-                location_text = getHint(hint.name, world.settings.clearer_hints).text
+                location_text = get_hint(hint.name, world.settings.clearer_hints).text
             if '#' not in location_text:
                 location_text = '#%s#' % location_text
-            first_item_text = getHint(getItemGenericName(firstLocation.item), world.settings.clearer_hints).text
-            second_item_text = getHint(getItemGenericName(secondLocation.item), world.settings.clearer_hints).text
-            add_hint(spoiler, world, stoneGroups, GossipText('%s #%s# and #%s#.' % (location_text, first_item_text, second_item_text), ['Red', 'Green', 'Green'], [firstLocation.name, secondLocation.name], [firstLocation.item.name, secondLocation.item.name]), hint_dist['dual_always'][1], [firstLocation, secondLocation], force_reachable=True)
+            first_item_text = get_hint(get_item_generic_name(first_location.item), world.settings.clearer_hints).text
+            second_item_text = get_hint(get_item_generic_name(second_location.item), world.settings.clearer_hints).text
+            add_hint(spoiler, world, stone_groups, GossipText('%s #%s# and #%s#.' % (location_text, first_item_text, second_item_text), ['Red', 'Green', 'Green'], [first_location.name, second_location.name], [first_location.item.name, second_location.item.name]), hint_dist['dual_always'][1], [first_location, second_location], force_reachable=True)
             logging.getLogger('').debug('Placed dual_always hint for %s.', hint.name)
 
     # Add required location hints, only if hint copies > 0
     if hint_dist['always'][1] > 0:
-        alwaysLocations = list(filter(lambda hint: is_not_checked([world.get_location(hint.name)], checkedAlwaysLocations), getHintGroup('always', world)))
-        for hint in alwaysLocations:
+        always_locations = list(filter(lambda hint: is_not_checked([world.get_location(hint.name)], checked_always_locations),
+                                       get_hint_group('always', world)))
+        for hint in always_locations:
             location = world.get_location(hint.name)
-            checkedAlwaysLocations.add(hint.name)
+            checked_always_locations.add(hint.name)
 
-            alwaysNamedItem(world, [location])
+            always_named_item(world, [location])
 
             if location.name in world.hint_text_overrides:
                 location_text = world.hint_text_overrides[location.name]
             else:
-                location_text = getHint(location.name, world.settings.clearer_hints).text
+                location_text = get_hint(location.name, world.settings.clearer_hints).text
             if '#' not in location_text:
                 location_text = '#%s#' % location_text
-            item_text = getHint(getItemGenericName(location.item), world.settings.clearer_hints).text
-            add_hint(spoiler, world, stoneGroups, GossipText('%s #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), hint_dist['always'][1], [location], force_reachable=True)
+            item_text = get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text
+            add_hint(spoiler, world, stone_groups, GossipText('%s #%s#.' % (location_text, item_text), ['Red', 'Green'], [location.name], [location.item.name]), hint_dist['always'][1], [location], force_reachable=True)
             logging.getLogger('').debug('Placed always hint for %s.', location.name)
 
     # Add required entrance hints, only if hint copies > 0
     if world.entrance_shuffle and 'entrance_always' in hint_dist and hint_dist['entrance_always'][1] > 0:
-        alwaysEntrances = getHintGroup('entrance_always', world)
-        for entrance_hint in alwaysEntrances:
+        always_entrances = get_hint_group('entrance_always', world)
+        for entrance_hint in always_entrances:
             entrance = world.get_entrance(entrance_hint.name)
             connected_region = entrance.connected_region
-            if entrance.shuffled and (connected_region.dungeon or any(hint.name == connected_region.name for hint in getHintGroup('region', world))):
-                checkedAlwaysLocations.add(entrance.name)
+            if entrance.shuffled and (connected_region.dungeon or any(hint.name == connected_region.name for hint in
+                                                                      get_hint_group('region', world))):
+                checked_always_locations.add(entrance.name)
 
                 entrance_text = entrance_hint.text
                 if '#' not in entrance_text:
                     entrance_text = '#%s#' % entrance_text
 
                 if connected_region.dungeon:
-                    region_text = getHint(connected_region.dungeon.name, world.settings.clearer_hints).text
+                    region_text = get_hint(connected_region.dungeon.name, world.settings.clearer_hints).text
                 else:
-                    region_text = getHint(connected_region.name, world.settings.clearer_hints).text
+                    region_text = get_hint(connected_region.name, world.settings.clearer_hints).text
                 if '#' not in region_text:
                     region_text = '#%s#' % region_text
 
-                add_hint(spoiler, world, stoneGroups, GossipText('%s %s.' % (entrance_text, region_text), ['Green', 'Light Blue']), hint_dist['entrance_always'][1], None, force_reachable=True)
+                add_hint(spoiler, world, stone_groups, GossipText('%s %s.' % (entrance_text, region_text), ['Green', 'Light Blue']), hint_dist['entrance_always'][1], None, force_reachable=True)
 
     # Add trial hints, only if hint copies > 0
     if hint_dist['trial'][1] > 0:
         if world.settings.trials_random and world.settings.trials == 6:
-            add_hint(spoiler, world, stoneGroups, GossipText("#Ganon's Tower# is protected by a powerful barrier.", ['Pink']), hint_dist['trial'][1], force_reachable=True)
+            add_hint(spoiler, world, stone_groups, GossipText("#Ganon's Tower# is protected by a powerful barrier.", ['Pink']), hint_dist['trial'][1], force_reachable=True)
         elif world.settings.trials_random and world.settings.trials == 0:
-            add_hint(spoiler, world, stoneGroups, GossipText("Sheik dispelled the barrier around #Ganon's Tower#.", ['Yellow']), hint_dist['trial'][1], force_reachable=True)
-        elif world.settings.trials < 6 and world.settings.trials > 3:
-            for trial,skipped in world.skipped_trials.items():
+            add_hint(spoiler, world, stone_groups, GossipText("Sheik dispelled the barrier around #Ganon's Tower#.", ['Yellow']), hint_dist['trial'][1], force_reachable=True)
+        elif 3 < world.settings.trials < 6:
+            for trial, skipped in world.skipped_trials.items():
                 if skipped:
-                    add_hint(spoiler, world, stoneGroups,GossipText("the #%s Trial# was dispelled by Sheik." % trial, ['Yellow']), hint_dist['trial'][1], force_reachable=True)
-        elif world.settings.trials <= 3 and world.settings.trials > 0:
-            for trial,skipped in world.skipped_trials.items():
+                    add_hint(spoiler, world, stone_groups, GossipText("the #%s Trial# was dispelled by Sheik." % trial, ['Yellow']), hint_dist['trial'][1], force_reachable=True)
+        elif 0 < world.settings.trials <= 3:
+            for trial, skipped in world.skipped_trials.items():
                 if not skipped:
-                    add_hint(spoiler, world, stoneGroups, GossipText("the #%s Trial# protects Ganon's Tower." % trial, ['Pink']), hint_dist['trial'][1], force_reachable=True)
+                    add_hint(spoiler, world, stone_groups, GossipText("the #%s Trial# protects Ganon's Tower." % trial, ['Pink']), hint_dist['trial'][1], force_reachable=True)
 
     # Add user-specified hinted item locations if using a built-in hint distribution
     # Raise error if hint copies is zero
@@ -1448,19 +1467,19 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             # Prevent conflict between Ganondorf Light Arrows hint and required named item hints.
             # Assumes that a "wasted" hint is desired since Light Arrows have to be added
             # explicitly to the list for named item hints.
-            filtered_checked = set(checkedLocations | checkedAlwaysLocations)
-            for location in (checkedLocations | checkedAlwaysLocations):
+            filtered_checked = set(checked_locations | checked_always_locations)
+            for location in (checked_locations | checked_always_locations):
                 try:
                     if world.get_location(location).item.name == 'Light Arrows':
                         filtered_checked.remove(location)
                 except KeyError:
-                    pass # checkedAlwaysLocations can also contain entrances from entrance_always hints, ignore those here
+                    pass  # checked_always_locations can also contain entrances from entrance_always hints, ignore those here
             for i in range(0, len(world.named_item_pool)):
                 hint = get_specific_item_hint(spoiler, world, filtered_checked)
                 if hint:
-                    checkedLocations.update(filtered_checked - checkedAlwaysLocations)
+                    checked_locations.update(filtered_checked - checked_always_locations)
                     gossip_text, location = hint
-                    place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, hint_dist['named-item'][1], location)
+                    place_ok = add_hint(spoiler, world, stone_groups, gossip_text, hint_dist['named-item'][1], location)
                     if not place_ok:
                         raise Exception('Not enough gossip stones for user-provided item hints')
 
@@ -1474,19 +1493,19 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     hint_counts = {}
 
     custom_fixed = True
-    while stoneGroups:
+    while stone_groups:
         if fixed_hint_types:
             hint_type = fixed_hint_types.pop(0)
             copies = hint_dist[hint_type][1]
-            if copies > len(stoneGroups):
+            if copies > len(stone_groups):
                 # Quiet to avoid leaking information.
-                logging.getLogger('').debug(f'Not enough gossip stone locations ({len(stoneGroups)} groups) for fixed hint type {hint_type} with {copies} copies, proceeding with available stones.')
-                copies = len(stoneGroups)
+                logging.getLogger('').debug(f'Not enough gossip stone locations ({len(stone_groups)} groups) for fixed hint type {hint_type} with {copies} copies, proceeding with available stones.')
+                copies = len(stone_groups)
         else:
             custom_fixed = False
             # Make sure there are enough stones left for each hint type
             num_types = len(hint_types)
-            hint_types = list(filter(lambda htype: hint_dist[htype][1] <= len(stoneGroups), hint_types))
+            hint_types = list(filter(lambda htype: hint_dist[htype][1] <= len(stone_groups), hint_types))
             new_num_types = len(hint_types)
             if new_num_types == 0:
                 raise Exception('Not enough gossip stone locations for remaining weighted hint types.')
@@ -1514,12 +1533,12 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             except IndexError:
                 raise Exception('Not enough valid hints to fill gossip stone locations.')
 
-        allCheckedLocations = checkedLocations | checkedAlwaysLocations
+        all_checked_locations = checked_locations | checked_always_locations
         if hint_type == 'barren':
-            hint = hint_func[hint_type](spoiler, world, checkedLocations, allCheckedLocations)
+            hint = hint_func[hint_type](spoiler, world, checked_locations, all_checked_locations)
         else:
-            hint = hint_func[hint_type](spoiler, world, allCheckedLocations)
-            checkedLocations.update(allCheckedLocations - checkedAlwaysLocations)
+            hint = hint_func[hint_type](spoiler, world, all_checked_locations)
+            checked_locations.update(all_checked_locations - checked_always_locations)
 
         if hint is None:
             index = hint_types.index(hint_type)
@@ -1529,7 +1548,7 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             hint_dist[hint_type] = (0.0, copies)
         else:
             gossip_text, locations = hint
-            place_ok = add_hint(spoiler, world, stoneGroups, gossip_text, copies, locations)
+            place_ok = add_hint(spoiler, world, stone_groups, gossip_text, copies, locations)
             if place_ok:
                 hint_counts[hint_type] = hint_counts.get(hint_type, 0) + 1
                 if locations is None:
@@ -1542,27 +1561,27 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
 
 
 # builds text that is displayed at the temple of time altar for child and adult, rewards pulled based off of item in a fixed order.
-def buildAltarHints(world, messages, include_rewards=True, include_wincons=True):
+def build_altar_hints(world: "World", messages: List[Message], include_rewards: bool = True, include_wincons: bool = True) -> None:
     # text that appears at altar as a child.
     child_text = '\x08'
     if include_rewards:
-        bossRewardsSpiritualStones = [
+        boss_rewards_spiritual_stones = [
             ('Kokiri Emerald',   'Green'),
             ('Goron Ruby',       'Red'),
             ('Zora Sapphire',    'Blue'),
         ]
-        child_text += getHint('Spiritual Stone Text Start', world.settings.clearer_hints).text + '\x04'
-        for (reward, color) in bossRewardsSpiritualStones:
-            child_text += buildBossString(reward, color, world)
-    child_text += getHint('Child Altar Text End', world.settings.clearer_hints).text
+        child_text += get_hint('Spiritual Stone Text Start', world.settings.clearer_hints).text + '\x04'
+        for (reward, color) in boss_rewards_spiritual_stones:
+            child_text += build_boss_string(reward, color, world)
+    child_text += get_hint('Child Altar Text End', world.settings.clearer_hints).text
     child_text += '\x0B'
     update_message_by_id(messages, 0x707A, get_raw_text(child_text), 0x20)
 
     # text that appears at altar as an adult.
     adult_text = '\x08'
-    adult_text += getHint('Adult Altar Text Start', world.settings.clearer_hints).text + '\x04'
+    adult_text += get_hint('Adult Altar Text Start', world.settings.clearer_hints).text + '\x04'
     if include_rewards:
-        bossRewardsMedallions = [
+        boss_rewards_medallions = [
             ('Light Medallion',  'Light Blue'),
             ('Forest Medallion', 'Green'),
             ('Fire Medallion',   'Red'),
@@ -1570,20 +1589,20 @@ def buildAltarHints(world, messages, include_rewards=True, include_wincons=True)
             ('Shadow Medallion', 'Pink'),
             ('Spirit Medallion', 'Yellow'),
         ]
-        for (reward, color) in bossRewardsMedallions:
-            adult_text += buildBossString(reward, color, world)
+        for (reward, color) in boss_rewards_medallions:
+            adult_text += build_boss_string(reward, color, world)
     if include_wincons:
-        adult_text += buildBridgeReqsString(world)
+        adult_text += build_bridge_reqs_string(world)
         adult_text += '\x04'
-        adult_text += buildGanonBossKeyString(world)
+        adult_text += build_ganon_boss_key_string(world)
     else:
-        adult_text += getHint('Adult Altar Text End', world.settings.clearer_hints).text
+        adult_text += get_hint('Adult Altar Text End', world.settings.clearer_hints).text
     adult_text += '\x0B'
     update_message_by_id(messages, 0x7057, get_raw_text(adult_text), 0x20)
 
 
 # pulls text string from hintlist for reward after sending the location to hintlist.
-def buildBossString(reward, color, world):
+def build_boss_string(reward: str, color: str, world: "World") -> str:
     item_icon = chr(Item(reward).special['item_id'])
     if reward in world.distribution.effective_starting_items and world.distribution.effective_starting_items[reward].count > 0:
         if world.settings.clearer_hints:
@@ -1597,12 +1616,12 @@ def buildBossString(reward, color, world):
     return str(text) + '\x04'
 
 
-def buildBridgeReqsString(world):
+def build_bridge_reqs_string(world: "World") -> str:
     string = "\x13\x12" # Light Arrow Icon
     if world.settings.bridge == 'open':
         string += "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
     else:
-        item_req_string = getHint('bridge_' + world.settings.bridge, world.settings.clearer_hints).text
+        item_req_string = get_hint('bridge_' + world.settings.bridge, world.settings.clearer_hints).text
         if world.settings.bridge == 'medallions':
             item_req_string = str(world.settings.bridge_medallions) + ' ' + item_req_string
         elif world.settings.bridge == 'stones':
@@ -1619,13 +1638,13 @@ def buildBridgeReqsString(world):
     return str(GossipText(string, ['Green'], prefix=''))
 
 
-def buildGanonBossKeyString(world):
+def build_ganon_boss_key_string(world: "World") -> str:
     string = "\x13\x74" # Boss Key Icon
     if world.settings.shuffle_ganon_bosskey == 'remove':
         string += "And the door to the \x05\x41evil one\x05\x40's chamber will be left #unlocked#."
     else:
         if world.settings.shuffle_ganon_bosskey == 'on_lacs':
-            item_req_string = getHint('lacs_' + world.settings.lacs_condition, world.settings.clearer_hints).text
+            item_req_string = get_hint('lacs_' + world.settings.lacs_condition, world.settings.clearer_hints).text
             if world.settings.lacs_condition == 'medallions':
                 item_req_string = str(world.settings.lacs_medallions) + ' ' + item_req_string
             elif world.settings.lacs_condition == 'stones':
@@ -1640,7 +1659,7 @@ def buildGanonBossKeyString(world):
                 item_req_string = '#%s#' % item_req_string
             bk_location_string = "provided by Zelda once %s are retrieved" % item_req_string
         elif world.settings.shuffle_ganon_bosskey in ['stones', 'medallions', 'dungeons', 'tokens', 'hearts']:
-            item_req_string = getHint('ganonBK_' + world.settings.shuffle_ganon_bosskey, world.settings.clearer_hints).text
+            item_req_string = get_hint('ganonBK_' + world.settings.shuffle_ganon_bosskey, world.settings.clearer_hints).text
             if world.settings.shuffle_ganon_bosskey == 'medallions':
                 item_req_string = str(world.settings.ganon_bosskey_medallions) + ' ' + item_req_string
             elif world.settings.shuffle_ganon_bosskey == 'stones':
@@ -1655,26 +1674,27 @@ def buildGanonBossKeyString(world):
                 item_req_string = '#%s#' % item_req_string
             bk_location_string = "automatically granted once %s are retrieved" % item_req_string
         else:
-            bk_location_string = getHint('ganonBK_' + world.settings.shuffle_ganon_bosskey, world.settings.clearer_hints).text
+            bk_location_string = get_hint('ganonBK_' + world.settings.shuffle_ganon_bosskey,
+                                          world.settings.clearer_hints).text
         string += "And the \x05\x41evil one\x05\x40's key will be %s." % bk_location_string
     return str(GossipText(string, ['Yellow'], prefix=''))
 
 
 # fun new lines for Ganon during the final battle
-def buildGanonText(world, messages):
+def build_ganon_text(world: "World", messages: List[Message]) -> None:
     # empty now unused messages to make space for ganon lines
     update_message_by_id(messages, 0x70C8, " ")
     update_message_by_id(messages, 0x70C9, " ")
     update_message_by_id(messages, 0x70CA, " ")
 
     # lines before battle
-    ganonLines = getHintGroup('ganonLine', world)
+    ganonLines = get_hint_group('ganonLine', world)
     random.shuffle(ganonLines)
     text = get_raw_text(ganonLines.pop().text)
     update_message_by_id(messages, 0x70CB, text)
 
 
-def buildMiscItemHints(world, messages):
+def build_misc_item_hints(world: "World", messages: List[Message]) -> None:
     for hint_type, data in misc_item_hint_table.items():
         if hint_type in world.settings.misc_hints:
             item = world.misc_hint_items[hint_type]
@@ -1689,17 +1709,17 @@ def buildMiscItemHints(world, messages):
                 if item == data['default_item']:
                     text = data['default_item_text'].format(area=area)
                 else:
-                    text = data['custom_item_text'].format(area=area, item=getHint(getItemGenericName(location.item), world.settings.clearer_hints).text)
+                    text = data['custom_item_text'].format(area=area, item=get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text)
             elif 'custom_item_fallback' in data:
                 if 'default_item_fallback' in data and item == data['default_item']:
                     text = data['default_item_fallback']
                 else:
                     text = data['custom_item_fallback'].format(item=item)
             else:
-                text = getHint('Validation Line', world.settings.clearer_hints).text
+                text = get_hint('Validation Line', world.settings.clearer_hints).text
                 for location in world.get_filled_locations():
                     if location.name == 'Ganons Tower Boss Key Chest':
-                        text += f"#{getHint(getItemGenericName(location.item), world.settings.clearer_hints).text}#"
+                        text += f"#{get_hint(get_item_generic_name(location.item), world.settings.clearer_hints).text}#"
                         break
             for find, replace in data.get('replace', {}).items():
                 text = text.replace(find, replace)
@@ -1707,19 +1727,19 @@ def buildMiscItemHints(world, messages):
             update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')))
 
 
-def buildMiscLocationHints(world, messages):
+def build_misc_location_hints(world: "World", messages: List[Message]) -> None:
     for hint_type, data in misc_location_hint_table.items():
         text = data['location_fallback']
         if hint_type in world.settings.misc_hints:
-            location = world.misc_hint_locations[hint_type]
             if hint_type in world.misc_hint_location_items:
                 item = world.misc_hint_location_items[hint_type]
-                text = data['location_text'].format(item=getHint(getItemGenericName(item), world.settings.clearer_hints).text)
+                text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
+                                                                  world.settings.clearer_hints).text)
 
         update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), 0x23)
 
 
-def get_raw_text(string):
+def get_raw_text(string: str) -> str:
     text = ''
     for char in string:
         if char == '^':
@@ -1735,29 +1755,27 @@ def get_raw_text(string):
     return text
 
 
-def HintDistFiles():
+def hint_dist_files() -> List[str]:
     return [os.path.join(data_path('Hints/'), d) for d in defaultHintDists] + [
             os.path.join(data_path('Hints/'), d)
             for d in sorted(os.listdir(data_path('Hints/')))
             if d.endswith('.json') and d not in defaultHintDists]
 
 
-def HintDistList():
+def hint_dist_list() -> Dict[str, str]:
     dists = {}
-    for d in HintDistFiles():
+    for d in hint_dist_files():
         with open(d, 'r') as dist_file:
             dist = json.load(dist_file)
-        dist_name = dist['name']
-        gui_name = dist['gui_name']
-        dists.update({ dist_name: gui_name })
+        dists[dist['name']] = dist['gui_name']
     return dists
 
 
-def HintDistTips():
+def hint_dist_tips() -> str:
     tips = ""
     first_dist = True
     line_char_limit = 33
-    for d in HintDistFiles():
+    for d in hint_dist_files():
         if not first_dist:
             tips = tips + "\n"
         else:

--- a/Hints.py
+++ b/Hints.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import sys
 import urllib.request
 from collections import OrderedDict, defaultdict
 from enum import Enum
@@ -16,7 +17,12 @@ from Messages import Message, COLOR_MAP, update_message_by_id
 from Region import Region
 from Search import Search
 from TextBox import line_wrap
-from Utils import TypeAlias, data_path
+from Utils import data_path
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    TypeAlias = str
 
 if TYPE_CHECKING:
     from Entrance import Entrance
@@ -27,8 +33,8 @@ if TYPE_CHECKING:
 
 Spot: TypeAlias = "Union[Entrance, Location, Region]"
 HintReturn: TypeAlias = "Optional[Tuple[GossipText, Optional[List[Location]]]]"
-HintFunc: TypeAlias = "Callable[[Spoiler, World, MutableSet[str]], HintReturn]"
-BarrenFunc: TypeAlias = "Callable[[Spoiler, World, MutableSet[str], MutableSet[str]], HintReturn]"
+HintFunc: TypeAlias = Callable[["Spoiler", "World", MutableSet[str]], HintReturn]
+BarrenFunc: TypeAlias = Callable[["Spoiler", "World", MutableSet[str], MutableSet[str]], HintReturn]
 
 bingoBottlesForHints: Set[str] = {
     "Bottle", "Bottle with Red Potion", "Bottle with Green Potion", "Bottle with Blue Potion",
@@ -467,8 +473,8 @@ class HintArea(Enum):
 
     # Formats the hint text for this area with proper grammar.
     # Dungeons are hinted differently depending on the clearer_hints setting.
-    def text(self, clearer_hints: bool, preposition: bool = False, world: "Optional[World]" = None) -> str:
-        if self.is_dungeon:
+    def text(self, clearer_hints: bool, preposition: bool = False, world: "Optional[int]" = None) -> str:
+        if self.is_dungeon and self.dungeon_name:
             text = get_hint(self.dungeon_name, clearer_hints).text
         else:
             text = str(self)

--- a/Hints.py
+++ b/Hints.py
@@ -169,6 +169,8 @@ def get_item_generic_name(item: Item) -> str:
 
 
 def is_restricted_dungeon_item(item: Item) -> bool:
+    if item.world is None:
+        return False
     return (
         ((item.map or item.compass) and item.world.settings.shuffle_mapcompass == 'dungeon') or
         (item.type == 'SmallKey' and item.world.settings.shuffle_smallkeys == 'dungeon') or
@@ -214,6 +216,7 @@ def add_hint(spoiler: Spoiler, world: World, groups: list[list[int]], gossip_tex
                                 event_item = make_event_item(stone_name, stone_locations[i], event_item)
                             else:
                                 make_event_item(stone_name, stone_locations[i], event_item)
+                        assert event_item is not None
 
                         # This mostly guarantees that we don't lock the player out of an item hint
                         # by establishing a (hint -> item) -> hint -> item -> (first hint) loop

--- a/IconManip.py
+++ b/IconManip.py
@@ -1,6 +1,12 @@
+import sys
 from typing import TYPE_CHECKING, Sequence, MutableSequence, Optional
 
-from Utils import data_path, TypeAlias
+from Utils import data_path
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    TypeAlias = str
 
 if TYPE_CHECKING:
     from Rom import Rom

--- a/IconManip.py
+++ b/IconManip.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 import sys
-from typing import TYPE_CHECKING, Sequence, MutableSequence, Optional
+from collections.abc import Sequence, MutableSequence
+from typing import TYPE_CHECKING, Optional
 
 from Utils import data_path
 
@@ -11,7 +13,7 @@ else:
 if TYPE_CHECKING:
     from Rom import Rom
 
-RGBValues: TypeAlias = MutableSequence[MutableSequence[int]]
+RGBValues: TypeAlias = "MutableSequence[MutableSequence[int]]"
 
 
 # TODO
@@ -140,7 +142,7 @@ def rgb_to_rgb5a1(rgb_values: RGBValues) -> bytes:
 
 
 # Patch overworld icons
-def patch_overworld_icon(rom: "Rom", color: Optional[Sequence[int]], address: int, filename: Optional[str] = None) -> None:
+def patch_overworld_icon(rom: Rom, color: Optional[Sequence[int]], address: int, filename: Optional[str] = None) -> None:
     original = rom.original.read_bytes(address, 0x800)
 
     if color is None:

--- a/IconManip.py
+++ b/IconManip.py
@@ -30,7 +30,8 @@ def add_hue(image: MutableSequence[int], color: Sequence[int], tiff: bool = Fals
             pass
     return image
 
-def add_rainbow(img, width, tiff=False):
+
+def add_rainbow(img: MutableSequence[int], width: int, tiff: bool = False) -> MutableSequence[int]:
     # Define the colors of the rainbow
     colors = [(255, 0, 0), (255, 165, 0), (255, 255, 0),
               (0, 128, 0), (0, 0, 255), (75, 0, 130),
@@ -49,6 +50,7 @@ def add_rainbow(img, width, tiff=False):
                 pass
     return img
 
+
 # Function for adding belt to tunic
 def add_belt(tunic: MutableSequence[int], belt: MutableSequence[int], tiff: bool = False) -> MutableSequence[int]:
     start = 154 if tiff else 0
@@ -62,6 +64,7 @@ def add_belt(tunic: MutableSequence[int], belt: MutableSequence[int], tiff: bool
             pass
     return tunic
 
+
 # Function for putting tunic colors together
 def generate_tunic_icon(color: Sequence[int]) -> MutableSequence[int]:
     with open(data_path('icons/grey.tiff'), 'rb') as grey_fil, open(data_path('icons/belt.tiff'), 'rb') as belt_fil:
@@ -69,7 +72,8 @@ def generate_tunic_icon(color: Sequence[int]) -> MutableSequence[int]:
         belt = list(belt_fil.read())
         return add_belt(add_hue(grey, color, True), belt, True)[154:]
 
-def generate_rainbow_tunic_icon():
+
+def generate_rainbow_tunic_icon() -> MutableSequence[int]:
     with open(data_path('icons/grey.tiff'), 'rb') as grey_fil, open(data_path('icons/belt.tiff'), 'rb') as belt_fil:
         grey = list(grey_fil.read())
         belt = list(belt_fil.read())

--- a/IconManip.py
+++ b/IconManip.py
@@ -1,10 +1,18 @@
-from Utils import data_path
+from typing import TYPE_CHECKING, Sequence, MutableSequence, Optional
+
+from Utils import data_path, TypeAlias
+
+if TYPE_CHECKING:
+    from Rom import Rom
+
+RGBValues: TypeAlias = MutableSequence[MutableSequence[int]]
+
 
 # TODO
 # Move the tunic to the generalized system
 
 # Function for adding hue to a greyscaled icon
-def add_hue(image, color, tiff=False):
+def add_hue(image: MutableSequence[int], color: Sequence[int], tiff: bool = False) -> MutableSequence[int]:
     start = 154 if tiff else 0
     for i in range(start, len(image), 4):
         try:
@@ -34,7 +42,7 @@ def add_rainbow(img, width, tiff=False):
     return img
 
 # Function for adding belt to tunic
-def add_belt(tunic, belt, tiff=False):
+def add_belt(tunic: MutableSequence[int], belt: MutableSequence[int], tiff: bool = False) -> MutableSequence[int]:
     start = 154 if tiff else 0
     for i in range(start, len(tunic), 4):
         try:
@@ -47,7 +55,7 @@ def add_belt(tunic, belt, tiff=False):
     return tunic
 
 # Function for putting tunic colors together
-def generate_tunic_icon(color):
+def generate_tunic_icon(color: Sequence[int]) -> MutableSequence[int]:
     with open(data_path('icons/grey.tiff'), 'rb') as grey_fil, open(data_path('icons/belt.tiff'), 'rb') as belt_fil:
         grey = list(grey_fil.read())
         belt = list(belt_fil.read())
@@ -61,47 +69,52 @@ def generate_rainbow_tunic_icon():
 
 # END TODO
 
+
 # Function to add extra data on top of icon
-def add_extra_data(rgbValues, fileName, intensity = 0.5):
-    fileRGB = []
-    with open(fileName, "rb") as fil:
+def add_extra_data(rgb_values: RGBValues, filename: str, intensity: float = 0.5) -> None:
+    file_rgb = []
+    with open(filename, "rb") as fil:
         data = fil.read()
         for i in range(0, len(data), 4):
-            fileRGB.append([data[i+0], data[i+1], data[i+2], data[i+3]])
-    for i in range(len(rgbValues)):
-        alpha = fileRGB[i][3] / 255
+            file_rgb.append([data[i + 0], data[i + 1], data[i + 2], data[i + 3]])
+    for i in range(len(rgb_values)):
+        alpha = file_rgb[i][3] / 255
         for x in range(3):
-            rgbValues[i][x] = int((fileRGB[i][x] * alpha + intensity) + (rgbValues[i][x] * (1 - alpha - intensity)))
+            rgb_values[i][x] = int((file_rgb[i][x] * alpha + intensity) + (rgb_values[i][x] * (1 - alpha - intensity)))
+
 
 # Function for desaturating RGB values
-def greyscaleRGB(rgbValues, intensity: int = 2):
-    for rgb in rgbValues:
+def greyscale_rgb(rgb_values: RGBValues, intensity: int = 2) -> RGBValues:
+    for rgb in rgb_values:
         rgb[0] = rgb[1] = rgb[2] = int((rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722) * intensity)
-    return rgbValues
+    return rgb_values
+
 
 # Converts rgb5a1 values to RGBA lists
-def rgb5a1ToRGB(rgb5a1Bytes):
+def rgb5a1_to_rgb(rgb5a1_bytes: bytes) -> RGBValues:
     pixels = []
-    for i in range(0, len(rgb5a1Bytes), 2):
-        bits = format(rgb5a1Bytes[i], '#010b')[2:] + format(rgb5a1Bytes[i+1], '#010b')[2:]
+    for i in range(0, len(rgb5a1_bytes), 2):
+        bits = format(rgb5a1_bytes[i], '#010b')[2:] + format(rgb5a1_bytes[i + 1], '#010b')[2:]
         r = int(int(bits[0:5], 2) * (255/31))
         g = int(int(bits[5:10], 2) * (255/31))
         b = int(int(bits[10:15], 2) * (255/31))
         a = int(bits[15], 2) * 255
-        pixels.append([r,g,b,a])
+        pixels.append([r, g, b, a])
     return pixels
 
+
 # Adds a hue to RGB values
-def addHueToRGB(rgbValues, color):
-    for rgb in rgbValues:
+def add_hue_to_rgb(rgb_values: RGBValues, color: Sequence[int]) -> RGBValues:
+    for rgb in rgb_values:
         for i in range(3):
             rgb[i] = int(((rgb[i]/255) * (color[i]/255)) * 255)
-    return rgbValues
+    return rgb_values
+
 
 # Convert RGB to RGB5a1 format
-def rgbToRGB5a1(rgbValues):
+def rgb_to_rgb5a1(rgb_values: RGBValues) -> bytes:
     rgb5a1 = []
-    for rgb in rgbValues:
+    for rgb in rgb_values:
         r = int(rgb[0] / (255/31))
         r = r if r <= 31 else 31
         r = r if r >= 0 else 0
@@ -119,17 +132,18 @@ def rgbToRGB5a1(rgbValues):
         assert i <= 255, i
     return bytes(rgb5a1)
 
+
 # Patch overworld icons
-def patch_overworld_icon(rom, color, address, fileName = None):
+def patch_overworld_icon(rom: "Rom", color: Optional[Sequence[int]], address: int, filename: Optional[str] = None) -> None:
     original = rom.original.read_bytes(address, 0x800)
 
     if color is None:
         rom.write_bytes(address, original)
         return
 
-    rgbBytes = rgb5a1ToRGB(original)
-    greyscaled = greyscaleRGB(rgbBytes)
-    rgbBytes = addHueToRGB(greyscaled, color)
-    if fileName != None:
-        add_extra_data(rgbBytes, fileName)
-    rom.write_bytes(address, rgbToRGB5a1(rgbBytes))
+    rgb_bytes = rgb5a1_to_rgb(original)
+    greyscaled = greyscale_rgb(rgb_bytes)
+    rgb_bytes = add_hue_to_rgb(greyscaled, color)
+    if filename is not None:
+        add_extra_data(rgb_bytes, filename)
+    rom.write_bytes(address, rgb_to_rgb5a1(rgb_bytes))

--- a/Item.py
+++ b/Item.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional, Tuple, List, Dict, Union, Iterable, Set, Any, Callable, overload
+from __future__ import annotations
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Optional, Any, overload
 
 from ItemList import item_table
 from RulesCommon import allowed_globals, escape_name
@@ -9,17 +11,17 @@ if TYPE_CHECKING:
 
 
 class ItemInfo:
-    items: 'Dict[str, ItemInfo]' = {}
-    events: 'Dict[str, ItemInfo]' = {}
-    bottles: Set[str] = set()
-    medallions: Set[str] = set()
-    stones: Set[str] = set()
-    junk_weight: Dict[str, int] = {}
+    items: dict[str, ItemInfo] = {}
+    events: dict[str, ItemInfo] = {}
+    bottles: set[str] = set()
+    medallions: set[str] = set()
+    stones: set[str] = set()
+    junk_weight: dict[str, int] = {}
 
-    solver_ids: Dict[str, int] = {}
-    bottle_ids: Set[int] = set()
-    medallion_ids: Set[int] = set()
-    stone_ids: Set[int] = set()
+    solver_ids: dict[str, int] = {}
+    bottle_ids: set[int] = set()
+    medallion_ids: set[int] = set()
+    stone_ids: set[int] = set()
 
     def __init__(self, name: str = '', event: bool = False) -> None:
         if event:
@@ -34,13 +36,13 @@ class ItemInfo:
         self.advancement: bool = (progressive is True)
         self.priority: bool = (progressive is False)
         self.type: str = item_type
-        self.special: Dict[str, Any] = special or {}
+        self.special: dict[str, Any] = special or {}
         self.index: Optional[int] = item_id
         self.price: Optional[int] = self.special.get('price', None)
         self.bottle: bool = self.special.get('bottle', False)
         self.medallion: bool = self.special.get('medallion', False)
         self.stone: bool = self.special.get('stone', False)
-        self.alias: Optional[Tuple[str, int]] = self.special.get('alias', None)
+        self.alias: Optional[tuple[str, int]] = self.special.get('alias', None)
         self.junk: Optional[int] = self.special.get('junk', None)
         self.trade: bool = self.special.get('trade', False)
 
@@ -68,9 +70,9 @@ for item_name in item_table:
 
 
 class Item:
-    def __init__(self, name: str = '', world: "Optional[World]" = None, event: bool = False) -> None:
+    def __init__(self, name: str = '', world: Optional[World] = None, event: bool = False) -> None:
         self.name: str = name
-        self.location: "Optional[Location]" = None
+        self.location: Optional[Location] = None
         self.event: bool = event
         if event:
             if name not in ItemInfo.events:
@@ -79,22 +81,22 @@ class Item:
         else:
             self.info: ItemInfo = ItemInfo.items[name]
         self.price: Optional[int] = self.info.special.get('price', None)
-        self.world: "Optional[World]" = world
-        self.looks_like_item: 'Optional[Item]' = None
+        self.world: Optional[World] = world
+        self.looks_like_item: Optional[Item] = None
         self.advancement: bool = self.info.advancement
         self.priority: bool = self.info.priority
         self.type: str = self.info.type
         self.special: dict = self.info.special
         self.index: Optional[int] = self.info.index
-        self.alias: Optional[Tuple[str, int]] = self.info.alias
+        self.alias: Optional[tuple[str, int]] = self.info.alias
 
         self.solver_id: Optional[int] = self.info.solver_id
         # Do not alias to junk--it has no solver id!
         self.alias_id: Optional[int] = ItemInfo.solver_ids[escape_name(self.alias[0])] if self.alias else None
 
-    item_worlds_to_fix: 'Dict[Item, int]' = {}
+    item_worlds_to_fix: dict[Item, int] = {}
 
-    def copy(self, new_world: "Optional[World]" = None) -> 'Item':
+    def copy(self, new_world: Optional[World] = None) -> Item:
         if new_world is not None and self.world is not None and new_world.id != self.world.id:
             new_world = None
 
@@ -107,7 +109,7 @@ class Item:
         return new_item
 
     @classmethod
-    def fix_worlds_after_copy(cls, worlds: "List[World]") -> None:
+    def fix_worlds_after_copy(cls, worlds: list[World]) -> None:
         items_fixed = []
         for item, world_id in cls.item_worlds_to_fix.items():
             item.world = worlds[world_id]
@@ -200,14 +202,16 @@ class Item:
 
 
 @overload
-def ItemFactory(items: str, world: "Optional[World]" = None, event: bool = False) -> Item:
+def ItemFactory(items: str, world: Optional[World] = None, event: bool = False) -> Item:
     pass
+
 
 @overload
-def ItemFactory(items: Iterable[str], world: "Optional[World]" = None, event: bool = False) -> List[Item]:
+def ItemFactory(items: Iterable[str], world: Optional[World] = None, event: bool = False) -> list[Item]:
     pass
 
-def ItemFactory(items: Union[str, Iterable[str]], world: "Optional[World]" = None, event: bool = False) -> Union[Item, List[Item]]:
+
+def ItemFactory(items: str | Iterable[str], world: Optional[World] = None, event: bool = False) -> Item | list[Item]:
     if isinstance(items, str):
         if not event and items not in ItemInfo.items:
             raise KeyError('Unknown Item: %s' % items)
@@ -222,7 +226,7 @@ def ItemFactory(items: Union[str, Iterable[str]], world: "Optional[World]" = Non
     return ret
 
 
-def make_event_item(name: str, location: "Location", item: Optional[Item] = None) -> Item:
+def make_event_item(name: str, location: Location, item: Optional[Item] = None) -> Item:
     if location.world is None:
         raise Exception(f"`make_event_item` called with location '{location.name}' that doesn't have a world.")
     if item is None:
@@ -239,7 +243,7 @@ def is_item(name: str) -> bool:
     return name in item_table
 
 
-def ItemIterator(predicate: Callable[[Item], bool] = lambda item: True, world: "Optional[World]" = None) -> Iterable[Item]:
+def ItemIterator(predicate: Callable[[Item], bool] = lambda item: True, world: Optional[World] = None) -> Iterable[Item]:
     for item_name in item_table:
         item = ItemFactory(item_name, world)
         if predicate(item):

--- a/ItemList.py
+++ b/ItemList.py
@@ -1,8 +1,10 @@
+from typing import Dict, Tuple, Optional, Any
+
 # Progressive: True  -> Advancement
 #              False -> Priority
 #              None  -> Normal
 #    Item:                                            (type, Progressive, GetItemID, special),
-item_table = {
+item_table: Dict[str, Tuple[str, Optional[bool], int, Dict[str, Any]]] = {
     'Bombs (5)':                                       ('Item',     None,  0x0001, {'junk': 8}),
     'Deku Nuts (5)':                                   ('Item',     None,  0x0002, {'junk': 5}),
     'Bombchus (10)':                                   ('Item',     True,  0x0003, None),

--- a/ItemList.py
+++ b/ItemList.py
@@ -1,10 +1,11 @@
-from typing import Dict, Tuple, Optional, Any
+from __future__ import annotations
+from typing import Optional, Any
 
 # Progressive: True  -> Advancement
 #              False -> Priority
 #              None  -> Normal
 #    Item:                                            (type, Progressive, GetItemID, special),
-item_table: Dict[str, Tuple[str, Optional[bool], Optional[int], Optional[Dict[str, Any]]]] = {
+item_table: dict[str, tuple[str, Optional[bool], Optional[int], Optional[dict[str, Any]]]] = {
     'Bombs (5)':                                       ('Item',     None,  0x0001, {'junk': 8}),
     'Deku Nuts (5)':                                   ('Item',     None,  0x0002, {'junk': 5}),
     'Bombchus (10)':                                   ('Item',     True,  0x0003, None),

--- a/ItemList.py
+++ b/ItemList.py
@@ -4,7 +4,7 @@ from typing import Dict, Tuple, Optional, Any
 #              False -> Priority
 #              None  -> Normal
 #    Item:                                            (type, Progressive, GetItemID, special),
-item_table: Dict[str, Tuple[str, Optional[bool], int, Dict[str, Any]]] = {
+item_table: Dict[str, Tuple[str, Optional[bool], Optional[int], Optional[Dict[str, Any]]]] = {
     'Bombs (5)':                                       ('Item',     None,  0x0001, {'junk': 8}),
     'Deku Nuts (5)':                                   ('Item',     None,  0x0002, {'junk': 5}),
     'Bombchus (10)':                                   ('Item',     True,  0x0003, None),

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1,10 +1,8 @@
 import random
 from decimal import Decimal, ROUND_UP
-from Hints import HintArea
 
 from Item import ItemFactory, ItemInfo
-from Location import DisableType, Location
-from Utils import random_choices
+from Location import DisableType
 
 
 # Generates item pools and places fixed items based on settings.
@@ -382,7 +380,7 @@ def get_junk_item(count=1, pool=None, plando_pool=None):
             raise RuntimeError("Not enough junk is available in the item pool to replace removed items.")
     else:
         junk_items, junk_weights = zip(*junk_pool)
-    return_pool.extend(random_choices(junk_items, weights=junk_weights, k=count))
+    return_pool.extend(random.choices(junk_items, weights=junk_weights, k=count))
 
     return return_pool
 

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1,13 +1,16 @@
 import random
 from decimal import Decimal, ROUND_UP
+from typing import TYPE_CHECKING, List, Dict, Tuple, Sequence, Union, Optional
 
-from Item import ItemFactory, ItemInfo
+from Item import ItemInfo, ItemFactory
 from Location import DisableType
 
+if TYPE_CHECKING:
+    from Plandomizer import ItemPoolRecord
+    from World import World
 
-# Generates item pools and places fixed items based on settings.
 
-plentiful_items = ([
+plentiful_items: List[str] = ([
     'Biggoron Sword',
     'Boomerang',
     'Lens of Truth',
@@ -37,7 +40,7 @@ plentiful_items = ([
 # Ludicrous replaces all health upgrades with heart containers
 # as done in plentiful. The item list is used separately to
 # dynamically replace all junk with even levels of each item.
-ludicrous_health = ['Heart Container'] * 8
+ludicrous_health: List[str] = ['Heart Container'] * 8
 
 # List of items that can be multiplied in ludicrous mode.
 # Used to filter the pre-plando pool for candidates instead
@@ -49,7 +52,7 @@ ludicrous_health = ['Heart Container'] * 8
 #
 # Base items will always be candidates to replace junk items,
 # even if the player starts with all "normal" copies of an item.
-ludicrous_items_base = [
+ludicrous_items_base: List[str] = [
     'Light Arrows',
     'Megaton Hammer',
     'Progressive Hookshot',
@@ -79,7 +82,7 @@ ludicrous_items_base = [
     'Deku Nut Capacity'
 ]
 
-ludicrous_items_extended = [
+ludicrous_items_extended: List[str] = [
     'Zeldas Lullaby',
     'Eponas Song',
     'Suns Song',
@@ -189,7 +192,7 @@ ludicrous_items_extended = [
     'Silver Rupee Pouch (Ganons Castle Forest Trial)',
 ]
 
-ludicrous_exclusions = [
+ludicrous_exclusions: List[str] = [
     'Triforce Piece',
     'Gold Skulltula Token',
     'Rutos Letter',
@@ -198,7 +201,7 @@ ludicrous_exclusions = [
     'Piece of Heart (Treasure Chest Game)'
 ]
 
-item_difficulty_max = {
+item_difficulty_max: Dict[str, Dict[str, int]] = {
     'ludicrous': {
         'Piece of Heart': 3,
     },
@@ -236,13 +239,13 @@ item_difficulty_max = {
     },
 }
 
-shopsanity_rupees = (
+shopsanity_rupees: List[str] = (
     ['Rupees (20)'] * 5 +
     ['Rupees (50)'] * 3 +
     ['Rupees (200)'] * 2
 )
 
-min_shop_items = (
+min_shop_items: List[str] = (
     ['Buy Deku Shield'] +
     ['Buy Hylian Shield'] +
     ['Buy Goron Tunic'] +
@@ -261,7 +264,7 @@ min_shop_items = (
     ['Buy Fish']
 )
 
-deku_scrubs_items = {
+deku_scrubs_items: Dict[str, Union[str, List[Tuple[str, int]]]] = {
     'Buy Deku Shield':     'Deku Shield',
     'Buy Deku Nut (5)':    'Deku Nuts (5)',
     'Buy Deku Stick (1)':  'Deku Stick (1)',
@@ -272,7 +275,7 @@ deku_scrubs_items = {
     'Buy Deku Seeds (30)': [('Arrows (30)', 3), ('Deku Seeds (30)', 1)],
 }
 
-trade_items = (
+trade_items: Tuple[str, ...] = (
     "Pocket Egg",
     "Pocket Cucco",
     "Cojiro",
@@ -286,7 +289,7 @@ trade_items = (
     "Claim Check",
 )
 
-child_trade_items = (
+child_trade_items: Tuple[str, ...] = (
     "Weird Egg",
     "Chicken",
     "Zeldas Letter",
@@ -300,12 +303,12 @@ child_trade_items = (
     "Mask of Truth",
 )
 
-normal_bottles = [bottle for bottle in sorted(ItemInfo.bottles) if bottle not in ['Deliver Letter', 'Sell Big Poe']] + ['Bottle with Big Poe']
-song_list = [item.name for item in sorted([i for n, i in ItemInfo.items.items() if i.type == 'Song'], key=lambda x: x.index)]
-junk_pool_base = [(item, weight) for (item, weight) in sorted(ItemInfo.junk.items()) if weight > 0]
-remove_junk_items = [item for (item, weight) in sorted(ItemInfo.junk.items()) if weight >= 0]
+normal_bottles: List[str] = [bottle for bottle in sorted(ItemInfo.bottles) if bottle not in ['Deliver Letter', 'Sell Big Poe']] + ['Bottle with Big Poe']
+song_list: List[str] = [item.name for item in sorted([i for n, i in ItemInfo.items.items() if i.type == 'Song'], key=lambda x: x.index)]
+junk_pool_base: List[Tuple[str, int]] = [(item, weight) for (item, weight) in sorted(ItemInfo.junk.items()) if weight > 0]
+remove_junk_items: List[str] = [item for (item, weight) in sorted(ItemInfo.junk.items()) if weight >= 0]
 
-remove_junk_ludicrous_items = [
+remove_junk_ludicrous_items: List[str] = [
     'Ice Arrows',
     'Deku Nut Capacity',
     'Deku Stick Capacity',
@@ -315,12 +318,12 @@ remove_junk_ludicrous_items = [
 
 # a useless placeholder item placed at some skipped and inaccessible locations
 # (e.g. HC Malon Egg with Skip Child Zelda, or the carpenters with Open Gerudo Fortress)
-IGNORE_LOCATION = 'Recovery Heart'
+IGNORE_LOCATION: str = 'Recovery Heart'
 
-pending_junk_pool = []
-junk_pool = []
+pending_junk_pool: List[str] = []
+junk_pool: List[Tuple[str, int]] = []
 
-exclude_from_major = [
+exclude_from_major: List[str] = [
     'Deliver Letter',
     'Sell Big Poe',
     'Magic Bean',
@@ -336,7 +339,7 @@ exclude_from_major = [
     'Piece of Heart (Treasure Chest Game)',
 ]
 
-item_groups = {
+item_groups: Dict[str, Sequence[str]] = {
     'Junk': remove_junk_items,
     'JunkSong': ('Prelude of Light', 'Serenade of Water'),
     'AdultTrade': trade_items,
@@ -361,7 +364,7 @@ item_groups = {
 }
 
 
-def get_junk_item(count=1, pool=None, plando_pool=None):
+def get_junk_item(count: int = 1, pool: Optional[List[str]] = None, plando_pool: "Optional[Dict[str, ItemPoolRecord]]" = None) -> List[str]:
     if count < 1:
         raise ValueError("get_junk_item argument 'count' must be greater than 0.")
 
@@ -385,16 +388,16 @@ def get_junk_item(count=1, pool=None, plando_pool=None):
     return return_pool
 
 
-def replace_max_item(items, item, max_count):
+def replace_max_item(items: List[str], item: str, max_count: int) -> None:
     count = 0
-    for i,val in enumerate(items):
+    for i, val in enumerate(items):
         if val == item:
             if count >= max_count:
                 items[i] = get_junk_item()[0]
             count += 1
 
 
-def generate_itempool(world):
+def generate_itempool(world: "World") -> None:
     junk_pool[:] = list(junk_pool_base)
     if world.settings.junk_ice_traps == 'on':
         junk_pool.append(('Ice Trap', 10))
@@ -416,13 +419,14 @@ def generate_itempool(world):
     world.distribution.set_complete_itempool(world.itempool)
 
     # make sure that there are enough gold skulltulas for bridge/ganon boss key/lacs
-    world.available_tokens = placed_items_count.get("Gold Skulltula Token", 0) \
-                           + pool.count("Gold Skulltula Token") \
-                           + world.distribution.get_starting_item("Gold Skulltula Token")
+    world.available_tokens = (placed_items_count.get("Gold Skulltula Token", 0)
+                              + pool.count("Gold Skulltula Token")
+                              + world.distribution.get_starting_item("Gold Skulltula Token"))
     if world.max_progressions["Gold Skulltula Token"] > world.available_tokens:
         raise ValueError(f"Not enough available Gold Skulltula Tokens to meet requirements. Available: {world.available_tokens}, Required: {world.max_progressions['Gold Skulltula Token']}.")
 
-def get_pool_core(world):
+
+def get_pool_core(world: "World") -> Tuple[List[str], Dict[str, str]]:
     pool = []
     placed_items = {}
     remain_shop_items = []

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 import random
+from collections.abc import Sequence
 from decimal import Decimal, ROUND_UP
-from typing import TYPE_CHECKING, List, Dict, Tuple, Sequence, Union, Optional
+from typing import TYPE_CHECKING, Optional
 
 from Item import ItemInfo, ItemFactory
 from Location import DisableType
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
     from World import World
 
 
-plentiful_items: List[str] = ([
+plentiful_items: list[str] = ([
     'Biggoron Sword',
     'Boomerang',
     'Lens of Truth',
@@ -40,7 +42,7 @@ plentiful_items: List[str] = ([
 # Ludicrous replaces all health upgrades with heart containers
 # as done in plentiful. The item list is used separately to
 # dynamically replace all junk with even levels of each item.
-ludicrous_health: List[str] = ['Heart Container'] * 8
+ludicrous_health: list[str] = ['Heart Container'] * 8
 
 # List of items that can be multiplied in ludicrous mode.
 # Used to filter the pre-plando pool for candidates instead
@@ -52,7 +54,7 @@ ludicrous_health: List[str] = ['Heart Container'] * 8
 #
 # Base items will always be candidates to replace junk items,
 # even if the player starts with all "normal" copies of an item.
-ludicrous_items_base: List[str] = [
+ludicrous_items_base: list[str] = [
     'Light Arrows',
     'Megaton Hammer',
     'Progressive Hookshot',
@@ -82,7 +84,7 @@ ludicrous_items_base: List[str] = [
     'Deku Nut Capacity'
 ]
 
-ludicrous_items_extended: List[str] = [
+ludicrous_items_extended: list[str] = [
     'Zeldas Lullaby',
     'Eponas Song',
     'Suns Song',
@@ -192,7 +194,7 @@ ludicrous_items_extended: List[str] = [
     'Silver Rupee Pouch (Ganons Castle Forest Trial)',
 ]
 
-ludicrous_exclusions: List[str] = [
+ludicrous_exclusions: list[str] = [
     'Triforce Piece',
     'Gold Skulltula Token',
     'Rutos Letter',
@@ -201,7 +203,7 @@ ludicrous_exclusions: List[str] = [
     'Piece of Heart (Treasure Chest Game)'
 ]
 
-item_difficulty_max: Dict[str, Dict[str, int]] = {
+item_difficulty_max: dict[str, dict[str, int]] = {
     'ludicrous': {
         'Piece of Heart': 3,
     },
@@ -239,13 +241,13 @@ item_difficulty_max: Dict[str, Dict[str, int]] = {
     },
 }
 
-shopsanity_rupees: List[str] = (
+shopsanity_rupees: list[str] = (
     ['Rupees (20)'] * 5 +
     ['Rupees (50)'] * 3 +
     ['Rupees (200)'] * 2
 )
 
-min_shop_items: List[str] = (
+min_shop_items: list[str] = (
     ['Buy Deku Shield'] +
     ['Buy Hylian Shield'] +
     ['Buy Goron Tunic'] +
@@ -264,7 +266,7 @@ min_shop_items: List[str] = (
     ['Buy Fish']
 )
 
-deku_scrubs_items: Dict[str, Union[str, List[Tuple[str, int]]]] = {
+deku_scrubs_items: dict[str, str | list[tuple[str, int]]] = {
     'Buy Deku Shield':     'Deku Shield',
     'Buy Deku Nut (5)':    'Deku Nuts (5)',
     'Buy Deku Stick (1)':  'Deku Stick (1)',
@@ -275,7 +277,7 @@ deku_scrubs_items: Dict[str, Union[str, List[Tuple[str, int]]]] = {
     'Buy Deku Seeds (30)': [('Arrows (30)', 3), ('Deku Seeds (30)', 1)],
 }
 
-trade_items: Tuple[str, ...] = (
+trade_items: tuple[str, ...] = (
     "Pocket Egg",
     "Pocket Cucco",
     "Cojiro",
@@ -289,7 +291,7 @@ trade_items: Tuple[str, ...] = (
     "Claim Check",
 )
 
-child_trade_items: Tuple[str, ...] = (
+child_trade_items: tuple[str, ...] = (
     "Weird Egg",
     "Chicken",
     "Zeldas Letter",
@@ -303,12 +305,12 @@ child_trade_items: Tuple[str, ...] = (
     "Mask of Truth",
 )
 
-normal_bottles: List[str] = [bottle for bottle in sorted(ItemInfo.bottles) if bottle not in ['Deliver Letter', 'Sell Big Poe']] + ['Bottle with Big Poe']
-song_list: List[str] = [item.name for item in sorted([i for n, i in ItemInfo.items.items() if i.type == 'Song'], key=lambda x: x.index if x.index is not None else 0)]
-junk_pool_base: List[Tuple[str, int]] = [(item, weight) for (item, weight) in sorted(ItemInfo.junk_weight.items()) if weight > 0]
-remove_junk_items: List[str] = [item for (item, weight) in sorted(ItemInfo.junk_weight.items()) if weight >= 0]
+normal_bottles: list[str] = [bottle for bottle in sorted(ItemInfo.bottles) if bottle not in ['Deliver Letter', 'Sell Big Poe']] + ['Bottle with Big Poe']
+song_list: list[str] = [item.name for item in sorted([i for n, i in ItemInfo.items.items() if i.type == 'Song'], key=lambda x: x.index if x.index is not None else 0)]
+junk_pool_base: list[tuple[str, int]] = [(item, weight) for (item, weight) in sorted(ItemInfo.junk_weight.items()) if weight > 0]
+remove_junk_items: list[str] = [item for (item, weight) in sorted(ItemInfo.junk_weight.items()) if weight >= 0]
 
-remove_junk_ludicrous_items: List[str] = [
+remove_junk_ludicrous_items: list[str] = [
     'Ice Arrows',
     'Deku Nut Capacity',
     'Deku Stick Capacity',
@@ -320,10 +322,10 @@ remove_junk_ludicrous_items: List[str] = [
 # (e.g. HC Malon Egg with Skip Child Zelda, or the carpenters with Open Gerudo Fortress)
 IGNORE_LOCATION: str = 'Recovery Heart'
 
-pending_junk_pool: List[str] = []
-junk_pool: List[Tuple[str, int]] = []
+pending_junk_pool: list[str] = []
+junk_pool: list[tuple[str, int]] = []
 
-exclude_from_major: List[str] = [
+exclude_from_major: list[str] = [
     'Deliver Letter',
     'Sell Big Poe',
     'Magic Bean',
@@ -339,7 +341,7 @@ exclude_from_major: List[str] = [
     'Piece of Heart (Treasure Chest Game)',
 ]
 
-item_groups: Dict[str, Sequence[str]] = {
+item_groups: dict[str, Sequence[str]] = {
     'Junk': remove_junk_items,
     'JunkSong': ('Prelude of Light', 'Serenade of Water'),
     'AdultTrade': trade_items,
@@ -364,7 +366,7 @@ item_groups: Dict[str, Sequence[str]] = {
 }
 
 
-def get_junk_item(count: int = 1, pool: Optional[List[str]] = None, plando_pool: "Optional[Dict[str, ItemPoolRecord]]" = None) -> List[str]:
+def get_junk_item(count: int = 1, pool: Optional[list[str]] = None, plando_pool: Optional[dict[str, ItemPoolRecord]] = None) -> list[str]:
     if count < 1:
         raise ValueError("get_junk_item argument 'count' must be greater than 0.")
 
@@ -386,7 +388,7 @@ def get_junk_item(count: int = 1, pool: Optional[List[str]] = None, plando_pool:
     return return_pool
 
 
-def replace_max_item(items: List[str], item: str, max_count: int) -> None:
+def replace_max_item(items: list[str], item: str, max_count: int) -> None:
     count = 0
     for i, val in enumerate(items):
         if val == item:
@@ -395,7 +397,7 @@ def replace_max_item(items: List[str], item: str, max_count: int) -> None:
             count += 1
 
 
-def generate_itempool(world: "World") -> None:
+def generate_itempool(world: World) -> None:
     junk_pool[:] = list(junk_pool_base)
     if world.settings.junk_ice_traps == 'on':
         junk_pool.append(('Ice Trap', 10))
@@ -424,7 +426,7 @@ def generate_itempool(world: "World") -> None:
         raise ValueError(f"Not enough available Gold Skulltula Tokens to meet requirements. Available: {world.available_tokens}, Required: {world.max_progressions['Gold Skulltula Token']}.")
 
 
-def get_pool_core(world: "World") -> Tuple[List[str], Dict[str, str]]:
+def get_pool_core(world: World) -> tuple[list[str], dict[str, str]]:
     pool = []
     placed_items = {}
     remain_shop_items = []

--- a/JSONDump.py
+++ b/JSONDump.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 import json
+from collections.abc import Sequence
 from functools import reduce
-from typing import Optional, Tuple
+from typing import Optional
 
 INDENT = '  '
 
@@ -73,7 +75,7 @@ def get_keys(obj: AlignedDict, depth: int):
             yield from get_keys(value, depth - 1)
 
 
-def dump_dict(obj: dict, current_indent: str = '', sub_width: Optional[Tuple[int, int]] = None, ensure_ascii: bool = False) -> str:
+def dump_dict(obj: dict, current_indent: str = '', sub_width: Optional[Sequence[int, int]] = None, ensure_ascii: bool = False) -> str:
     entries = []
 
     key_width = None
@@ -120,7 +122,7 @@ def dump_dict(obj: dict, current_indent: str = '', sub_width: Optional[Tuple[int
     return output
 
 
-def dump_obj(obj, current_indent: str = '', sub_width: Optional[Tuple[int, int]] = None, ensure_ascii: bool = False) -> str:
+def dump_obj(obj, current_indent: str = '', sub_width: Optional[Sequence[int, int]] = None, ensure_ascii: bool = False) -> str:
     if is_list(obj):
         return dump_list(obj, current_indent, ensure_ascii)
     elif is_dict(obj):

--- a/JSONDump.py
+++ b/JSONDump.py
@@ -1,38 +1,45 @@
 import json
-
 from functools import reduce
+from typing import Optional, Tuple
 
 INDENT = '  '
 
+
 class CollapseList(list):
     pass
+
+
 class CollapseDict(dict):
     pass
+
+
 class AlignedDict(dict):
-    def __init__(self, src_dict, depth):
+    def __init__(self, src_dict: dict, depth: int) -> None:
         self.depth = depth - 1
         super().__init__(src_dict)
+
+
 class SortedDict(dict):
     pass
 
 
-def is_scalar(value):
+def is_scalar(value) -> bool:
     return not is_list(value) and not is_dict(value)
 
 
-def is_list(value):
+def is_list(value) -> bool:
     return isinstance(value, list) or isinstance(value, tuple)
 
 
-def is_dict(value):
+def is_dict(value) -> bool:
     return isinstance(value, dict)
 
 
-def dump_scalar(obj, ensure_ascii=False):
+def dump_scalar(obj, ensure_ascii: bool = False) -> str:
     return json.dumps(obj, ensure_ascii=ensure_ascii)
 
 
-def dump_list(obj, current_indent='', ensure_ascii=False):
+def dump_list(obj: list, current_indent: str = '', ensure_ascii: bool = False) -> str:
     entries = [dump_obj(value, current_indent + INDENT, ensure_ascii=ensure_ascii) for value in obj]
 
     if len(entries) == 0:
@@ -58,7 +65,7 @@ def dump_list(obj, current_indent='', ensure_ascii=False):
     return output
 
 
-def get_keys(obj, depth):
+def get_keys(obj: AlignedDict, depth: int):
     if depth == 0:
         yield from obj.keys()
     else:
@@ -66,7 +73,7 @@ def get_keys(obj, depth):
             yield from get_keys(value, depth - 1)
 
 
-def dump_dict(obj, current_indent='', sub_width=None, ensure_ascii=False):
+def dump_dict(obj: dict, current_indent: str = '', sub_width: Optional[Tuple[int, int]] = None, ensure_ascii: bool = False) -> str:
     entries = []
 
     key_width = None
@@ -113,7 +120,7 @@ def dump_dict(obj, current_indent='', sub_width=None, ensure_ascii=False):
     return output
 
 
-def dump_obj(obj, current_indent='', sub_width=None, ensure_ascii=False):
+def dump_obj(obj, current_indent: str = '', sub_width: Optional[Tuple[int, int]] = None, ensure_ascii: bool = False) -> str:
     if is_list(obj):
         return dump_list(obj, current_indent, ensure_ascii)
     elif is_dict(obj):

--- a/LocationList.py
+++ b/LocationList.py
@@ -1,16 +1,17 @@
+from __future__ import annotations
 import sys
 from collections import OrderedDict
-from typing import Dict, Tuple, Optional, Union, List
+from typing import Optional
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
 else:
     TypeAlias = str
 
-LocationDefault: TypeAlias = Optional[Union[int, Tuple[int, ...], List[Tuple[int, ...]]]]
-LocationAddress: TypeAlias = Optional[Union[int, List[int]]]
-LocationAddresses: TypeAlias = Optional[Tuple[LocationAddress, LocationAddress]]
-LocationFilterTags: TypeAlias = Optional[Union[Tuple[str, ...], str]]
+LocationDefault: TypeAlias = "Optional[int | tuple[int, ...] | list[tuple[int, ...]]]"
+LocationAddress: TypeAlias = "Optional[int | list[int]]"
+LocationAddresses: TypeAlias = "Optional[tuple[LocationAddress, LocationAddress]]"
+LocationFilterTags: TypeAlias = "Optional[tuple[str, ...] | str]"
 
 
 def shop_address(shop_id: int, shelf_id: int) -> int:
@@ -56,7 +57,7 @@ def shop_address(shop_id: int, shelf_id: int) -> int:
 # Note: for ActorOverride locations, the "Addresses" variable is in the form ([addresses], [bytes]) where addresses is a list of memory locations in ROM to be updated, and bytes is the data that will be written to that location
 
 #   Location:                                                        Type             Scene  Default Addresses                      Vanilla Item                             Categories
-location_table: Dict[str, Tuple[str, Optional[int], LocationDefault, LocationAddresses, Optional[str], LocationFilterTags]] = OrderedDict([
+location_table: dict[str, tuple[str, Optional[int], LocationDefault, LocationAddresses, Optional[str], LocationFilterTags]] = OrderedDict([
     ## Dungeon Rewards
     ("Links Pocket",                                                 ("Boss",         None,  None, None,                            'Light Medallion',                       None)),
     ("Queen Gohma",                                                  ("Boss",         None,  0x6C, (0x0CA315F, 0x2079571),          'Kokiri Emerald',                        None)),
@@ -2260,12 +2261,12 @@ location_table: Dict[str, Tuple[str, Optional[int], LocationDefault, LocationAdd
     ("Ganondorf Hint",                                               ("Hint",         None,  None, None,                            None,                                    None)),
 ])
 
-location_sort_order: Dict[str, int] = {
+location_sort_order: dict[str, int] = {
     loc: i for i, loc in enumerate(location_table.keys())
 }
 
 # Business Scrub Details
-business_scrubs: List[Tuple[int, int, int, List[str]]] = [
+business_scrubs: list[tuple[int, int, int, list[str]]] = [
     # id   price  text   text replacement
     (0x30, 20,   0x10A0, ["Deku Nuts", "a \x05\x42mysterious item\x05\x40"]),
     (0x31, 15,   0x10A1, ["Deku Sticks", "a \x05\x42mysterious item\x05\x40"]),
@@ -2280,8 +2281,8 @@ business_scrubs: List[Tuple[int, int, int, List[str]]] = [
     (0x79, 40,   0x10DD, ["enable you to pick up more \x05\x41Deku\x01Nuts", "sell you a \x05\x42mysterious item"]),
 ]
 
-dungeons: Tuple[str, ...] = ('Deku Tree', "Dodongo's Cavern", "Jabu Jabu's Belly", 'Forest Temple', 'Fire Temple', 'Water Temple', 'Spirit Temple', 'Shadow Temple', 'Ice Cavern', 'Bottom of the Well', 'Gerudo Training Ground', "Ganon's Castle")
-location_groups: Dict[str, List[str]] = {
+dungeons: tuple[str, ...] = ('Deku Tree', "Dodongo's Cavern", "Jabu Jabu's Belly", 'Forest Temple', 'Fire Temple', 'Water Temple', 'Spirit Temple', 'Shadow Temple', 'Ice Cavern', 'Bottom of the Well', 'Gerudo Training Ground', "Ganon's Castle")
+location_groups: dict[str, list[str]] = {
     'Song': [name for (name, data) in location_table.items() if data[0] == 'Song'],
     'Chest': [name for (name, data) in location_table.items() if data[0] == 'Chest'],
     'Collectable': [name for (name, data) in location_table.items() if data[0] == 'Collectable'],

--- a/LocationList.py
+++ b/LocationList.py
@@ -1,7 +1,11 @@
+import sys
 from collections import OrderedDict
 from typing import Dict, Tuple, Optional, Union, List
 
-from Utils import TypeAlias
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    TypeAlias = str
 
 LocationDefault: TypeAlias = Optional[Union[int, Tuple[int, ...], List[Tuple[int, ...]]]]
 LocationAddress: TypeAlias = Optional[Union[int, List[int]]]

--- a/LocationList.py
+++ b/LocationList.py
@@ -1,8 +1,17 @@
 from collections import OrderedDict
+from typing import Dict, Tuple, Optional, Union, List
+
+from Utils import TypeAlias
+
+LocationDefault: TypeAlias = Optional[Union[int, Tuple[int, ...], List[Tuple[int, ...]]]]
+LocationAddress: TypeAlias = Optional[Union[int, List[int]]]
+LocationAddresses: TypeAlias = Optional[Tuple[LocationAddress, LocationAddress]]
+LocationFilterTags: TypeAlias = Optional[Union[Tuple[str, ...], str]]
 
 
-def shop_address(shop_id, shelf_id):
+def shop_address(shop_id: int, shelf_id: int) -> int:
     return 0xC71ED0 + (0x40 * shop_id) + (0x08 * shelf_id)
+
 
 #   Abbreviations
 #       DMC     Death Mountain Crater
@@ -43,7 +52,7 @@ def shop_address(shop_id, shelf_id):
 # Note: for ActorOverride locations, the "Addresses" variable is in the form ([addresses], [bytes]) where addresses is a list of memory locations in ROM to be updated, and bytes is the data that will be written to that location
 
 #   Location:                                                        Type             Scene  Default Addresses                      Vanilla Item                             Categories
-location_table = OrderedDict([
+location_table: Dict[str, Tuple[str, Optional[int], LocationDefault, LocationAddresses, Optional[str], LocationFilterTags]] = OrderedDict([
     ## Dungeon Rewards
     ("Links Pocket",                                                 ("Boss",         None,  None, None,                            'Light Medallion',                       None)),
     ("Queen Gohma",                                                  ("Boss",         None,  0x6C, (0x0CA315F, 0x2079571),          'Kokiri Emerald',                        None)),
@@ -674,7 +683,7 @@ location_table = OrderedDict([
     ("LH Lab Dive Red Rupee 1",                                      ("Freestanding", 0x38,  (0,0,2), None,                         'Rupees (20)',                           ("Lake Hylia", "Freestandings",))),
     ("LH Lab Dive Red Rupee 2",                                      ("Freestanding", 0x38,  (0,0,3), None,                         'Rupees (20)',                           ("Lake Hylia", "Freestandings",))),
     ("LH Lab Dive Red Rupee 3",                                      ("Freestanding", 0x38,  (0,0,4), None,                         'Rupees (20)',                           ("Lake Hylia", "Freestandings",))),
-    #Lake Hylia Beehives
+    # Lake Hylia Beehives
     ("LH Grotto Beehive",                                            ("Beehive",      0x3E,  (12,0,0x44 + (0x0F * 2)), None,        'Rupees (20)',                           ("Lake Hylia", "Grottos", "Beehives",))),
 
     # Gerudo Valley
@@ -757,7 +766,7 @@ location_table = OrderedDict([
     # Wasteland Pots/Crates
     ("Wasteland Near GS Pot 1",                                      ("Pot",          0x5E,  (0,0,1), None,                         'Recovery Heart',                        ("Haunted Wasteland", "Pots",))),
     ("Wasteland Near GS Pot 2",                                      ("Pot",          0x5E,  (0,0,2), None,                         'Deku Nuts (5)',                         ("Haunted Wasteland", "Pots",))),
-   #("Wasteland Near GS Pot 3",                                      ("Pot",          0x5E,  (0,0,3), None,                            'Rupees (5)',                            ("Haunted Wasteland", "Pots",))), Fairy
+   #("Wasteland Near GS Pot 3",                                      ("Pot",          0x5E,  (0,0,3), None,                         'Rupees (5)',                            ("Haunted Wasteland", "Pots",))), Fairy
     ("Wasteland Near GS Pot 3",                                      ("Pot",          0x5E,  (0,0,4), None,                         'Rupees (5)',                            ("Haunted Wasteland", "Pots",))),
     ("Wasteland Crate Before Quicksand",                             ("Crate",        0x5E,  (1,0,38),None,                         'Rupee (1)',                             ("Haunted Wasteland", "Crates",))),
     ("Wasteland Crate After Quicksand 1",                            ("Crate",        0x5E,  (1,0,35),None,                         'Rupee (1)',                             ("Haunted Wasteland", "Crates",))),
@@ -1557,7 +1566,7 @@ location_table = OrderedDict([
     ("Shadow Temple 3 Spinning Pots Rupee 7",                        ("RupeeTower",   0x07,  (12,0,26), None,                       'Rupee (1)',                             ("Shadow Temple", "Vanilla Dungeons", "Rupee Towers",))),
     ("Shadow Temple 3 Spinning Pots Rupee 8",                        ("RupeeTower",   0x07,  (12,0,27), None,                       'Rupees (5)',                            ("Shadow Temple", "Vanilla Dungeons", "Rupee Towers",))),
     ("Shadow Temple 3 Spinning Pots Rupee 9",                        ("RupeeTower",   0x07,  (12,0,28), None,                       'Rupees (20)',                           ("Shadow Temple", "Vanilla Dungeons", "Rupee Towers",))),
-    #Shadow Temple Vanilla Pots
+    # Shadow Temple Vanilla Pots
     ("Shadow Temple Whispering Walls Near Dead Hand Pot",            ("Pot",          0x07,  (0,0,1), None,                         'Rupees (5)',                            ("Shadow Temple", "Vanilla Dungeons", "Pots",))),
     ("Shadow Temple Whispering Walls Left Pot 1",                    ("Pot",          0x07,  (0,0,2), None,                         'Rupees (5)',                            ("Shadow Temple", "Vanilla Dungeons", "Pots",))),
     ("Shadow Temple Whispering Walls Left Pot 2",                    ("Pot",          0x07,  (0,0,3), None,                         'Recovery Heart',                        ("Shadow Temple", "Vanilla Dungeons", "Pots",))),
@@ -2247,12 +2256,12 @@ location_table = OrderedDict([
     ("Ganondorf Hint",                                               ("Hint",         None,  None, None,                            None,                                    None)),
 ])
 
-location_sort_order = {
+location_sort_order: Dict[str, int] = {
     loc: i for i, loc in enumerate(location_table.keys())
 }
 
 # Business Scrub Details
-business_scrubs = [
+business_scrubs: List[Tuple[int, int, int, List[str]]] = [
     # id   price  text   text replacement
     (0x30, 20,   0x10A0, ["Deku Nuts", "a \x05\x42mysterious item\x05\x40"]),
     (0x31, 15,   0x10A1, ["Deku Sticks", "a \x05\x42mysterious item\x05\x40"]),
@@ -2267,8 +2276,8 @@ business_scrubs = [
     (0x79, 40,   0x10DD, ["enable you to pick up more \x05\x41Deku\x01Nuts", "sell you a \x05\x42mysterious item"]),
 ]
 
-dungeons = ('Deku Tree', 'Dodongo\'s Cavern', 'Jabu Jabu\'s Belly', 'Forest Temple', 'Fire Temple', 'Water Temple', 'Spirit Temple', 'Shadow Temple', 'Ice Cavern', 'Bottom of the Well', 'Gerudo Training Ground', 'Ganon\'s Castle')
-location_groups = {
+dungeons: Tuple[str, ...] = ('Deku Tree', "Dodongo's Cavern", "Jabu Jabu's Belly", 'Forest Temple', 'Fire Temple', 'Water Temple', 'Spirit Temple', 'Shadow Temple', 'Ice Cavern', 'Bottom of the Well', 'Gerudo Training Ground', "Ganon's Castle")
+location_groups: Dict[str, List[str]] = {
     'Song': [name for (name, data) in location_table.items() if data[0] == 'Song'],
     'Chest': [name for (name, data) in location_table.items() if data[0] == 'Chest'],
     'Collectable': [name for (name, data) in location_table.items() if data[0] == 'Collectable'],
@@ -2284,14 +2293,6 @@ location_groups = {
 }
 
 
-def location_is_viewable(loc_name, correct_chest_appearances, fast_chests):
+def location_is_viewable(loc_name: str, correct_chest_appearances: str, fast_chests: bool) -> bool:
     return (((correct_chest_appearances in ['textures', 'both', 'classic'] or not fast_chests) and loc_name in location_groups['Chest'])
-        or loc_name in location_groups['CanSee'])
-
-
-# Function to run exactly once after after placing items in drop locations for each world
-# Sets all Drop locations to a unique name in order to avoid name issues and to identify locations in the spoiler
-def set_drop_location_names(world):
-    for location in world.get_locations():
-        if location.type == 'Drop':
-            location.name = location.parent_region.name + " " + location.name
+            or loc_name in location_groups['CanSee'])

--- a/MBSDIFFPatch.py
+++ b/MBSDIFFPatch.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
 import logging
 import gzip
 import os
 import platform
 import shutil
-import struct
-from typing import Optional, MutableSequence
+from typing import Optional
 
 from Rom import Rom
 from Utils import default_output_path, is_bundled, local_path, run_process
@@ -99,7 +99,7 @@ def apply_minibsdiff_patch_file(rom: Rom, file: str) -> None:
     if size_difference > 0:
         rom.append_bytes([0] * size_difference)
 
-    ctrl_block: MutableSequence[int] = [0] * 3
+    ctrl_block: list[int] = [0] * 3
     ctrl_block_address: int = 32
     diff_block_address: int = ctrl_block_address + ctrl_len
     extra_block_address: int = diff_block_address + data_len

--- a/MBSDIFFPatch.py
+++ b/MBSDIFFPatch.py
@@ -11,7 +11,7 @@ from ntype import BigStream
 
 
 # Handle 3.0 website patches.
-def apply_ootr_3_web_patch(settings, rom: Rom, window):
+def apply_ootr_3_web_patch(settings, rom: Rom):
     logger = logging.getLogger('')
     minibsdiff_path = "./" if is_bundled() else "bin/minibsdiff/"
     minibsdiff_python = False
@@ -56,7 +56,7 @@ def apply_ootr_3_web_patch(settings, rom: Rom, window):
 
         # Patch the base ROM.
         decompressed_patched_rom_file = output_path + "_patched.z64"
-        run_process(window, logger, [minibsdiff_path, "app", local_path('ZOOTDEC.z64'), decompressed_patch_file, decompressed_patched_rom_file])
+        run_process(logger, [minibsdiff_path, "app", local_path('ZOOTDEC.z64'), decompressed_patch_file, decompressed_patched_rom_file])
         os.remove(decompressed_patch_file)
 
         # Read the ROM back in and check for changes.

--- a/MBSDIFFPatch.py
+++ b/MBSDIFFPatch.py
@@ -4,17 +4,18 @@ import os
 import platform
 import shutil
 import struct
+from typing import Optional, MutableSequence
 
-import Rom
+from Rom import Rom
 from Utils import default_output_path, is_bundled, local_path, run_process
 from ntype import BigStream
 
 
 # Handle 3.0 website patches.
-def apply_ootr_3_web_patch(settings, rom: Rom):
+def apply_ootr_3_web_patch(settings, rom: Rom) -> None:
     logger = logging.getLogger('')
-    minibsdiff_path = "./" if is_bundled() else "bin/minibsdiff/"
-    minibsdiff_python = False
+    minibsdiff_path: str = "./" if is_bundled() else "bin/minibsdiff/"
+    minibsdiff_python: bool = False
     if platform.system() == 'Windows':
         if platform.machine() == 'AMD64':
             minibsdiff_path += "minibsdiff.exe"
@@ -79,31 +80,32 @@ def apply_ootr_3_web_patch(settings, rom: Rom):
 
 
 # Re-implementation of https://github.com/mhinds7/minibsdiff
-def apply_minibsdiff_patch_file(rom: Rom, file):
+def apply_minibsdiff_patch_file(rom: Rom, file: str) -> None:
     with gzip.open(file, 'r') as stream:
-        patch_data = BigStream(stream.read())
+        patch_data: BigStream = BigStream(bytearray(stream.read()))
 
     if patch_data.read_bytes(length=8) != b'MBSDIF43':  # minibsdiff header
         raise Exception("Patch file does not have a valid header. Aborting.")
 
-    ctrl_len = minibsdiff_read_int64(patch_data)
-    data_len = minibsdiff_read_int64(patch_data)
-    new_size = minibsdiff_read_int64(patch_data)
+    ctrl_len: int = minibsdiff_read_int64(patch_data)
+    data_len: int = minibsdiff_read_int64(patch_data)
+    new_size: int = minibsdiff_read_int64(patch_data)
 
     if ctrl_len < 0 or data_len < 0 or new_size < 0:
         raise Exception("Patch file is invalid. Aborting.")
 
-    original_size = len(rom.original.buffer)
-    size_difference = new_size - len(rom.buffer)
+    original_size: int = len(rom.original.buffer)
+    size_difference: int = new_size - len(rom.buffer)
     if size_difference > 0:
         rom.append_bytes([0] * size_difference)
 
-    ctrl_block = [0] * 3
-    ctrl_block_address = 32
-    diff_block_address = ctrl_block_address + ctrl_len
-    extra_block_address = diff_block_address + data_len
+    ctrl_block: MutableSequence[int] = [0] * 3
+    ctrl_block_address: int = 32
+    diff_block_address: int = ctrl_block_address + ctrl_len
+    extra_block_address: int = diff_block_address + data_len
 
-    old_pos = new_pos = 0
+    old_pos: int = 0
+    new_pos: int = 0
     while new_pos < new_size:
         ctrl_block[0] = minibsdiff_read_int64(patch_data, ctrl_block_address)
         ctrl_block[1] = minibsdiff_read_int64(patch_data)
@@ -116,7 +118,7 @@ def apply_minibsdiff_patch_file(rom: Rom, file):
                 raise Exception("Patch file is invalid. Aborting.")
 
             # Read diff bytes.
-            diff_bytes = patch_data.read_bytes(diff_block_address, ctrl_block[0])
+            diff_bytes: bytearray = patch_data.read_bytes(diff_block_address, ctrl_block[0])
             diff_block_address += ctrl_block[0]
 
             # Check for differences.
@@ -153,25 +155,13 @@ def apply_minibsdiff_patch_file(rom: Rom, file):
         new_pos += ctrl_block[1]
 
 
-def minibsdiff_read_int64(patch_data: BigStream, position=None):
-    buf = patch_data.read_bytes(position, 8)
-    y = buf[7] & 0x7F
-    y = y * 256
-    y += buf[6]
-    y = y * 256
-    y += buf[5]
-    y = y * 256
-    y += buf[4]
-    y = y * 256
-    y += buf[3]
-    y = y * 256
-    y += buf[2]
-    y = y * 256
-    y += buf[1]
-    y = y * 256
-    y += buf[0]
+def minibsdiff_read_int64(patch_data: BigStream, position: Optional[int] = None) -> int:
+    buffer: bytearray = patch_data.read_bytes(position, 8)
+    y: int = 0
 
-    if buf[7] & 0x80:
-        y = -y
+    for i in reversed(range(0, 8)):
+        y *= 256
+        y += buffer[i] & (0xFF if i != 7 else 0x7F)
 
+    y *= -1 if buffer[7] & 0x80 else 1
     return y

--- a/MQ.py
+++ b/MQ.py
@@ -3,7 +3,7 @@
 #
 # Scenes:
 #
-# Ice Cavern (Scene 9) needs to have it's header altered to support MQ's path list. This
+# Ice Cavern (Scene 9) needs to have its header altered to support MQ's path list. This
 # expansion will delete the otherwise unused alternate headers command
 #
 # Transition actors will be patched over the old data, as the number of records is the same
@@ -43,37 +43,45 @@
 # the floor map data is missing a vertex pointer that would point within kaleido_scope.
 # As such, if the file moves, the patch will break.
 
-from Utils import data_path
-from Rom import Rom
 import json
 from struct import pack, unpack
+from typing import Dict, List, Tuple, Optional, Union, Any
 
-SCENE_TABLE = 0xB71440
+from Rom import Rom
+from Utils import data_path
+
+SCENE_TABLE: int = 0xB71440
 
 
-class File(object):
-    def __init__(self, file):
-        self.name = file['Name']
-        self.start = int(file['Start'], 16) if 'Start' in file else 0
-        self.end = int(file['End'], 16) if 'End' in file else self.start
-        self.remap = file['RemapStart'] if 'RemapStart' in file else None
-        self.from_file = self.start
+class File:
+    def __init__(self, name: str, start: int = 0, end: Optional[int] = None, remap: Optional[int] = None) -> None:
+        self.name: str = name
+        self.start: int = start
+        self.end: int = end if end is not None else self.start
+        self.remap: Optional[int] = remap
+        self.from_file: int = self.start
 
         # used to update the file's associated dmadata record
-        self.dma_key = self.start
+        self.dma_key: int = self.start
 
-        if self.remap is not None:
-            self.remap = int(self.remap, 16)
+    @classmethod
+    def from_json(cls, file: Dict[str, Optional[str]]) -> 'File':
+        return cls(
+            file['Name'],
+            int(file['Start'], 16) if file.get('Start', None) is not None else 0,
+            int(file['End'], 16) if file.get('End', None) is not None else None,
+            int(file['RemapStart'], 16) if file.get('RemapStart', None) is not None else None
+        )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         remap = "None"
         if self.remap is not None:
             remap = "{0:x}".format(self.remap)
         return "{0}: {1:x} {2:x}, remap {3}".format(self.name, self.start, self.end, remap)
 
-    def relocate(self, rom:Rom):
+    def relocate(self, rom: Rom) -> None:
         if self.remap is None:
-            self.remap = rom.free_space()
+            self.remap = rom.dma.free_space()
 
         new_start = self.remap
 
@@ -86,39 +94,39 @@ class File(object):
         update_dmadata(rom, self)
 
     # The file will now refer to the new copy of the file
-    def copy(self, rom:Rom):
+    def copy(self, rom: Rom) -> None:
         self.dma_key = None
         self.relocate(rom)
 
 
-class CollisionMesh(object):
-    def __init__(self, rom:Rom, start, offset):
+class CollisionMesh:
+    def __init__(self, rom: Rom, start: int, offset: int) -> None:
         self.offset = offset
         self.poly_addr = rom.read_int32(start + offset + 0x18)
         self.polytypes_addr = rom.read_int32(start + offset + 0x1C)
         self.camera_data_addr = rom.read_int32(start + offset + 0x20)
         self.polytypes = (self.poly_addr - self.polytypes_addr) // 8
 
-    def write_to_scene(self, rom:Rom, start):
+    def write_to_scene(self, rom: Rom, start: int) -> None:
         addr = start + self.offset + 0x18
         rom.write_int32s(addr, [self.poly_addr, self.polytypes_addr, self.camera_data_addr])
 
 
-class ColDelta(object):
-    def __init__(self, delta):
-        self.is_larger = delta['IsLarger']
-        self.polys = delta['Polys']
-        self.polytypes = delta['PolyTypes']
-        self.cams = delta['Cams']
+class ColDelta:
+    def __init__(self, delta: Dict[str, Union[bool, List[Dict[str, int]]]]) -> None:
+        self.is_larger: bool = delta['IsLarger']
+        self.polys: List[Dict[str, int]] = delta['Polys']
+        self.polytypes: List[Dict[str, int]] = delta['PolyTypes']
+        self.cams: List[Dict[str, int]] = delta['Cams']
 
 
-class Icon(object):
-    def __init__(self, data):
-        self.icon = data["Icon"];
-        self.count = data["Count"];
-        self.points = [IconPoint(x) for x in data["IconPoints"]]
+class Icon:
+    def __init__(self, data: Dict[str, Union[int, List[Dict[str, int]]]]) -> None:
+        self.icon: int = data["Icon"]
+        self.count: int = data["Count"]
+        self.points: List[IconPoint] = [IconPoint(x) for x in data["IconPoints"]]
 
-    def write_to_minimap(self, rom:Rom, addr):
+    def write_to_minimap(self, rom: Rom, addr: int) -> None:
         rom.write_sbyte(addr, self.icon)
         rom.write_byte(addr + 1,  self.count)
         cur = 2
@@ -126,7 +134,7 @@ class Icon(object):
             p.write_to_minimap(rom, addr + cur)
             cur += 0x03
 
-    def write_to_floormap(self, rom:Rom, addr):
+    def write_to_floormap(self, rom: Rom, addr: int) -> None:
         rom.write_int16(addr, self.icon)
         rom.write_int32(addr + 0x10, self.count)
 
@@ -136,39 +144,38 @@ class Icon(object):
             cur += 0x0C
 
 
-class IconPoint(object):
-    def __init__(self, point):
+class IconPoint:
+    def __init__(self, point: Dict[str, int]) -> None:
         self.flag = point["Flag"]
         self.x = point["x"]
         self.y = point["y"]
 
-    def write_to_minimap(self, rom:Rom, addr):
+    def write_to_minimap(self, rom: Rom, addr: int) -> None:
         rom.write_sbyte(addr, self.flag)
         rom.write_byte(addr+1, self.x)
         rom.write_byte(addr+2, self.y)
 
-    def write_to_floormap(self, rom:Rom, addr):
+    def write_to_floormap(self, rom: Rom, addr: int) -> None:
         rom.write_int16(addr, self.flag)
         rom.write_f32(addr + 4, float(self.x))
         rom.write_f32(addr + 8, float(self.y))
 
 
-class Scene(object):
-    def __init__(self, scene):
-        self.file = File(scene['File'])
-        self.id = scene['Id']
-        self.transition_actors = [convert_actor_data(x) for x in scene['TActors']]
-        self.rooms = [Room(x) for x in scene['Rooms']]
-        self.paths = []
-        self.coldelta = ColDelta(scene["ColDelta"])
-        self.minimaps = [[Icon(icon) for icon in minimap['Icons']] for minimap in scene['Minimaps']]
-        self.floormaps = [[Icon(icon) for icon in floormap['Icons']] for floormap in scene['Floormaps']]
+class Scene:
+    def __init__(self, scene: Dict[str, Any]) -> None:
+        self.file: File = File.from_json(scene['File'])
+        self.id: int = scene['Id']
+        self.transition_actors: List[List[int]] = [convert_actor_data(x) for x in scene['TActors']]
+        self.rooms: List[Room] = [Room(x) for x in scene['Rooms']]
+        self.paths: List[List[List[int]]] = []
+        self.coldelta: ColDelta = ColDelta(scene["ColDelta"])
+        self.minimaps: List[List[Icon]] = [[Icon(icon) for icon in minimap['Icons']] for minimap in scene['Minimaps']]
+        self.floormaps: List[List[Icon]] = [[Icon(icon) for icon in floormap['Icons']] for floormap in scene['Floormaps']]
         temp_paths = scene['Paths']
         for item in temp_paths:
             self.paths.append(item['Points'])
 
-
-    def write_data(self, rom:Rom):
+    def write_data(self, rom: Rom) -> None:
         # write floormap and minimap data
         self.write_map_data(rom)
 
@@ -183,22 +190,22 @@ class Scene(object):
 
         code = rom.read_byte(headcur)
         loop = 0x20
-        while loop > 0 and code != 0x14: #terminator
+        while loop > 0 and code != 0x14:  # terminator
             loop -= 1
 
-            if code == 0x03: #collision
+            if code == 0x03:  # collision
                 col_mesh_offset = rom.read_int24(headcur + 5)
                 col_mesh = CollisionMesh(rom, start, col_mesh_offset)
-                self.patch_mesh(rom, col_mesh);
+                self.patch_mesh(rom, col_mesh)
 
-            elif code == 0x04: #rooms
+            elif code == 0x04:  # rooms
                 room_list_offset = rom.read_int24(headcur + 5)
 
-            elif code == 0x0D: #paths
+            elif code == 0x0D:  # paths
                 path_offset = self.append_path_data(rom)
                 rom.write_int32(headcur + 4, path_offset)
 
-            elif code == 0x0E: #transition actors
+            elif code == 0x0E:  # transition actors
                 t_offset = rom.read_int24(headcur + 5)
                 addr = self.file.start + t_offset
                 write_actor_data(rom, addr, self.transition_actors)
@@ -222,8 +229,7 @@ class Scene(object):
             rom.write_int32s(cur, [room.file.start, room.file.end])
             cur += 0x08
 
-
-    def write_map_data(self, rom:Rom):
+    def write_map_data(self, rom: Rom) -> None:
         if self.id >= 10:
             return
 
@@ -231,7 +237,7 @@ class Scene(object):
         floormap_indices = 0xB6C934
         floormap_vrom = 0xBC7E00
         floormap_index = rom.read_int16(floormap_indices + (self.id * 2))
-        floormap_index //= 2 # game uses texture index, where two textures are used per floor
+        floormap_index //= 2  # game uses texture index, where two textures are used per floor
 
         cur = floormap_vrom + (floormap_index * 0x1EC)
         for floormap in self.floormaps:
@@ -239,17 +245,16 @@ class Scene(object):
                 Icon.write_to_floormap(icon, rom, cur)
                 cur += 0xA4
 
-
         # fixes jabu jabu floor B1 having no chest data
         if self.id == 2:
             cur = floormap_vrom + (0x08 * 0x1EC + 4)
-            kaleido_scope_chest_verts = 0x803A3DA0 # hax, should be vram 0x8082EA00
+            kaleido_scope_chest_verts = 0x803A3DA0  # hax, should be vram 0x8082EA00
             rom.write_int32s(cur, [0x17, kaleido_scope_chest_verts, 0x04])
 
         # write minimaps
         map_mark_vrom = 0xBF40D0
         map_mark_vram = 0x808567F0
-        map_mark_array_vram = 0x8085D2DC # ptr array in map_mark_data to minimap "marks"
+        map_mark_array_vram = 0x8085D2DC  # ptr array in map_mark_data to minimap "marks"
 
         array_vrom = map_mark_array_vram - map_mark_vram + map_mark_vrom
         map_mark_scene_vram = rom.read_int32(self.id * 4 + array_vrom)
@@ -261,8 +266,7 @@ class Scene(object):
                 Icon.write_to_minimap(icon, rom, cur)
                 cur += 0x26
 
-
-    def patch_mesh(self, rom:Rom, mesh:CollisionMesh):
+    def patch_mesh(self, rom: Rom, mesh: CollisionMesh) -> None:
         start = self.file.start
 
         final_cams = []
@@ -297,7 +301,7 @@ class Scene(object):
             self.write_cam_data(rom, addr, final_cams)
 
         # if polytypes needs to be moved, do so
-        if (types_move_addr != mesh.polytypes_addr):
+        if types_move_addr != mesh.polytypes_addr:
             a_start = self.file.start + (mesh.polytypes_addr & 0xFFFFFF)
             b_start = self.file.start + (types_move_addr & 0xFFFFFF)
             size = mesh.polytypes * 8
@@ -320,25 +324,23 @@ class Scene(object):
             flags = item['Flags']
 
             addr = self.file.start + (mesh.poly_addr & 0xFFFFFF) + (id * 0x10)
-            vert_bit =  rom.read_byte(addr + 0x02) & 0x1F # VertexA id data
+            vert_bit =  rom.read_byte(addr + 0x02) & 0x1F  # VertexA id data
             rom.write_int16(addr, t)
             rom.write_byte(addr + 0x02, (flags << 5) + vert_bit)
 
         # Write Mesh to Scene
         mesh.write_to_scene(rom, self.file.start)
 
-
-    def write_cam_data(self, rom:Rom, addr, cam_data):
-
+    @staticmethod
+    def write_cam_data(rom: Rom, addr: int, cam_data: List[Tuple[int, int]]) -> None:
         for item in cam_data:
             data, pos = item
             rom.write_int32s(addr, [data, pos])
             addr += 8
 
-
     # appends path data to the end of the rom
     # returns segment address to path data
-    def append_path_data(self, rom:Rom):
+    def append_path_data(self, rom: Rom) -> int:
         start = self.file.start
         cur = self.file.end
         records = []
@@ -348,7 +350,7 @@ class Scene(object):
             offset = get_segment_address(2, cur - start)
             records.append((nodes, offset))
 
-            #flatten
+            # flatten
             points = [x for points in path for x in points]
             rom.write_int16s(cur, points)
             path_size = align4(len(path) * 6)
@@ -364,14 +366,14 @@ class Scene(object):
         return records_offset
 
 
-class Room(object):
-    def __init__(self, room):
-        self.file = File(room['File'])
-        self.id = room['Id']
-        self.objects = [int(x, 16) for x in room['Objects']]
-        self.actors = [convert_actor_data(x) for x in room['Actors']]
+class Room:
+    def __init__(self, room: Dict[str, Union[int, List[str], Dict[str, Optional[str]]]]):
+        self.file: File = File.from_json(room['File'])
+        self.id: int = room['Id']
+        self.objects: List[int] = [int(x, 16) for x in room['Objects']]
+        self.actors: List[List[int]] = [convert_actor_data(x) for x in room['Actors']]
 
-    def write_data(self, rom:Rom):
+    def write_data(self, rom: Rom) -> None:
         # move file to remap address
         if self.file.remap is not None:
             self.file.relocate(rom)
@@ -381,7 +383,7 @@ class Room(object):
         code = rom.read_byte(headcur)
         loop = 0x20
 
-        while loop != 0 and code != 0x14: #terminator
+        while loop != 0 and code != 0x14:  # terminator
             loop -= 1
 
             if code == 0x01: # actors
@@ -405,8 +407,7 @@ class Room(object):
         self.file.end = align16(self.file.end)
         update_dmadata(rom, self.file)
 
-
-    def append_object_data(self, rom:Rom, objects):
+    def append_object_data(self, rom: Rom, objects: List[int]) -> int:
         offset = self.file.end - self.file.start
         cur = self.file.end
         rom.write_int16s(cur, objects)
@@ -416,8 +417,7 @@ class Room(object):
         return offset
 
 
-def patch_files(rom:Rom, mq_scenes:list):
-
+def patch_files(rom: Rom, mq_scenes: List[int]) -> None:
     data = get_json()
     scenes = [Scene(x) for x in data]
     for scene in scenes:
@@ -427,30 +427,29 @@ def patch_files(rom:Rom, mq_scenes:list):
             scene.write_data(rom)
 
 
-
-def get_json():
+def get_json() -> Any:
     with open(data_path('mqu.json'), 'r') as stream:
         data = json.load(stream)
     return data
 
 
-def convert_actor_data(str):
-    spawn_args = str.split(" ")
+def convert_actor_data(string: str) -> List[int]:
+    spawn_args = string.split(" ")
     return [ int(x,16) for x in spawn_args ]
 
 
-def get_segment_address(base, offset):
+def get_segment_address(base: int, offset: int) -> int:
     offset &= 0xFFFFFF
     base *= 0x01000000
     return base + offset
 
 
-def patch_ice_cavern_scene_header(rom):
+def patch_ice_cavern_scene_header(rom: Rom) -> None:
     rom.buffer[0x2BEB000:0x2BEB038] = rom.buffer[0x2BEB008:0x2BEB040]
     rom.write_int32s(0x2BEB038, [0x0D000000, 0x02000000])
 
 
-def patch_spirit_temple_mq_room_6(rom:Rom, room_addr):
+def patch_spirit_temple_mq_room_6(rom: Rom, room_addr: int) -> None:
     cur = room_addr
 
     actor_list_addr = 0
@@ -458,8 +457,8 @@ def patch_spirit_temple_mq_room_6(rom:Rom, room_addr):
 
     # scan for actor list and header end
     code = rom.read_byte(cur)
-    while code != 0x14: #terminator
-        if code == 0x01: # actors
+    while code != 0x14:  # terminator
+        if code == 0x01:  # actors
             actor_list_addr = rom.read_int32(cur + 4)
             cmd_actors_offset = cur - room_addr
 
@@ -475,7 +474,7 @@ def patch_spirit_temple_mq_room_6(rom:Rom, room_addr):
     alt_data_off = header_size + 8
 
     # set new alternate header offset
-    alt_header_off = align16(alt_data_off + (4 * 3)) # alt header record size * num records
+    alt_header_off = align16(alt_data_off + (4 * 3))  # alt header record size * num records
 
     # write alternate header data
     # the first 3 words are mandatory. the last 3 are just to make the binary
@@ -506,8 +505,8 @@ def patch_spirit_temple_mq_room_6(rom:Rom, room_addr):
     rom.write_int32s(room_addr, [0x18000000, seg])
 
 
-def verify_remap(scenes):
-    def test_remap(file:File):
+def verify_remap(scenes: List[Scene]) -> None:
+    def test_remap(file: File) -> bool:
         if file.remap is not None:
             if file.start < file.remap:
                 return False
@@ -525,32 +524,36 @@ def verify_remap(scenes):
             print("{0} - {1}".format(result, file))
 
 
-def update_dmadata(rom:Rom, file:File):
+def update_dmadata(rom: Rom, file: File) -> None:
     key, start, end, from_file = file.dma_key, file.start, file.end, file.from_file
-    rom.update_dmadata_record(key, start, end, from_file)
+    rom.update_dmadata_record_by_key(key, start, end, from_file)
     file.dma_key = file.start
 
-def update_scene_table(rom:Rom, sceneId, start, end):
-    cur = sceneId * 0x14 + SCENE_TABLE
+
+def update_scene_table(rom: Rom, scene_id: int, start: int, end: int) -> None:
+    cur = scene_id * 0x14 + SCENE_TABLE
     rom.write_int32s(cur, [start, end])
 
 
-def write_actor_data(rom:Rom, cur, actors):
+def write_actor_data(rom: Rom, cur: int, actors: List[List[int]]) -> None:
     for actor in actors:
         rom.write_int16s(cur, actor)
         cur += 0x10
 
-def align4(value):
+
+def align4(value: int) -> int:
     return ((value + 3) // 4) * 4
 
-def align16(value):
+
+def align16(value: int) -> int:
     return ((value + 0xF) // 0x10) * 0x10
+
 
 # This function inserts space in a ovl section at the section's offset
 # The section size is expanded
-# Every relocation entry in the section after the offet is moved accordingly
+# Every relocation entry in the section after the offset is moved accordingly
 # Every relocation value that is after the inserted space is increased accordingly
-def insert_space(rom, file, vram_start, insert_section, insert_offset, insert_size):
+def insert_space(rom: Rom, file: File, vram_start: int, insert_section: int, insert_offset: int, insert_size: int) -> None:
     sections = []
     val_hi = {}
     adr_hi = {}
@@ -598,7 +601,7 @@ def insert_space(rom, file, vram_start, insert_section, insert_offset, insert_si
 
         # value contains the vram address
         value = rom.read_int32(address)
-        raw_value = value
+        reg = None
         if type == 2:
             # Data entry: value is the raw vram address
             pass
@@ -624,7 +627,7 @@ def insert_space(rom, file, vram_start, insert_section, insert_offset, insert_si
             value = None
 
         # update the vram values if it's been moved
-        if value != None and value >= insert_vram:
+        if value is not None and value >= insert_vram:
             # value = new vram address
             new_value = value + insert_size
 
@@ -659,7 +662,7 @@ def insert_space(rom, file, vram_start, insert_section, insert_offset, insert_si
     file.end += insert_size
 
 
-def add_relocations(rom, file, addresses):
+def add_relocations(rom: Rom, file: File, addresses: List[Union[int, Tuple[int, int]]]) -> None:
     relocations = []
     sections = []
     header_size = rom.read_int32(file.end - 4)

--- a/MQ.py
+++ b/MQ.py
@@ -480,8 +480,7 @@ def patch_spirit_temple_mq_room_6(rom:Rom, room_addr):
     # write alternate header data
     # the first 3 words are mandatory. the last 3 are just to make the binary
     # cleaner to read
-    rom.write_int32s(room_addr + alt_data_off,
-                    [0, get_segment_address(3, alt_header_off), 0, 0, 0, 0])
+    rom.write_int32s(room_addr + alt_data_off, [0, get_segment_address(3, alt_header_off), 0, 0, 0, 0])
 
     # clone header
     a_start = room_addr

--- a/Main.py
+++ b/Main.py
@@ -71,7 +71,7 @@ def resolve_settings(settings):
         logger.error('Tricks are set in two places! Using only the tricks from the distribution file.')
 
     for trick in logic_tricks.values():
-        settings.__dict__[trick['name']] = trick['name'] in settings.allowed_tricks
+        settings.settings_dict[trick['name']] = trick['name'] in settings.allowed_tricks
 
     # we load the rom before creating the seed so that errors get caught early
     outputting_specific_world = settings.create_uncompressed_rom or settings.create_compressed_rom or settings.create_wad_file
@@ -124,7 +124,7 @@ def build_world_graphs(settings):
     logger = logging.getLogger('')
     worlds = []
     for i in range(0, settings.world_count):
-        worlds.append(World(i, copy.copy(settings)))
+        worlds.append(World(i, settings.copy()))
 
     savewarps_to_connect = []
     for id, world in enumerate(worlds):

--- a/Main.py
+++ b/Main.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import copy
 import hashlib
 import logging
@@ -7,7 +8,7 @@ import random
 import shutil
 import time
 import zipfile
-from typing import List, Optional
+from typing import Optional
 
 
 from Cosmetics import CosmeticsLog, patch_cosmetics
@@ -119,7 +120,7 @@ def generate(settings: Settings) -> Spoiler:
     return make_spoiler(settings, worlds)
 
 
-def build_world_graphs(settings: Settings) -> List[World]:
+def build_world_graphs(settings: Settings) -> list[World]:
     logger = logging.getLogger('')
     worlds = []
     for i in range(0, settings.world_count):
@@ -165,13 +166,13 @@ def build_world_graphs(settings: Settings) -> List[World]:
     return worlds
 
 
-def place_items(worlds: List[World]) -> None:
+def place_items(worlds: list[World]) -> None:
     logger = logging.getLogger('')
     logger.info('Fill the world.')
     distribute_items_restrictive(worlds)
 
 
-def make_spoiler(settings: Settings, worlds: List[World]) -> Spoiler:
+def make_spoiler(settings: Settings, worlds: list[World]) -> Spoiler:
     logger = logging.getLogger('')
     spoiler = Spoiler(worlds)
     if settings.create_spoiler:

--- a/Main.py
+++ b/Main.py
@@ -1,15 +1,11 @@
 from collections import OrderedDict
 import copy
 import hashlib
-import io
-import itertools
 import logging
 import os
 import platform
 import random
 import shutil
-import subprocess
-import sys
 import struct
 import time
 import zipfile
@@ -29,9 +25,8 @@ from Utils import default_output_path, is_bundled, run_process, data_path
 from Models import patch_model_adult, patch_model_child
 from N64Patch import create_patch_file, apply_patch_file
 from MBSDIFFPatch import apply_ootr_3_web_patch
-from SettingsList import setting_infos, logic_tricks
+from SettingsList import logic_tricks
 from Rules import set_rules, set_shop_rules
-from Plandomizer import Distribution
 from Search import Search, RewindableSearch
 from EntranceShuffle import set_entrances
 from LocationList import set_drop_location_names
@@ -789,8 +784,9 @@ def create_playthrough(spoiler):
 
     # Regenerate the spheres as we might not reach places the same way anymore.
     search.reset() # search state has no items, okay to reuse sphere 0 cache
-    collection_spheres = []
-    collection_spheres.append(list(filter(lambda loc: loc.item.advancement and loc.item.world.max_progressions[loc.item.name] > 0, search.iter_pseudo_starting_locations())))
+    collection_spheres = [list(
+        filter(lambda loc: loc.item.advancement and loc.item.world.max_progressions[loc.item.name] > 0,
+               search.iter_pseudo_starting_locations()))]
     entrance_spheres = []
     remaining_entrances = set(required_entrances)
     collected = set()
@@ -798,7 +794,8 @@ def create_playthrough(spoiler):
         # Not collecting while the generator runs means we only get one sphere at a time
         # Otherwise, an item we collect could influence later item collection in the same sphere
         collected.update(search.iter_reachable_locations(required_locations))
-        if not collected: break
+        if not collected:
+            break
         internal = collected & internal_locations
         if internal:
             # collect only the internal events but don't record them in a sphere

--- a/Messages.py
+++ b/Messages.py
@@ -1,30 +1,36 @@
 # text details: https://wiki.cloudmodding.com/oot/Text_Format
 
 import random
+from typing import TYPE_CHECKING, Dict, List, Tuple, Callable, Any, Union, Optional, Iterable, Set
+
 from HintList import misc_item_hint_table, misc_location_hint_table
 from TextBox import line_wrap
 from Utils import find_last
 
-ENG_TEXT_START = 0x92D000
-JPN_TEXT_START = 0x8EB000
-ENG_TEXT_SIZE_LIMIT = 0x39000
-JPN_TEXT_SIZE_LIMIT = 0x3B000
+if TYPE_CHECKING:
+    from Rom import Rom
+    from World import World
 
-JPN_TABLE_START = 0xB808AC
-ENG_TABLE_START = 0xB849EC
-CREDITS_TABLE_START = 0xB88C0C
+ENG_TEXT_START: int = 0x92D000
+JPN_TEXT_START: int = 0x8EB000
+ENG_TEXT_SIZE_LIMIT: int = 0x39000
+JPN_TEXT_SIZE_LIMIT: int = 0x3B000
 
-JPN_TABLE_SIZE = ENG_TABLE_START - JPN_TABLE_START
-ENG_TABLE_SIZE = CREDITS_TABLE_START - ENG_TABLE_START
+JPN_TABLE_START: int = 0xB808AC
+ENG_TABLE_START: int = 0xB849EC
+CREDITS_TABLE_START: int = 0xB88C0C
 
-EXTENDED_TABLE_START = JPN_TABLE_START # start writing entries to the jp table instead of english for more space
-EXTENDED_TABLE_SIZE = JPN_TABLE_SIZE + ENG_TABLE_SIZE # 0x8360 bytes, 4204 entries
+JPN_TABLE_SIZE: int = ENG_TABLE_START - JPN_TABLE_START
+ENG_TABLE_SIZE: int = CREDITS_TABLE_START - ENG_TABLE_START
 
-EXTENDED_TEXT_START = JPN_TABLE_START # start writing text to the jp table instead of english for more space
-EXTENDED_TEXT_SIZE_LIMIT = JPN_TEXT_SIZE_LIMIT + ENG_TEXT_SIZE_LIMIT # 0x74000 bytes
+EXTENDED_TABLE_START: int = JPN_TABLE_START # start writing entries to the jp table instead of english for more space
+EXTENDED_TABLE_SIZE: int = JPN_TABLE_SIZE + ENG_TABLE_SIZE # 0x8360 bytes, 4204 entries
+
+EXTENDED_TEXT_START: int = JPN_TABLE_START # start writing text to the jp table instead of english for more space
+EXTENDED_TEXT_SIZE_LIMIT: int = JPN_TEXT_SIZE_LIMIT + ENG_TEXT_SIZE_LIMIT # 0x74000 bytes
 
 # name of type, followed by number of additional bytes to read, follwed by a function that prints the code
-CONTROL_CODES = {
+CONTROL_CODES: Dict[int, Tuple[str, int, Callable[[Any], str]]] = {
     0x00: ('pad', 0, lambda _: '<pad>' ),
     0x01: ('line-break', 0, lambda _: '\n' ),
     0x02: ('end', 0, lambda _: '' ),
@@ -59,7 +65,7 @@ CONTROL_CODES = {
 }
 
 # Maps unicode characters to corresponding bytes in OOTR's character set.
-CHARACTER_MAP = {
+CHARACTER_MAP: Dict[str, int] = {
     'Ⓐ': 0x9F,
     'Ⓑ': 0xA0,
     'Ⓒ': 0xA1,
@@ -90,7 +96,7 @@ CHARACTER_MAP.update((c, ix) for ix, c in enumerate(
         start=0x7f
 ))
 
-SPECIAL_CHARACTERS = {
+SPECIAL_CHARACTERS: Dict[int, str] = {
     0x9F: '[A]',
     0xA0: '[B]',
     0xA1: '[C]',
@@ -105,22 +111,22 @@ SPECIAL_CHARACTERS = {
     0xAA: '[Control Stick]',
 }
 
-REVERSE_MAP = list(chr(x) for x in range(256))
+REVERSE_MAP: List[str] = list(chr(x) for x in range(256))
 
 for char, byte in CHARACTER_MAP.items():
     SPECIAL_CHARACTERS.setdefault(byte, char)
     REVERSE_MAP[byte] = char
 
 # [0x0500,0x0560] (inclusive) are reserved for plandomakers
-GOSSIP_STONE_MESSAGES = list( range(0x0401, 0x04FF) ) # ids of the actual hints
-GOSSIP_STONE_MESSAGES += [0x2053, 0x2054] # shared initial stone messages
-TEMPLE_HINTS_MESSAGES = [0x7057, 0x707A] # dungeon reward hints from the temple of time pedestal
-GS_TOKEN_MESSAGES = [0x00B4, 0x00B5] # Get Gold Skulltula Token messages
-ERROR_MESSAGE = 0x0001
+GOSSIP_STONE_MESSAGES: List[int] = list(range(0x0401, 0x04FF))  # ids of the actual hints
+GOSSIP_STONE_MESSAGES += [0x2053, 0x2054]  # shared initial stone messages
+TEMPLE_HINTS_MESSAGES: List[int] = [0x7057, 0x707A]  # dungeon reward hints from the temple of time pedestal
+GS_TOKEN_MESSAGES: List[int] = [0x00B4, 0x00B5]  # Get Gold Skulltula Token messages
+ERROR_MESSAGE: int = 0x0001
 
 # messages for shorter item messages
 # ids are in the space freed up by move_shop_item_messages()
-ITEM_MESSAGES = [
+ITEM_MESSAGES: List[Tuple[int, str]] = [
     (0x0001, "\x08\x06\x30\x05\x41TEXT ID ERROR!\x05\x40"),
     (0x9001, "\x08\x13\x2DYou borrowed a \x05\x41Pocket Egg\x05\x40!\x01A Pocket Cucco will hatch from\x01it overnight. Be sure to give it\x01back."),
     (0x0002, "\x08\x13\x2FYou returned the Pocket Cucco\x01and got \x05\x41Cojiro\x05\x40 in return!\x01Unlike other Cuccos, Cojiro\x01rarely crows."),
@@ -267,7 +273,7 @@ ITEM_MESSAGES = [
     (0x901A, "\x08You can't buy Bombchus without a\x01\x05\x41Bombchu Bag\x05\x40!")
 ]
 
-KEYSANITY_MESSAGES = [
+KEYSANITY_MESSAGES: List[Tuple[int, str]] = [
     (0x001C, "\x13\x74\x08You got the \x05\x41Boss Key\x05\x40\x01for the \x05\x41Fire Temple\x05\x40!\x09"),
     (0x0006, "\x13\x74\x08You got the \x05\x41Boss Key\x05\x40\x01for the \x05\x42Forest Temple\x05\x40!\x09"),
     (0x001D, "\x13\x74\x08You got the \x05\x41Boss Key\x05\x40\x01for the \x05\x43Water Temple\x05\x40!\x09"),
@@ -479,7 +485,7 @@ for dungeon_name in key_rings_with_bk_dungeon_names:
     KEYSANITY_MESSAGES.append((i, f"\x13\x77\x08You found a \x05\x41Key Ring\x05\x40\x01for {dungeon_name}!\x09\x01It includes the \x05\x41Boss Key\x05\x40!"))
     i += 1
 
-COLOR_MAP = {
+COLOR_MAP: Dict[str, str] = {
     'White':      '\x40',
     'Red':        '\x41',
     'Green':      '\x42',
@@ -490,12 +496,12 @@ COLOR_MAP = {
     'Black':      '\x47',
 }
 
-MISC_MESSAGES = {
+MISC_MESSAGES: Dict[int, Tuple[Union[str, bytearray], int]] = {
     0x507B: (bytearray(
-            b"\x08I tell you, I saw him!\x04" \
-            b"\x08I saw the ghostly figure of Damp\x96\x01" \
-            b"the gravekeeper sinking into\x01" \
-            b"his grave. It looked like he was\x01" \
+            b"\x08I tell you, I saw him!\x04"
+            b"\x08I saw the ghostly figure of Damp\x96\x01"
+            b"the gravekeeper sinking into\x01"
+            b"his grave. It looked like he was\x01"
             b"holding some kind of \x05\x41treasure\x05\x40!\x02"
             ), None),
     0x0422: ("They say that once \x05\x41Morpha's Curse\x05\x40\x01is lifted, striking \x05\x42this stone\x05\x40 can\x01shift the tides of \x05\x44Lake Hylia\x05\x40.\x02", 0x23),
@@ -517,23 +523,23 @@ MISC_MESSAGES = {
 
 
 # convert byte array to an integer
-def bytes_to_int(bytes, signed=False):
-    return int.from_bytes(bytes, byteorder='big', signed=signed)
+def bytes_to_int(data: bytes, signed: bool = False) -> int:
+    return int.from_bytes(data, byteorder='big', signed=signed)
 
 
 # convert int to an array of bytes of the given width
-def int_to_bytes(num, width, signed=False):
+def int_to_bytes(num: int, width: int, signed: bool = False) -> bytes:
     return int.to_bytes(num, width, byteorder='big', signed=signed)
 
 
-def display_code_list(codes):
+def display_code_list(codes: 'List[TextCode]') -> str:
     message = ""
     for code in codes:
         message += str(code)
     return message
 
 
-def encode_text_string(text):
+def encode_text_string(text: str) -> List[int]:
     result = []
     it = iter(text)
     for ch in it:
@@ -554,26 +560,26 @@ def encode_text_string(text):
     return result
 
 
-def parse_control_codes(text):
+def parse_control_codes(text: Union[List[int], bytearray, str]) -> 'List[TextCode]':
     if isinstance(text, list):
-        bytes = text
+        text_bytes = text
     elif isinstance(text, bytearray):
-        bytes = list(text)
+        text_bytes = list(text)
     else:
-        bytes = encode_text_string(text)
+        text_bytes = encode_text_string(text)
 
     text_codes = []
     index = 0
-    while index < len(bytes):
-        next_char = bytes[index]
+    while index < len(text_bytes):
+        next_char = text_bytes[index]
         data = 0
         index += 1
         if next_char in CONTROL_CODES:
             extra_bytes = CONTROL_CODES[next_char][1]
             if extra_bytes > 0:
-                data = bytes_to_int(bytes[index : index + extra_bytes])
+                data = bytes_to_int(text_bytes[index: index + extra_bytes])
                 index += extra_bytes
-        text_code = Text_Code(next_char, data)
+        text_code = TextCode(next_char, data)
         text_codes.append(text_code)
         if text_code.code == 0x02:  # message end code
             break
@@ -582,8 +588,16 @@ def parse_control_codes(text):
 
 
 # holds a single character or control code of a string
-class Text_Code:
-    def display(self):
+class TextCode:
+    def __init__(self, code: int, data: int) -> None:
+        self.code: int = code
+        if code in CONTROL_CODES:
+            self.type = CONTROL_CODES[code][0]
+        else:
+            self.type = 'character'
+        self.data: int = data
+
+    def display(self) -> str:
         if self.code in CONTROL_CODES:
             return CONTROL_CODES[self.code][2](self.data)
         elif self.code in SPECIAL_CHARACTERS:
@@ -593,23 +607,23 @@ class Text_Code:
         else:
             return chr(self.code)
 
-    def get_python_string(self):
+    def get_python_string(self) -> str:
         if self.code in CONTROL_CODES:
             ret = ''
-            subdata = self.data
+            data = self.data
             for _ in range(0, CONTROL_CODES[self.code][1]):
-                ret = ('\\x%02X' % (subdata & 0xFF)) + ret
-                subdata = subdata >> 8
-            ret = '\\x%02X' % self.code + ret
+                ret = f'\\x{data & 0xFF:02X}{ret}'
+                data = data >> 8
+            ret = f'\\x{self.code:02X}{ret}'
             return ret
         elif self.code in SPECIAL_CHARACTERS:
-            return '\\x%02X' % self.code
+            return f'\\x{self.code:02X}'
         elif self.code >= 0x7F:
             return '?'
         else:
             return chr(self.code)
 
-    def get_string(self):
+    def get_string(self) -> str:
         if self.code in CONTROL_CODES:
             ret = ''
             subdata = self.data
@@ -622,15 +636,14 @@ class Text_Code:
             # raise ValueError(repr(REVERSE_MAP))
             return REVERSE_MAP[self.code]
 
-    # writes the code to the given offset, and returns the offset of the next byte
-    def size(self):
+    def size(self) -> int:
         size = 1
         if self.code in CONTROL_CODES:
             size += CONTROL_CODES[self.code][1]
         return size
 
     # writes the code to the given offset, and returns the offset of the next byte
-    def write(self, rom, text_start, offset):
+    def write(self, rom: "Rom", text_start: int, offset: int) -> int:
         rom.write_byte(text_start + offset, self.code)
 
         extra_bytes = 0
@@ -641,20 +654,42 @@ class Text_Code:
 
         return offset + 1 + extra_bytes
 
-    def __init__(self, code, data):
-        self.code = code
-        if code in CONTROL_CODES:
-            self.type = CONTROL_CODES[code][0]
-        else:
-            self.type = 'character'
-        self.data = data
-
     __str__ = __repr__ = display
 
 
 # holds a single message, and all its data
 class Message:
-    def display(self):
+    def __init__(self, raw_text: Union[List[int], bytearray, str], index: int, id: int, opts: int, offset: int, length: int) -> None:
+        if isinstance(raw_text, str):
+            raw_text = bytearray(raw_text, encoding='utf-8')
+        elif not isinstance(raw_text, bytearray):
+            raw_text = bytearray(raw_text)
+
+        self.raw_text: bytearray = raw_text
+
+        self.index: int = index
+        self.id: int = id
+        self.opts: int = opts  # Textbox type and y position
+        self.box_type: int = (self.opts & 0xF0) >> 4
+        self.position: int = (self.opts & 0x0F)
+        self.offset: int = offset
+        self.length: int = length
+
+        self.has_goto: bool = False
+        self.has_keep_open: bool = False
+        self.has_event: bool = False
+        self.has_fade: bool = False
+        self.has_ocarina: bool = False
+        self.has_two_choice: bool = False
+        self.has_three_choice: bool = False
+        self.ending: Optional[TextCode] = None
+
+        self.text_codes: List[TextCode] = []
+        self.text: str = ''
+        self.unpadded_length: int = 0
+        self.parse_text()
+
+    def display(self) -> str:
         meta_data = [
             "#" + str(self.index),
             "ID: 0x" + "{:04x}".format(self.id),
@@ -665,14 +700,14 @@ class Message:
         ]
         return ', '.join(meta_data) + '\n' + self.text
 
-    def get_python_string(self):
+    def get_python_string(self) -> str:
         ret = ''
         for code in self.text_codes:
             ret = ret + code.get_python_string()
         return ret
 
     # check if this is an unused message that just contains it's own id as text
-    def is_id_message(self):
+    def is_id_message(self) -> bool:
         if self.unpadded_length != 5 or self.id == 0xFFFC:
             return False
         for i in range(4):
@@ -685,7 +720,7 @@ class Message:
                 return False
         return True
 
-    def parse_text(self):
+    def parse_text(self) -> None:
         self.text_codes = parse_control_codes(self.raw_text)
 
         index = 0
@@ -715,11 +750,11 @@ class Message:
         self.text = display_code_list(self.text_codes)
         self.unpadded_length = index
 
-    def is_basic(self):
+    def is_basic(self) -> bool:
         return not (self.has_goto or self.has_keep_open or self.has_event or self.has_fade or self.has_ocarina or self.has_two_choice or self.has_three_choice)
 
     # computes the size of a message, including padding
-    def size(self):
+    def size(self) -> int:
         size = 0
 
         for code in self.text_codes:
@@ -730,14 +765,15 @@ class Message:
         return size
 
     # applies whatever transformations we want to the dialogs
-    def transform(self, replace_ending=False, ending=None, always_allow_skip=True, speed_up_text=True):
+    def transform(self, replace_ending: bool = False, ending: Optional[TextCode] = None,
+                  always_allow_skip: bool = True, speed_up_text: bool = True) -> None:
         ending_codes = [0x02, 0x07, 0x0A, 0x0B, 0x0E, 0x10]
         box_breaks = [0x04, 0x0C]
         slows_text = [0x08, 0x09, 0x14]
         slow_icons = [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x04, 0x02]
 
         text_codes = []
-        instant_text_code = Text_Code(0x08, 0)
+        instant_text_code = TextCode(0x08, 0)
 
         # # speed the text
         if speed_up_text:
@@ -764,7 +800,7 @@ class Message:
                     text_codes.append(code)
                     text_codes.append(instant_text_code)  # allow instant
                 else:
-                    text_codes.append(Text_Code(0x04, 0))  # un-delayed break
+                    text_codes.append(TextCode(0x04, 0))  # un-delayed break
                     text_codes.append(instant_text_code)  # allow instant
             elif speed_up_text and code.code == 0x13 and code.data in slow_icons:
                 text_codes.append(code)
@@ -776,15 +812,15 @@ class Message:
         if replace_ending:
             if ending:
                 if speed_up_text and ending.code == 0x10:  # ocarina
-                    text_codes.append(Text_Code(0x09, 0))  # disallow instant text
+                    text_codes.append(TextCode(0x09, 0))  # disallow instant text
                 text_codes.append(ending)  # write special ending
-            text_codes.append(Text_Code(0x02, 0))  # write end code
+            text_codes.append(TextCode(0x02, 0))  # write end code
 
         self.text_codes = text_codes
 
     # writes a Message back into the rom, using the given index and offset to update the table
     # returns the offset of the next message
-    def write(self, rom, index, text_start, offset, bank):
+    def write(self, rom: "Rom", index: int, text_start: int, offset: int, bank: int) -> int:
         # construct the table entry
         id_bytes = int_to_bytes(self.id, 2)
         offset_bytes = int_to_bytes(offset, 3)
@@ -797,36 +833,13 @@ class Message:
             offset = code.write(rom, text_start, offset)
 
         while offset % 4 > 0:
-            offset = Text_Code(0x00, 0).write(rom, text_start, offset) # pad to 4 byte align
+            offset = TextCode(0x00, 0).write(rom, text_start, offset) # pad to 4 byte align
 
         return offset
 
-
-    def __init__(self, raw_text, index, id, opts, offset, length):
-        self.raw_text = raw_text
-
-        self.index = index
-        self.id = id
-        self.opts = opts  # Textbox type and y position
-        self.box_type = (self.opts & 0xF0) >> 4
-        self.position = (self.opts & 0x0F)
-        self.offset = offset
-        self.length = length
-
-        self.has_goto = False
-        self.has_keep_open = False
-        self.has_event = False
-        self.has_fade = False
-        self.has_ocarina = False
-        self.has_two_choice = False
-        self.has_three_choice = False
-        self.ending = None
-
-        self.parse_text()
-
     # read a single message from rom
     @classmethod
-    def from_rom(cls, rom, index, eng=True):
+    def from_rom(cls, rom: "Rom", index: int, eng: bool = True) -> 'Message':
         if eng:
             table_start = ENG_TABLE_START
             text_start = ENG_TEXT_START
@@ -847,21 +860,21 @@ class Message:
         return cls(raw_text, index, id, opts, offset, length)
 
     @classmethod
-    def from_string(cls, text, id=0, opts=0x00):
+    def from_string(cls, text: str, id: int = 0, opts: int = 0x00) -> 'Message':
         bytes = text + "\x02"
         return cls(bytes, 0, id, opts, 0, len(bytes) + 1)
 
     @classmethod
-    def from_bytearray(cls, bytearray, id=0, opts=0x00):
-        bytes = list(bytearray) + [0x02]
-
+    def from_bytearray(cls, text: bytearray, id: int = 0, opts: int = 0x00) -> 'Message':
+        bytes = list(text) + [0x02]
         return cls(bytes, 0, id, opts, 0, len(bytes) + 1)
 
     __str__ = __repr__ = display
 
+
 # wrapper for updating the text of a message, given its message id
 # if the id does not exist in the list, then it will add it
-def update_message_by_id(messages, id, text, opts=None):
+def update_message_by_id(messages: List[Message], id: int, text: Union[bytearray, str], opts: Optional[int] = None) -> None:
     # get the message index
     index = next( (m.index for m in messages if m.id == id), -1)
     # update if it was found
@@ -870,8 +883,9 @@ def update_message_by_id(messages, id, text, opts=None):
     else:
         add_message(messages, text, id, opts)
 
+
 # Gets the message by its ID. Returns None if the index does not exist
-def get_message_by_id(messages, id):
+def get_message_by_id(messages: List[Message], id: int) -> Optional[Message]:
     # get the message index
     index = next( (m.index for m in messages if m.id == id), -1)
     if index >= 0:
@@ -879,8 +893,9 @@ def get_message_by_id(messages, id):
     else:
         return None
 
+
 # wrapper for updating the text of a message, given its index in the list
-def update_message_by_index(messages, index, text, opts=None):
+def update_message_by_index(messages: List[Message], index: int, text: Union[bytearray, str], opts: Optional[int] = None) -> None:
     if opts is None:
         opts = messages[index].opts
 
@@ -890,95 +905,101 @@ def update_message_by_index(messages, index, text, opts=None):
         messages[index] = Message.from_string(text, messages[index].id, opts)
     messages[index].index = index
 
+
 # wrapper for adding a string message to a list of messages
-def add_message(messages, text, id=0, opts=0x00):
+def add_message(messages: List[Message], text: Union[bytearray, str], id: int = 0, opts: int = 0x00) -> None:
     if isinstance(text, bytearray):
-        messages.append( Message.from_bytearray(text, id, opts) )
+        messages.append(Message.from_bytearray(text, id, opts))
     else:
-        messages.append( Message.from_string(text, id, opts) )
+        messages.append(Message.from_string(text, id, opts))
     messages[-1].index = len(messages) - 1
 
+
 # holds a row in the shop item table (which contains pointers to the description and purchase messages)
-class Shop_Item():
-
-    def display(self):
-        meta_data = ["#" + str(self.index),
-         "Item: 0x" + "{:04x}".format(self.get_item_id),
-         "Price: " + str(self.price),
-         "Amount: " + str(self.pieces),
-         "Object: 0x" + "{:04x}".format(self.object),
-         "Model: 0x" + "{:04x}".format(self.model),
-         "Description: 0x" + "{:04x}".format(self.description_message),
-         "Purchase: 0x" + "{:04x}".format(self.purchase_message),]
-        func_data = [
-         "func1: 0x" + "{:08x}".format(self.func1),
-         "func2: 0x" + "{:08x}".format(self.func2),
-         "func3: 0x" + "{:08x}".format(self.func3),
-         "func4: 0x" + "{:08x}".format(self.func4),]
-        return ', '.join(meta_data) + '\n' + ', '.join(func_data)
-
-    # write the shop item back
-    def write(self, rom, shop_table_address, index):
-
-        entry_offset = shop_table_address + 0x20 * index
-
-        bytes = []
-        bytes += int_to_bytes(self.object, 2)
-        bytes += int_to_bytes(self.model, 2)
-        bytes += int_to_bytes(self.func1, 4)
-        bytes += int_to_bytes(self.price, 2, signed=True)
-        bytes += int_to_bytes(self.pieces, 2)
-        bytes += int_to_bytes(self.description_message, 2)
-        bytes += int_to_bytes(self.purchase_message, 2)
-        bytes += [0x00, 0x00]
-        bytes += int_to_bytes(self.get_item_id, 2)
-        bytes += int_to_bytes(self.func2, 4)
-        bytes += int_to_bytes(self.func3, 4)
-        bytes += int_to_bytes(self.func4, 4)
-
-        rom.write_bytes(entry_offset, bytes)
-
+class ShopItem:
     # read a single message
-    def __init__(self, rom, shop_table_address, index):
-
+    def __init__(self, rom: "Rom", shop_table_address: int, index: int) -> None:
         entry_offset = shop_table_address + 0x20 * index
         entry = rom.read_bytes(entry_offset, 0x20)
 
-        self.index = index
-        self.object = bytes_to_int(entry[0x00:0x02])
-        self.model = bytes_to_int(entry[0x02:0x04])
-        self.func1 = bytes_to_int(entry[0x04:0x08])
-        self.price = bytes_to_int(entry[0x08:0x0A])
-        self.pieces = bytes_to_int(entry[0x0A:0x0C])
-        self.description_message = bytes_to_int(entry[0x0C:0x0E])
-        self.purchase_message = bytes_to_int(entry[0x0E:0x10])
+        self.index: int = index
+        self.object: int = bytes_to_int(entry[0x00:0x02])
+        self.model: int = bytes_to_int(entry[0x02:0x04])
+        self.func1: int = bytes_to_int(entry[0x04:0x08])
+        self.price: int = bytes_to_int(entry[0x08:0x0A])
+        self.pieces: int = bytes_to_int(entry[0x0A:0x0C])
+        self.description_message: int = bytes_to_int(entry[0x0C:0x0E])
+        self.purchase_message: int = bytes_to_int(entry[0x0E:0x10])
         # 0x10-0x11 is always 0000 padded apparently
-        self.get_item_id = bytes_to_int(entry[0x12:0x14])
-        self.func2 = bytes_to_int(entry[0x14:0x18])
-        self.func3 = bytes_to_int(entry[0x18:0x1C])
-        self.func4 = bytes_to_int(entry[0x1C:0x20])
+        self.get_item_id: int = bytes_to_int(entry[0x12:0x14])
+        self.func2: int = bytes_to_int(entry[0x14:0x18])
+        self.func3: int = bytes_to_int(entry[0x18:0x1C])
+        self.func4: int = bytes_to_int(entry[0x1C:0x20])
+
+    def display(self) -> str:
+        meta_data = [
+            "#" + str(self.index),
+            "Item: 0x" + "{:04x}".format(self.get_item_id),
+            "Price: " + str(self.price),
+            "Amount: " + str(self.pieces),
+            "Object: 0x" + "{:04x}".format(self.object),
+            "Model: 0x" + "{:04x}".format(self.model),
+            "Description: 0x" + "{:04x}".format(self.description_message),
+            "Purchase: 0x" + "{:04x}".format(self.purchase_message),
+        ]
+        func_data = [
+            "func1: 0x" + "{:08x}".format(self.func1),
+            "func2: 0x" + "{:08x}".format(self.func2),
+            "func3: 0x" + "{:08x}".format(self.func3),
+            "func4: 0x" + "{:08x}".format(self.func4),
+        ]
+        return ', '.join(meta_data) + '\n' + ', '.join(func_data)
+
+    # write the shop item back
+    def write(self, rom: "Rom", shop_table_address: int, index: int) -> None:
+        entry_offset = shop_table_address + 0x20 * index
+
+        data = []
+        data += int_to_bytes(self.object, 2)
+        data += int_to_bytes(self.model, 2)
+        data += int_to_bytes(self.func1, 4)
+        data += int_to_bytes(self.price, 2, signed=True)
+        data += int_to_bytes(self.pieces, 2)
+        data += int_to_bytes(self.description_message, 2)
+        data += int_to_bytes(self.purchase_message, 2)
+        data += [0x00, 0x00]
+        data += int_to_bytes(self.get_item_id, 2)
+        data += int_to_bytes(self.func2, 4)
+        data += int_to_bytes(self.func3, 4)
+        data += int_to_bytes(self.func4, 4)
+
+        rom.write_bytes(entry_offset, data)
 
     __str__ = __repr__ = display
 
+
 # reads each of the shop items
-def read_shop_items(rom, shop_table_address):
+def read_shop_items(rom: "Rom", shop_table_address: int) -> List[ShopItem]:
     shop_items = []
 
     for index in range(0, 100):
-        shop_items.append( Shop_Item(rom, shop_table_address, index) )
+        shop_items.append(ShopItem(rom, shop_table_address, index))
 
     return shop_items
 
+
 # writes each of the shop item back into rom
-def write_shop_items(rom, shop_table_address, shop_items):
+def write_shop_items(rom: "Rom", shop_table_address: int, shop_items: Iterable[ShopItem]) -> None:
     for s in shop_items:
         s.write(rom, shop_table_address, s.index)
 
+
 # these are unused shop items, and contain text ids that are used elsewhere, and should not be moved
-SHOP_ITEM_EXCEPTIONS = [0x0A, 0x0B, 0x11, 0x12, 0x13, 0x14, 0x29]
+SHOP_ITEM_EXCEPTIONS: List[int] = [0x0A, 0x0B, 0x11, 0x12, 0x13, 0x14, 0x29]
+
 
 # returns a set of all message ids used for shop items
-def get_shop_message_id_set(shop_items):
+def get_shop_message_id_set(shop_items: Iterable[ShopItem]) -> Set[int]:
     ids = set()
     for shop in shop_items:
         if shop.index not in SHOP_ITEM_EXCEPTIONS:
@@ -986,18 +1007,21 @@ def get_shop_message_id_set(shop_items):
             ids.add(shop.purchase_message)
     return ids
 
+
 # remove all messages that easy to tell are unused to create space in the message index table
-def remove_unused_messages(messages):
+def remove_unused_messages(messages: List[Message]) -> None:
     messages[:] = [m for m in messages if not m.is_id_message()]
     for index, m in enumerate(messages):
         m.index = index
 
+
 # takes all messages used for shop items, and moves messages from the 00xx range into the unused 80xx range
-def move_shop_item_messages(messages, shop_items):
+def move_shop_item_messages(messages: List[Message], shop_items: Iterable[ShopItem]) -> None:
     # checks if a message id is in the item message range
-    def is_in_item_range(id):
+    def is_in_item_range(id: int) -> bool:
         bytes = int_to_bytes(id, 2)
         return bytes[0] == 0x00
+
     # get the ids we want to move
     ids = set( id for id in get_shop_message_id_set(shop_items) if is_in_item_range(id) )
     # update them in the message list
@@ -1016,7 +1040,8 @@ def move_shop_item_messages(messages, shop_items):
         if is_in_item_range(shop.purchase_message):
             shop.purchase_message |= 0x8000
 
-def make_player_message(text):
+
+def make_player_message(text: str) -> str:
     player_text = '\x05\x42\x0F\x05\x40'
     pronoun_mapping = {
         "You have ": player_text + " ",
@@ -1064,7 +1089,7 @@ def make_player_message(text):
 
 # reduce item message sizes and add new item messages
 # make sure to call this AFTER move_shop_item_messages()
-def update_item_messages(messages, world):
+def update_item_messages(messages: List[Message], world: "World") -> None:
     new_item_messages = ITEM_MESSAGES + KEYSANITY_MESSAGES
     check_message_dupes(new_item_messages)
     for id, text in new_item_messages:
@@ -1087,12 +1112,12 @@ def check_message_dupes(new_item_messages):
                     raise Exception("Duplicate MessageID found: " + hex(message_id1) + ", " + message1 + ", " + message2)
 
 # run all keysanity related patching to add messages for dungeon specific items
-def add_item_messages(messages, shop_items, world):
+def add_item_messages(messages: List[Message], shop_items: Iterable[ShopItem], world: "World") -> None:
     move_shop_item_messages(messages, shop_items)
     update_item_messages(messages, world)
 
 # reads each of the game's messages into a list of Message objects
-def read_messages(rom):
+def read_messages(rom: "Rom") -> List[Message]:
     table_offset = ENG_TABLE_START
     index = 0
     messages = []
@@ -1115,11 +1140,12 @@ def read_messages(rom):
     messages.append(read_fffc_message(rom))
     return messages
 
+
 # The JP text table is the only source for ID 0xFFFC, which is used by the
 # title and file select screens. Preserve this table entry and text data when
 # overwriting the JP data. The regular read_messages function only reads English
 # data.
-def read_fffc_message(rom):
+def read_fffc_message(rom: "Rom") -> Message:
     table_offset = JPN_TABLE_START
     index = 0
     while True:
@@ -1135,11 +1161,12 @@ def read_fffc_message(rom):
 
     return message
 
-# write the messages back
-def repack_messages(rom, messages, permutation=None, always_allow_skip=True, speed_up_text=True):
 
-    rom.update_dmadata_record(ENG_TEXT_START, ENG_TEXT_START, ENG_TEXT_START + ENG_TEXT_SIZE_LIMIT)
-    rom.update_dmadata_record(JPN_TEXT_START, JPN_TEXT_START, JPN_TEXT_START + JPN_TEXT_SIZE_LIMIT)
+# write the messages back
+def repack_messages(rom: "Rom", messages: List[Message], permutation: Optional[List[int]] = None,
+                    always_allow_skip: bool = True, speed_up_text: bool = True) -> None:
+    rom.update_dmadata_record_by_key(ENG_TEXT_START, ENG_TEXT_START, ENG_TEXT_START + ENG_TEXT_SIZE_LIMIT)
+    rom.update_dmadata_record_by_key(JPN_TEXT_START, JPN_TEXT_START, JPN_TEXT_START + JPN_TEXT_SIZE_LIMIT)
 
     if permutation is None:
         permutation = range(len(messages))
@@ -1222,12 +1249,30 @@ def repack_messages(rom, messages, permutation=None, always_allow_skip=True, spe
         raise(TypeError("Message ID table is too large: 0x" + "{:x}".format(8 * (table_index + 1)) + " written / 0x" + "{:x}".format(EXTENDED_TABLE_SIZE) + " allowed."))
     rom.write_bytes(entry_offset, [0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
 
+
 # shuffles the messages in the game, making sure to keep various message types in their own group
-def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
+def shuffle_messages(messages: List[Message], except_hints: bool = True) -> List[int]:
+    if not hasattr(shuffle_messages, "shop_item_messages"):
+        shuffle_messages.shop_item_messages = []
+    if not hasattr(shuffle_messages, "scrubs_message_ids"):
+        shuffle_messages.scrubs_message_ids = []
+
+    hint_ids = (
+        GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES +
+        [data['id'] for data in misc_item_hint_table.values()] +
+        [data['id'] for data in misc_location_hint_table.values()] +
+        list(KEYSANITY_MESSAGES.keys()) + shuffle_messages.shop_item_messages +
+        shuffle_messages.scrubs_message_ids +
+        [0x5036, 0x70F5] # Chicken count and poe count respectively
+    )
+    shuffle_exempt = [
+        0x208D,         # "One more lap!" for Cow in House race.
+        0xFFFC,         # Character data from JP table used on title and file select screens
+    ]
 
     permutation = [i for i, _ in enumerate(messages)]
 
-    def is_exempt(m):
+    def is_exempt(m: Message) -> bool:
         hint_ids = (
             GOSSIP_STONE_MESSAGES + TEMPLE_HINTS_MESSAGES +
             [data['id'] for data in misc_item_hint_table.values()] +
@@ -1244,19 +1289,18 @@ def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
         is_hint = (except_hints and m.id in hint_ids)
         is_error_message = (m.id == ERROR_MESSAGE)
         is_shuffle_exempt = (m.id in shuffle_exempt)
-        return (is_hint or is_error_message or m.is_id_message() or is_shuffle_exempt)
+        return is_hint or is_error_message or m.is_id_message() or is_shuffle_exempt
 
-    have_goto         = list( filter(lambda m: not is_exempt(m) and m.has_goto,         messages) )
-    have_keep_open    = list( filter(lambda m: not is_exempt(m) and m.has_keep_open,    messages) )
-    have_event        = list( filter(lambda m: not is_exempt(m) and m.has_event,        messages) )
-    have_fade         = list( filter(lambda m: not is_exempt(m) and m.has_fade,         messages) )
-    have_ocarina      = list( filter(lambda m: not is_exempt(m) and m.has_ocarina,      messages) )
-    have_two_choice   = list( filter(lambda m: not is_exempt(m) and m.has_two_choice,   messages) )
-    have_three_choice = list( filter(lambda m: not is_exempt(m) and m.has_three_choice, messages) )
-    basic_messages    = list( filter(lambda m: not is_exempt(m) and m.is_basic(),       messages) )
+    have_goto         = list(filter(lambda m: not is_exempt(m) and m.has_goto,         messages))
+    have_keep_open    = list(filter(lambda m: not is_exempt(m) and m.has_keep_open,    messages))
+    have_event        = list(filter(lambda m: not is_exempt(m) and m.has_event,        messages))
+    have_fade         = list(filter(lambda m: not is_exempt(m) and m.has_fade,         messages))
+    have_ocarina      = list(filter(lambda m: not is_exempt(m) and m.has_ocarina,      messages))
+    have_two_choice   = list(filter(lambda m: not is_exempt(m) and m.has_two_choice,   messages))
+    have_three_choice = list(filter(lambda m: not is_exempt(m) and m.has_three_choice, messages))
+    basic_messages    = list(filter(lambda m: not is_exempt(m) and m.is_basic(),       messages))
 
-
-    def shuffle_group(group):
+    def shuffle_group(group: List[Message]) -> None:
         group_permutation = [i for i, _ in enumerate(group)]
         random.shuffle(group_permutation)
 
@@ -1273,8 +1317,9 @@ def shuffle_messages(messages, except_hints=True, always_allow_skip=True):
 
     return permutation
 
+
 # Update warp song text boxes for ER
-def update_warp_song_text(messages, world):
+def update_warp_song_text(messages: List[Message], world: "World") -> None:
     from Hints import HintArea
 
     msg_list = {

--- a/Messages.py
+++ b/Messages.py
@@ -1,7 +1,9 @@
 # text details: https://wiki.cloudmodding.com/oot/Text_Format
 
+from __future__ import annotations
 import random
-from typing import TYPE_CHECKING, Dict, List, Tuple, Callable, Any, Union, Optional, Iterable, Set
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Optional, Any
 
 from HintList import misc_item_hint_table, misc_location_hint_table
 from TextBox import line_wrap
@@ -23,14 +25,14 @@ CREDITS_TABLE_START: int = 0xB88C0C
 JPN_TABLE_SIZE: int = ENG_TABLE_START - JPN_TABLE_START
 ENG_TABLE_SIZE: int = CREDITS_TABLE_START - ENG_TABLE_START
 
-EXTENDED_TABLE_START: int = JPN_TABLE_START # start writing entries to the jp table instead of english for more space
-EXTENDED_TABLE_SIZE: int = JPN_TABLE_SIZE + ENG_TABLE_SIZE # 0x8360 bytes, 4204 entries
+EXTENDED_TABLE_START: int = JPN_TABLE_START  # start writing entries to the jp table instead of english for more space
+EXTENDED_TABLE_SIZE: int = JPN_TABLE_SIZE + ENG_TABLE_SIZE  # 0x8360 bytes, 4204 entries
 
-EXTENDED_TEXT_START: int = JPN_TABLE_START # start writing text to the jp table instead of english for more space
-EXTENDED_TEXT_SIZE_LIMIT: int = JPN_TEXT_SIZE_LIMIT + ENG_TEXT_SIZE_LIMIT # 0x74000 bytes
+EXTENDED_TEXT_START: int = JPN_TABLE_START  # start writing text to the jp table instead of english for more space
+EXTENDED_TEXT_SIZE_LIMIT: int = JPN_TEXT_SIZE_LIMIT + ENG_TEXT_SIZE_LIMIT  # 0x74000 bytes
 
 # name of type, followed by number of additional bytes to read, follwed by a function that prints the code
-CONTROL_CODES: Dict[int, Tuple[str, int, Callable[[Any], str]]] = {
+CONTROL_CODES: dict[int, tuple[str, int, Callable[[Any], str]]] = {
     0x00: ('pad', 0, lambda _: '<pad>' ),
     0x01: ('line-break', 0, lambda _: '\n' ),
     0x02: ('end', 0, lambda _: '' ),
@@ -65,7 +67,7 @@ CONTROL_CODES: Dict[int, Tuple[str, int, Callable[[Any], str]]] = {
 }
 
 # Maps unicode characters to corresponding bytes in OOTR's character set.
-CHARACTER_MAP: Dict[str, int] = {
+CHARACTER_MAP: dict[str, int] = {
     'Ⓐ': 0x9F,
     'Ⓑ': 0xA0,
     'Ⓒ': 0xA1,
@@ -96,7 +98,7 @@ CHARACTER_MAP.update((c, ix) for ix, c in enumerate(
         start=0x7f
 ))
 
-SPECIAL_CHARACTERS: Dict[int, str] = {
+SPECIAL_CHARACTERS: dict[int, str] = {
     0x9F: '[A]',
     0xA0: '[B]',
     0xA1: '[C]',
@@ -111,22 +113,22 @@ SPECIAL_CHARACTERS: Dict[int, str] = {
     0xAA: '[Control Stick]',
 }
 
-REVERSE_MAP: List[str] = list(chr(x) for x in range(256))
+REVERSE_MAP: list[str] = list(chr(x) for x in range(256))
 
 for char, byte in CHARACTER_MAP.items():
     SPECIAL_CHARACTERS.setdefault(byte, char)
     REVERSE_MAP[byte] = char
 
 # [0x0500,0x0560] (inclusive) are reserved for plandomakers
-GOSSIP_STONE_MESSAGES: List[int] = list(range(0x0401, 0x04FF))  # ids of the actual hints
+GOSSIP_STONE_MESSAGES: list[int] = list(range(0x0401, 0x04FF))  # ids of the actual hints
 GOSSIP_STONE_MESSAGES += [0x2053, 0x2054]  # shared initial stone messages
-TEMPLE_HINTS_MESSAGES: List[int] = [0x7057, 0x707A]  # dungeon reward hints from the temple of time pedestal
-GS_TOKEN_MESSAGES: List[int] = [0x00B4, 0x00B5]  # Get Gold Skulltula Token messages
+TEMPLE_HINTS_MESSAGES: list[int] = [0x7057, 0x707A]  # dungeon reward hints from the temple of time pedestal
+GS_TOKEN_MESSAGES: list[int] = [0x00B4, 0x00B5]  # Get Gold Skulltula Token messages
 ERROR_MESSAGE: int = 0x0001
 
 # messages for shorter item messages
 # ids are in the space freed up by move_shop_item_messages()
-ITEM_MESSAGES: List[Tuple[int, str]] = [
+ITEM_MESSAGES: list[tuple[int, str]] = [
     (0x0001, "\x08\x06\x30\x05\x41TEXT ID ERROR!\x05\x40"),
     (0x9001, "\x08\x13\x2DYou borrowed a \x05\x41Pocket Egg\x05\x40!\x01A Pocket Cucco will hatch from\x01it overnight. Be sure to give it\x01back."),
     (0x0002, "\x08\x13\x2FYou returned the Pocket Cucco\x01and got \x05\x41Cojiro\x05\x40 in return!\x01Unlike other Cuccos, Cojiro\x01rarely crows."),
@@ -273,7 +275,7 @@ ITEM_MESSAGES: List[Tuple[int, str]] = [
     (0x901A, "\x08You can't buy Bombchus without a\x01\x05\x41Bombchu Bag\x05\x40!")
 ]
 
-KEYSANITY_MESSAGES: List[Tuple[int, str]] = [
+KEYSANITY_MESSAGES: list[tuple[int, str]] = [
     (0x001C, "\x13\x74\x08You got the \x05\x41Boss Key\x05\x40\x01for the \x05\x41Fire Temple\x05\x40!\x09"),
     (0x0006, "\x13\x74\x08You got the \x05\x41Boss Key\x05\x40\x01for the \x05\x42Forest Temple\x05\x40!\x09"),
     (0x001D, "\x13\x74\x08You got the \x05\x41Boss Key\x05\x40\x01for the \x05\x43Water Temple\x05\x40!\x09"),
@@ -485,7 +487,7 @@ for dungeon_name in key_rings_with_bk_dungeon_names:
     KEYSANITY_MESSAGES.append((i, f"\x13\x77\x08You found a \x05\x41Key Ring\x05\x40\x01for {dungeon_name}!\x09\x01It includes the \x05\x41Boss Key\x05\x40!"))
     i += 1
 
-COLOR_MAP: Dict[str, str] = {
+COLOR_MAP: dict[str, str] = {
     'White':      '\x40',
     'Red':        '\x41',
     'Green':      '\x42',
@@ -496,16 +498,16 @@ COLOR_MAP: Dict[str, str] = {
     'Black':      '\x47',
 }
 
-MISC_MESSAGES: Dict[int, Tuple[Union[str, bytearray], int]] = {
+MISC_MESSAGES: dict[int, tuple[str | bytearray, int]] = {
     0x507B: (bytearray(
             b"\x08I tell you, I saw him!\x04"
             b"\x08I saw the ghostly figure of Damp\x96\x01"
             b"the gravekeeper sinking into\x01"
             b"his grave. It looked like he was\x01"
             b"holding some kind of \x05\x41treasure\x05\x40!\x02"
-            ), None),
+            ), 0x00),
     0x0422: ("They say that once \x05\x41Morpha's Curse\x05\x40\x01is lifted, striking \x05\x42this stone\x05\x40 can\x01shift the tides of \x05\x44Lake Hylia\x05\x40.\x02", 0x23),
-    0x401C: ("Please find my dear \05\x41Princess Ruto\x05\x40\x01immediately... Zora!\x12\x68\x7A", 0x23),
+    0x401C: ("Please find my dear \05\x41Princess Ruto\x05\x40\x01immediately... Zora!\x12\x68\x7A", 0x03),
     0x9100: ("I am out of goods now.\x01Sorry!\x04The mark that will lead you to\x01the Spirit Temple is the \x05\x41flag on\x01the left \x05\x40outside the shop.\x01Be seeing you!\x02", 0x00),
     0x0451: ("\x12\x68\x7AMweep\x07\x04\x52", 0x23),
     0x0452: ("\x12\x68\x7AMweep\x07\x04\x53", 0x23),
@@ -532,14 +534,14 @@ def int_to_bytes(num: int, width: int, signed: bool = False) -> bytes:
     return int.to_bytes(num, width, byteorder='big', signed=signed)
 
 
-def display_code_list(codes: 'List[TextCode]') -> str:
+def display_code_list(codes: list[TextCode]) -> str:
     message = ""
     for code in codes:
         message += str(code)
     return message
 
 
-def encode_text_string(text: str) -> List[int]:
+def encode_text_string(text: str) -> list[int]:
     result = []
     it = iter(text)
     for ch in it:
@@ -560,7 +562,7 @@ def encode_text_string(text: str) -> List[int]:
     return result
 
 
-def parse_control_codes(text: Union[List[int], bytearray, str]) -> 'List[TextCode]':
+def parse_control_codes(text: list[int] | bytearray | str) -> list[TextCode]:
     if isinstance(text, list):
         text_bytes = text
     elif isinstance(text, bytearray):
@@ -643,7 +645,7 @@ class TextCode:
         return size
 
     # writes the code to the given offset, and returns the offset of the next byte
-    def write(self, rom: "Rom", text_start: int, offset: int) -> int:
+    def write(self, rom: Rom, text_start: int, offset: int) -> int:
         rom.write_byte(text_start + offset, self.code)
 
         extra_bytes = 0
@@ -659,7 +661,7 @@ class TextCode:
 
 # holds a single message, and all its data
 class Message:
-    def __init__(self, raw_text: Union[List[int], bytearray, str], index: int, id: int, opts: int, offset: int, length: int) -> None:
+    def __init__(self, raw_text: list[int] | bytearray | str, index: int, id: int, opts: int, offset: int, length: int) -> None:
         if isinstance(raw_text, str):
             raw_text = bytearray(raw_text, encoding='utf-8')
         elif not isinstance(raw_text, bytearray):
@@ -684,7 +686,7 @@ class Message:
         self.has_three_choice: bool = False
         self.ending: Optional[TextCode] = None
 
-        self.text_codes: List[TextCode] = []
+        self.text_codes: list[TextCode] = []
         self.text: str = ''
         self.unpadded_length: int = 0
         self.parse_text()
@@ -820,7 +822,7 @@ class Message:
 
     # writes a Message back into the rom, using the given index and offset to update the table
     # returns the offset of the next message
-    def write(self, rom: "Rom", index: int, text_start: int, offset: int, bank: int) -> int:
+    def write(self, rom: Rom, index: int, text_start: int, offset: int, bank: int) -> int:
         # construct the table entry
         id_bytes = int_to_bytes(self.id, 2)
         offset_bytes = int_to_bytes(offset, 3)
@@ -839,7 +841,7 @@ class Message:
 
     # read a single message from rom
     @classmethod
-    def from_rom(cls, rom: "Rom", index: int, eng: bool = True) -> 'Message':
+    def from_rom(cls, rom: Rom, index: int, eng: bool = True) -> Message:
         if eng:
             table_start = ENG_TABLE_START
             text_start = ENG_TEXT_START
@@ -860,12 +862,12 @@ class Message:
         return cls(raw_text, index, id, opts, offset, length)
 
     @classmethod
-    def from_string(cls, text: str, id: int = 0, opts: int = 0x00) -> 'Message':
+    def from_string(cls, text: str, id: int = 0, opts: int = 0x00) -> Message:
         bytes = text + "\x02"
         return cls(bytes, 0, id, opts, 0, len(bytes) + 1)
 
     @classmethod
-    def from_bytearray(cls, text: bytearray, id: int = 0, opts: int = 0x00) -> 'Message':
+    def from_bytearray(cls, text: bytearray, id: int = 0, opts: int = 0x00) -> Message:
         bytes = list(text) + [0x02]
         return cls(bytes, 0, id, opts, 0, len(bytes) + 1)
 
@@ -874,7 +876,7 @@ class Message:
 
 # wrapper for updating the text of a message, given its message id
 # if the id does not exist in the list, then it will add it
-def update_message_by_id(messages: List[Message], id: int, text: Union[bytearray, str], opts: Optional[int] = None) -> None:
+def update_message_by_id(messages: list[Message], id: int, text: bytearray | str, opts: Optional[int] = None) -> None:
     # get the message index
     index = next( (m.index for m in messages if m.id == id), -1)
     # update if it was found
@@ -885,7 +887,7 @@ def update_message_by_id(messages: List[Message], id: int, text: Union[bytearray
 
 
 # Gets the message by its ID. Returns None if the index does not exist
-def get_message_by_id(messages: List[Message], id: int) -> Optional[Message]:
+def get_message_by_id(messages: list[Message], id: int) -> Optional[Message]:
     # get the message index
     index = next( (m.index for m in messages if m.id == id), -1)
     if index >= 0:
@@ -895,7 +897,7 @@ def get_message_by_id(messages: List[Message], id: int) -> Optional[Message]:
 
 
 # wrapper for updating the text of a message, given its index in the list
-def update_message_by_index(messages: List[Message], index: int, text: Union[bytearray, str], opts: Optional[int] = None) -> None:
+def update_message_by_index(messages: list[Message], index: int, text: bytearray | str, opts: Optional[int] = None) -> None:
     if opts is None:
         opts = messages[index].opts
 
@@ -907,7 +909,7 @@ def update_message_by_index(messages: List[Message], index: int, text: Union[byt
 
 
 # wrapper for adding a string message to a list of messages
-def add_message(messages: List[Message], text: Union[bytearray, str], id: int = 0, opts: int = 0x00) -> None:
+def add_message(messages: list[Message], text: bytearray | str, id: int = 0, opts: int = 0x00) -> None:
     if isinstance(text, bytearray):
         messages.append(Message.from_bytearray(text, id, opts))
     else:
@@ -918,7 +920,7 @@ def add_message(messages: List[Message], text: Union[bytearray, str], id: int = 
 # holds a row in the shop item table (which contains pointers to the description and purchase messages)
 class ShopItem:
     # read a single message
-    def __init__(self, rom: "Rom", shop_table_address: int, index: int) -> None:
+    def __init__(self, rom: Rom, shop_table_address: int, index: int) -> None:
         entry_offset = shop_table_address + 0x20 * index
         entry = rom.read_bytes(entry_offset, 0x20)
 
@@ -956,7 +958,7 @@ class ShopItem:
         return ', '.join(meta_data) + '\n' + ', '.join(func_data)
 
     # write the shop item back
-    def write(self, rom: "Rom", shop_table_address: int, index: int) -> None:
+    def write(self, rom: Rom, shop_table_address: int, index: int) -> None:
         entry_offset = shop_table_address + 0x20 * index
 
         data = []
@@ -979,7 +981,7 @@ class ShopItem:
 
 
 # reads each of the shop items
-def read_shop_items(rom: "Rom", shop_table_address: int) -> List[ShopItem]:
+def read_shop_items(rom: Rom, shop_table_address: int) -> list[ShopItem]:
     shop_items = []
 
     for index in range(0, 100):
@@ -989,17 +991,17 @@ def read_shop_items(rom: "Rom", shop_table_address: int) -> List[ShopItem]:
 
 
 # writes each of the shop item back into rom
-def write_shop_items(rom: "Rom", shop_table_address: int, shop_items: Iterable[ShopItem]) -> None:
+def write_shop_items(rom: Rom, shop_table_address: int, shop_items: Iterable[ShopItem]) -> None:
     for s in shop_items:
         s.write(rom, shop_table_address, s.index)
 
 
 # these are unused shop items, and contain text ids that are used elsewhere, and should not be moved
-SHOP_ITEM_EXCEPTIONS: List[int] = [0x0A, 0x0B, 0x11, 0x12, 0x13, 0x14, 0x29]
+SHOP_ITEM_EXCEPTIONS: list[int] = [0x0A, 0x0B, 0x11, 0x12, 0x13, 0x14, 0x29]
 
 
 # returns a set of all message ids used for shop items
-def get_shop_message_id_set(shop_items: Iterable[ShopItem]) -> Set[int]:
+def get_shop_message_id_set(shop_items: Iterable[ShopItem]) -> set[int]:
     ids = set()
     for shop in shop_items:
         if shop.index not in SHOP_ITEM_EXCEPTIONS:
@@ -1009,14 +1011,14 @@ def get_shop_message_id_set(shop_items: Iterable[ShopItem]) -> Set[int]:
 
 
 # remove all messages that easy to tell are unused to create space in the message index table
-def remove_unused_messages(messages: List[Message]) -> None:
+def remove_unused_messages(messages: list[Message]) -> None:
     messages[:] = [m for m in messages if not m.is_id_message()]
     for index, m in enumerate(messages):
         m.index = index
 
 
 # takes all messages used for shop items, and moves messages from the 00xx range into the unused 80xx range
-def move_shop_item_messages(messages: List[Message], shop_items: Iterable[ShopItem]) -> None:
+def move_shop_item_messages(messages: list[Message], shop_items: Iterable[ShopItem]) -> None:
     # checks if a message id is in the item message range
     def is_in_item_range(id: int) -> bool:
         bytes = int_to_bytes(id, 2)
@@ -1089,7 +1091,7 @@ def make_player_message(text: str) -> str:
 
 # reduce item message sizes and add new item messages
 # make sure to call this AFTER move_shop_item_messages()
-def update_item_messages(messages: List[Message], world: "World") -> None:
+def update_item_messages(messages: list[Message], world: World) -> None:
     new_item_messages = ITEM_MESSAGES + KEYSANITY_MESSAGES
     check_message_dupes(new_item_messages)
     for id, text in new_item_messages:
@@ -1112,12 +1114,12 @@ def check_message_dupes(new_item_messages):
                     raise Exception("Duplicate MessageID found: " + hex(message_id1) + ", " + message1 + ", " + message2)
 
 # run all keysanity related patching to add messages for dungeon specific items
-def add_item_messages(messages: List[Message], shop_items: Iterable[ShopItem], world: "World") -> None:
+def add_item_messages(messages: list[Message], shop_items: Iterable[ShopItem], world: World) -> None:
     move_shop_item_messages(messages, shop_items)
     update_item_messages(messages, world)
 
 # reads each of the game's messages into a list of Message objects
-def read_messages(rom: "Rom") -> List[Message]:
+def read_messages(rom: Rom) -> list[Message]:
     table_offset = ENG_TABLE_START
     index = 0
     messages = []
@@ -1145,7 +1147,7 @@ def read_messages(rom: "Rom") -> List[Message]:
 # title and file select screens. Preserve this table entry and text data when
 # overwriting the JP data. The regular read_messages function only reads English
 # data.
-def read_fffc_message(rom: "Rom") -> Message:
+def read_fffc_message(rom: Rom) -> Message:
     table_offset = JPN_TABLE_START
     index = 0
     while True:
@@ -1163,7 +1165,7 @@ def read_fffc_message(rom: "Rom") -> Message:
 
 
 # write the messages back
-def repack_messages(rom: "Rom", messages: List[Message], permutation: Optional[List[int]] = None,
+def repack_messages(rom: Rom, messages: list[Message], permutation: Optional[list[int]] = None,
                     always_allow_skip: bool = True, speed_up_text: bool = True) -> None:
     rom.update_dmadata_record_by_key(ENG_TEXT_START, ENG_TEXT_START, ENG_TEXT_START + ENG_TEXT_SIZE_LIMIT)
     rom.update_dmadata_record_by_key(JPN_TEXT_START, JPN_TEXT_START, JPN_TEXT_START + JPN_TEXT_SIZE_LIMIT)
@@ -1251,7 +1253,7 @@ def repack_messages(rom: "Rom", messages: List[Message], permutation: Optional[L
 
 
 # shuffles the messages in the game, making sure to keep various message types in their own group
-def shuffle_messages(messages: List[Message], except_hints: bool = True) -> List[int]:
+def shuffle_messages(messages: list[Message], except_hints: bool = True) -> list[int]:
     if not hasattr(shuffle_messages, "shop_item_messages"):
         shuffle_messages.shop_item_messages = []
     if not hasattr(shuffle_messages, "scrubs_message_ids"):
@@ -1300,7 +1302,7 @@ def shuffle_messages(messages: List[Message], except_hints: bool = True) -> List
     have_three_choice = list(filter(lambda m: not is_exempt(m) and m.has_three_choice, messages))
     basic_messages    = list(filter(lambda m: not is_exempt(m) and m.is_basic(),       messages))
 
-    def shuffle_group(group: List[Message]) -> None:
+    def shuffle_group(group: list[Message]) -> None:
         group_permutation = [i for i, _ in enumerate(group)]
         random.shuffle(group_permutation)
 
@@ -1319,7 +1321,7 @@ def shuffle_messages(messages: List[Message], except_hints: bool = True) -> List
 
 
 # Update warp song text boxes for ER
-def update_warp_song_text(messages: List[Message], world: "World") -> None:
+def update_warp_song_text(messages: list[Message], world: World) -> None:
     from Hints import HintArea
 
     msg_list = {

--- a/Messages.py
+++ b/Messages.py
@@ -1089,6 +1089,7 @@ def make_player_message(text: str) -> str:
 
     return new_text
 
+
 # reduce item message sizes and add new item messages
 # make sure to call this AFTER move_shop_item_messages()
 def update_item_messages(messages: list[Message], world: World) -> None:
@@ -1103,8 +1104,9 @@ def update_item_messages(messages: list[Message], world: World) -> None:
     for id, (text, opt) in MISC_MESSAGES.items():
         update_message_by_id(messages, id, text, opt)
 
+
 # Check the message table to ensure no duplicate entries exist.
-def check_message_dupes(new_item_messages):
+def check_message_dupes(new_item_messages: list[tuple[int, str]]) -> None:
     for i in range(0, len(new_item_messages)):
         for j in range(1, len(new_item_messages)):
             if i != j:
@@ -1113,10 +1115,12 @@ def check_message_dupes(new_item_messages):
                 if message_id1 == message_id2:
                     raise Exception("Duplicate MessageID found: " + hex(message_id1) + ", " + message1 + ", " + message2)
 
+
 # run all keysanity related patching to add messages for dungeon specific items
 def add_item_messages(messages: list[Message], shop_items: Iterable[ShopItem], world: World) -> None:
     move_shop_item_messages(messages, shop_items)
     update_item_messages(messages, world)
+
 
 # reads each of the game's messages into a list of Message objects
 def read_messages(rom: Rom) -> list[Message]:

--- a/Models.py
+++ b/Models.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
 import os
 import random
 from enum import IntEnum
-from typing import TYPE_CHECKING, List, Union, Dict, Tuple
+from typing import TYPE_CHECKING
 
 from Utils import data_path
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from Settings import Settings
 
 
-def get_model_choices(age: int) -> List[str]:
+def get_model_choices(age: int) -> list[str]:
     names = ["Default"]
     path = data_path("Models/Adult")
     if age == 1:
@@ -36,8 +37,8 @@ class ModelDefinitionError(ModelError):
 
 # Used for writer model pointers to the rom in place of the vanilla pointers
 class ModelPointerWriter:
-    def __init__(self, rom: "Rom") -> None:
-        self.rom: "Rom" = rom
+    def __init__(self, rom: Rom) -> None:
+        self.rom: Rom = rom
         self.offset: int = 0
         self.advance: int = 4
         self.base: int = CODE_START
@@ -92,7 +93,7 @@ class ModelPointerWriter:
 
 # Either return the starting index of the requested data (when start == 0)
 # or the offset of the element in the footer, if it exists (start > 0)
-def scan(bytes: bytearray, data: Union[bytearray, str], start: int = 0) -> int:
+def scan(bytes: bytearray, data: bytearray | str, start: int = 0) -> int:
     databytes = data
     # If a string was passed, encode string as bytes
     if isinstance(data, str):
@@ -193,7 +194,7 @@ def unwrap(zobj: bytearray, address: int) -> int:
 
 
 # Used to overwrite pointers in the displaylist with new ones
-def WriteDLPointer(dl: List[int], index: int, data: int) -> None:
+def WriteDLPointer(dl: list[int], index: int, data: int) -> None:
     bytes = data.to_bytes(4, 'big')
     for i in range(4):
         dl[index + i] = bytes[i]
@@ -201,8 +202,8 @@ def WriteDLPointer(dl: List[int], index: int, data: int) -> None:
 
 # An extensive function which loads pieces from the vanilla Link model to add to the user-provided zobj
 # Based on https://github.com/hylian-modding/ML64-Z64Lib/blob/master/cores/Z64Lib/API/zzoptimize.ts function optimize()
-def LoadVanilla(rom: "Rom", missing: List[str], rebase: int, linkstart: int, linksize: int,
-                pieces: 'Dict[str, Tuple[Offsets, int]]', skips: Dict[str, List[Tuple[int, int]]]) -> Tuple[List[int], Dict[str, int]]:
+def LoadVanilla(rom: Rom, missing: list[str], rebase: int, linkstart: int, linksize: int,
+                pieces: dict[str, tuple[Offsets, int]], skips: dict[str, list[tuple[int, int]]]) -> tuple[list[int], dict[str, int]]:
     # Get vanilla "zobj" of Link's model
     vanillaData = []
     for i in range(linksize):
@@ -440,7 +441,7 @@ def CheckDiff(limb: int, skeleton: int) -> bool:
     return diff > TOLERANCE
 
 
-def CorrectSkeleton(zobj: bytearray, skeleton: List[List[int]], agestr: str) -> bool:
+def CorrectSkeleton(zobj: bytearray, skeleton: list[list[int]], agestr: str) -> bool:
     # Get the hierarchy pointer
     hierarchy = FindHierarchy(zobj, agestr)
     # Get what the hierarchy pointer points to (pointer to limb 0)
@@ -483,7 +484,7 @@ def CorrectSkeleton(zobj: bytearray, skeleton: List[List[int]], agestr: str) -> 
 
 
 # Loads model from file and processes it by adding vanilla pieces and setting up the LUT if necessary.
-def LoadModel(rom: "Rom", model: str, age: int) -> int:
+def LoadModel(rom: Rom, model: str, age: int) -> int:
     # age 0 = adult, 1 = child
     linkstart = ADULT_START
     linksize = ADULT_SIZE
@@ -603,7 +604,7 @@ def LoadModel(rom: "Rom", model: str, age: int) -> int:
 
 
 # Write in the adult model and repoint references to it
-def patch_model_adult(rom: "Rom", settings: "Settings", log: "CosmeticsLog") -> None:
+def patch_model_adult(rom: Rom, settings: Settings, log: CosmeticsLog) -> None:
     # Get model filepath
     model = settings.model_adult_filepicker
     # Default to filepicker if non-empty
@@ -775,7 +776,7 @@ def patch_model_adult(rom: "Rom", settings: "Settings", log: "CosmeticsLog") -> 
 
 
 # Write in the child model and repoint references to it
-def patch_model_child(rom: "Rom", settings: "Settings", log: "CosmeticsLog") -> None:
+def patch_model_child(rom: Rom, settings: Settings, log: CosmeticsLog) -> None:
     # Get model filepath
     model = settings.model_child_filepicker
     # Default to filepicker if non-empty
@@ -1089,7 +1090,7 @@ class Offsets(IntEnum):
 
 
 # Adult model pieces and their offsets, both in the LUT and in vanilla
-AdultPieces: Dict[str, Tuple[Offsets, int]] = {
+AdultPieces: dict[str, tuple[Offsets, int]] = {
     "Sheath": (Offsets.ADULT_LINK_LUT_DL_SWORD_SHEATH, 0x249D8),
     "FPS.Hookshot": (Offsets.ADULT_LINK_LUT_DL_FPS_HOOKSHOT, 0x2A738),
     "Hilt.2": (Offsets.ADULT_LINK_LUT_DL_SWORD_HILT, 0x22060),  # 0x21F78 + 0xE8, skips blade
@@ -1149,7 +1150,7 @@ AdultPieces: Dict[str, Tuple[Offsets, int]] = {
 # Note: Some skips which can be implemented by skipping the beginning portion of the model
 # rather than specifying those indices here, simply have their offset in the table above
 # increased by whatever amount of starting indices would be skipped.
-adultSkips: Dict[str, List[Tuple[int, int]]] = {
+adultSkips: dict[str, list[tuple[int, int]]] = {
     "FPS.Hookshot":  [(0x2F0, 0x618)],
     "Hilt.2": [(0x1E8, 0x430)],
     "Hilt.3": [(0x160, 0x480)],
@@ -1163,7 +1164,7 @@ adultSkips: Dict[str, List[Tuple[int, int]]] = {
     "Shield.3": [(0x1B8, 0x3E8)],
 }
 
-adultSkeleton: List[List[int]] = [
+adultSkeleton: list[list[int]] = [
     [0xFFC7, 0x0D31, 0x0000],  # Limb 0
     [0x0000, 0x0000, 0x0000],  # Limb 1
     [0x03B1, 0x0000, 0x0000],  # Limb 2
@@ -1188,7 +1189,7 @@ adultSkeleton: List[List[int]] = [
 ]
 
 
-ChildPieces: Dict[str, Tuple[Offsets, int]] = {
+ChildPieces: dict[str, tuple[Offsets, int]] = {
     "Slingshot.String": (Offsets.CHILD_LINK_LUT_DL_SLINGSHOT_STRING, 0x221A8),
     "Sheath": (Offsets.CHILD_LINK_LUT_DL_SWORD_SHEATH, 0x15408),
     "Blade.2": (Offsets.CHILD_LINK_LUT_DL_MASTER_SWORD, 0x15698),  # 0x15540 + 0x158, skips fist
@@ -1235,14 +1236,14 @@ ChildPieces: Dict[str, Tuple[Offsets, int]] = {
 }
 
 
-childSkips: Dict[str, List[Tuple[int, int]]] = {
+childSkips: dict[str, list[tuple[int, int]]] = {
     "Boomerang": [(0x140, 0x240)],
     "Hilt.1": [(0xC8, 0x170)],
     "Shield.1": [(0x140, 0x218)],
     "Ocarina.1": [(0x110, 0x240)],
 }
 
-childSkeleton: List[List[int]] = [
+childSkeleton: list[list[int]] = [
     [0x0000, 0x0948, 0x0000],  # Limb 0
     [0xFFFC, 0xFF98, 0x0000],  # Limb 1
     [0x025F, 0x0000, 0x0000],  # Limb 2
@@ -1313,7 +1314,7 @@ CHILD_HIERARCHY: int     = 0x060053A8
 CHILD_POST_START: int    = 0x00005228
 
 # Parts of the rom to not overwrite when applying a patch file
-restrictiveBytes: List[Tuple[int, int]] = [
+restrictiveBytes: list[tuple[int, int]] = [
     (ADULT_START, ADULT_SIZE),  # Ignore adult model
     (CHILD_START, CHILD_SIZE),  # Ignore child model
     # Adult model pointers

--- a/Models.py
+++ b/Models.py
@@ -1,10 +1,17 @@
 import os
 import random
 from enum import IntEnum
+from typing import TYPE_CHECKING, List, Union, Dict, Tuple
+
 from Utils import data_path
 
+if TYPE_CHECKING:
+    from Cosmetics import CosmeticsLog
+    from Rom import Rom
+    from Settings import Settings
 
-def get_model_choices(age):
+
+def get_model_choices(age: int) -> List[str]:
     names = ["Default"]
     path = data_path("Models/Adult")
     if age == 1:
@@ -29,14 +36,13 @@ class ModelDefinitionError(ModelError):
 
 # Used for writer model pointers to the rom in place of the vanilla pointers
 class ModelPointerWriter:
+    def __init__(self, rom: "Rom") -> None:
+        self.rom: "Rom" = rom
+        self.offset: int = 0
+        self.advance: int = 4
+        self.base: int = CODE_START
 
-    def __init__(self, rom):
-        self.rom = rom
-        self.offset = 0
-        self.advance = 4
-        self.SetBase('Code')
-
-    def SetBase(self, base):
+    def SetBase(self, base: str) -> None:
         if base == 'Code':
             self.base = CODE_START
         elif base == 'Player':
@@ -54,30 +60,30 @@ class ModelPointerWriter:
         elif base == 'RunningMan':
             self.base = RUNNING_MAN_START
 
-    def GoTo(self, dest):
+    def GoTo(self, dest: int) -> None:
         self.offset = dest
 
-    def SetAdvance(self, adv):
+    def SetAdvance(self, adv: int) -> None:
         self.advance = adv
 
-    def GetAddress(self):
+    def GetAddress(self) -> int:
         return self.base + self.offset
 
-    def WriteModelData(self, data):
+    def WriteModelData(self, data: int) -> None:
         self.rom.write_bytes(self.GetAddress(), data.to_bytes(4, 'big'))
         self.offset += self.advance
 
-    def WriteModelData16(self, data):
+    def WriteModelData16(self, data: int) -> None:
         self.rom.write_bytes(self.GetAddress(), data.to_bytes(2, 'big'))
         self.offset += 2
 
-    def WriteModelDataHi(self, data):
+    def WriteModelDataHi(self, data: int) -> None:
         bytes = data.to_bytes(4, 'big')
         for i in range(2):
             self.rom.write_byte(self.GetAddress(), bytes[i])
             self.offset += 1
 
-    def WriteModelDataLo(self, data):
+    def WriteModelDataLo(self, data: int) -> None:
         bytes = data.to_bytes(4, 'big')
         for i in range(2, 4):
             self.rom.write_byte(self.GetAddress(), bytes[i])
@@ -86,7 +92,7 @@ class ModelPointerWriter:
 
 # Either return the starting index of the requested data (when start == 0)
 # or the offset of the element in the footer, if it exists (start > 0)
-def scan(bytes, data, start=0):
+def scan(bytes: bytearray, data: Union[bytearray, str], start: int = 0) -> int:
     databytes = data
     # If a string was passed, encode string as bytes
     if isinstance(data, str):
@@ -174,20 +180,20 @@ def scan(bytes, data, start=0):
 
 
 # Follows pointers from the LUT until finding the actual DList, and returns the offset of the DList
-def unwrap(zobj, address):
+def unwrap(zobj: bytearray, address: int) -> int:
     # An entry in the LUT will look something like 0xDE 01 0000 06014050
     # Only the last 3 bytes should be necessary.
     data = int.from_bytes(zobj[address+5:address+8], 'big')
     # If the data here points to another entry in the LUT, keep searching until
     # an address outside the table is found.
-    while LUT_START <= data and data <= LUT_END:
+    while LUT_START <= data <= LUT_END:
         address = data
         data = int.from_bytes(zobj[address+5:address+8], 'big')
     return address
 
 
 # Used to overwrite pointers in the displaylist with new ones
-def WriteDLPointer(dl, index, data):
+def WriteDLPointer(dl: List[int], index: int, data: int) -> None:
     bytes = data.to_bytes(4, 'big')
     for i in range(4):
         dl[index + i] = bytes[i]
@@ -195,7 +201,8 @@ def WriteDLPointer(dl, index, data):
 
 # An extensive function which loads pieces from the vanilla Link model to add to the user-provided zobj
 # Based on https://github.com/hylian-modding/ML64-Z64Lib/blob/master/cores/Z64Lib/API/zzoptimize.ts function optimize()
-def LoadVanilla(rom, missing, rebase, linkstart, linksize, pieces, skips):
+def LoadVanilla(rom: "Rom", missing: List[str], rebase: int, linkstart: int, linksize: int,
+                pieces: 'Dict[str, Tuple[Offsets, int]]', skips: Dict[str, List[Tuple[int, int]]]) -> Tuple[List[int], Dict[str, int]]:
     # Get vanilla "zobj" of Link's model
     vanillaData = []
     for i in range(linksize):
@@ -381,19 +388,19 @@ def LoadVanilla(rom, missing, rebase, linkstart, linksize, pieces, skips):
                     dlEntry = oldDL2New[lo & 0x00FFFFFF]
                     WriteDLPointer(dl, i + 4, BASE_OFFSET + dlEntry + rebase)
         vanillaZobj.extend(dl)
-        # Pad to nearest multiple of 16
+        # Pad to the nearest multiple of 16
         while len(vanillaZobj) % 0x10 != 0:
             vanillaZobj.append(0x00)
     # Now find the relation of items to new offsets
     DLOffsets = {}
     for item in missing:
         DLOffsets[item] = oldDL2New[pieces[item][1]]
-    return (vanillaZobj, DLOffsets)
+    return vanillaZobj, DLOffsets
 
 
 # Finds the address of the model's hierarchy so we can write the hierarchy pointer
 # Based on https://github.com/hylian-modding/Z64Online/blob/master/src/Z64Online/common/cosmetics/UniversalAliasTable.ts function findHierarchy()
-def FindHierarchy(zobj, agestr):
+def FindHierarchy(zobj: bytearray, agestr: str) -> int:
     # Scan until we find a segmented pointer which is 0x0C or 0x10 more than
     # the preceeding data and loop until something that's not a segmented pointer is found
     # then return the position of the last segemented pointer.
@@ -416,14 +423,15 @@ def FindHierarchy(zobj, agestr):
     raise ModelDefinitionError("No hierarchy found in " + agestr + " model- Did you check \"Link hierarchy format\" in zzconvert?")
 
 
-TOLERANCE = 0x100
+TOLERANCE: int = 0x100
 
-def CheckDiff(limb, skeleton):
+
+def CheckDiff(limb: int, skeleton: int) -> bool:
     # The normal difference
     normalDiff = abs(limb - skeleton)
     # Underflow/overflow diff
     # For example, if limb is 0xFFFF and skeleton is 0x0001, then they are technically only 2 apart
-    # So subtract 0xFFFF from the absolute value of the difference to get the true differene in this case
+    # So subtract 0xFFFF from the absolute value of the difference to get the true difference in this case
     # Necessary since values are signed, but not represented as signed here
     flowDiff = abs(normalDiff - 0xFFFF)
     # Take the minimum of the two differences
@@ -431,7 +439,8 @@ def CheckDiff(limb, skeleton):
     # Return true if diff is too big
     return diff > TOLERANCE
 
-def CorrectSkeleton(zobj, skeleton, agestr):
+
+def CorrectSkeleton(zobj: bytearray, skeleton: List[List[int]], agestr: str) -> bool:
     # Get the hierarchy pointer
     hierarchy = FindHierarchy(zobj, agestr)
     # Get what the hierarchy pointer points to (pointer to limb 0)
@@ -474,7 +483,7 @@ def CorrectSkeleton(zobj, skeleton, agestr):
 
 
 # Loads model from file and processes it by adding vanilla pieces and setting up the LUT if necessary.
-def LoadModel(rom, model, age):
+def LoadModel(rom: "Rom", model: str, age: int) -> int:
     # age 0 = adult, 1 = child
     linkstart = ADULT_START
     linksize = ADULT_SIZE
@@ -594,10 +603,10 @@ def LoadModel(rom, model, age):
 
 
 # Write in the adult model and repoint references to it
-def patch_model_adult(rom, settings, log):
+def patch_model_adult(rom: "Rom", settings: "Settings", log: "CosmeticsLog") -> None:
     # Get model filepath
     model = settings.model_adult_filepicker
-    # Default to filepicker if non empty
+    # Default to filepicker if non-empty
     if len(model) == 0:
         model = settings.model_adult
         if settings.model_adult == "Random":
@@ -611,7 +620,7 @@ def patch_model_adult(rom, settings, log):
 
     # Load and process model
     dfAddress = LoadModel(rom, model, 0)
-    dfAddress = dfAddress | 0x06000000 # Add segment to DF address
+    dfAddress = dfAddress | 0x06000000  # Add segment to DF address
 
     # Write adult Link pointer data
     writer = ModelPointerWriter(rom)
@@ -706,8 +715,8 @@ def patch_model_adult(rom, settings, log):
     writer.GoTo(0xE6B64)
     writer.SetAdvance(4)
     writer.WriteModelData(Offsets.ADULT_LINK_LUT_DL_BOW_STRING)
-    writer.WriteModelData(0x00000000) # string anchor x: 0.0
-    writer.WriteModelData(0xC3B43333) # string anchor y: -360.4
+    writer.WriteModelData(0x00000000)  # string anchor x: 0.0
+    writer.WriteModelData(0xC3B43333)  # string anchor y: -360.4
 
     writer.GoTo(0x69112)
     writer.WriteModelDataHi(Offsets.ADULT_LINK_LUT_DL_UPGRADE_LFOREARM)
@@ -762,14 +771,14 @@ def patch_model_adult(rom, settings, log):
 
     writer.SetBase('Code')
     writer.GoTo(0xE65A0)
-    writer.WriteModelData(ADULT_HIERARCHY) # Hierarchy pointer
+    writer.WriteModelData(ADULT_HIERARCHY)  # Hierarchy pointer
 
 
 # Write in the child model and repoint references to it
-def patch_model_child(rom, settings, log):
+def patch_model_child(rom: "Rom", settings: "Settings", log: "CosmeticsLog") -> None:
     # Get model filepath
     model = settings.model_child_filepicker
-    # Default to filepicker if non empty
+    # Default to filepicker if non-empty
     if len(model) == 0:
         model = settings.model_child
         if settings.model_child == "Random":
@@ -783,7 +792,7 @@ def patch_model_child(rom, settings, log):
 
     # Load and process model
     dfAddress = LoadModel(rom, model, 1)
-    dfAddress = dfAddress | 0x06000000 # Add segment to DF address
+    dfAddress = dfAddress | 0x06000000  # Add segment to DF address
 
     # Write child Link pointer data
     writer = ModelPointerWriter(rom)
@@ -871,8 +880,8 @@ def patch_model_child(rom, settings, log):
     writer.GoTo(0xE6B74)
     writer.SetAdvance(4)
     writer.WriteModelData(Offsets.CHILD_LINK_LUT_DL_SLINGSHOT_STRING)
-    writer.WriteModelData(0x44178000) # string anchor x: 606.0
-    writer.WriteModelData(0x436C0000) # string anchor y: 236.0
+    writer.WriteModelData(0x44178000)  # string anchor x: 606.0
+    writer.WriteModelData(0x436C0000)  # string anchor y: 236.0
 
     writer.GoTo(0x6922E)
     writer.WriteModelDataHi(Offsets.CHILD_LINK_LUT_DL_GORON_BRACELET)
@@ -927,7 +936,7 @@ def patch_model_child(rom, settings, log):
 
     writer.SetBase('Code')
     writer.GoTo(0xE65A4)
-    writer.WriteModelData(CHILD_HIERARCHY) # Hierarchy pointer
+    writer.WriteModelData(CHILD_HIERARCHY)  # Hierarchy pointer
 
 
 # LUT offsets for adult and child
@@ -1080,10 +1089,10 @@ class Offsets(IntEnum):
 
 
 # Adult model pieces and their offsets, both in the LUT and in vanilla
-AdultPieces = {
+AdultPieces: Dict[str, Tuple[Offsets, int]] = {
     "Sheath": (Offsets.ADULT_LINK_LUT_DL_SWORD_SHEATH, 0x249D8),
     "FPS.Hookshot": (Offsets.ADULT_LINK_LUT_DL_FPS_HOOKSHOT, 0x2A738),
-    "Hilt.2": (Offsets.ADULT_LINK_LUT_DL_SWORD_HILT, 0x22060), # 0x21F78 + 0xE8, skips blade
+    "Hilt.2": (Offsets.ADULT_LINK_LUT_DL_SWORD_HILT, 0x22060),  # 0x21F78 + 0xE8, skips blade
     "Hilt.3": (Offsets.ADULT_LINK_LUT_DL_LONGSWORD_HILT, 0x238C8),
     "Blade.2": (Offsets.ADULT_LINK_LUT_DL_SWORD_BLADE, 0x21F78),
     "Hookshot.Spike": (Offsets.ADULT_LINK_LUT_DL_HOOKSHOT_HOOK, 0x2B288),
@@ -1104,9 +1113,9 @@ AdultPieces = {
     "Bow.String": (Offsets.ADULT_LINK_LUT_DL_BOW_STRING, 0x2B108),
     "Bow": (Offsets.ADULT_LINK_LUT_DL_BOW, 0x22DA8),
     "Blade.3.Break": (Offsets.ADULT_LINK_LUT_DL_BLADEBREAK, 0x2BA38),
-    "Blade.3": (Offsets.ADULT_LINK_LUT_DL_LONGSWORD_BLADE, 0x23A28), # 0x238C8 + 0x160, skips hilt
+    "Blade.3": (Offsets.ADULT_LINK_LUT_DL_LONGSWORD_BLADE, 0x23A28),  # 0x238C8 + 0x160, skips hilt
     "Bottle": (Offsets.ADULT_LINK_LUT_DL_BOTTLE, 0x2AD58),
-    "Broken.Blade.3": (Offsets.ADULT_LINK_LUT_DL_LONGSWORD_BROKEN, 0x23EB0), # 0x23D50 + 0x160, skips hilt
+    "Broken.Blade.3": (Offsets.ADULT_LINK_LUT_DL_LONGSWORD_BROKEN, 0x23EB0),  # 0x23D50 + 0x160, skips hilt
     "Foot.2.L": (Offsets.ADULT_LINK_LUT_DL_BOOT_LIRON, 0x25918),
     "Foot.2.R": (Offsets.ADULT_LINK_LUT_DL_BOOT_RIRON, 0x25A60),
     "Foot.3.L": (Offsets.ADULT_LINK_LUT_DL_BOOT_LHOVER, 0x25BA8),
@@ -1114,7 +1123,7 @@ AdultPieces = {
     "Hammer": (Offsets.ADULT_LINK_LUT_DL_HAMMER, 0x233E0),
     "Hookshot.Aiming.Reticule": (Offsets.ADULT_LINK_LUT_DL_HOOKSHOT_AIM, 0x2CB48),
     "Hookshot.Chain": (Offsets.ADULT_LINK_LUT_DL_HOOKSHOT_CHAIN, 0x2AFF0),
-    "Ocarina.2": (Offsets.ADULT_LINK_LUT_DL_OCARINA_TIME, 0x248D8), # 0x24698 + 0x240, skips hand
+    "Ocarina.2": (Offsets.ADULT_LINK_LUT_DL_OCARINA_TIME, 0x248D8),  # 0x24698 + 0x240, skips hand
     "Shield.2": (Offsets.ADULT_LINK_LUT_DL_SHIELD_HYLIAN, 0x22970),
     "Shield.3": (Offsets.ADULT_LINK_LUT_DL_SHIELD_MIRROR, 0x241C0),
     "Limb 1": (Offsets.ADULT_LINK_LUT_DL_WAIST, 0x35330),
@@ -1140,7 +1149,7 @@ AdultPieces = {
 # Note: Some skips which can be implemented by skipping the beginning portion of the model
 # rather than specifying those indices here, simply have their offset in the table above
 # increased by whatever amount of starting indices would be skipped.
-adultSkips = {
+adultSkips: Dict[str, List[Tuple[int, int]]] = {
     "FPS.Hookshot":  [(0x2F0, 0x618)],
     "Hilt.2": [(0x1E8, 0x430)],
     "Hilt.3": [(0x160, 0x480)],
@@ -1150,50 +1159,50 @@ adultSkips = {
     "Blade.3": [(0xB8, 0x320)],
     "Broken.Blade.3": [(0xA0, 0x308)],
     "Hammer": [(0x278, 0x4E0)],
-    "Shield.2": [(0x158, 0x2B8), (0x3A8, 0x430)], # Fist is in 2 pieces
+    "Shield.2": [(0x158, 0x2B8), (0x3A8, 0x430)],  # Fist is in 2 pieces
     "Shield.3": [(0x1B8, 0x3E8)],
 }
 
-adultSkeleton = [
-    [0xFFC7, 0x0D31, 0x0000], # Limb 0
-    [0x0000, 0x0000, 0x0000], # Limb 1
-    [0x03B1, 0x0000, 0x0000], # Limb 2
-    [0xFE71, 0x0045, 0xFF07], # Limb 3
-    [0x051A, 0x0000, 0x0000], # Limb 4
-    [0x04E8, 0x0005, 0x000B], # Limb 5
-    [0xFE74, 0x004C, 0x0108], # Limb 6
-    [0x0518, 0x0000, 0x0000], # Limb 7
-    [0x04E9, 0x0006, 0x0003], # Limb 8
-    [0x0000, 0x0015, 0xFFF9], # Limb 9
-    [0x0570, 0xFEFD, 0x0000], # Limb 10
-    [0xFED6, 0xFD44, 0x0000], # Limb 11
-    [0x0000, 0x0000, 0x0000], # Limb 12
-    [0x040F, 0xFF54, 0x02A8], # Limb 13
-    [0x0397, 0x0000, 0x0000], # Limb 14
-    [0x02F2, 0x0000, 0x0000], # Limb 15
-    [0x040F, 0xFF53, 0xFD58], # Limb 16
-    [0x0397, 0x0000, 0x0000], # Limb 17
-    [0x02F2, 0x0000, 0x0000], # Limb 18
-    [0x03D2, 0xFD4C, 0x0156], # Limb 19
-    [0x0000, 0x0000, 0x0000], # Limb 20
+adultSkeleton: List[List[int]] = [
+    [0xFFC7, 0x0D31, 0x0000],  # Limb 0
+    [0x0000, 0x0000, 0x0000],  # Limb 1
+    [0x03B1, 0x0000, 0x0000],  # Limb 2
+    [0xFE71, 0x0045, 0xFF07],  # Limb 3
+    [0x051A, 0x0000, 0x0000],  # Limb 4
+    [0x04E8, 0x0005, 0x000B],  # Limb 5
+    [0xFE74, 0x004C, 0x0108],  # Limb 6
+    [0x0518, 0x0000, 0x0000],  # Limb 7
+    [0x04E9, 0x0006, 0x0003],  # Limb 8
+    [0x0000, 0x0015, 0xFFF9],  # Limb 9
+    [0x0570, 0xFEFD, 0x0000],  # Limb 10
+    [0xFED6, 0xFD44, 0x0000],  # Limb 11
+    [0x0000, 0x0000, 0x0000],  # Limb 12
+    [0x040F, 0xFF54, 0x02A8],  # Limb 13
+    [0x0397, 0x0000, 0x0000],  # Limb 14
+    [0x02F2, 0x0000, 0x0000],  # Limb 15
+    [0x040F, 0xFF53, 0xFD58],  # Limb 16
+    [0x0397, 0x0000, 0x0000],  # Limb 17
+    [0x02F2, 0x0000, 0x0000],  # Limb 18
+    [0x03D2, 0xFD4C, 0x0156],  # Limb 19
+    [0x0000, 0x0000, 0x0000],  # Limb 20
 ]
 
 
-ChildPieces = {
+ChildPieces: Dict[str, Tuple[Offsets, int]] = {
     "Slingshot.String": (Offsets.CHILD_LINK_LUT_DL_SLINGSHOT_STRING, 0x221A8),
     "Sheath": (Offsets.CHILD_LINK_LUT_DL_SWORD_SHEATH, 0x15408),
-    "Blade.2": (Offsets.CHILD_LINK_LUT_DL_MASTER_SWORD, 0x15698), # 0x15540 + 0x158, skips fist
-    "Blade.1": (Offsets.CHILD_LINK_LUT_DL_SWORD_BLADE, 0x14110), # 0x13F38 + 0x1D8, skips fist and hilt
+    "Blade.2": (Offsets.CHILD_LINK_LUT_DL_MASTER_SWORD, 0x15698),  # 0x15540 + 0x158, skips fist
+    "Blade.1": (Offsets.CHILD_LINK_LUT_DL_SWORD_BLADE, 0x14110),  # 0x13F38 + 0x1D8, skips fist and hilt
     "Boomerang": (Offsets.CHILD_LINK_LUT_DL_BOOMERANG, 0x14660),
     "Fist.L": (Offsets.CHILD_LINK_LUT_DL_LFIST, 0x13E18),
     "Fist.R": (Offsets.CHILD_LINK_LUT_DL_RFIST, 0x14320),
-    "Hilt.1": (Offsets.CHILD_LINK_LUT_DL_SWORD_HILT, 0x14048), # 0x13F38 + 0x110, skips fist
+    "Hilt.1": (Offsets.CHILD_LINK_LUT_DL_SWORD_HILT, 0x14048),  # 0x13F38 + 0x110, skips fist
     "Shield.1": (Offsets.CHILD_LINK_LUT_DL_SHIELD_DEKU, 0x14440),
-    "Slingshot": (Offsets.CHILD_LINK_LUT_DL_SLINGSHOT, 0x15F08), # 0x15DF0 + 0x118, skips fist
+    "Slingshot": (Offsets.CHILD_LINK_LUT_DL_SLINGSHOT, 0x15F08),  # 0x15DF0 + 0x118, skips fist
     "Ocarina.1": (Offsets.CHILD_LINK_LUT_DL_OCARINA_FAIRY, 0x15BA8),
     "Bottle": (Offsets.CHILD_LINK_LUT_DL_BOTTLE, 0x18478),
-    "Ocarina.2": (Offsets.CHILD_LINK_LUT_DL_OCARINA_TIME, 0x15AB8), # 0x15958 + 0x160, skips hand
-    "Bottle.Hand.L": (Offsets.CHILD_LINK_LUT_DL_LHAND_BOTTLE, 0x18478), # Just the bottle, couldn't find one with hand and bottle
+    "Ocarina.2": (Offsets.CHILD_LINK_LUT_DL_OCARINA_TIME, 0x15AB8),  # 0x15958 + 0x160, skips hand
+    "Bottle.Hand.L": (Offsets.CHILD_LINK_LUT_DL_LHAND_BOTTLE, 0x18478),  # Just the bottle, couldn't find one with hand and bottle
     "GoronBracelet": (Offsets.CHILD_LINK_LUT_DL_GORON_BRACELET, 0x16118),
     "Mask.Bunny": (Offsets.CHILD_LINK_LUT_DL_MASK_BUNNY, 0x2CA38),
     "Mask.Skull": (Offsets.CHILD_LINK_LUT_DL_MASK_SKULL, 0x2AD40),
@@ -1205,7 +1214,7 @@ ChildPieces = {
     "Mask.Zora": (Offsets.CHILD_LINK_LUT_DL_MASK_ZORA, 0x2B580),
     "FPS.Forearm.R": (Offsets.CHILD_LINK_LUT_DL_FPS_RIGHT_ARM, 0x18048),
     "DekuStick": (Offsets.CHILD_LINK_LUT_DL_DEKU_STICK, 0x6CC0),
-    "Shield.2": (Offsets.CHILD_LINK_LUT_DL_SHIELD_HYLIAN_BACK, 0x14C30), # 0x14B40 + 0xF0, skips sheath
+    "Shield.2": (Offsets.CHILD_LINK_LUT_DL_SHIELD_HYLIAN_BACK, 0x14C30),  # 0x14B40 + 0xF0, skips sheath
     "Limb 1": (Offsets.CHILD_LINK_LUT_DL_WAIST, 0x202A8),
     "Limb 3": (Offsets.CHILD_LINK_LUT_DL_RTHIGH, 0x204F0),
     "Limb 4": (Offsets.CHILD_LINK_LUT_DL_RSHIN, 0x206E8),
@@ -1226,35 +1235,35 @@ ChildPieces = {
 }
 
 
-childSkips = {
+childSkips: Dict[str, List[Tuple[int, int]]] = {
     "Boomerang": [(0x140, 0x240)],
     "Hilt.1": [(0xC8, 0x170)],
     "Shield.1": [(0x140, 0x218)],
     "Ocarina.1": [(0x110, 0x240)],
 }
 
-childSkeleton = [
-    [0x0000, 0x0948, 0x0000], # Limb 0
-    [0xFFFC, 0xFF98, 0x0000], # Limb 1
-    [0x025F, 0x0000, 0x0000], # Limb 2
-    [0xFF54, 0x0032, 0xFF42], # Limb 3
-    [0x02B9, 0x0000, 0x0000], # Limb 4
-    [0x0339, 0x0005, 0x000B], # Limb 5
-    [0xFF56, 0x0039, 0x00C0], # Limb 6
-    [0x02B7, 0x0000, 0x0000], # Limb 7
-    [0x0331, 0x0008, 0x0004], # Limb 8
-    [0x0000, 0xFF99, 0xFFF9], # Limb 9
-    [0x03E4, 0xFF37, 0xFFFF], # Limb 10
-    [0xFE93, 0xFD62, 0x0000], # Limb 11
-    [0x0000, 0x0000, 0x0000], # Limb 12
-    [0x02B8, 0xFF51, 0x01D2], # Limb 13
-    [0x0245, 0x0000, 0x0000], # Limb 14
-    [0x0202, 0x0000, 0x0000], # Limb 15
-    [0x02B8, 0xFF51, 0xFE2E], # Limb 16
-    [0x0241, 0x0000, 0x0000], # Limb 17
-    [0x020D, 0x0000, 0x0000], # Limb 18
-    [0x0291, 0xFDF5, 0x016F], # Limb 19
-    [0x0000, 0x0000, 0x0000], # Limb 20
+childSkeleton: List[List[int]] = [
+    [0x0000, 0x0948, 0x0000],  # Limb 0
+    [0xFFFC, 0xFF98, 0x0000],  # Limb 1
+    [0x025F, 0x0000, 0x0000],  # Limb 2
+    [0xFF54, 0x0032, 0xFF42],  # Limb 3
+    [0x02B9, 0x0000, 0x0000],  # Limb 4
+    [0x0339, 0x0005, 0x000B],  # Limb 5
+    [0xFF56, 0x0039, 0x00C0],  # Limb 6
+    [0x02B7, 0x0000, 0x0000],  # Limb 7
+    [0x0331, 0x0008, 0x0004],  # Limb 8
+    [0x0000, 0xFF99, 0xFFF9],  # Limb 9
+    [0x03E4, 0xFF37, 0xFFFF],  # Limb 10
+    [0xFE93, 0xFD62, 0x0000],  # Limb 11
+    [0x0000, 0x0000, 0x0000],  # Limb 12
+    [0x02B8, 0xFF51, 0x01D2],  # Limb 13
+    [0x0245, 0x0000, 0x0000],  # Limb 14
+    [0x0202, 0x0000, 0x0000],  # Limb 15
+    [0x02B8, 0xFF51, 0xFE2E],  # Limb 16
+    [0x0241, 0x0000, 0x0000],  # Limb 17
+    [0x020D, 0x0000, 0x0000],  # Limb 18
+    [0x0291, 0xFDF5, 0x016F],  # Limb 19
+    [0x0000, 0x0000, 0x0000],  # Limb 20
 ]
 
 # Maps old pipeline limb names to new pipeline names
@@ -1279,39 +1288,39 @@ oldToNewPipeline = {
 }
 
 # Misc. constants
-CODE_START          = 0x00A87000
-PLAYER_START        = 0x00BCDB70
-HOOK_START          = 0x00CAD2C0
-SHIELD_START        = 0x00DB1F40
-STICK_START         = 0x00EAD0F0
-GRAVEYARD_KID_START = 0x00E60920
-GUARD_START         = 0x00D1A690
-RUNNING_MAN_START   = 0x00E50440
+CODE_START: int          = 0x00A87000
+PLAYER_START: int        = 0x00BCDB70
+HOOK_START: int          = 0x00CAD2C0
+SHIELD_START: int        = 0x00DB1F40
+STICK_START: int         = 0x00EAD0F0
+GRAVEYARD_KID_START: int = 0x00E60920
+GUARD_START: int         = 0x00D1A690
+RUNNING_MAN_START: int   = 0x00E50440
 
-BASE_OFFSET         = 0x06000000
-LUT_START           = 0x00005000
-LUT_END             = 0x00005800
-PRE_CONSTANT_START  = 0X0000500C
+BASE_OFFSET: int         = 0x06000000
+LUT_START: int           = 0x00005000
+LUT_END: int             = 0x00005800
+PRE_CONSTANT_START: int  = 0X0000500C
 
-ADULT_START         = 0x00F86000
-ADULT_SIZE          = 0x00037800
-ADULT_HIERARCHY     = 0x06005380
-ADULT_POST_START    = 0x00005238
+ADULT_START: int         = 0x00F86000
+ADULT_SIZE: int          = 0x00037800
+ADULT_HIERARCHY: int     = 0x06005380
+ADULT_POST_START: int    = 0x00005238
 
-CHILD_START         = 0x00FBE000
-CHILD_SIZE          = 0x0002CF80
-CHILD_HIERARCHY     = 0x060053A8
-CHILD_POST_START    = 0x00005228
+CHILD_START: int         = 0x00FBE000
+CHILD_SIZE: int          = 0x0002CF80
+CHILD_HIERARCHY: int     = 0x060053A8
+CHILD_POST_START: int    = 0x00005228
 
 # Parts of the rom to not overwrite when applying a patch file
-restrictiveBytes = [
-    (ADULT_START, ADULT_SIZE), # Ignore adult model
-    (CHILD_START, CHILD_SIZE), # Ignore child model
+restrictiveBytes: List[Tuple[int, int]] = [
+    (ADULT_START, ADULT_SIZE),  # Ignore adult model
+    (CHILD_START, CHILD_SIZE),  # Ignore child model
     # Adult model pointers
-    (CODE_START + 0xE6718, 75 * 8), # Writes 75 4-byte pointers with 4 bytes between
-    (CODE_START + 0xE6A4C, 4 * 4), # Writes 4 4-byte pointers
-    (CODE_START + 0xE6B28, 1 * 4), # Writes 1 4-byte pointer
-    (CODE_START + 0xE6B64, 3 * 4), # Writes 1 4-byte pointer and 2 4-byte values
+    (CODE_START + 0xE6718, 75 * 8),  # Writes 75 4-byte pointers with 4 bytes between
+    (CODE_START + 0xE6A4C, 4 * 4),  # Writes 4 4-byte pointers
+    (CODE_START + 0xE6B28, 1 * 4),  # Writes 1 4-byte pointer
+    (CODE_START + 0xE6B64, 3 * 4),  # Writes 1 4-byte pointer and 2 4-byte values
     # 2 byte hi/lo segments of pointers
     (CODE_START + 0x69112, 2),
     (CODE_START + 0x69116, 2),
@@ -1333,28 +1342,28 @@ restrictiveBytes = [
     (HOOK_START + 0xA76, 2),
     (HOOK_START + 0xB66, 2),
     (HOOK_START + 0xB6A, 2),
-    (HOOK_START + 0xBA8, 1 * 2), # Writes 1 2-byte value
-    (STICK_START + 0x32C, 1 * 4), # Writes 1 4-byte pointer
-    (STICK_START + 0x328, 1 * 2), # Writes 1 2-byte value
-    (CODE_START + 0xE65A0, 1 * 4), # Writes 4-byte hierarchy pointer
+    (HOOK_START + 0xBA8, 1 * 2),  # Writes 1 2-byte value
+    (STICK_START + 0x32C, 1 * 4),  # Writes 1 4-byte pointer
+    (STICK_START + 0x328, 1 * 2),  # Writes 1 2-byte value
+    (CODE_START + 0xE65A0, 1 * 4),  # Writes 4-byte hierarchy pointer
     # Child model pointers
-    (CODE_START + 0xE671C, 75 * 8), # Writes 75 4-byte pointers with 4 bytes between
-    (CODE_START + 0xE6B2C, 1 * 8), # Writes 1 4-byte pointer with 4 bytes after
-    (CODE_START + 0xE6B74, 3 * 4), # Writes 1 4-byte pointer and 2 4-byte values
+    (CODE_START + 0xE671C, 75 * 8),  # Writes 75 4-byte pointers with 4 bytes between
+    (CODE_START + 0xE6B2C, 1 * 8),  # Writes 1 4-byte pointer with 4 bytes after
+    (CODE_START + 0xE6B74, 3 * 4),  # Writes 1 4-byte pointer and 2 4-byte values
     (CODE_START + 0x6922E, 2),
     (CODE_START + 0x69232, 2),
     (CODE_START + 0x6A80E, 2),
     (CODE_START + 0x6A812, 2),
-    (STICK_START + 0x334, 1 * 4), # Writes 1 4-byte pointer
-    (STICK_START + 0x330, 1 * 2), # Writes 1 2-byte value
+    (STICK_START + 0x334, 1 * 4),  # Writes 1 4-byte pointer
+    (STICK_START + 0x330, 1 * 2),  # Writes 1 2-byte value
     (SHIELD_START + 0x7EE, 2),
     (SHIELD_START + 0x7F2, 2),
-    (PLAYER_START + 0x2253C, 8 * 4), # Writes 8 4-byte pointers
+    (PLAYER_START + 0x2253C, 8 * 4),  # Writes 8 4-byte pointers
     (GRAVEYARD_KID_START + 0xE62, 2),
     (GRAVEYARD_KID_START + 0xE66, 2),
     (GUARD_START + 0x1EA2, 2),
     (GUARD_START + 0x1EA6, 2),
     (RUNNING_MAN_START + 0x1142, 2),
     (RUNNING_MAN_START + 0x1146, 2),
-    (CODE_START + 0xE65A4, 1 * 4), # Writes 4-byte hierarchy pointer
+    (CODE_START + 0xE65A4, 1 * 4),  # Writes 4-byte hierarchy pointer
 ]

--- a/Models.py
+++ b/Models.py
@@ -306,7 +306,7 @@ def LoadVanilla(rom: "Rom", missing: List[str], rebase: int, linkstart: int, lin
                         # Branch to another texture
                         if segJ == segment:
                             if vanillaData[j+1] == 0x0:
-                                returnStack.push(j)
+                                returnStack.append(j)
                             j = loJ & 0x00FFFFFF
                     elif opJ == 0xF0:
                         # F0: G_LOADTLUT

--- a/Music.py
+++ b/Music.py
@@ -437,8 +437,8 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog) -> None:
 
     # Handle groups.
     plando_groups = {n: s for n, s in log.src_dict.get('bgm_groups', {}).get('groups', {}).items()}
-    bgm_groups_full = chain_groups([{n: s} for n, s in itertools.chain(bgm_groups.items(), plando_groups.items())], sequences)
-    ff_groups_full = chain_groups([{n: s} for n, s in itertools.chain(fanfare_groups.items(), plando_groups.items())], fanfare_sequences)
+    bgm_groups_full = chain_groups([(n, s) for n, s in itertools.chain(bgm_groups.items(), plando_groups.items())], sequences)
+    ff_groups_full = chain_groups([(n, s) for n, s in itertools.chain(fanfare_groups.items(), plando_groups.items())], fanfare_sequences)
     bgm_groups = {n: s.copy() for n, s in bgm_groups_full.items()}
     ff_groups = {n: s.copy() for n, s in ff_groups_full.items()}
     for target, mapping in music_mapping.copy().items():
@@ -556,12 +556,11 @@ def restore_music(rom: Rom) -> None:
         dma_entry.update(orig_start, orig_end, start)
 
 
-def chain_groups(group_list, sequences):
+def chain_groups(group_list: list[tuple[str, list[str] | str]], sequences: dict[str, Sequence]) -> dict[str, list[str]]:
     result = {}
-    for iterator in group_list:
-        for n, s in iterator.items():
-            if isinstance(s, list):
-                result.setdefault(n, []).extend(ns for ns in s if ns in sequences)
-            else:
-                result.setdefault(n, []).append(ns for ns in s if ns in sequences)
+    for group_name, sequence_names in group_list:
+        if isinstance(sequence_names, list):
+            result.setdefault(group_name, []).extend(ns for ns in sequence_names if ns in sequences)
+        elif sequence_names in sequences:
+            result.setdefault(group_name, []).append(sequence_names)
     return result

--- a/Music.py
+++ b/Music.py
@@ -331,7 +331,7 @@ def rebuild_sequences(rom: Rom, sequences: list[Sequence]) -> None:
         rom.buffer[audioseq_start:audioseq_end] = [0] * audioseq_size
 
         # Find free space and update dmatable
-        new_address = rom.dma.free_space()
+        new_address = rom.dma.free_space(address)
         dma_entry.update(new_address, new_address + address)
 
     # Write new audio sequence file

--- a/Music.py
+++ b/Music.py
@@ -209,7 +209,7 @@ def process_sequences(rom: Rom, ids: Iterable[Tuple[str, int]], seq_type: str = 
 
 
 def shuffle_music(log: "CosmeticsLog", source_sequences: Dict[str, Sequence], target_sequences: Dict[str, Sequence],
-                  music_mapping: Dict[str, Union[str, List[str]]], seq_type: str = "music") -> List[Sequence]:
+                  music_mapping: Dict[str, str], seq_type: str = "music") -> List[Sequence]:
     sequences = []
     favorites = log.src_dict.get('bgm_groups', {}).get('favorites', []).copy()
 

--- a/Music.py
+++ b/Music.py
@@ -1,13 +1,20 @@
-#Much of this is heavily inspired from and/or based on az64's / Deathbasket's MM randomizer
-
+# Much of this is heavily inspired from and/or based on az64's / Deathbasket's MM randomizer
 import itertools
-import random
 import os
+import random
+from typing import TYPE_CHECKING, Tuple, List, Dict, Iterable, Optional, Union
+
+from Rom import Rom
 from Utils import compare_version, data_path
 
+if TYPE_CHECKING:
+    from Cosmetics import CosmeticsLog
+    from Settings import Settings
+
+AUDIOSEQ_DMADATA_INDEX: int = 4
 
 # Format: (Title, Sequence ID)
-bgm_sequence_ids = (
+bgm_sequence_ids: Tuple[Tuple[str, int], ...] = (
     ("Hyrule Field", 0x02),
     ("Dodongos Cavern", 0x18),
     ("Kakariko Adult", 0x19),
@@ -54,10 +61,10 @@ bgm_sequence_ids = (
     ("Ganondorf Battle", 0x64),
     ("Ganon Battle", 0x65),
     ("Fire Boss", 0x6B),
-    ("Mini-game", 0x6C)
+    ("Mini-game", 0x6C),
 )
 
-fanfare_sequence_ids = (
+fanfare_sequence_ids: Tuple[Tuple[str, int], ...] = (
     ("Game Over", 0x20),
     ("Boss Defeated", 0x21),
     ("Item Get", 0x22),
@@ -72,10 +79,10 @@ fanfare_sequence_ids = (
     ("Medallion Get", 0x43),
     ("Zelda Turns Around", 0x51),
     ("Master Sword", 0x53),
-    ("Door of Time", 0x59)
+    ("Door of Time", 0x59),
 )
 
-ocarina_sequence_ids = (
+ocarina_sequence_ids: Tuple[Tuple[str, int], ...] = (
     ("Prelude of Light", 0x25),
     ("Bolero of Fire", 0x33),
     ("Minuet of Forest", 0x34),
@@ -87,35 +94,38 @@ ocarina_sequence_ids = (
     ("Zelda's Lullaby", 0x46),
     ("Sun's Song", 0x47),
     ("Song of Time", 0x48),
-    ("Song of Storms", 0x49)
+    ("Song of Storms", 0x49),
 )
 
 
 # Represents the information associated with a sequence, aside from the sequence data itself
-class Sequence(object):
-    def __init__(self, name, cosmetic_name, type = 0x0202, instrument_set = 0x03, replaces = -1, vanilla_id = -1):
-        self.name = name
-        self.cosmetic_name = cosmetic_name
-        self.replaces = replaces
-        self.vanilla_id = vanilla_id
-        self.type = type
-        self.instrument_set = instrument_set
+class Sequence:
+    def __init__(self, name: str, cosmetic_name: str, type: int = 0x0202, instrument_set: int = 0x03,
+                 replaces: int = -1, vanilla_id: int = -1) -> None:
+        self.name: str = name
+        self.cosmetic_name: str = cosmetic_name
+        self.replaces: int = replaces
+        self.vanilla_id: int = vanilla_id
+        self.type: int = type
+        self.instrument_set: int = instrument_set
 
-
-    def copy(self):
+    def copy(self) -> 'Sequence':
         copy = Sequence(self.name, self.cosmetic_name, self.type, self.instrument_set, self.replaces, self.vanilla_id)
         return copy
 
 
 # Represents actual sequence data, along with metadata for the sequence data block
-class SequenceData(object):
-    def __init__(self):
-        self.address = -1
-        self.size = -1
-        self.data = []
+class SequenceData:
+    def __init__(self) -> None:
+        self.address: int = -1
+        self.size: int = -1
+        self.data: bytearray = bytearray()
 
 
-def process_sequences(rom, ids, seq_type='bgm', disabled_source_sequences=None, disabled_target_sequences=None, include_custom=True, sequences=None, target_sequences=None, groups=None):
+def process_sequences(rom: Rom, ids: Iterable[Tuple[str, int]], seq_type: str = 'bgm', disabled_source_sequences: Optional[List[str]] = None,
+                      disabled_target_sequences: Optional[Dict[str, Tuple[str, int]]] = None, include_custom: bool = True,
+                      sequences: Optional[Dict[str, Sequence]] = None, target_sequences: Optional[Dict[str, Sequence]] = None,
+                      groups: Optional[Dict[str, List[str]]] = None) -> Tuple[Dict[str, Sequence], Dict[str, Sequence], Dict[str, List[str]]]:
     disabled_source_sequences = [] if disabled_source_sequences is None else disabled_source_sequences
     disabled_target_sequences = {} if disabled_target_sequences is None else disabled_target_sequences
     sequences = {} if sequences is None else sequences
@@ -198,12 +208,13 @@ def process_sequences(rom, ids, seq_type='bgm', disabled_source_sequences=None, 
     return sequences, target_sequences, groups
 
 
-def shuffle_music(log, source_sequences, target_sequences, music_mapping, type="music"):
+def shuffle_music(log: "CosmeticsLog", source_sequences: Dict[str, Sequence], target_sequences: Dict[str, Sequence],
+                  music_mapping: Dict[str, Union[str, List[str]]], seq_type: str = "music") -> List[Sequence]:
     sequences = []
     favorites = log.src_dict.get('bgm_groups', {}).get('favorites', []).copy()
 
     if not source_sequences:
-        raise Exception(f"Not enough custom {type} ({len(source_sequences)}) to omit base Ocarina of Time sequences ({len(target_sequences)}).")
+        raise Exception(f"Not enough custom {seq_type} ({len(source_sequences)}) to omit base Ocarina of Time sequences ({len(target_sequences)}).")
 
     # Shuffle the sequences
     sequence_ids = [name for name in source_sequences.keys() if name not in music_mapping.values()]
@@ -228,11 +239,13 @@ def shuffle_music(log, source_sequences, target_sequences, music_mapping, type="
         log.bgm[target_sequence.cosmetic_name] = sequence.cosmetic_name
 
     if refill_needed:
-        log.errors.append(f"Not enough {type} available to not have repeats. There were {len(source_sequences)} sequences available to fill {len(target_sequences)} target tracks.")
+        log.errors.append(f"Not enough {seq_type} available to not have repeats. There were {len(source_sequences)} sequences available to fill {len(target_sequences)} target tracks.")
     return sequences
 
 
-def rebuild_sequences(rom, sequences):
+def rebuild_sequences(rom: Rom, sequences: List[Sequence]) -> None:
+    dma_entry = rom.dma[AUDIOSEQ_DMADATA_INDEX]
+    audioseq_start, audioseq_end, audioseq_size = dma_entry.as_tuple()
     replacement_dict = {seq.replaces: seq for seq in sequences}
     # List of sequences (actual sequence data objects) containing the vanilla sequence data
     old_sequences = []
@@ -248,7 +261,7 @@ def rebuild_sequences(rom, sequences):
 
         # If size > 0, read the sequence data from the rom into the sequence object
         if entry.size > 0:
-            entry.data = rom.read_bytes(entry.address + 0x029DE0, entry.size)
+            entry.data = rom.read_bytes(entry.address + audioseq_start, entry.size)
         else:
             seq = replacement_dict.get(i, None)
             if seq and 0 < entry.address < 128:
@@ -309,15 +322,15 @@ def rebuild_sequences(rom, sequences):
             # Increment the current address by the size of the new sequence
             address += new_entry.size
 
-    new_address = 0x029DE0
+    new_address = audioseq_start
     # Check if the new audio sequence is larger than the vanilla one
-    if address > 0x04F690:
+    if address > audioseq_size:
         # Zero out the old audio sequence
-        rom.buffer[0x029DE0 : 0x029DE0 + 0x04F690] = [0] * 0x04F690
+        rom.buffer[audioseq_start:audioseq_end] = [0] * audioseq_size
 
         # Find free space and update dmatable
-        new_address = rom.free_space()
-        rom.update_dmadata_record(0x029DE0, new_address, new_address + address)
+        new_address = rom.dma.free_space()
+        dma_entry.update(new_address, new_address + address)
 
     # Write new audio sequence file
     rom.write_bytes(new_address, new_audio_sequence)
@@ -338,7 +351,7 @@ def rebuild_sequences(rom, sequences):
             rom.write_byte(base, j.instrument_set)
 
 
-def rebuild_pointers_table(rom, sequences):
+def rebuild_pointers_table(rom: Rom, sequences: List[Sequence]) -> None:
     for sequence in [s for s in sequences if s.vanilla_id and s.replaces]:
         bgm_sequence = rom.original.read_bytes(0xB89AE0 + (sequence.vanilla_id * 0x10), 0x10)
         bgm_instrument = rom.original.read_int16(0xB89910 + 0xDD + (sequence.vanilla_id * 2))
@@ -349,7 +362,7 @@ def rebuild_pointers_table(rom, sequences):
     rom.write_int16(0xB89910 + 0xDD + (0x57 * 2), rom.read_int16(0xB89910 + 0xDD + (0x28 * 2)))
 
 
-def randomize_music(rom, settings, log):
+def randomize_music(rom: Rom, settings: "Settings", log: "CosmeticsLog") -> None:
     shuffled_sequences = shuffled_fanfare_sequences = []
     sequences = fanfare_sequences = target_sequences = target_fanfare_sequences = bgm_groups = fanfare_groups = {}
     disabled_source_sequences = log.src_dict.get('bgm_groups', {}).get('exclude', []).copy()
@@ -436,7 +449,7 @@ def randomize_music(rom, settings, log):
             groups_alias = ff_groups
             sequences_alias = fanfare_sequences
         else:
-            log.error.append(f'Target sequence "{target}" from plando file is invalid.')
+            log.errors.append(f'Target sequence "{target}" from plando file is invalid.')
             del music_mapping[target]
             continue
 
@@ -508,7 +521,7 @@ def randomize_music(rom, settings, log):
         disable_music(rom, log, disabled_target_sequences.values())
 
 
-def disable_music(rom, log, ids):
+def disable_music(rom: Rom, log: "CosmeticsLog", ids: Iterable[Tuple[str, int]]) -> None:
     # First track is no music
     blank_track = rom.read_bytes(0xB89AE0 + (0 * 0x10), 0x10)
     for bgm in ids:
@@ -516,7 +529,7 @@ def disable_music(rom, log, ids):
         log.bgm[bgm[0]] = "None"
 
 
-def restore_music(rom):
+def restore_music(rom: Rom) -> None:
     # Restore all music from original
     for bgm in bgm_sequence_ids + fanfare_sequence_ids + ocarina_sequence_ids:
         bgm_sequence = rom.original.read_bytes(0xB89AE0 + (bgm[1] * 0x10), 0x10)
@@ -529,15 +542,16 @@ def restore_music(rom):
     rom.write_int16(0xB89910 + 0xDD + (0x57 * 2), bgm_instrument)
 
     # Rebuild audioseq
-    orig_start, orig_end, orig_size = rom.original._get_dmadata_record(0x7470)
+    orig_start, orig_end, orig_size = rom.original.dma[AUDIOSEQ_DMADATA_INDEX].as_tuple()
     rom.write_bytes(orig_start, rom.original.read_bytes(orig_start, orig_size))
 
     # If Audioseq was relocated
-    start, end, size = rom._get_dmadata_record(0x7470)
-    if start != 0x029DE0:
+    dma_entry = rom.dma[AUDIOSEQ_DMADATA_INDEX]
+    start, end, size = dma_entry.as_tuple()
+    if start != orig_start:
         # Zero out old audioseq
         rom.write_bytes(start, [0] * size)
-        rom.update_dmadata_record(start, orig_start, orig_end)
+        dma_entry.update(orig_start, orig_end, start)
 
 
 def chain_groups(group_list, sequences):
@@ -549,4 +563,3 @@ def chain_groups(group_list, sequences):
             else:
                 result.setdefault(n, []).append(ns for ns in s if ns in sequences)
     return result
-

--- a/N64Patch.py
+++ b/N64Patch.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 import copy
 import random
 import zipfile
 import zlib
-from typing import TYPE_CHECKING, Tuple, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 from Rom import Rom
 from ntype import BigStream
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 # get the next XOR key. Uses some location in the source rom.
 # This will skip of 0s, since if we hit a block of 0s, the
 # patch data will be raw.
-def key_next(rom: Rom, key_address: int, address_range: Tuple[int, int]) -> Tuple[int, int]:
+def key_next(rom: Rom, key_address: int, address_range: tuple[int, int]) -> tuple[int, int]:
     key = 0
     while key == 0:
         key_address += 1
@@ -27,8 +28,8 @@ def key_next(rom: Rom, key_address: int, address_range: Tuple[int, int]) -> Tupl
 # creates a XOR block for the patch. This might break it up into
 # multiple smaller blocks if there is a concern about the XOR key
 # or if it is too long.
-def write_block(rom: Rom, xor_address: int, xor_range: Tuple[int, int], block_start: int,
-                data: List[int], patch_data: BigStream) -> int:
+def write_block(rom: Rom, xor_address: int, xor_range: tuple[int, int], block_start: int,
+                data: list[int], patch_data: BigStream) -> int:
     new_data = []
     key_offset = 0
     continue_block = False
@@ -79,7 +80,7 @@ def write_block(rom: Rom, xor_address: int, xor_range: Tuple[int, int], block_st
 # then it will include the address to write to. Otherwise, it will
 # have a number of XOR keys to skip and then continue writing after
 # the previous block
-def write_block_section(start: int, key_skip: int, in_data: List[int], patch_data: BigStream, is_continue: bool) -> None:
+def write_block_section(start: int, key_skip: int, in_data: list[int], patch_data: BigStream, is_continue: bool) -> None:
     if not is_continue:
         patch_data.append_int32(start)
     else:
@@ -92,7 +93,7 @@ def write_block_section(start: int, key_skip: int, in_data: List[int], patch_dat
 # xor_range is the range the XOR key will read from. This range is not
 # too important, but I tried to choose from a section that didn't really
 # have big gaps of 0s which we want to avoid.
-def create_patch_file(rom: Rom, file: str, xor_range: Tuple[int, int] = (0x00B8AD30, 0x00F029A0)) -> None:
+def create_patch_file(rom: Rom, file: str, xor_range: tuple[int, int] = (0x00B8AD30, 0x00F029A0)) -> None:
     dma_start, dma_end = rom.dma.dma_start, rom.dma.dma_end
 
     # add header
@@ -179,7 +180,7 @@ def create_patch_file(rom: Rom, file: str, xor_range: Tuple[int, int] = (0x00B8A
 
 
 # This will apply a patch file to a source rom to generate a patched rom.
-def apply_patch_file(rom: Rom, settings: "Settings", sub_file: Optional[str] = None) -> None:
+def apply_patch_file(rom: Rom, settings: Settings, sub_file: Optional[str] = None) -> None:
     file = settings.patch_file
 
     # load the patch file and decompress

--- a/N64Patch.py
+++ b/N64Patch.py
@@ -1,17 +1,20 @@
-import struct
-import random
-import io
-import array
-import zlib
 import copy
+import random
 import zipfile
+import zlib
+from typing import TYPE_CHECKING, Tuple, List, Optional
+
+from Rom import Rom
 from ntype import BigStream
+
+if TYPE_CHECKING:
+    from Settings import Settings
 
 
 # get the next XOR key. Uses some location in the source rom.
 # This will skip of 0s, since if we hit a block of 0s, the
 # patch data will be raw.
-def key_next(rom, key_address, address_range):
+def key_next(rom: Rom, key_address: int, address_range: Tuple[int, int]) -> Tuple[int, int]:
     key = 0
     while key == 0:
         key_address += 1
@@ -24,7 +27,8 @@ def key_next(rom, key_address, address_range):
 # creates a XOR block for the patch. This might break it up into
 # multiple smaller blocks if there is a concern about the XOR key
 # or if it is too long.
-def write_block(rom, xor_address, xor_range, block_start, data, patch_data):
+def write_block(rom: Rom, xor_address: int, xor_range: Tuple[int, int], block_start: int,
+                data: List[int], patch_data: BigStream) -> int:
     new_data = []
     key_offset = 0
     continue_block = False
@@ -60,7 +64,7 @@ def write_block(rom, xor_address, xor_range, block_start, data, patch_data):
             new_data += [b ^ key]
 
             # Break the block if it's too long
-            if (len(new_data) == 0xFFFF):
+            if len(new_data) == 0xFFFF:
                 write_block_section(block_start, key_offset, new_data, patch_data, continue_block)
                 new_data = []
                 key_offset = 0
@@ -72,10 +76,10 @@ def write_block(rom, xor_address, xor_range, block_start, data, patch_data):
 
 
 # This saves a sub-block for the XOR block. If it's the first part
-# then it will include the address to write to. Otherwise it will
+# then it will include the address to write to. Otherwise, it will
 # have a number of XOR keys to skip and then continue writing after
 # the previous block
-def write_block_section(start, key_skip, in_data, patch_data, is_continue):
+def write_block_section(start: int, key_skip: int, in_data: List[int], patch_data: BigStream, is_continue: bool) -> None:
     if not is_continue:
         patch_data.append_int32(start)
     else:
@@ -88,11 +92,11 @@ def write_block_section(start, key_skip, in_data, patch_data, is_continue):
 # xor_range is the range the XOR key will read from. This range is not
 # too important, but I tried to choose from a section that didn't really
 # have big gaps of 0s which we want to avoid.
-def create_patch_file(rom, file, xor_range=(0x00B8AD30, 0x00F029A0)):
-    dma_start, dma_end = rom.get_dma_table_range()
+def create_patch_file(rom: Rom, file: str, xor_range: Tuple[int, int] = (0x00B8AD30, 0x00F029A0)) -> None:
+    dma_start, dma_end = rom.dma.dma_start, rom.dma.dma_end
 
     # add header
-    patch_data = BigStream([])
+    patch_data = BigStream(bytearray())
     patch_data.append_bytes(list(map(ord, 'ZPFv1')))
     patch_data.append_int32(dma_start)
     patch_data.append_int32(xor_range[0])
@@ -120,7 +124,7 @@ def create_patch_file(rom, file, xor_range=(0x00B8AD30, 0x00F029A0)):
 
         # Simulate moving the files to know which addresses have changed
         if from_file >= 0:
-            old_dma_start, old_dma_end, old_size = rom.original.get_dmadata_record_by_key(from_file)
+            old_dma_start, old_dma_end, old_size = rom.original.dma.get_dmadata_record_by_key(from_file).as_tuple()
             copy_size = min(size, old_size)
             new_buffer[start:start+copy_size] = rom.original.read_bytes(from_file, copy_size)
             new_buffer[start+copy_size:start+size] = [0] * (size - copy_size)
@@ -133,16 +137,16 @@ def create_patch_file(rom, file, xor_range=(0x00B8AD30, 0x00F029A0)):
 
     # filter down the addresses that will actually need to change.
     # Make sure to not include any of the DMA table addresses
-    changed_addresses = [address for address,value in rom.changed_address.items() \
-        if (address >= dma_end or address < dma_start) and \
-            (address in rom.force_patch or new_buffer[address] != value)]
+    changed_addresses = [address for address, value in rom.changed_address.items()
+                         if (address >= dma_end or address < dma_start) and
+                         (address in rom.force_patch or new_buffer[address] != value)]
     changed_addresses.sort()
 
     # Write the address changes. We'll store the data with XOR so that
     # the patch data won't be raw data from the patched rom.
     data = []
-    block_start = None
-    BLOCK_HEADER_SIZE = 7 # this is used to break up gaps
+    block_start = block_end = None
+    BLOCK_HEADER_SIZE = 7  # this is used to break up gaps
     for address in changed_addresses:
         # if there's a block to write and there's a gap, write it
         if block_start:
@@ -161,7 +165,7 @@ def create_patch_file(rom, file, xor_range=(0x00B8AD30, 0x00F029A0)):
         # save the new data
         data += rom.buffer[block_end+1:address+1]
 
-    # if there was any left over blocks, write them out
+    # if there was any leftover blocks, write them out
     if block_start:
         xor_address = write_block(rom, xor_address, xor_range, block_start, data, patch_data)
 
@@ -175,7 +179,7 @@ def create_patch_file(rom, file, xor_range=(0x00B8AD30, 0x00F029A0)):
 
 
 # This will apply a patch file to a source rom to generate a patched rom.
-def apply_patch_file(rom, settings, sub_file=None):
+def apply_patch_file(rom: Rom, settings: "Settings", sub_file: Optional[str] = None) -> None:
     file = settings.patch_file
 
     # load the patch file and decompress
@@ -189,7 +193,7 @@ def apply_patch_file(rom, settings, sub_file=None):
     else:
         with open(file, 'rb') as stream:
             patch_data = stream.read()
-    patch_data = BigStream(zlib.decompress(patch_data))
+    patch_data = BigStream(bytearray(zlib.decompress(patch_data)))
 
     # make sure the header is correct
     if patch_data.read_bytes(length=4) != b'ZPFv':
@@ -230,7 +234,7 @@ def apply_patch_file(rom, settings, sub_file=None):
 
         if from_file != 0xFFFFFFFF:
             # If a source file is listed, copy from there
-            old_dma_start, old_dma_end, old_size = rom.original.get_dmadata_record_by_key(from_file)
+            old_dma_start, old_dma_end, old_size = rom.original.dma.get_dmadata_record_by_key(from_file).as_tuple()
             copy_size = min(size, old_size)
             rom.write_bytes(start, rom.original.read_bytes(from_file, copy_size))
             rom.buffer[start+copy_size:start+size] = [0] * (size - copy_size)
@@ -273,4 +277,3 @@ def apply_patch_file(rom, settings, sub_file=None):
         else:
             rom.write_bytes(block_start, data)
         block_start = block_start+block_size
-

--- a/N64Patch.py
+++ b/N64Patch.py
@@ -243,7 +243,7 @@ def apply_patch_file(rom: Rom, settings: "Settings", sub_file: Optional[str] = N
             rom.buffer[start:start+size] = [0] * size
 
     # Read in the XOR data blocks. This goes to the end of the file.
-    block_start = None
+    block_start = 0
     while not patch_data.eof():
         is_new_block = patch_data.read_byte() != 0xFF
 

--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -1,9 +1,14 @@
 import random
+import sys
 from itertools import chain
 from typing import TYPE_CHECKING, Dict, List, Tuple, Sequence, Callable, Optional, Union
 
 from Fill import ShuffleError
-from Utils import TypeAlias
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    TypeAlias = str
 
 if TYPE_CHECKING:
     from Rom import Rom

--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -1,3 +1,7 @@
+import random
+from itertools import chain
+from Fill import ShuffleError
+
 PLAYBACK_START = 0xB781DC
 PLAYBACK_LENGTH = 0xA0
 ACTIVATION_START = 0xB78E5C
@@ -61,10 +65,6 @@ SONG_TABLE = {
     'Prelude of Light':   ( 5, True,  '^>^><^'),
 }
 
-import random
-from itertools import chain
-from Fill import ShuffleError
-from Utils import random_choices
 
 # checks if one list is a sublist of the other (in either direction)
 # python is magic.....
@@ -116,7 +116,7 @@ def identity(x):
     return x
 
 def random_piece(count, allowed=range(0,5)):
-    return random_choices(allowed, k=count)
+    return random.choices(allowed, k=count)
 
 def invert_piece(piece):
     return [4 - note for note in piece]
@@ -243,7 +243,7 @@ class Song():
             self.activation = activation
         elif rand_song:
             self.length = random.randint(4, 8)
-            self.activation = random_choices(range(0,5), k=self.length)
+            self.activation = random.choices(range(0,5), k=self.length)
         else:
             if extra_position != 'none':
                 piece_size = 3
@@ -274,28 +274,28 @@ class Song():
 # randomly choose song parameters
 def get_random_song():
 
-    rand_song = random_choices([True, False], [1, 9])[0]
-    piece_size = random_choices([3, 4], [5, 2])[0]
-    extra_position = random_choices(['none', 'start', 'middle', 'end'], [12, 1, 1, 1])[0]
+    rand_song = random.choices([True, False], [1, 9])[0]
+    piece_size = random.choices([3, 4], [5, 2])[0]
+    extra_position = random.choices(['none', 'start', 'middle', 'end'], [12, 1, 1, 1])[0]
     activation_transform = identity
     playback_transform = identity
     weight_damage = 0
-    should_transpose = random_choices([True, False], [1, 4])[0]
+    should_transpose = random.choices([True, False], [1, 4])[0]
     starting_range=range(0,5)
     if should_transpose:
         weight_damage = 2
-        direction = random_choices(['up', 'down'], [1, 1])[0]
+        direction = random.choices(['up', 'down'], [1, 1])[0]
         if direction == 'up':
             starting_range=range(0,4)
             activation_transform = transpose_piece(1)
         elif direction == 'down':
             starting_range=range(1,5)
             activation_transform = transpose_piece(-1)
-    should_invert = random_choices([True, False], [3 - weight_damage, 6])[0]
+    should_invert = random.choices([True, False], [3 - weight_damage, 6])[0]
     if should_invert:
         weight_damage += 1
         activation_transform = compose(invert_piece, activation_transform)
-    should_reflect = random_choices([True, False], [5 - weight_damage, 4])[0]
+    should_reflect = random.choices([True, False], [5 - weight_damage, 4])[0]
     if should_reflect:
         activation_transform = compose(reverse_piece, activation_transform)
         playback_transform = reverse_piece

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -4,17 +4,10 @@ if sys.version_info < (3, 6, 0):
     print("OoT Randomizer requires Python version 3.6 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
     sys.exit(1)
 
-import argparse
 import datetime
 import logging
 import os
-import textwrap
 import time
-
-
-class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
-    def _get_help_string(self, action):
-        return textwrap.dedent(action.help)
 
 
 def start() -> None:

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
-if sys.version_info < (3, 6, 0):
-    print("OoT Randomizer requires Python version 3.6 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
+if sys.version_info < (3, 7, 0):
+    print("OoT Randomizer requires Python version 3.7 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
     sys.exit(1)
 
 import datetime

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
-if sys.version_info < (3, 7, 0):
-    print("OoT Randomizer requires Python version 3.7 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
+if sys.version_info < (3, 8):
+    print("OoT Randomizer requires Python version 3.8 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
     sys.exit(1)
 
 import datetime

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
+import sys
+if sys.version_info < (3, 6, 0):
+    print("OoT Randomizer requires Python version 3.6 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))
+    sys.exit(1)
+
 import argparse
 import os
 import logging
 import textwrap
 import time
 import datetime
-import sys
-
-from Gui import guiMain
-from Main import main, from_patch_file, cosmetic_patch, diff_roms
-from Utils import check_version, VersionError, check_python_version, local_path
-from Settings import get_settings_from_command_line_args
 
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
-
     def _get_help_string(self, action):
         return textwrap.dedent(action.help)
 
 
 def start():
-
+    from Main import main, from_patch_file, cosmetic_patch, diff_roms
+    from Settings import get_settings_from_command_line_args
+    from Utils import check_version, VersionError, local_path
     settings, gui, args_loglevel, no_log_file, diff_rom = get_settings_from_command_line_args()
 
     # set up logger
@@ -48,14 +48,15 @@ def start():
 
     try:
         if gui:
-            guiMain()
+            from Gui import gui_main
+            gui_main()
         elif diff_rom:
             diff_roms(settings, diff_rom)
         elif settings.cosmetics_only:
             cosmetic_patch(settings)
         elif settings.patch_file != '':
             from_patch_file(settings)
-        elif settings.count != None and settings.count > 1:
+        elif settings.count is not None and settings.count > 1:
             orig_seed = settings.seed
             for i in range(settings.count):
                 settings.update_seed(orig_seed + '-' + str(i))
@@ -68,5 +69,4 @@ def start():
 
 
 if __name__ == '__main__':
-    check_python_version()
     start()

--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -5,11 +5,11 @@ if sys.version_info < (3, 6, 0):
     sys.exit(1)
 
 import argparse
-import os
+import datetime
 import logging
+import os
 import textwrap
 import time
-import datetime
 
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
@@ -17,7 +17,7 @@ class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
         return textwrap.dedent(action.help)
 
 
-def start():
+def start() -> None:
     from Main import main, from_patch_file, cosmetic_patch, diff_roms
     from Settings import get_settings_from_command_line_args
     from Utils import check_version, VersionError, local_path

--- a/Patches.py
+++ b/Patches.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import datetime
 import itertools
 import random
@@ -5,7 +6,8 @@ import re
 import struct
 import sys
 import zlib
-from typing import Dict, List, Iterable, Tuple, Set, Callable, Optional, Any
+from collections.abc import Callable, Iterable
+from typing import Optional, Any
 
 from Entrance import Entrance
 from HintList import get_hint
@@ -35,7 +37,7 @@ if sys.version_info >= (3, 10):
 else:
     TypeAlias = str
 
-OverrideEntry: TypeAlias = Tuple[int, int, int, int, int, int]
+OverrideEntry: TypeAlias = "tuple[int, int, int, int, int, int]"
 
 
 def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
@@ -231,7 +233,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         rom.write_int32(rom.sym('FREE_BOMBCHU_DROPS'), 1)
 
     # show seed info on file select screen
-    def make_bytes(txt: str, size: int) -> List[int]:
+    def make_bytes(txt: str, size: int) -> list[int]:
         bytes = list(ord(c) for c in txt[:size-1]) + [0] * size
         return bytes[:size]
 
@@ -911,7 +913,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
 
     exit_updates = []
 
-    def generate_exit_lookup_table() -> Dict[int, List[int]]:
+    def generate_exit_lookup_table() -> dict[int, list[int]]:
         # Assumes that the last exit on a scene's exit list cannot be 0000
         exit_table = {
             0x0028: [0xAC95C2]  # Jabu with the fish is entered from a cutscene hardcode
@@ -2031,7 +2033,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     rom.write_int16s(0x3417400, list(shop_objs))
 
     # Scrub text stuff.
-    def update_scrub_text(message: bytearray, text_replacement: List[str], default_price: int, price: int,
+    def update_scrub_text(message: bytearray, text_replacement: list[str], default_price: int, price: int,
                           item_name: Optional[str] = None) -> bytearray:
         scrub_strip_text = ["some ", "1 piece   ", "5 pieces   ", "30 pieces   "]
         for text in scrub_strip_text:
@@ -2538,20 +2540,20 @@ def add_to_extended_object_table(rom: Rom, object_id: int, start_adddress: int, 
 
 
 item_row_struct = struct.Struct('>BBHHBBIIhhBxxxI') # Match item_row_t in item_table.h
-item_row_fields = [
+item_row_fields: list[str] = [
     'base_item_id', 'action_id', 'text_id', 'object_id', 'graphic_id', 'chest_type',
     'upgrade_fn', 'effect_fn', 'effect_arg1', 'effect_arg2', 'collectible', 'alt_text_fn',
 ]
 
 
-def read_rom_item(rom: Rom, item_id: int) -> Dict[str, Any]:
+def read_rom_item(rom: Rom, item_id: int) -> dict[str, Any]:
     addr = rom.sym('item_table') + (item_id * item_row_struct.size)
     row_bytes = rom.read_bytes(addr, item_row_struct.size)
     row = item_row_struct.unpack(row_bytes)
     return { item_row_fields[i]: row[i] for i in range(len(item_row_fields)) }
 
 
-def write_rom_item(rom: Rom, item_id: int, item: Dict[str, Any]) -> None:
+def write_rom_item(rom: Rom, item_id: int, item: dict[str, Any]) -> None:
     addr = rom.sym('item_table') + (item_id * item_row_struct.size)
     row = [item[f] for f in item_row_fields]
     row_bytes = item_row_struct.pack(*row)
@@ -2559,17 +2561,17 @@ def write_rom_item(rom: Rom, item_id: int, item: Dict[str, Any]) -> None:
 
 
 texture_struct = struct.Struct('>HBxxxxxII')  # Match texture_t in textures.c
-texture_fields: List[str] = ['texture_id', 'file_buf', 'file_vrom_start', 'file_size']
+texture_fields: list[str] = ['texture_id', 'file_buf', 'file_vrom_start', 'file_size']
 
 
-def read_rom_texture(rom: Rom, texture_id: int) -> Dict[str, Any]:
+def read_rom_texture(rom: Rom, texture_id: int) -> dict[str, Any]:
     addr = rom.sym('texture_table') + (texture_id * texture_struct.size)
     row_bytes = rom.read_bytes(addr, texture_struct.size)
     row = texture_struct.unpack(row_bytes)
     return {texture_fields[i]: row[i] for i in range(len(texture_fields))}
 
 
-def write_rom_texture(rom: Rom, texture_id: int, texture: Dict[str, Any]) -> None:
+def write_rom_texture(rom: Rom, texture_id: int, texture: dict[str, Any]) -> None:
     addr = rom.sym('texture_table') + (texture_id * texture_struct.size)
     row = [texture[f] for f in texture_fields]
     row_bytes = texture_struct.pack(*row)
@@ -2645,7 +2647,7 @@ def check_location_dupes(world: World) -> None:
                 raise Exception(f'Discovered duplicate location: {check_i.name}')
 
 
-chestTypeMap: Dict[int, List[int]] = {
+chestTypeMap: dict[int, list[int]] = {
     #         small   big     boss
     0x0000: [0x5000, 0x0000, 0x2000],  # Large
     0x1000: [0x7000, 0x1000, 0x1000],  # Large, Appears, Clear Flag
@@ -2667,7 +2669,7 @@ chestTypeMap: Dict[int, List[int]] = {
 
 
 def room_get_actors(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any], room_data: int, scene: int,
-                    alternate: Optional[int] = None) -> Dict[int, Any]:
+                    alternate: Optional[int] = None) -> dict[int, Any]:
     actors = {}
     room_start = alternate if alternate else room_data
     command = 0
@@ -2694,7 +2696,7 @@ def room_get_actors(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any], r
 
 
 def scene_get_actors(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any], scene_data: int, scene: int,
-                     alternate: Optional[int] = None, processed_rooms: Optional[List[int]] = None) -> Dict[int, Any]:
+                     alternate: Optional[int] = None, processed_rooms: Optional[list[int]] = None) -> dict[int, Any]:
     if processed_rooms is None:
         processed_rooms = []
     actors = {}
@@ -2733,7 +2735,7 @@ def scene_get_actors(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any], 
     return actors
 
 
-def get_actor_list(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any]) -> Dict[int, Any]:
+def get_actor_list(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any]) -> dict[int, Any]:
     actors = {}
     scene_table = 0x00B71440
     for scene in range(0x00, 0x65):
@@ -2858,8 +2860,8 @@ def move_fado_in_lost_woods(rom):
 # If boss keys are set to remove, returns boss key doors
 # If ganons boss key is set to remove, returns ganons boss key doors
 # If pot/crate shuffle is enabled, returns the first ganon's boss key door so that it can be unlocked separately to allow access to the room w/ the pots..
-def get_doors_to_unlock(rom: Rom, world: World) -> Dict[int, List[int]]:
-    def get_door_to_unlock(rom: Rom, actor_id: int, actor: int, scene: int) -> List[int]:
+def get_doors_to_unlock(rom: Rom, world: World) -> dict[int, list[int]]:
+    def get_door_to_unlock(rom: Rom, actor_id: int, actor: int, scene: int) -> list[int]:
         actor_var = rom.read_int16(actor + 14)
         door_type = actor_var >> 6
         switch_flag = actor_var & 0x003F
@@ -2886,7 +2888,7 @@ def get_doors_to_unlock(rom: Rom, world: World) -> Dict[int, List[int]]:
 def create_fake_name(name: str) -> str:
     vowels = 'aeiou'
     list_name = list(name)
-    vowel_indexes = [i for i,c in enumerate(list_name) if c in vowels]
+    vowel_indexes = [i for i, c in enumerate(list_name) if c in vowels]
     for i in random.sample(vowel_indexes, min(2, len(vowel_indexes))):
         c = list_name[i]
         list_name[i] = random.choice([v for v in vowels if v != c])
@@ -2901,7 +2903,7 @@ def create_fake_name(name: str) -> str:
     return new_name
 
 
-def place_shop_items(rom: Rom, world: World, shop_items, messages, locations, init_shop_id: bool = False) -> Set[int]:
+def place_shop_items(rom: Rom, world: World, shop_items, messages, locations, init_shop_id: bool = False) -> set[int]:
     if init_shop_id:
         place_shop_items.shop_id = 0x32
 
@@ -2950,9 +2952,9 @@ def place_shop_items(rom: Rom, world: World, shop_items, messages, locations, in
             # give it and set this as sold out.
             # With complete mask quest, it's free to take normally
             if not world.settings.complete_mask_quest and \
-              ((location.vanilla_item == 'Mask of Truth' and 'Mask of Truth' in world.settings.shuffle_child_trade) or \
-               ('mask_shop' in world.settings.misc_hints and location.vanilla_item == 'Goron Mask' and 'Goron Mask' in world.settings.shuffle_child_trade) or \
-               ('mask_shop' in world.settings.misc_hints and location.vanilla_item == 'Zora Mask' and 'Zora Mask' in world.settings.shuffle_child_trade) or \
+              ((location.vanilla_item == 'Mask of Truth' and 'Mask of Truth' in world.settings.shuffle_child_trade) or
+               ('mask_shop' in world.settings.misc_hints and location.vanilla_item == 'Goron Mask' and 'Goron Mask' in world.settings.shuffle_child_trade) or
+               ('mask_shop' in world.settings.misc_hints and location.vanilla_item == 'Zora Mask' and 'Zora Mask' in world.settings.shuffle_child_trade) or
                ('mask_shop' in world.settings.misc_hints and location.vanilla_item == 'Gerudo Mask' and 'Gerudo Mask' in world.settings.shuffle_child_trade)):
                 shop_item.func2 = 0x80863714  # override to custom CanBuy function to prevent purchase before trade quest complete
 

--- a/Patches.py
+++ b/Patches.py
@@ -28,7 +28,7 @@ from texture_util import ci4_rgba16patch_to_ci8, rgba16_patch
 from SettingsList import setting_infos
 
 
-def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
+def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     with open(data_path('generated/rom_patch.txt'), 'r') as stream:
         for line in stream:
             address, value = [int(x, 16) for x in line.split(',')]
@@ -160,9 +160,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_byte(symbol, 0x01)
 
     # Remove color commands inside certain object display lists
-    rom.write_int32s(0x1455818, [0x00000000, 0x00000000, 0x00000000, 0x00000000]) # Small Key
-    rom.write_int32s(0x14B9CB8, [0x00000000, 0x00000000, 0x00000000, 0x00000000]) # Boss Key (Key)
-    rom.write_int32s(0x14B9F20, [0x00000000, 0x00000000, 0x00000000, 0x00000000]) # Boss Key (Gem)
+    rom.write_int32s(0x1455818, [0x00000000, 0x00000000, 0x00000000, 0x00000000])  # Small Key
+    rom.write_int32s(0x14B9CB8, [0x00000000, 0x00000000, 0x00000000, 0x00000000])  # Boss Key (Key)
+    rom.write_int32s(0x14B9F20, [0x00000000, 0x00000000, 0x00000000, 0x00000000])  # Boss Key (Gem)
 
     # Force language to be English in the event a Japanese rom was submitted
     rom.write_byte(0x3E, 0x45)
@@ -190,7 +190,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_byte(0xE12ADD, 0x00)
 
     # Fix deku theater rewards to be static
-    rom.write_bytes(0xEC9A7C, [0x00, 0x00, 0x00, 0x00]) #Sticks
+    rom.write_bytes(0xEC9A7C, [0x00, 0x00, 0x00, 0x00])  #Sticks
     rom.write_byte(0xEC9CD5, 0x00) #Nuts
 
     # Fix deku scrub who sells stick upgrade
@@ -332,19 +332,19 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         rom.write_byte(rom.sym('SONGS_AS_ITEMS'), 1)
 
     # Speed learning Zelda's Lullaby
-    rom.write_int32s(0x02E8E90C, [0x000003E8, 0x00000001]) # Terminator Execution
+    rom.write_int32s(0x02E8E90C, [0x000003E8, 0x00000001])  # Terminator Execution
     if songs_as_items:
-        rom.write_int16s(None, [0x0073, 0x001, 0x0002, 0x0002]) # ID, start, end, end
+        rom.write_int16s(None, [0x0073, 0x001, 0x0002, 0x0002])  # ID, start, end, end
     else:
-        rom.write_int16s(None, [0x0073, 0x003B, 0x003C, 0x003C]) # ID, start, end, end
+        rom.write_int16s(None, [0x0073, 0x003B, 0x003C, 0x003C])  # ID, start, end, end
 
 
-    rom.write_int32s(0x02E8E91C, [0x00000013, 0x0000000C]) # Textbox, Count
+    rom.write_int32s(0x02E8E91C, [0x00000013, 0x0000000C])  # Textbox, Count
     if songs_as_items:
-        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
     else:
-        rom.write_int16s(None, [0x0017, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x00D4, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0x0017, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x00D4, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     # Speed learning Sun's Song
     if songs_as_items:
@@ -352,9 +352,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x0332A4A4, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x0332A868, [0x00000013, 0x00000008]) # Textbox, Count
-    rom.write_int16s(None, [0x0018, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x00D3, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x0332A868, [0x00000013, 0x00000008])  # Textbox, Count
+    rom.write_int16s(None, [0x0018, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x00D3, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     # Speed learning Saria's Song
     if songs_as_items:
@@ -362,44 +362,44 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x020B1734, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x20B1DA8, [0x00000013, 0x0000000C]) # Textbox, Count
-    rom.write_int16s(None, [0x0015, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x00D1, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x20B1DA8, [0x00000013, 0x0000000C])  # Textbox, Count
+    rom.write_int16s(None, [0x0015, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x00D1, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x020B19C0, [0x0000000A, 0x00000006]) # Link, Count
-    rom.write_int16s(0x020B19C8, [0x0011, 0x0000, 0x0010, 0x0000]) #action, start, end, ????
-    rom.write_int16s(0x020B19F8, [0x003E, 0x0011, 0x0020, 0x0000]) #action, start, end, ????
-    rom.write_int32s(None,         [0x80000000,                          # ???
-                                     0x00000000, 0x000001D4, 0xFFFFF731,  # start_XYZ
-                                     0x00000000, 0x000001D4, 0xFFFFF712]) # end_XYZ
+    rom.write_int32s(0x020B19C0, [0x0000000A, 0x00000006])  # Link, Count
+    rom.write_int16s(0x020B19C8, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x020B19F8, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
+    rom.write_int32s(None, [0x80000000,  # ???
+                            0x00000000, 0x000001D4, 0xFFFFF731,  # start_XYZ
+                            0x00000000, 0x000001D4, 0xFFFFF712])  # end_XYZ
 
     # Speed learning Epona's Song
-    rom.write_int32s(0x029BEF60, [0x000003E8, 0x00000001]) # Terminator Execution
+    rom.write_int32s(0x029BEF60, [0x000003E8, 0x00000001])  # Terminator Execution
     if songs_as_items:
-        rom.write_int16s(None, [0x005E, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
+        rom.write_int16s(None, [0x005E, 0x0001, 0x0002, 0x0002])  # ID, start, end, end
     else:
-        rom.write_int16s(None, [0x005E, 0x000A, 0x000B, 0x000B]) # ID, start, end, end
+        rom.write_int16s(None, [0x005E, 0x000A, 0x000B, 0x000B])  # ID, start, end, end
 
-    rom.write_int32s(0x029BECB0, [0x00000013, 0x00000002]) # Textbox, Count
+    rom.write_int32s(0x029BECB0, [0x00000013, 0x00000002])  # Textbox, Count
     if songs_as_items:
-        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0009, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0009, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
     else:
-        rom.write_int16s(None, [0x00D2, 0x0000, 0x0009, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0xFFFF, 0x000A, 0x003C, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0x00D2, 0x0000, 0x0009, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0xFFFF, 0x000A, 0x003C, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     # Speed learning Song of Time
-    rom.write_int32s(0x0252FB98, [0x000003E8, 0x00000001]) # Terminator Execution
+    rom.write_int32s(0x0252FB98, [0x000003E8, 0x00000001])  # Terminator Execution
     if songs_as_items:
-        rom.write_int16s(None, [0x0035, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
+        rom.write_int16s(None, [0x0035, 0x0001, 0x0002, 0x0002])  # ID, start, end, end
     else:
-        rom.write_int16s(None, [0x0035, 0x003B, 0x003C, 0x003C]) # ID, start, end, end
+        rom.write_int16s(None, [0x0035, 0x003B, 0x003C, 0x003C])  # ID, start, end, end
 
-    rom.write_int32s(0x0252FC80, [0x00000013, 0x0000000C]) # Textbox, Count
+    rom.write_int32s(0x0252FC80, [0x00000013, 0x0000000C])  # Textbox, Count
     if songs_as_items:
-        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
     else:
-        rom.write_int16s(None, [0x0019, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x00D5, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0x0019, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x00D5, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     rom.write_int32(0x01FC3B84, 0xFFFFFFFF) # Other Header?: frame_count
 
@@ -409,9 +409,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x03041084, 0x0000000A) # Header: frame_count
 
-    rom.write_int32s(0x03041088, [0x00000013, 0x00000002]) # Textbox, Count
-    rom.write_int16s(None, [0x00D6, 0x0000, 0x0009, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0xFFFF, 0x00BE, 0x00C8, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x03041088, [0x00000013, 0x00000002])  # Textbox, Count
+    rom.write_int16s(None, [0x00D6, 0x0000, 0x0009, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0xFFFF, 0x00BE, 0x00C8, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     # Speed learning Minuet of Forest
     if songs_as_items:
@@ -419,19 +419,19 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x020AFF84, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x020B0800, [0x00000013, 0x0000000A]) # Textbox, Count
-    rom.write_int16s(None, [0x000F, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x0073, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x020B0800, [0x00000013, 0x0000000A])  # Textbox, Count
+    rom.write_int16s(None, [0x000F, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x0073, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x020AFF88, [0x0000000A, 0x00000005]) # Link, Count
-    rom.write_int16s(0x020AFF90, [0x0011, 0x0000, 0x0010, 0x0000]) #action, start, end, ????
-    rom.write_int16s(0x020AFFC1, [0x003E, 0x0011, 0x0020, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x020AFF88, [0x0000000A, 0x00000005])  # Link, Count
+    rom.write_int16s(0x020AFF90, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x020AFFC1, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
 
-    rom.write_int32s(0x020B0488, [0x00000056, 0x00000001]) # Music Change, Count
-    rom.write_int16s(None, [0x003F, 0x0021, 0x0022, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x020B0488, [0x00000056, 0x00000001])  # Music Change, Count
+    rom.write_int16s(None, [0x003F, 0x0021, 0x0022, 0x0000])  #action, start, end, ????
 
-    rom.write_int32s(0x020B04C0, [0x0000007C, 0x00000001]) # Music Fade Out, Count
-    rom.write_int16s(None, [0x0004, 0x0000, 0x0000, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x020B04C0, [0x0000007C, 0x00000001])  # Music Fade Out, Count
+    rom.write_int16s(None, [0x0004, 0x0000, 0x0000, 0x0000])  #action, start, end, ????
 
     # Speed learning Bolero of Fire
     if songs_as_items:
@@ -439,19 +439,19 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x0224B5D4, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x0224D7E8, [0x00000013, 0x0000000A]) # Textbox, Count
-    rom.write_int16s(None, [0x0010, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x0074, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x0224D7E8, [0x00000013, 0x0000000A])  # Textbox, Count
+    rom.write_int16s(None, [0x0010, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x0074, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x0224B5D8, [0x0000000A, 0x0000000B]) # Link, Count
-    rom.write_int16s(0x0224B5E0, [0x0011, 0x0000, 0x0010, 0x0000]) #action, start, end, ????
-    rom.write_int16s(0x0224B610, [0x003E, 0x0011, 0x0020, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x0224B5D8, [0x0000000A, 0x0000000B])  # Link, Count
+    rom.write_int16s(0x0224B5E0, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x0224B610, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
 
-    rom.write_int32s(0x0224B7F0, [0x0000002F, 0x0000000E]) # Sheik, Count
-    rom.write_int16s(0x0224B7F8, [0x0000]) #action
-    rom.write_int16s(0x0224B828, [0x0000]) #action
-    rom.write_int16s(0x0224B858, [0x0000]) #action
-    rom.write_int16s(0x0224B888, [0x0000]) #action
+    rom.write_int32s(0x0224B7F0, [0x0000002F, 0x0000000E])  # Sheik, Count
+    rom.write_int16s(0x0224B7F8, [0x0000])  #action
+    rom.write_int16s(0x0224B828, [0x0000])  #action
+    rom.write_int16s(0x0224B858, [0x0000])  #action
+    rom.write_int16s(0x0224B888, [0x0000])  #action
 
     # Speed learning Serenade of Water
     if songs_as_items:
@@ -459,65 +459,65 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x02BEB254, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x02BEC880, [0x00000013, 0x00000010]) # Textbox, Count
-    rom.write_int16s(None, [0x0011, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x0075, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x02BEC880, [0x00000013, 0x00000010])  # Textbox, Count
+    rom.write_int16s(None, [0x0011, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x0075, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x02BEB258, [0x0000000A, 0x0000000F]) # Link, Count
-    rom.write_int16s(0x02BEB260, [0x0011, 0x0000, 0x0010, 0x0000]) #action, start, end, ????
-    rom.write_int16s(0x02BEB290, [0x003E, 0x0011, 0x0020, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x02BEB258, [0x0000000A, 0x0000000F])  # Link, Count
+    rom.write_int16s(0x02BEB260, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x02BEB290, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
 
-    rom.write_int32s(0x02BEB530, [0x0000002F, 0x00000006]) # Sheik, Count
-    rom.write_int16s(0x02BEB538, [0x0000, 0x0000, 0x018A, 0x0000]) #action, start, end, ????
-    rom.write_int32s(None,         [0x1BBB0000,                          # ???
-                                     0xFFFFFB10, 0x8000011A, 0x00000330,  # start_XYZ
-                                     0xFFFFFB10, 0x8000011A, 0x00000330]) # end_XYZ
+    rom.write_int32s(0x02BEB530, [0x0000002F, 0x00000006])  # Sheik, Count
+    rom.write_int16s(0x02BEB538, [0x0000, 0x0000, 0x018A, 0x0000])  #action, start, end, ????
+    rom.write_int32s(None, [0x1BBB0000,  # ???
+                            0xFFFFFB10, 0x8000011A, 0x00000330,  # start_XYZ
+                            0xFFFFFB10, 0x8000011A, 0x00000330])  # end_XYZ
 
-    rom.write_int32s(0x02BEC848, [0x00000056, 0x00000001]) # Music Change, Count
-    rom.write_int16s(None, [0x0059, 0x0021, 0x0022, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x02BEC848, [0x00000056, 0x00000001])  # Music Change, Count
+    rom.write_int16s(None, [0x0059, 0x0021, 0x0022, 0x0000])  #action, start, end, ????
 
     # Speed learning Nocturne of Shadow
-    rom.write_int32s(0x01FFE458, [0x000003E8, 0x00000001]) # Other Scene? Terminator Execution
-    rom.write_int16s(None, [0x002F, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
+    rom.write_int32s(0x01FFE458, [0x000003E8, 0x00000001])  # Other Scene? Terminator Execution
+    rom.write_int16s(None, [0x002F, 0x0001, 0x0002, 0x0002])  # ID, start, end, end
 
     rom.write_int32(0x01FFFDF4, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x02000FD8, [0x00000013, 0x0000000E]) # Textbox, Count
+    rom.write_int32s(0x02000FD8, [0x00000013, 0x0000000E])  # Textbox, Count
     if songs_as_items:
-        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
     else:
-        rom.write_int16s(None, [0x0013, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x0077, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0x0013, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x0077, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x02000128, [0x000003E8, 0x00000001]) # Terminator Execution
+    rom.write_int32s(0x02000128, [0x000003E8, 0x00000001])  # Terminator Execution
     if songs_as_items:
-        rom.write_int16s(None, [0x0032, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
+        rom.write_int16s(None, [0x0032, 0x0001, 0x0002, 0x0002])  # ID, start, end, end
     else:
-        rom.write_int16s(None, [0x0032, 0x003A, 0x003B, 0x003B]) # ID, start, end, end
+        rom.write_int16s(None, [0x0032, 0x003A, 0x003B, 0x003B])  # ID, start, end, end
 
     # Speed learning Requiem of Spirit
     rom.write_int32(0x0218AF14, 0x0000003C) # Header: frame_count
 
-    rom.write_int32s(0x0218C574, [0x00000013, 0x00000008]) # Textbox, Count
+    rom.write_int32s(0x0218C574, [0x00000013, 0x00000008])  # Textbox, Count
     if songs_as_items:
-        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
     else:
-        rom.write_int16s(None, [0x0012, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x0076, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+        rom.write_int16s(None, [0x0012, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x0076, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x0218B478, [0x000003E8, 0x00000001]) # Terminator Execution
+    rom.write_int32s(0x0218B478, [0x000003E8, 0x00000001])  # Terminator Execution
     if songs_as_items:
-        rom.write_int16s(None, [0x0030, 0x0001, 0x0002, 0x0002]) # ID, start, end, end
+        rom.write_int16s(None, [0x0030, 0x0001, 0x0002, 0x0002])  # ID, start, end, end
     else:
-        rom.write_int16s(None, [0x0030, 0x003A, 0x003B, 0x003B]) # ID, start, end, end
+        rom.write_int16s(None, [0x0030, 0x003A, 0x003B, 0x003B])  # ID, start, end, end
 
-    rom.write_int32s(0x0218AF18, [0x0000000A, 0x0000000B]) # Link, Count
-    rom.write_int16s(0x0218AF20, [0x0011, 0x0000, 0x0010, 0x0000]) #action, start, end, ????
-    rom.write_int32s(None,         [0x40000000,                          # ???
-                                     0xFFFFFAF9, 0x00000008, 0x00000001,  # start_XYZ
-                                     0xFFFFFAF9, 0x00000008, 0x00000001,  # end_XYZ
-                                     0x0F671408, 0x00000000, 0x00000001]) # normal_XYZ
-    rom.write_int16s(0x0218AF50, [0x003E, 0x0011, 0x0020, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x0218AF18, [0x0000000A, 0x0000000B])  # Link, Count
+    rom.write_int16s(0x0218AF20, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
+    rom.write_int32s(None, [0x40000000,  # ???
+                            0xFFFFFAF9, 0x00000008, 0x00000001,  # start_XYZ
+                            0xFFFFFAF9, 0x00000008, 0x00000001,  # end_XYZ
+                            0x0F671408, 0x00000000, 0x00000001])  # normal_XYZ
+    rom.write_int16s(0x0218AF50, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
 
     # Speed learning Prelude of Light
     if songs_as_items:
@@ -525,15 +525,15 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     else:
         rom.write_int32(0x0252FD24, 0x0000004A) # Header: frame_count
 
-    rom.write_int32s(0x02531320, [0x00000013, 0x0000000E]) # Textbox, Count
-    rom.write_int16s(None, [0x0014, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF]) # ID, start, end, type, alt1, alt2
-    rom.write_int16s(None, [0x0078, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF]) # ID, start, end, type, alt1, alt2
+    rom.write_int32s(0x02531320, [0x00000013, 0x0000000E])  # Textbox, Count
+    rom.write_int16s(None, [0x0014, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
+    rom.write_int16s(None, [0x0078, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32s(0x0252FF10, [0x0000002F, 0x00000009]) # Sheik, Count
-    rom.write_int16s(0x0252FF18, [0x0006, 0x0000, 0x0000, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x0252FF10, [0x0000002F, 0x00000009])  # Sheik, Count
+    rom.write_int16s(0x0252FF18, [0x0006, 0x0000, 0x0000, 0x0000])  #action, start, end, ????
 
-    rom.write_int32s(0x025313D0, [0x00000056, 0x00000001]) # Music Change, Count
-    rom.write_int16s(None, [0x003B, 0x0021, 0x0022, 0x0000]) #action, start, end, ????
+    rom.write_int32s(0x025313D0, [0x00000056, 0x00000001])  # Music Change, Count
+    rom.write_int16s(None, [0x003B, 0x0021, 0x0022, 0x0000])  #action, start, end, ????
 
     # Speed scene after Deku Tree
     rom.write_bytes(0x2077E20, [0x00, 0x07, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02])
@@ -584,7 +584,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_byte(0x2F5B559, 0x04)
     rom.write_byte(0x2F5B621, 0x04)
     rom.write_byte(0x2F5B761, 0x07)
-    rom.write_bytes(0x2F5B840, [0x00, 0x05, 0x00, 0x01, 0x00, 0x05, 0x00, 0x05]) #shorten white flash
+    rom.write_bytes(0x2F5B840, [0x00, 0x05, 0x00, 0x01, 0x00, 0x05, 0x00, 0x05])  #shorten white flash
 
     # Speed scene with all medallions
     rom.write_bytes(0x2512680, [0x00, 0x74, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02])
@@ -622,12 +622,12 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_bytes(0xE84C80, [0x10, 0x00])
 
     # Speed completion of the trials in Ganon's Castle
-    rom.write_int16s(0x31A8090, [0x006B, 0x0001, 0x0002, 0x0002]) #Forest
-    rom.write_int16s(0x31A9E00, [0x006E, 0x0001, 0x0002, 0x0002]) #Fire
-    rom.write_int16s(0x31A8B18, [0x006C, 0x0001, 0x0002, 0x0002]) #Water
-    rom.write_int16s(0x31A9430, [0x006D, 0x0001, 0x0002, 0x0002]) #Shadow
-    rom.write_int16s(0x31AB200, [0x0070, 0x0001, 0x0002, 0x0002]) #Spirit
-    rom.write_int16s(0x31AA830, [0x006F, 0x0001, 0x0002, 0x0002]) #Light
+    rom.write_int16s(0x31A8090, [0x006B, 0x0001, 0x0002, 0x0002])  #Forest
+    rom.write_int16s(0x31A9E00, [0x006E, 0x0001, 0x0002, 0x0002])  #Fire
+    rom.write_int16s(0x31A8B18, [0x006C, 0x0001, 0x0002, 0x0002])  #Water
+    rom.write_int16s(0x31A9430, [0x006D, 0x0001, 0x0002, 0x0002])  #Shadow
+    rom.write_int16s(0x31AB200, [0x0070, 0x0001, 0x0002, 0x0002])  #Spirit
+    rom.write_int16s(0x31AA830, [0x006F, 0x0001, 0x0002, 0x0002])  #Light
 
     # Speed obtaining Fairy Ocarina
     rom.write_bytes(0x2151230, [0x00, 0x72, 0x00, 0x3C, 0x00, 0x3D, 0x00, 0x3D])
@@ -665,26 +665,26 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_bytes(0x292D924, [0xFF, 0xFF, 0x00, 0x14, 0x00, 0x96, 0xFF, 0xFF])
 
     #Speed Pushing of All Pushable Objects
-    rom.write_bytes(0xDD2B86, [0x40, 0x80])             #block speed
-    rom.write_bytes(0xDD2D26, [0x00, 0x01])             #block delay
-    rom.write_bytes(0xDD9682, [0x40, 0x80])             #milk crate speed
-    rom.write_bytes(0xDD981E, [0x00, 0x01])             #milk crate delay
-    rom.write_bytes(0xCE1BD0, [0x40, 0x80, 0x00, 0x00]) #amy puzzle speed
-    rom.write_bytes(0xCE0F0E, [0x00, 0x01])             #amy puzzle delay
-    rom.write_bytes(0xC77CA8, [0x40, 0x80, 0x00, 0x00]) #fire block speed
-    rom.write_bytes(0xC770C2, [0x00, 0x01])             #fire block delay
-    rom.write_bytes(0xCC5DBC, [0x29, 0xE1, 0x00, 0x01]) #forest basement puzzle delay
-    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x00]) #spirit cobra mirror startup
-    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x01]) #spirit cobra mirror delay
-    rom.write_bytes(0xDBA230, [0x28, 0x41, 0x00, 0x19]) #truth spinner speed
-    rom.write_bytes(0xDBA3A4, [0x24, 0x18, 0x00, 0x00]) #truth spinner delay
+    rom.write_bytes(0xDD2B86, [0x40, 0x80])  #block speed
+    rom.write_bytes(0xDD2D26, [0x00, 0x01])  #block delay
+    rom.write_bytes(0xDD9682, [0x40, 0x80])  #milk crate speed
+    rom.write_bytes(0xDD981E, [0x00, 0x01])  #milk crate delay
+    rom.write_bytes(0xCE1BD0, [0x40, 0x80, 0x00, 0x00])  #amy puzzle speed
+    rom.write_bytes(0xCE0F0E, [0x00, 0x01])  #amy puzzle delay
+    rom.write_bytes(0xC77CA8, [0x40, 0x80, 0x00, 0x00])  #fire block speed
+    rom.write_bytes(0xC770C2, [0x00, 0x01])  #fire block delay
+    rom.write_bytes(0xCC5DBC, [0x29, 0xE1, 0x00, 0x01])  #forest basement puzzle delay
+    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x00])  #spirit cobra mirror startup
+    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x01])  #spirit cobra mirror delay
+    rom.write_bytes(0xDBA230, [0x28, 0x41, 0x00, 0x19])  #truth spinner speed
+    rom.write_bytes(0xDBA3A4, [0x24, 0x18, 0x00, 0x00])  #truth spinner delay
 
     #Speed Deku Seed Upgrade Scrub Cutscene
-    rom.write_bytes(0xECA900, [0x24, 0x03, 0xC0, 0x00]) #scrub angle
-    rom.write_bytes(0xECAE90, [0x27, 0x18, 0xFD, 0x04]) #skip straight to giving item
-    rom.write_bytes(0xECB618, [0x25, 0x6B, 0x00, 0xD4]) #skip straight to digging back in
-    rom.write_bytes(0xECAE70, [0x00, 0x00, 0x00, 0x00]) #never initialize cs camera
-    rom.write_bytes(0xE5972C, [0x24, 0x08, 0x00, 0x01]) #timer set to 1 frame for giving item
+    rom.write_bytes(0xECA900, [0x24, 0x03, 0xC0, 0x00])  #scrub angle
+    rom.write_bytes(0xECAE90, [0x27, 0x18, 0xFD, 0x04])  #skip straight to giving item
+    rom.write_bytes(0xECB618, [0x25, 0x6B, 0x00, 0xD4])  #skip straight to digging back in
+    rom.write_bytes(0xECAE70, [0x00, 0x00, 0x00, 0x00])  #never initialize cs camera
+    rom.write_bytes(0xE5972C, [0x24, 0x08, 0x00, 0x01])  #timer set to 1 frame for giving item
 
     # Remove remaining owls
     rom.write_bytes(0x1FE30CE, [0x01, 0x4B])
@@ -712,10 +712,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_bytes(0x275906E, [0xFF, 0xB3, 0xFB, 0x20, 0xF9, 0x56])
 
     #Move fire/forest temple switches down 1 unit to make it easier to press
-    rom.write_bytes(0x24860A8, [0xFC, 0xF4]) #forest basement 1
-    rom.write_bytes(0x24860C8, [0xFC, 0xF4]) #forest basement 2
-    rom.write_bytes(0x24860E8, [0xFC, 0xF4]) #forest basement 3
-    rom.write_bytes(0x236C148, [0x11, 0x93]) #fire hammer room
+    rom.write_bytes(0x24860A8, [0xFC, 0xF4])  #forest basement 1
+    rom.write_bytes(0x24860C8, [0xFC, 0xF4])  #forest basement 2
+    rom.write_bytes(0x24860E8, [0xFC, 0xF4])  #forest basement 3
+    rom.write_bytes(0x236C148, [0x11, 0x93])  #fire hammer room
 
     # Speed up Epona race start
     rom.write_bytes(0x29BE984, [0x00, 0x00, 0x00, 0x02])
@@ -842,9 +842,12 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_bytes(0xE2D440, [0x24, 0x19, 0x00, 0x00])
 
     # Offset kakariko carpenter starting position
-    rom.write_bytes(0x1FF93A4, [0x01, 0x8D, 0x00, 0x11, 0x01, 0x6C, 0xFF, 0x92, 0x00, 0x00, 0x01, 0x78, 0xFF, 0x2E, 0x00, 0x00, 0x00, 0x03, 0xFD, 0x2B, 0x00, 0xC8, 0xFF, 0xF9, 0xFD, 0x03, 0x00, 0xC8, 0xFF, 0xA9, 0xFD, 0x5D, 0x00, 0xC8, 0xFE, 0x5F]) # re order the carpenter's path
+    rom.write_bytes(0x1FF93A4,
+                    [0x01, 0x8D, 0x00, 0x11, 0x01, 0x6C, 0xFF, 0x92, 0x00, 0x00, 0x01, 0x78, 0xFF, 0x2E, 0x00, 0x00,
+                     0x00, 0x03, 0xFD, 0x2B, 0x00, 0xC8, 0xFF, 0xF9, 0xFD, 0x03, 0x00, 0xC8, 0xFF, 0xA9, 0xFD, 0x5D,
+                     0x00, 0xC8, 0xFE, 0x5F])  # re order the carpenter's path
     rom.write_byte(0x1FF93D0, 0x06) # set the path points to 6
-    rom.write_bytes(0x20160B6, [0x01, 0x8D, 0x00, 0x11, 0x01, 0x6C]) # set the carpenter's start position
+    rom.write_bytes(0x20160B6, [0x01, 0x8D, 0x00, 0x11, 0x01, 0x6C])  # set the carpenter's start position
 
     # Give hp after first ocarina minigame round
     rom.write_bytes(0xDF2204, [0x24, 0x03, 0x00, 0x02])
@@ -1042,7 +1045,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.disable_trade_revert:
         # Disable trade quest timers and prevent trade items from ever reverting
         rom.write_byte(rom.sym('DISABLE_TIMERS'), 0x01)
-        rom.write_int16s(0xB6D460, [0x0030, 0x0035, 0x0036]) # Change trade items revert table to prevent all reverts
+        rom.write_int16s(0xB6D460, [0x0030, 0x0035, 0x0036])  # Change trade items revert table to prevent all reverts
 
     if world.settings.adult_trade_shuffle or world.settings.item_pool_value in ['plentiful', 'ludicrous']:
         rom.write_int16(rom.sym('CFG_ADULT_TRADE_SHUFFLE'), 0x0001)
@@ -1449,8 +1452,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     # "fast-ganon" stuff
     symbol = rom.sym('NO_ESCAPE_SEQUENCE')
     if world.settings.no_escape_sequence:
-        rom.write_bytes(0xD82A12, [0x05, 0x17]) # Sets exit from Ganondorf fight to entrance to Ganon fight
-        rom.write_bytes(0xB139A2, [0x05, 0x17]) # Sets Ganon deathwarp back to Ganon
+        rom.write_bytes(0xD82A12, [0x05, 0x17])  # Sets exit from Ganondorf fight to entrance to Ganon fight
+        rom.write_bytes(0xB139A2, [0x05, 0x17])  # Sets Ganon deathwarp back to Ganon
         rom.write_byte(symbol, 0x01)
     else:
         rom.write_byte(symbol, 0x00)
@@ -1609,11 +1612,10 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     add_relocations(rom, shop_item_file, new_relocations)
 
     # update actor table
-    rom.write_int32s(0x00B5E490 + (0x20 * 4),
-        [shop_item_file.start,
-        shop_item_file.end,
-        shop_item_vram_start,
-        shop_item_vram_start + (shop_item_file.end - shop_item_file.start)])
+    rom.write_int32s(0x00B5E490 + (0x20 * 4), [shop_item_file.start,
+                                               shop_item_file.end,
+                                               shop_item_vram_start,
+                                               shop_item_vram_start + (shop_item_file.end - shop_item_file.start)])
 
     # Update DMA Table
     update_dmadata(rom, shop_item_file)
@@ -1627,19 +1629,22 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     bazaar_room_file.copy(rom)
 
     # Add new Bazaar Room to Bazaar Scene
-    rom.write_int32s(0x28E3030, [0x00010000, 0x02000058]) #reduce position list size
-    rom.write_int32s(0x28E3008, [0x04020000, 0x02000070]) #expand room list size
+    rom.write_int32s(0x28E3030, [0x00010000, 0x02000058])  #reduce position list size
+    rom.write_int32s(0x28E3008, [0x04020000, 0x02000070])  #expand room list size
 
     rom.write_int32s(0x28E3070, [0x028E4000, 0x0290D7B0,
-                     bazaar_room_file.start, bazaar_room_file.end]) #room list
-    rom.write_int16s(0x28E3080, [0x0000, 0x0001]) # entrance list
+                                 bazaar_room_file.start, bazaar_room_file.end])  #room list
+    rom.write_int16s(0x28E3080, [0x0000, 0x0001])  # entrance list
     rom.write_int16(0x28E4076, 0x0005) # Change shop to Kakariko Bazaar
     #rom.write_int16(0x3489076, 0x0005) # Change shop to Kakariko Bazaar
 
     # write shop info to auto-tracker context
     rom.write_bytes(rom.sym('SPECIAL_DEAL_COUNTS'), [
-        sum(f'{shop} Item {idx}' in world.shop_prices for idx in ('7', '5', '8', '6')) # number of special deals in this shop
-        for shop in ('KF Shop', 'Market Bazaar', 'Market Potion Shop', 'Market Bombchu Shop', 'Kak Bazaar', 'Kak Potion Shop', 'GC Shop', 'ZD Shop')
+        sum(f'{shop} Item {idx}' in world.shop_prices for idx in ('7', '5', '8', '6'))
+        # number of special deals in this shop
+        for shop in (
+        'KF Shop', 'Market Bazaar', 'Market Potion Shop', 'Market Bombchu Shop', 'Kak Bazaar', 'Kak Potion Shop',
+        'GC Shop', 'ZD Shop')
     ])
 
     # Load Message and Shop Data
@@ -2050,11 +2055,11 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.settings.shuffle_scrubs == 'off':
         # Revert Deku Scrubs changes
         rom.write_int32s(0xEBB85C, [
-            0x24010002, # addiu at, zero, 2
-            0x3C038012, # lui v1, 0x8012
-            0x14410004, # bne v0, at, 0xd8
-            0x2463A5D0, # addiu v1, v1, -0x5a30
-            0x94790EF0])# lhu t9, 0xef0(v1)
+            0x24010002,  # addiu at, zero, 2
+            0x3C038012,  # lui v1, 0x8012
+            0x14410004,  # bne v0, at, 0xd8
+            0x2463A5D0,  # addiu v1, v1, -0x5a30
+            0x94790EF0])  # lhu t9, 0xef0(v1)
         rom.write_int32(0xDF7CB0,
             0xA44F0EF0)  # sh t7, 0xef0(v0)
 
@@ -2100,8 +2105,8 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if world.settings.shuffle_cows:
         rom.write_byte(rom.sym('SHUFFLE_COWS'), 0x01)
         # Move some cows because they are too close from each other in vanilla
-        rom.write_bytes(0x33650CA, [0xFE, 0xD3, 0x00, 0x00, 0x00, 0x6E, 0x00, 0x00, 0x4A, 0x34]) # LLR Tower right cow
-        rom.write_bytes(0x2C550AE, [0x00, 0x82]) # LLR Stable right cow
+        rom.write_bytes(0x33650CA, [0xFE, 0xD3, 0x00, 0x00, 0x00, 0x6E, 0x00, 0x00, 0x4A, 0x34])  # LLR Tower right cow
+        rom.write_bytes(0x2C550AE, [0x00, 0x82])  # LLR Stable right cow
         set_cow_id_data(rom, world)
 
     if world.settings.shuffle_beans:
@@ -3019,6 +3024,7 @@ def configure_dungeon_info(rom, world):
     rom.write_bytes(rom.sym('CFG_DUNGEON_IS_MQ'), dungeon_is_mq)
     rom.write_bytes(rom.sym('CFG_DUNGEON_REWARD_AREAS'), dungeon_reward_areas)
 
+
 # Overwrite an actor in rom w/ the actor data from LocationList
 def patch_actor_override(location, rom: Rom):
     addresses = location.address
@@ -3027,18 +3033,22 @@ def patch_actor_override(location, rom: Rom):
         for address in addresses:
             rom.write_bytes(address, patch)
 
+
 # Patch rupee towers (circular patterns of rupees) to include their flag in their actor initialization data z rotation.
 # Also used for goron pot, shadow spinning pots
 def patch_rupee_tower(location, rom: Rom):
-    flag = location.default
     if isinstance(location.default, tuple):
         room, scene_setup, flag = location.default
     elif isinstance(location.default, list):
         room, scene_setup, flag = location.default[0]
+    else:
+        raise Exception(f"Location does not have compatible data for patch_rupee_tower: {location.name}")
+
     flag = flag + (room << 8)
     if location.address:
         for address in location.address:
             rom.write_bytes(address + 12, flag.to_bytes(2, byteorder='big'))
+
 
 # Patch the first boss key door in ganons tower that leads to the room w/ the pots
 def patch_ganons_tower_bk_door(rom: Rom, flag):

--- a/Patches.py
+++ b/Patches.py
@@ -25,7 +25,6 @@ from version import __version__
 from ItemPool import song_list, trade_items, child_trade_items
 from SceneFlags import get_alt_list_bytes, get_collectible_flag_table, get_collectible_flag_table_bytes
 from texture_util import ci4_rgba16patch_to_ci8, rgba16_patch
-from SettingsList import setting_infos
 
 
 def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:

--- a/Patches.py
+++ b/Patches.py
@@ -1,33 +1,38 @@
-import random
-import struct
-import itertools
-import re
-import zlib
 import datetime
+import itertools
+import random
+import re
+import struct
+import zlib
+from typing import Dict, List, Iterable, Tuple, Set, Callable, Optional, Any
 
-from World import World
-from Rom import Rom
-from Spoiler import Spoiler
-from Location import DisableType
+from Entrance import Entrance
+from HintList import get_hint
+from Hints import GossipText, HintArea, write_gossip_stone_hints, build_altar_hints, \
+        build_ganon_text, build_misc_item_hints, build_misc_location_hints, get_simple_hint_no_prefix, get_item_generic_name
+from Item import Item
+from ItemPool import song_list, trade_items, child_trade_items
+from Location import Location, DisableType
 from LocationList import business_scrubs
-from HintList import getHint
-from Hints import GossipText, HintArea, writeGossipStoneHints, buildAltarHints, \
-        buildGanonText, buildMiscItemHints, buildMiscLocationHints, getSimpleHintNoPrefix, getItemGenericName
-from Utils import data_path
 from Messages import read_messages, update_message_by_id, read_shop_items, update_warp_song_text, \
         write_shop_items, remove_unused_messages, make_player_message, \
         add_item_messages, repack_messages, shuffle_messages, \
-        get_message_by_id, Text_Code
-from OcarinaSongs import replace_songs
+        get_message_by_id, TextCode
 from MQ import patch_files, File, update_dmadata, insert_space, add_relocations
+from OcarinaSongs import replace_songs
+from Rom import Rom
 from SaveContext import SaveContext, Scenes, FlagType
-from version import __version__
-from ItemPool import song_list, trade_items, child_trade_items
 from SceneFlags import get_alt_list_bytes, get_collectible_flag_table, get_collectible_flag_table_bytes
+from Spoiler import Spoiler
+from Utils import TypeAlias, data_path
+from World import World
 from texture_util import ci4_rgba16patch_to_ci8, rgba16_patch
+from version import __version__
+
+OverrideEntry: TypeAlias = Tuple[int, int, int, int, int, int]
 
 
-def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
+def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     with open(data_path('generated/rom_patch.txt'), 'r') as stream:
         for line in stream:
             address, value = [int(x, 16) for x in line.split(',')]
@@ -39,6 +44,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         (data_path('title.bin'),  0x01795300),  # Randomizer title screen logo
         (data_path('keaton.bin'), 0x8A7C00),    # Fixes the typo of "Keatan Mask" in the item select screen
     ]
+
     for (bin_path, write_address) in bin_patches:
         with open(bin_path, 'rb') as stream:
             bytes_compressed = stream.read()
@@ -55,7 +61,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         ('object_gi_chubag',   data_path('ChuBag.zobj'),   0x197),  # Bombchu Bag
     ]
 
-    extended_objects_start = start_address = rom.free_space()
+    extended_objects_start = start_address = rom.dma.free_space()
     for (name, zobj_path, object_id) in zobj_imports:
         with open(zobj_path, 'rb') as stream:
             obj_data = stream.read()
@@ -96,7 +102,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         start_address = end_address
 
     # Add the extended objects data to the DMA table.
-    rom.update_dmadata_record(None, extended_objects_start, end_address)
+    rom.update_dmadata_record_by_key(None, extended_objects_start, end_address)
 
     # Create the textures for pots/crates. Note: No copyrighted material can be distributed w/ the randomizer. Because of this, patch files are used to create the new textures from the original texture in ROM.
     # Apply patches for custom textures for pots and crates and add as new files in rom
@@ -136,7 +142,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     ]
 
     # Loop through the textures and apply the patch. Add the new textures as a new file in rom.
-    extended_textures_start = start_address = rom.free_space()
+    extended_textures_start = start_address = rom.dma.free_space()
     for texture_id, texture_name, rom_address_base, rom_address_palette, size, func, patch_file in crate_textures:
         # Apply the texture patch. Resulting texture will be stored in texture_data as a bytearray
         texture_data = func(rom, rom_address_base, rom_address_palette, size, data_path(patch_file) if patch_file else None)
@@ -151,7 +157,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         start_address = end_address
 
     # Add the extended texture data to the DMA table.
-    rom.update_dmadata_record(None, extended_textures_start, end_address)
+    rom.update_dmadata_record_by_key(None, extended_textures_start, end_address)
 
     # Create an option so that recovery hearts no longer drop by changing the code which checks Link's health when an item is spawned.
     if world.settings.no_collectible_hearts:
@@ -173,7 +179,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Can always return to youth
     rom.write_byte(0xCB6844, 0x35)
-    rom.write_byte(0x253C0E2, 0x03) # Moves sheik from pedestal
+    rom.write_byte(0x253C0E2, 0x03)  # Moves sheik from pedestal
 
     # Fix Ice Cavern Alcove Camera
     if not world.dungeon_mq['Ice Cavern']:
@@ -189,8 +195,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_byte(0xE12ADD, 0x00)
 
     # Fix deku theater rewards to be static
-    rom.write_bytes(0xEC9A7C, [0x00, 0x00, 0x00, 0x00])  #Sticks
-    rom.write_byte(0xEC9CD5, 0x00) #Nuts
+    rom.write_bytes(0xEC9A7C, [0x00, 0x00, 0x00, 0x00])  # Sticks
+    rom.write_byte(0xEC9CD5, 0x00)  # Nuts
 
     # Fix deku scrub who sells stick upgrade
     rom.write_bytes(0xDF8060, [0x00, 0x00, 0x00, 0x00])
@@ -219,20 +225,15 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_int32(rom.sym('FREE_BOMBCHU_DROPS'), 1)
 
     # show seed info on file select screen
-    def makebytes(txt, size):
+    def make_bytes(txt: str, size: int) -> List[int]:
         bytes = list(ord(c) for c in txt[:size-1]) + [0] * size
         return bytes[:size]
-
-    def truncstr(txt, size):
-        if len(txt) > size:
-            txt = txt[:size-3] + "..."
-        return txt
 
     line_len = 21
     version_str = "version " + __version__
     if len(version_str) > line_len:
         version_str = "ver. " + __version__
-    rom.write_bytes(rom.sym('VERSION_STRING_TXT'), makebytes(version_str, 25))
+    rom.write_bytes(rom.sym('VERSION_STRING_TXT'), make_bytes(version_str, 25))
 
     if world.settings.create_spoiler:
         rom.write_byte(rom.sym('SPOILER_AVAILABLE'), 0x01)
@@ -241,13 +242,13 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_byte(rom.sym('PLANDOMIZER_USED'), 0x01)
 
     if world.settings.world_count > 1:
-        world_str = "{} of {}".format(world.id + 1, world.settings.world_count)
+        world_str = f"{world.id + 1} of {world.settings.world_count}"
     else:
         world_str = ""
-    rom.write_bytes(rom.sym('WORLD_STRING_TXT'), makebytes(world_str, 12))
+    rom.write_bytes(rom.sym('WORLD_STRING_TXT'), make_bytes(world_str, 12))
 
     time_str = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M") + " UTC"
-    rom.write_bytes(rom.sym('TIME_STRING_TXT'), makebytes(time_str, 25))
+    rom.write_bytes(rom.sym('TIME_STRING_TXT'), make_bytes(time_str, 25))
 
     if world.settings.show_seed_info:
         rom.write_byte(rom.sym('CFG_SHOW_SETTING_INFO'), 0x01)
@@ -263,7 +264,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         if len(part1[-1]) + len(msg[1]) < line_len:
             msg = [" ".join(part1[:-1]), part1[-1] + msg[1]]
         else:
-        # Is it a URL?
+            # Is it a URL?
             part1 = msg[0].split('/')
             if len(part1[-1]) + len(msg[1]) < line_len:
                 msg = ["/".join(part1[:-1]) + "/", part1[-1] + msg[1]]
@@ -319,8 +320,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_bytes(0xEFE950, [0x00, 0x00, 0x00, 0x00])
 
     # Speed Zelda escaping from Hyrule Castle
-    Block_code = [0x00, 0x00, 0x00, 0x01, 0x00, 0x21, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02]
-    rom.write_bytes(0x1FC0CF8, Block_code)
+    block_code = [0x00, 0x00, 0x00, 0x01, 0x00, 0x21, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02]
+    rom.write_bytes(0x1FC0CF8, block_code)
 
     # songs as items flag
     songs_as_items = world.settings.shuffle_song_items != 'song' or \
@@ -337,7 +338,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     else:
         rom.write_int16s(None, [0x0073, 0x003B, 0x003C, 0x003C])  # ID, start, end, end
 
-
     rom.write_int32s(0x02E8E91C, [0x00000013, 0x0000000C])  # Textbox, Count
     if songs_as_items:
         rom.write_int16s(None, [0xFFFF, 0x0000, 0x0010, 0xFFFF, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
@@ -347,9 +347,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Speed learning Sun's Song
     if songs_as_items:
-        rom.write_int32(0x0332A4A4, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x0332A4A4, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x0332A4A4, 0x0000003C) # Header: frame_count
+        rom.write_int32(0x0332A4A4, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x0332A868, [0x00000013, 0x00000008])  # Textbox, Count
     rom.write_int16s(None, [0x0018, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
@@ -357,17 +357,17 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Speed learning Saria's Song
     if songs_as_items:
-        rom.write_int32(0x020B1734, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x020B1734, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x020B1734, 0x0000003C) # Header: frame_count
+        rom.write_int32(0x020B1734, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x20B1DA8, [0x00000013, 0x0000000C])  # Textbox, Count
     rom.write_int16s(None, [0x0015, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x00D1, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x020B19C0, [0x0000000A, 0x00000006])  # Link, Count
-    rom.write_int16s(0x020B19C8, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
-    rom.write_int16s(0x020B19F8, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x020B19C8, [0x0011, 0x0000, 0x0010, 0x0000])  # action, start, end, ????
+    rom.write_int16s(0x020B19F8, [0x003E, 0x0011, 0x0020, 0x0000])  # action, start, end, ????
     rom.write_int32s(None, [0x80000000,  # ???
                             0x00000000, 0x000001D4, 0xFFFFF731,  # start_XYZ
                             0x00000000, 0x000001D4, 0xFFFFF712])  # end_XYZ
@@ -400,13 +400,13 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_int16s(None, [0x0019, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x00D5, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
-    rom.write_int32(0x01FC3B84, 0xFFFFFFFF) # Other Header?: frame_count
+    rom.write_int32(0x01FC3B84, 0xFFFFFFFF)  # Other Header?: frame_count
 
     # Speed learning Song of Storms
     if songs_as_items:
-        rom.write_int32(0x03041084, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x03041084, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x03041084, 0x0000000A) # Header: frame_count
+        rom.write_int32(0x03041084, 0x0000000A)  # Header: frame_count
 
     rom.write_int32s(0x03041088, [0x00000013, 0x00000002])  # Textbox, Count
     rom.write_int16s(None, [0x00D6, 0x0000, 0x0009, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
@@ -414,72 +414,72 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Speed learning Minuet of Forest
     if songs_as_items:
-        rom.write_int32(0x020AFF84, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x020AFF84, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x020AFF84, 0x0000003C) # Header: frame_count
+        rom.write_int32(0x020AFF84, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x020B0800, [0x00000013, 0x0000000A])  # Textbox, Count
     rom.write_int16s(None, [0x000F, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x0073, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x020AFF88, [0x0000000A, 0x00000005])  # Link, Count
-    rom.write_int16s(0x020AFF90, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
-    rom.write_int16s(0x020AFFC1, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x020AFF90, [0x0011, 0x0000, 0x0010, 0x0000])  # action, start, end, ????
+    rom.write_int16s(0x020AFFC1, [0x003E, 0x0011, 0x0020, 0x0000])  # action, start, end, ????
 
     rom.write_int32s(0x020B0488, [0x00000056, 0x00000001])  # Music Change, Count
-    rom.write_int16s(None, [0x003F, 0x0021, 0x0022, 0x0000])  #action, start, end, ????
+    rom.write_int16s(None, [0x003F, 0x0021, 0x0022, 0x0000])  # action, start, end, ????
 
     rom.write_int32s(0x020B04C0, [0x0000007C, 0x00000001])  # Music Fade Out, Count
-    rom.write_int16s(None, [0x0004, 0x0000, 0x0000, 0x0000])  #action, start, end, ????
+    rom.write_int16s(None, [0x0004, 0x0000, 0x0000, 0x0000])  # action, start, end, ????
 
     # Speed learning Bolero of Fire
     if songs_as_items:
-        rom.write_int32(0x0224B5D4, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x0224B5D4, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x0224B5D4, 0x0000003C) # Header: frame_count
+        rom.write_int32(0x0224B5D4, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x0224D7E8, [0x00000013, 0x0000000A])  # Textbox, Count
     rom.write_int16s(None, [0x0010, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x0074, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x0224B5D8, [0x0000000A, 0x0000000B])  # Link, Count
-    rom.write_int16s(0x0224B5E0, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
-    rom.write_int16s(0x0224B610, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x0224B5E0, [0x0011, 0x0000, 0x0010, 0x0000])  # action, start, end, ????
+    rom.write_int16s(0x0224B610, [0x003E, 0x0011, 0x0020, 0x0000])  # action, start, end, ????
 
     rom.write_int32s(0x0224B7F0, [0x0000002F, 0x0000000E])  # Sheik, Count
-    rom.write_int16s(0x0224B7F8, [0x0000])  #action
-    rom.write_int16s(0x0224B828, [0x0000])  #action
-    rom.write_int16s(0x0224B858, [0x0000])  #action
-    rom.write_int16s(0x0224B888, [0x0000])  #action
+    rom.write_int16s(0x0224B7F8, [0x0000])  # action
+    rom.write_int16s(0x0224B828, [0x0000])  # action
+    rom.write_int16s(0x0224B858, [0x0000])  # action
+    rom.write_int16s(0x0224B888, [0x0000])  # action
 
     # Speed learning Serenade of Water
     if songs_as_items:
-        rom.write_int32(0x02BEB254, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x02BEB254, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x02BEB254, 0x0000003C) # Header: frame_count
+        rom.write_int32(0x02BEB254, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x02BEC880, [0x00000013, 0x00000010])  # Textbox, Count
     rom.write_int16s(None, [0x0011, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x0075, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x02BEB258, [0x0000000A, 0x0000000F])  # Link, Count
-    rom.write_int16s(0x02BEB260, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
-    rom.write_int16s(0x02BEB290, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x02BEB260, [0x0011, 0x0000, 0x0010, 0x0000])  # action, start, end, ????
+    rom.write_int16s(0x02BEB290, [0x003E, 0x0011, 0x0020, 0x0000])  # action, start, end, ????
 
     rom.write_int32s(0x02BEB530, [0x0000002F, 0x00000006])  # Sheik, Count
-    rom.write_int16s(0x02BEB538, [0x0000, 0x0000, 0x018A, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x02BEB538, [0x0000, 0x0000, 0x018A, 0x0000])  # action, start, end, ????
     rom.write_int32s(None, [0x1BBB0000,  # ???
                             0xFFFFFB10, 0x8000011A, 0x00000330,  # start_XYZ
                             0xFFFFFB10, 0x8000011A, 0x00000330])  # end_XYZ
 
     rom.write_int32s(0x02BEC848, [0x00000056, 0x00000001])  # Music Change, Count
-    rom.write_int16s(None, [0x0059, 0x0021, 0x0022, 0x0000])  #action, start, end, ????
+    rom.write_int16s(None, [0x0059, 0x0021, 0x0022, 0x0000])  # action, start, end, ????
 
     # Speed learning Nocturne of Shadow
     rom.write_int32s(0x01FFE458, [0x000003E8, 0x00000001])  # Other Scene? Terminator Execution
     rom.write_int16s(None, [0x002F, 0x0001, 0x0002, 0x0002])  # ID, start, end, end
 
-    rom.write_int32(0x01FFFDF4, 0x0000003C) # Header: frame_count
+    rom.write_int32(0x01FFFDF4, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x02000FD8, [0x00000013, 0x0000000E])  # Textbox, Count
     if songs_as_items:
@@ -495,7 +495,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_int16s(None, [0x0032, 0x003A, 0x003B, 0x003B])  # ID, start, end, end
 
     # Speed learning Requiem of Spirit
-    rom.write_int32(0x0218AF14, 0x0000003C) # Header: frame_count
+    rom.write_int32(0x0218AF14, 0x0000003C)  # Header: frame_count
 
     rom.write_int32s(0x0218C574, [0x00000013, 0x00000008])  # Textbox, Count
     if songs_as_items:
@@ -511,35 +511,35 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_int16s(None, [0x0030, 0x003A, 0x003B, 0x003B])  # ID, start, end, end
 
     rom.write_int32s(0x0218AF18, [0x0000000A, 0x0000000B])  # Link, Count
-    rom.write_int16s(0x0218AF20, [0x0011, 0x0000, 0x0010, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x0218AF20, [0x0011, 0x0000, 0x0010, 0x0000])  # action, start, end, ????
     rom.write_int32s(None, [0x40000000,  # ???
                             0xFFFFFAF9, 0x00000008, 0x00000001,  # start_XYZ
                             0xFFFFFAF9, 0x00000008, 0x00000001,  # end_XYZ
                             0x0F671408, 0x00000000, 0x00000001])  # normal_XYZ
-    rom.write_int16s(0x0218AF50, [0x003E, 0x0011, 0x0020, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x0218AF50, [0x003E, 0x0011, 0x0020, 0x0000])  # action, start, end, ????
 
     # Speed learning Prelude of Light
     if songs_as_items:
-        rom.write_int32(0x0252FD24, 0xFFFFFFFF) # Header: frame_count
+        rom.write_int32(0x0252FD24, 0xFFFFFFFF)  # Header: frame_count
     else:
-        rom.write_int32(0x0252FD24, 0x0000004A) # Header: frame_count
+        rom.write_int32(0x0252FD24, 0x0000004A)  # Header: frame_count
 
     rom.write_int32s(0x02531320, [0x00000013, 0x0000000E])  # Textbox, Count
     rom.write_int16s(None, [0x0014, 0x0000, 0x0010, 0x0002, 0x088B, 0xFFFF])  # ID, start, end, type, alt1, alt2
     rom.write_int16s(None, [0x0078, 0x0011, 0x0020, 0x0000, 0xFFFF, 0xFFFF])  # ID, start, end, type, alt1, alt2
 
     rom.write_int32s(0x0252FF10, [0x0000002F, 0x00000009])  # Sheik, Count
-    rom.write_int16s(0x0252FF18, [0x0006, 0x0000, 0x0000, 0x0000])  #action, start, end, ????
+    rom.write_int16s(0x0252FF18, [0x0006, 0x0000, 0x0000, 0x0000])  # action, start, end, ????
 
     rom.write_int32s(0x025313D0, [0x00000056, 0x00000001])  # Music Change, Count
-    rom.write_int16s(None, [0x003B, 0x0021, 0x0022, 0x0000])  #action, start, end, ????
+    rom.write_int16s(None, [0x003B, 0x0021, 0x0022, 0x0000])  # action, start, end, ????
 
     # Speed scene after Deku Tree
     rom.write_bytes(0x2077E20, [0x00, 0x07, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02])
     rom.write_bytes(0x2078A10, [0x00, 0x0E, 0x00, 0x1F, 0x00, 0x20, 0x00, 0x20])
-    Block_code = [0x00, 0x80, 0x00, 0x00, 0x00, 0x1E, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+    block_code = [0x00, 0x80, 0x00, 0x00, 0x00, 0x1E, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
                   0xFF, 0xFF, 0x00, 0x1E, 0x00, 0x28, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
-    rom.write_bytes(0x2079570, Block_code)
+    rom.write_bytes(0x2079570, block_code)
 
     # Speed scene after Dodongo's Cavern
     rom.write_bytes(0x2221E88, [0x00, 0x0C, 0x00, 0x3B, 0x00, 0x3C, 0x00, 0x3C])
@@ -583,7 +583,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_byte(0x2F5B559, 0x04)
     rom.write_byte(0x2F5B621, 0x04)
     rom.write_byte(0x2F5B761, 0x07)
-    rom.write_bytes(0x2F5B840, [0x00, 0x05, 0x00, 0x01, 0x00, 0x05, 0x00, 0x05])  #shorten white flash
+    rom.write_bytes(0x2F5B840, [0x00, 0x05, 0x00, 0x01, 0x00, 0x05, 0x00, 0x05])  # shorten white flash
 
     # Speed scene with all medallions
     rom.write_bytes(0x2512680, [0x00, 0x74, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02])
@@ -621,23 +621,23 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_bytes(0xE84C80, [0x10, 0x00])
 
     # Speed completion of the trials in Ganon's Castle
-    rom.write_int16s(0x31A8090, [0x006B, 0x0001, 0x0002, 0x0002])  #Forest
-    rom.write_int16s(0x31A9E00, [0x006E, 0x0001, 0x0002, 0x0002])  #Fire
-    rom.write_int16s(0x31A8B18, [0x006C, 0x0001, 0x0002, 0x0002])  #Water
-    rom.write_int16s(0x31A9430, [0x006D, 0x0001, 0x0002, 0x0002])  #Shadow
-    rom.write_int16s(0x31AB200, [0x0070, 0x0001, 0x0002, 0x0002])  #Spirit
-    rom.write_int16s(0x31AA830, [0x006F, 0x0001, 0x0002, 0x0002])  #Light
+    rom.write_int16s(0x31A8090, [0x006B, 0x0001, 0x0002, 0x0002])  # Forest
+    rom.write_int16s(0x31A9E00, [0x006E, 0x0001, 0x0002, 0x0002])  # Fire
+    rom.write_int16s(0x31A8B18, [0x006C, 0x0001, 0x0002, 0x0002])  # Water
+    rom.write_int16s(0x31A9430, [0x006D, 0x0001, 0x0002, 0x0002])  # Shadow
+    rom.write_int16s(0x31AB200, [0x0070, 0x0001, 0x0002, 0x0002])  # Spirit
+    rom.write_int16s(0x31AA830, [0x006F, 0x0001, 0x0002, 0x0002])  # Light
 
     # Speed obtaining Fairy Ocarina
     rom.write_bytes(0x2151230, [0x00, 0x72, 0x00, 0x3C, 0x00, 0x3D, 0x00, 0x3D])
-    Block_code = [0x00, 0x4A, 0x00, 0x00, 0x00, 0x3A, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+    block_code = [0x00, 0x4A, 0x00, 0x00, 0x00, 0x3A, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
                   0xFF, 0xFF, 0x00, 0x3C, 0x00, 0x81, 0xFF, 0xFF]
-    rom.write_bytes(0x2151240, Block_code)
+    rom.write_bytes(0x2151240, block_code)
     rom.write_bytes(0x2150E20, [0xFF, 0xFF, 0xFA, 0x4C])
 
     if world.settings.shuffle_ocarinas:
         symbol = rom.sym('OCARINAS_SHUFFLED')
-        rom.write_byte(symbol,0x01)
+        rom.write_byte(symbol, 0x01)
 
     # Speed Zelda Light Arrow cutscene
     rom.write_bytes(0x2531B40, [0x00, 0x28, 0x00, 0x01, 0x00, 0x02, 0x00, 0x02])
@@ -663,27 +663,27 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_bytes(0x292D810, [0x00, 0x02, 0x00, 0x3C])
     rom.write_bytes(0x292D924, [0xFF, 0xFF, 0x00, 0x14, 0x00, 0x96, 0xFF, 0xFF])
 
-    #Speed Pushing of All Pushable Objects
-    rom.write_bytes(0xDD2B86, [0x40, 0x80])  #block speed
-    rom.write_bytes(0xDD2D26, [0x00, 0x01])  #block delay
-    rom.write_bytes(0xDD9682, [0x40, 0x80])  #milk crate speed
-    rom.write_bytes(0xDD981E, [0x00, 0x01])  #milk crate delay
-    rom.write_bytes(0xCE1BD0, [0x40, 0x80, 0x00, 0x00])  #amy puzzle speed
-    rom.write_bytes(0xCE0F0E, [0x00, 0x01])  #amy puzzle delay
-    rom.write_bytes(0xC77CA8, [0x40, 0x80, 0x00, 0x00])  #fire block speed
-    rom.write_bytes(0xC770C2, [0x00, 0x01])  #fire block delay
-    rom.write_bytes(0xCC5DBC, [0x29, 0xE1, 0x00, 0x01])  #forest basement puzzle delay
-    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x00])  #spirit cobra mirror startup
-    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x01])  #spirit cobra mirror delay
-    rom.write_bytes(0xDBA230, [0x28, 0x41, 0x00, 0x19])  #truth spinner speed
-    rom.write_bytes(0xDBA3A4, [0x24, 0x18, 0x00, 0x00])  #truth spinner delay
+    # Speed Pushing of All Pushable Objects
+    rom.write_bytes(0xDD2B86, [0x40, 0x80])  # block speed
+    rom.write_bytes(0xDD2D26, [0x00, 0x01])  # block delay
+    rom.write_bytes(0xDD9682, [0x40, 0x80])  # milk crate speed
+    rom.write_bytes(0xDD981E, [0x00, 0x01])  # milk crate delay
+    rom.write_bytes(0xCE1BD0, [0x40, 0x80, 0x00, 0x00])  # amy puzzle speed
+    rom.write_bytes(0xCE0F0E, [0x00, 0x01])  # amy puzzle delay
+    rom.write_bytes(0xC77CA8, [0x40, 0x80, 0x00, 0x00])  # fire block speed
+    rom.write_bytes(0xC770C2, [0x00, 0x01])  # fire block delay
+    rom.write_bytes(0xCC5DBC, [0x29, 0xE1, 0x00, 0x01])  # forest basement puzzle delay
+    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x00])  # spirit cobra mirror startup
+    rom.write_bytes(0xDBCF70, [0x2B, 0x01, 0x00, 0x01])  # spirit cobra mirror delay
+    rom.write_bytes(0xDBA230, [0x28, 0x41, 0x00, 0x19])  # truth spinner speed
+    rom.write_bytes(0xDBA3A4, [0x24, 0x18, 0x00, 0x00])  # truth spinner delay
 
-    #Speed Deku Seed Upgrade Scrub Cutscene
-    rom.write_bytes(0xECA900, [0x24, 0x03, 0xC0, 0x00])  #scrub angle
-    rom.write_bytes(0xECAE90, [0x27, 0x18, 0xFD, 0x04])  #skip straight to giving item
-    rom.write_bytes(0xECB618, [0x25, 0x6B, 0x00, 0xD4])  #skip straight to digging back in
-    rom.write_bytes(0xECAE70, [0x00, 0x00, 0x00, 0x00])  #never initialize cs camera
-    rom.write_bytes(0xE5972C, [0x24, 0x08, 0x00, 0x01])  #timer set to 1 frame for giving item
+    # Speed Deku Seed Upgrade Scrub Cutscene
+    rom.write_bytes(0xECA900, [0x24, 0x03, 0xC0, 0x00])  # scrub angle
+    rom.write_bytes(0xECAE90, [0x27, 0x18, 0xFD, 0x04])  # skip straight to giving item
+    rom.write_bytes(0xECB618, [0x25, 0x6B, 0x00, 0xD4])  # skip straight to digging back in
+    rom.write_bytes(0xECAE70, [0x00, 0x00, 0x00, 0x00])  # never initialize cs camera
+    rom.write_bytes(0xE5972C, [0x24, 0x08, 0x00, 0x01])  # timer set to 1 frame for giving item
 
     # Remove remaining owls
     rom.write_bytes(0x1FE30CE, [0x01, 0x4B])
@@ -707,14 +707,14 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # Ruto never disappears from Jabu Jabu's Belly
     rom.write_byte(0xD01EA3, 0x00)
 
-    #Shift octorock in jabu forward
+    # Shift octorock in jabu forward
     rom.write_bytes(0x275906E, [0xFF, 0xB3, 0xFB, 0x20, 0xF9, 0x56])
 
-    #Move fire/forest temple switches down 1 unit to make it easier to press
-    rom.write_bytes(0x24860A8, [0xFC, 0xF4])  #forest basement 1
-    rom.write_bytes(0x24860C8, [0xFC, 0xF4])  #forest basement 2
-    rom.write_bytes(0x24860E8, [0xFC, 0xF4])  #forest basement 3
-    rom.write_bytes(0x236C148, [0x11, 0x93])  #fire hammer room
+    # Move fire/forest temple switches down 1 unit to make it easier to press
+    rom.write_bytes(0x24860A8, [0xFC, 0xF4])  # forest basement 1
+    rom.write_bytes(0x24860C8, [0xFC, 0xF4])  # forest basement 2
+    rom.write_bytes(0x24860E8, [0xFC, 0xF4])  # forest basement 3
+    rom.write_bytes(0x236C148, [0x11, 0x93])  # fire hammer room
 
     # Speed up Epona race start
     rom.write_bytes(0x29BE984, [0x00, 0x00, 0x00, 0x02])
@@ -737,7 +737,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_byte(0x2025159, 0x02)
     rom.write_byte(0x2023E19, 0x02)
 
-    #Speed opening of Door of Time
+    # Speed opening of Door of Time
     rom.write_bytes(0xE0A176, [0x00, 0x02])
     rom.write_bytes(0xE0A35A, [0x00, 0x01, 0x00, 0x02])
 
@@ -748,12 +748,12 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_bytes(0x223B6B2, [0x00, 0x01])
 
     # Speed up magic arrow equips
-    rom.write_int16(0xBB84CE, 0x0000) # Skips the initial growing glowing orb phase
-    rom.write_byte(0xBB84B7, 0xFF) # Set glowing orb above magic arrow to be small sized immediately
-    rom.write_byte(0xBB84CB, 0x01) # Sets timer for holding icon above magic arrow (1 frame)
-    rom.write_byte(0xBB7E67, 0x04) # speed up magic arrow icon -> bow icon interpolation (4 frames)
-    rom.write_byte(0xBB8957, 0x01) # Sets timer for holding icon above bow (1 frame)
-    rom.write_byte(0xBB854B, 0x05) # speed up bow icon -> c button interpolation (5 frames)
+    rom.write_int16(0xBB84CE, 0x0000)  # Skips the initial growing glowing orb phase
+    rom.write_byte(0xBB84B7, 0xFF)  # Set glowing orb above magic arrow to be small sized immediately
+    rom.write_byte(0xBB84CB, 0x01)  # Sets timer for holding icon above magic arrow (1 frame)
+    rom.write_byte(0xBB7E67, 0x04)  # speed up magic arrow icon -> bow icon interpolation (4 frames)
+    rom.write_byte(0xBB8957, 0x01)  # Sets timer for holding icon above bow (1 frame)
+    rom.write_byte(0xBB854B, 0x05)  # speed up bow icon -> c button interpolation (5 frames)
 
     # Poacher's Saw no longer messes up Forest Stage
     rom.write_bytes(0xAE72CC, [0x00, 0x00, 0x00, 0x00])
@@ -791,8 +791,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Change Mido, Saria, and Kokiri to check for Deku Tree complete flag
     # bitwise pointer for 0x80
-    kokiriAddresses = [0xE52836, 0xE53A56, 0xE51D4E, 0xE51F3E, 0xE51D96, 0xE51E1E, 0xE51E7E, 0xE51EDE, 0xE51FC6, 0xE51F96, 0xE293B6, 0xE29B8E, 0xE62EDA, 0xE630D6, 0xE633AA, 0xE6369E]
-    for kokiri in kokiriAddresses:
+    kokiri_addresses = [0xE52836, 0xE53A56, 0xE51D4E, 0xE51F3E, 0xE51D96, 0xE51E1E, 0xE51E7E, 0xE51EDE, 0xE51FC6, 0xE51F96, 0xE293B6, 0xE29B8E, 0xE62EDA, 0xE630D6, 0xE633AA, 0xE6369E]
+    for kokiri in kokiri_addresses:
         rom.write_bytes(kokiri, [0x8C, 0x0C])
     # Kokiri
     rom.write_bytes(0xE52838, [0x94, 0x48, 0x0E, 0xD4])
@@ -844,7 +844,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_bytes(0x1FF93A4,
                     [0x01, 0x8D, 0x00, 0x11, 0x01, 0x6C, 0xFF, 0x92, 0x00, 0x00, 0x01, 0x78, 0xFF, 0x2E, 0x00, 0x00,
                      0x00, 0x03, 0xFD, 0x2B, 0x00, 0xC8, 0xFF, 0xF9, 0xFD, 0x03, 0x00, 0xC8, 0xFF, 0xA9, 0xFD, 0x5D,
-                     0x00, 0xC8, 0xFE, 0x5F])  # re order the carpenter's path
+                     0x00, 0xC8, 0xFE, 0x5F])  # re-order the carpenter's path
     rom.write_byte(0x1FF93D0, 0x06) # set the path points to 6
     rom.write_bytes(0x20160B6, [0x01, 0x8D, 0x00, 0x11, 0x01, 0x6C])  # set the carpenter's start position
 
@@ -870,10 +870,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_byte(address,0x01)
 
     # Allow Warp Songs in additional places
-    rom.write_byte(0xB6D3D2, 0x00) # Gerudo Training Ground
-    rom.write_byte(0xB6D42A, 0x00) # Inside Ganon's Castle
+    rom.write_byte(0xB6D3D2, 0x00)  # Gerudo Training Ground
+    rom.write_byte(0xB6D42A, 0x00)  # Inside Ganon's Castle
 
-    #Tell Sheik at Ice Cavern we are always an Adult
+    # Tell Sheik at Ice Cavern we are always an Adult
     rom.write_int32(0xC7B9C0, 0x00000000)
     rom.write_int32(0xC7BAEC, 0x00000000)
     rom.write_int32(0xc7BCA4, 0x00000000)
@@ -887,31 +887,31 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_byte(0xB6D30A, 0x51) # Archery
 
     # Remove disruptive text from Gerudo Training Ground and early Shadow Temple (vanilla)
-    Wonder_text = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, 0x27CE080,
+    wonder_text = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, 0x27CE080,
                    0x27CE090, 0x2887070, 0x2887080, 0x2887090, 0x2897070, 0x28C7134, 0x28D91BC, 0x28A60F4, 0x28AE084,
                    0x28B9174, 0x28BF168, 0x28BF178, 0x28BF188, 0x28A1144, 0x28A6104, 0x28D0094]
-    for address in Wonder_text:
+    for address in wonder_text:
         rom.write_byte(address, 0xFB)
 
     # Speed dig text for Dampe
     rom.write_bytes(0x9532F8, [0x08, 0x08, 0x08, 0x59])
 
     # Make item descriptions into a single box
-    Short_item_descriptions = [0x92EC84, 0x92F9E3, 0x92F2B4, 0x92F37A, 0x92F513, 0x92F5C6, 0x92E93B, 0x92EA12]
-    for address in Short_item_descriptions:
-        rom.write_byte(address,0x02)
+    short_item_descriptions = [0x92EC84, 0x92F9E3, 0x92F2B4, 0x92F37A, 0x92F513, 0x92F5C6, 0x92E93B, 0x92EA12]
+    for address in short_item_descriptions:
+        rom.write_byte(address, 0x02)
 
     et_original = rom.read_bytes(0xB6FBF0, 4 * 0x0614)
 
     exit_updates = []
 
-    def generate_exit_lookup_table():
+    def generate_exit_lookup_table() -> Dict[int, List[int]]:
         # Assumes that the last exit on a scene's exit list cannot be 0000
         exit_table = {
-            0x0028: [0xAC95C2] #Jabu with the fish is entered from a cutscene hardcode
-            }
+            0x0028: [0xAC95C2]  # Jabu with the fish is entered from a cutscene hardcode
+        }
 
-        def add_scene_exits(scene_start, offset = 0):
+        def add_scene_exits(scene_start: int, offset: int = 0) -> None:
             current = scene_start + offset
             exit_list_start_off = 0
             exit_list_end_off = 0
@@ -919,16 +919,16 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
             while command != 0x14:
                 command = rom.read_byte(current)
-                if command == 0x18: # Alternate header list
+                if command == 0x18:  # Alternate header list
                     header_list = scene_start + (rom.read_int32(current + 4) & 0x00FFFFFF)
                     for alt_id in range(0,3):
                         header_offset = rom.read_int32(header_list) & 0x00FFFFFF
                         if header_offset != 0:
                             add_scene_exits(scene_start, header_offset)
                         header_list += 4
-                if command == 0x13: # Exit List
+                if command == 0x13:  # Exit List
                     exit_list_start_off = rom.read_int32(current + 4) & 0x00FFFFFF
-                if command == 0x0F: # Lighting list, follows exit list
+                if command == 0x0F:  # Lighting list, follows exit list
                     exit_list_end_off = rom.read_int32(current + 4) & 0x00FFFFFF
                 current += 8
 
@@ -952,7 +952,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
         scene_table = 0x00B71440
         for scene in range(0x00, 0x65):
-            scene_start = rom.read_int32(scene_table + (scene * 0x14));
+            scene_start = rom.read_int32(scene_table + (scene * 0x14))
             add_scene_exits(scene_start)
 
         return exit_table
@@ -961,13 +961,13 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         # Credit to rattus128 for this ASM block.
         # Gohma's save/death warp is optimized to use immediate 0 for the
         # deku tree respawn. Use the delay slot before the switch table
-        # to hold Gohmas jump entrance as actual data so we can substitute
+        # to hold Gohma's jump entrance as actual data so we can substitute
         # the entrance index later.
-        rom.write_int32(0xB06290, 0x240E0000) #li t6, 0
-        rom.write_int32(0xB062B0, 0xAE0E0000) #sw t6, 0(s0)
-        rom.write_int32(0xBC60AC, 0x24180000) #li t8, 0
-        rom.write_int32(0xBC6160, 0x24180000) #li t8, 0
-        rom.write_int32(0xBC6168, 0xAD380000) #sw t8, 0(t1)
+        rom.write_int32(0xB06290, 0x240E0000)  # li t6, 0
+        rom.write_int32(0xB062B0, 0xAE0E0000)  # sw t6, 0(s0)
+        rom.write_int32(0xBC60AC, 0x24180000)  # li t8, 0
+        rom.write_int32(0xBC6160, 0x24180000)  # li t8, 0
+        rom.write_int32(0xBC6168, 0xAD380000)  # sw t8, 0(t1)
 
         # Credit to engineer124
         # Update the Jabu-Jabu Boss Exit to actually useful coordinates (and to load the correct room)
@@ -977,7 +977,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # Update the Water Temple Boss Exit to load the correct room
     rom.write_byte(0x25B82E3, 0x0B)
 
-    def set_entrance_updates(entrances):
+    def set_entrance_updates(entrances: Iterable[Entrance]) -> None:
         if world.settings.shuffle_bosses != 'off':
             # Connect lake hylia fill exit to revisit exit
             rom.write_int16(0xAC995A, 0x060C)
@@ -1062,17 +1062,17 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         for k in (0x028A, 0x028E, 0x0292): # Southern, Western, Eastern Gates
             exit_table[0x01F9] += exit_table[k] # Hyrule Field entrance from Lon Lon Ranch (main land entrance)
             del exit_table[k]
-        exit_table[0x01F9].append(0xD52722) # 0x0476, Front Gate
+        exit_table[0x01F9].append(0xD52722)  # 0x0476, Front Gate
 
         # Combine the water exits between Hyrule Field and Zora River to lead to the land entrance instead of the water entrance
-        exit_table[0x00EA] += exit_table[0x01D9] # Hyrule Field -> Zora River
-        exit_table[0x0181] += exit_table[0x0311] # Zora River -> Hyrule Field
+        exit_table[0x00EA] += exit_table[0x01D9]  # Hyrule Field -> Zora River
+        exit_table[0x0181] += exit_table[0x0311]  # Zora River -> Hyrule Field
         del exit_table[0x01D9]
         del exit_table[0x0311]
 
         # Change Impa escorts to bring link at the hyrule castle grounds entrance from market, instead of hyrule field
-        rom.write_int16(0xACAA2E, 0x0138) # 1st Impa escort
-        rom.write_int16(0xD12D6E, 0x0138) # 2nd+ Impa escort
+        rom.write_int16(0xACAA2E, 0x0138)  # 1st Impa escort
+        rom.write_int16(0xD12D6E, 0x0138)  # 2nd+ Impa escort
 
     if world.settings.shuffle_hideout_entrances:
         rom.write_byte(rom.sym('HIDEOUT_SHUFFLED'), 1)
@@ -1087,9 +1087,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         # checking the well drain event flag instead of links age. This actor doesn't need a
         # code check for links age as the stone is absent for child via the scene alternate
         # lists. So replace the age logic with drain logic.
-        rom.write_int32(0xE2887C, rom.read_int32(0xE28870)) # relocate this to nop delay slot
-        rom.write_int32(0xE2886C, 0x95CEB4B0) # lhu
-        rom.write_int32(0xE28870, 0x31CE0080) # andi
+        rom.write_int32(0xE2887C, rom.read_int32(0xE28870))  # relocate this to nop delay slot
+        rom.write_int32(0xE2886C, 0x95CEB4B0)  # lhu
+        rom.write_int32(0xE28870, 0x31CE0080)  # andi
 
         remove_entrance_blockers(rom)
 
@@ -1128,85 +1128,85 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Initial Save Data
     if not world.settings.useful_cutscenes and 'Forest Temple' not in world.settings.dungeon_shortcuts:
-        save_context.write_bits(0x00D4 + 0x03 * 0x1C + 0x04 + 0x0, 0x08) # Forest Temple switch flag (Poe Sisters cutscene)
+        save_context.write_bits(0x00D4 + 0x03 * 0x1C + 0x04 + 0x0, 0x08)  # Forest Temple switch flag (Poe Sisters cutscene)
 
     if 'Deku Tree' in world.settings.dungeon_shortcuts:
         # Deku Tree, flags are the same between vanilla/MQ
-        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x1, 0x01) # Deku Block down
-        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.CLEAR,  0x2, 0x02) # Deku 231/312
-        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x3, 0x20) # Deku 1st Web
-        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x3, 0x40) # Deku 2nd Web
+        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x1, 0x01)  # Deku Block down
+        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.CLEAR,  0x2, 0x02)  # Deku 231/312
+        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x3, 0x20)  # Deku 1st Web
+        save_context.write_permanent_flag(Scenes.DEKU_TREE, FlagType.SWITCH, 0x3, 0x40)  # Deku 2nd Web
 
     if 'Dodongos Cavern' in world.settings.dungeon_shortcuts:
         # Dodongo's Cavern, flags are the same between vanilla/MQ
-        save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x3, 0x80) # DC Entrance Mud Wall
-        save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x04) # DC Mouth
+        save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x3, 0x80)  # DC Entrance Mud Wall
+        save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x04)  # DC Mouth
         # Extra permanent flag in MQ for the child route
         if world.dungeon_mq['Dodongos Cavern']:
-            save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x02) # Armos wall switch
+            save_context.write_permanent_flag(Scenes.DODONGOS_CAVERN, FlagType.SWITCH, 0x0, 0x02)  # Armos wall switch
 
     if 'Jabu Jabus Belly' in world.settings.dungeon_shortcuts:
         # Jabu
         if not world.dungeon_mq['Jabu Jabus Belly']:
-            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x0, 0x20) # Jabu Pathway down
+            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x0, 0x20)  # Jabu Pathway down
         else:
-            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x1, 0x20) # Jabu Lobby Slingshot Door open
-            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x0, 0x20) # Jabu Pathway down
-            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.CLEAR,  0x2, 0x01) # Jabu Red Slimy Thing defeated
-            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x2, 0x08) # Jabu Red Slimy Thing not in front of boss lobby
-            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x1, 0x10) # Jabu Boss Door Switch Activated
+            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x1, 0x20)  # Jabu Lobby Slingshot Door open
+            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x0, 0x20)  # Jabu Pathway down
+            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.CLEAR,  0x2, 0x01)  # Jabu Red Slimy Thing defeated
+            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x2, 0x08)  # Jabu Red Slimy Thing not in front of boss lobby
+            save_context.write_permanent_flag(Scenes.JABU_JABU, FlagType.SWITCH, 0x1, 0x10)  # Jabu Boss Door Switch Activated
 
     if 'Forest Temple' in world.settings.dungeon_shortcuts:
         # Forest, flags are the same between vanilla/MQ
-        save_context.write_permanent_flag(Scenes.FOREST_TEMPLE, FlagType.SWITCH, 0x0, 0x10) # Forest Elevator up
-        save_context.write_permanent_flag(Scenes.FOREST_TEMPLE, FlagType.SWITCH, 0x1, 0x01 + 0x02 + 0x04) # Forest Basement Puzzle Done
+        save_context.write_permanent_flag(Scenes.FOREST_TEMPLE, FlagType.SWITCH, 0x0, 0x10)  # Forest Elevator up
+        save_context.write_permanent_flag(Scenes.FOREST_TEMPLE, FlagType.SWITCH, 0x1, 0x01 + 0x02 + 0x04)  # Forest Basement Puzzle Done
 
     if 'Fire Temple' in world.settings.dungeon_shortcuts:
         # Fire, flags are the same between vanilla/MQ
-        save_context.write_permanent_flag(Scenes.FIRE_TEMPLE, FlagType.SWITCH, 0x2, 0x40) # Fire Pillar down
+        save_context.write_permanent_flag(Scenes.FIRE_TEMPLE, FlagType.SWITCH, 0x2, 0x40)  # Fire Pillar down
 
     if 'Spirit Temple' in world.settings.dungeon_shortcuts:
         # Spirit
         if not world.dungeon_mq['Spirit Temple']:
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x1, 0x80) # Spirit Chains
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x2, 0x02 + 0x08 + 0x10) # Spirit main room elevator (N block, Rusted Switch, E block)
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x3, 0x10) # Spirit Face
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x1, 0x80)  # Spirit Chains
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x2, 0x02 + 0x08 + 0x10)  # Spirit main room elevator (N block, Rusted Switch, E block)
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x3, 0x10)  # Spirit Face
         else:
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x2, 0x10) # Spirit Bombchu Boulder
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x2, 0x02) # Spirit Silver Block
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x1, 0x80) # Spirit Chains
-            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x3, 0x10) # Spirit Face
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x2, 0x10)  # Spirit Bombchu Boulder
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x2, 0x02)  # Spirit Silver Block
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x1, 0x80)  # Spirit Chains
+            save_context.write_permanent_flag(Scenes.SPIRIT_TEMPLE, FlagType.SWITCH, 0x3, 0x10)  # Spirit Face
 
     if 'Shadow Temple' in world.settings.dungeon_shortcuts:
         # Shadow
         if not world.dungeon_mq['Shadow Temple']:
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x08) # Shadow Truthspinner
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x20) # Shadow Boat Block
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x1, 0x01) # Shadow Bird Bridge
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x08)  # Shadow Truthspinner
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x20)  # Shadow Boat Block
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x1, 0x01)  # Shadow Bird Bridge
         else:
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x2, 0x08) # Shadow Truthspinner
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x3, 0x20) # Shadow Fire Arrow Platform
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x3, 0x80) # Shadow Spinning Blades room Skulltulas defeated
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.CLEAR,  0x3, 0x40) # Shadow Spinning Blades room Skulltulas defeated
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x20) # Shadow Boat Block
-            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x1, 0x01) # Shadow Bird Bridge
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x2, 0x08)  # Shadow Truthspinner
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x3, 0x20)  # Shadow Fire Arrow Platform
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x3, 0x80)  # Shadow Spinning Blades room Skulltulas defeated
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.CLEAR,  0x3, 0x40)  # Shadow Spinning Blades room Skulltulas defeated
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x0, 0x20)  # Shadow Boat Block
+            save_context.write_permanent_flag(Scenes.SHADOW_TEMPLE, FlagType.SWITCH, 0x1, 0x01)  # Shadow Bird Bridge
 
     if world.region_has_shortcuts('King Dodongo Boss Room'):
-        save_context.write_permanent_flag(Scenes.KING_DODONGO_LOBBY, FlagType.SWITCH, 0x3, 0x02) # DC Boss Floor
+        save_context.write_permanent_flag(Scenes.KING_DODONGO_LOBBY, FlagType.SWITCH, 0x3, 0x02)  # DC Boss Floor
 
     set_spirit_shortcut_actors(rom) # Change elevator starting position to avoid waiting a half cycle from the temple entrance
 
     if world.settings.plant_beans:
-        save_context.write_permanent_flag(Scenes.GRAVEYARD, FlagType.SWITCH, 0x3, 0x08) # Plant Graveyard bean
-        save_context.write_permanent_flag(Scenes.ZORAS_RIVER, FlagType.SWITCH, 0x3, 0x08) # Plant Zora's River bean
-        save_context.write_permanent_flag(Scenes.KOKIRI_FOREST, FlagType.SWITCH, 0x2, 0x02) # Plant Kokiri Forest bean
-        save_context.write_permanent_flag(Scenes.LAKE_HYLIA, FlagType.SWITCH, 0x3, 0x02) # Plant Lake Hylia bean
-        save_context.write_permanent_flag(Scenes.GERUDO_VALLEY, FlagType.SWITCH, 0x3, 0x08) # Plant Gerudo Valley bean
-        save_context.write_permanent_flag(Scenes.LOST_WOODS, FlagType.SWITCH, 0x3, 0x10) # Plant Lost Woods bridge bean
-        save_context.write_permanent_flag(Scenes.LOST_WOODS, FlagType.SWITCH, 0x1, 0x04) # Plant Lost Woods theater bean
-        save_context.write_permanent_flag(Scenes.DESERT_COLOSSUS, FlagType.SWITCH, 0x0, 0x1) # Plant Desert Colossus bean
-        save_context.write_permanent_flag(Scenes.DEATH_MOUNTAIN_TRAIL, FlagType.SWITCH, 0x3, 0x40) # Plant Death Mountain Trail bean
-        save_context.write_permanent_flag(Scenes.DEATH_MOUNTAIN_CRATER, FlagType.SWITCH, 0x3, 0x08) # Plant Death Mountain Crater bean
+        save_context.write_permanent_flag(Scenes.GRAVEYARD, FlagType.SWITCH, 0x3, 0x08)  # Plant Graveyard bean
+        save_context.write_permanent_flag(Scenes.ZORAS_RIVER, FlagType.SWITCH, 0x3, 0x08)  # Plant Zora's River bean
+        save_context.write_permanent_flag(Scenes.KOKIRI_FOREST, FlagType.SWITCH, 0x2, 0x02)  # Plant Kokiri Forest bean
+        save_context.write_permanent_flag(Scenes.LAKE_HYLIA, FlagType.SWITCH, 0x3, 0x02)  # Plant Lake Hylia bean
+        save_context.write_permanent_flag(Scenes.GERUDO_VALLEY, FlagType.SWITCH, 0x3, 0x08)  # Plant Gerudo Valley bean
+        save_context.write_permanent_flag(Scenes.LOST_WOODS, FlagType.SWITCH, 0x3, 0x10)  # Plant Lost Woods bridge bean
+        save_context.write_permanent_flag(Scenes.LOST_WOODS, FlagType.SWITCH, 0x1, 0x04)  # Plant Lost Woods theater bean
+        save_context.write_permanent_flag(Scenes.DESERT_COLOSSUS, FlagType.SWITCH, 0x0, 0x1)  # Plant Desert Colossus bean
+        save_context.write_permanent_flag(Scenes.DEATH_MOUNTAIN_TRAIL, FlagType.SWITCH, 0x3, 0x40)  # Plant Death Mountain Trail bean
+        save_context.write_permanent_flag(Scenes.DEATH_MOUNTAIN_CRATER, FlagType.SWITCH, 0x3, 0x08)  # Plant Death Mountain Crater bean
 
     save_context.write_bits(0x00D4 + 0x05 * 0x1C + 0x04 + 0x1, 0x01) # Water temple switch flag (Ruto)
     save_context.write_bits(0x00D4 + 0x51 * 0x1C + 0x04 + 0x2, 0x08) # Hyrule Field switch flag (Owl)
@@ -1218,67 +1218,67 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     save_context.write_bits(0x00D4 + 0x5F * 0x1C + 0x04 + 0x3, 0x20) # Hyrule Castle switch flag (Owl)
     save_context.write_bits(0x0F2B, 0x20) # Spoke to Lake Hylia Owl once
 
-    save_context.write_bits(0x0ED4, 0x10) # "Met Deku Tree"
-    save_context.write_bits(0x0ED5, 0x20) # "Deku Tree Opened Mouth"
-    save_context.write_bits(0x0ED6, 0x08) # "Rented Horse From Ingo"
-    save_context.write_bits(0x0ED6, 0x10) # "Spoke to Mido After Deku Tree's Death"
-    save_context.write_bits(0x0EDA, 0x08) # "Began Nabooru Battle"
-    save_context.write_bits(0x0EDC, 0x80) # "Entered the Master Sword Chamber"
-    save_context.write_bits(0x0EDD, 0x20) # "Pulled Master Sword from Pedestal"
-    save_context.write_bits(0x0EE0, 0x80) # "Spoke to Kaepora Gaebora by Lost Woods"
-    save_context.write_bits(0x0EE7, 0x20) # "Nabooru Captured by Twinrova"
-    save_context.write_bits(0x0EE7, 0x10) # "Spoke to Nabooru in Spirit Temple"
-    save_context.write_bits(0x0EED, 0x20) # "Sheik, Spawned at Master Sword Pedestal as Adult"
-    save_context.write_bits(0x0EED, 0x01) # "Nabooru Ordered to Fight by Twinrova"
-    save_context.write_bits(0x0EED, 0x80) # "Watched Ganon's Tower Collapse / Caught by Gerudo"
-    save_context.write_bits(0x0EF9, 0x01) # "Greeted by Saria"
-    save_context.write_bits(0x0F0A, 0x04) # "Spoke to Ingo Once as Adult"
-    save_context.write_bits(0x0F0F, 0x40) # "Met Poe Collector in Ruined Market"
+    save_context.write_bits(0x0ED4, 0x10)  # "Met Deku Tree"
+    save_context.write_bits(0x0ED5, 0x20)  # "Deku Tree Opened Mouth"
+    save_context.write_bits(0x0ED6, 0x08)  # "Rented Horse From Ingo"
+    save_context.write_bits(0x0ED6, 0x10)  # "Spoke to Mido After Deku Tree's Death"
+    save_context.write_bits(0x0EDA, 0x08)  # "Began Nabooru Battle"
+    save_context.write_bits(0x0EDC, 0x80)  # "Entered the Master Sword Chamber"
+    save_context.write_bits(0x0EDD, 0x20)  # "Pulled Master Sword from Pedestal"
+    save_context.write_bits(0x0EE0, 0x80)  # "Spoke to Kaepora Gaebora by Lost Woods"
+    save_context.write_bits(0x0EE7, 0x20)  # "Nabooru Captured by Twinrova"
+    save_context.write_bits(0x0EE7, 0x10)  # "Spoke to Nabooru in Spirit Temple"
+    save_context.write_bits(0x0EED, 0x20)  # "Sheik, Spawned at Master Sword Pedestal as Adult"
+    save_context.write_bits(0x0EED, 0x01)  # "Nabooru Ordered to Fight by Twinrova"
+    save_context.write_bits(0x0EED, 0x80)  # "Watched Ganon's Tower Collapse / Caught by Gerudo"
+    save_context.write_bits(0x0EF9, 0x01)  # "Greeted by Saria"
+    save_context.write_bits(0x0F0A, 0x04)  # "Spoke to Ingo Once as Adult"
+    save_context.write_bits(0x0F0F, 0x40)  # "Met Poe Collector in Ruined Market"
     if not world.settings.useful_cutscenes:
-        save_context.write_bits(0x0F1A, 0x04) # "Met Darunia in Fire Temple"
+        save_context.write_bits(0x0F1A, 0x04)  # "Met Darunia in Fire Temple"
 
-    save_context.write_bits(0x0ED7, 0x01) # "Spoke to Child Malon at Castle or Market"
-    save_context.write_bits(0x0ED7, 0x20) # "Spoke to Child Malon at Ranch"
-    save_context.write_bits(0x0ED7, 0x40) # "Invited to Sing With Child Malon"
-    save_context.write_bits(0x0F09, 0x10) # "Met Child Malon at Castle or Market"
-    save_context.write_bits(0x0F09, 0x20) # "Child Malon Said Epona Was Scared of You"
+    save_context.write_bits(0x0ED7, 0x01)  # "Spoke to Child Malon at Castle or Market"
+    save_context.write_bits(0x0ED7, 0x20)  # "Spoke to Child Malon at Ranch"
+    save_context.write_bits(0x0ED7, 0x40)  # "Invited to Sing With Child Malon"
+    save_context.write_bits(0x0F09, 0x10)  # "Met Child Malon at Castle or Market"
+    save_context.write_bits(0x0F09, 0x20)  # "Child Malon Said Epona Was Scared of You"
 
-    save_context.write_bits(0x0F21, 0x04) # "Ruto in JJ (M3) Talk First Time"
-    save_context.write_bits(0x0F21, 0x02) # "Ruto in JJ (M2) Meet Ruto"
+    save_context.write_bits(0x0F21, 0x04)  # "Ruto in JJ (M3) Talk First Time"
+    save_context.write_bits(0x0F21, 0x02)  # "Ruto in JJ (M2) Meet Ruto"
 
-    save_context.write_bits(0x0EE2, 0x01) # "Began Ganondorf Battle"
-    save_context.write_bits(0x0EE3, 0x80) # "Began Bongo Bongo Battle"
-    save_context.write_bits(0x0EE3, 0x40) # "Began Barinade Battle"
-    save_context.write_bits(0x0EE3, 0x20) # "Began Twinrova Battle"
-    save_context.write_bits(0x0EE3, 0x10) # "Began Morpha Battle"
-    save_context.write_bits(0x0EE3, 0x08) # "Began Volvagia Battle"
-    save_context.write_bits(0x0EE3, 0x04) # "Began Phantom Ganon Battle"
-    save_context.write_bits(0x0EE3, 0x02) # "Began King Dodongo Battle"
-    save_context.write_bits(0x0EE3, 0x01) # "Began Gohma Battle"
+    save_context.write_bits(0x0EE2, 0x01)  # "Began Ganondorf Battle"
+    save_context.write_bits(0x0EE3, 0x80)  # "Began Bongo Bongo Battle"
+    save_context.write_bits(0x0EE3, 0x40)  # "Began Barinade Battle"
+    save_context.write_bits(0x0EE3, 0x20)  # "Began Twinrova Battle"
+    save_context.write_bits(0x0EE3, 0x10)  # "Began Morpha Battle"
+    save_context.write_bits(0x0EE3, 0x08)  # "Began Volvagia Battle"
+    save_context.write_bits(0x0EE3, 0x04)  # "Began Phantom Ganon Battle"
+    save_context.write_bits(0x0EE3, 0x02)  # "Began King Dodongo Battle"
+    save_context.write_bits(0x0EE3, 0x01)  # "Began Gohma Battle"
 
-    save_context.write_bits(0x0EE8, 0x01) # "Entered Deku Tree"
-    save_context.write_bits(0x0EE9, 0x80) # "Entered Temple of Time"
-    save_context.write_bits(0x0EE9, 0x40) # "Entered Goron City"
-    save_context.write_bits(0x0EE9, 0x20) # "Entered Hyrule Castle"
-    save_context.write_bits(0x0EE9, 0x10) # "Entered Zora's Domain"
-    save_context.write_bits(0x0EE9, 0x08) # "Entered Kakariko Village"
-    save_context.write_bits(0x0EE9, 0x02) # "Entered Death Mountain Trail"
-    save_context.write_bits(0x0EE9, 0x01) # "Entered Hyrule Field"
-    save_context.write_bits(0x0EEA, 0x04) # "Entered Ganon's Castle (Exterior)"
-    save_context.write_bits(0x0EEA, 0x02) # "Entered Death Mountain Crater"
-    save_context.write_bits(0x0EEA, 0x01) # "Entered Desert Colossus"
-    save_context.write_bits(0x0EEB, 0x80) # "Entered Zora's Fountain"
-    save_context.write_bits(0x0EEB, 0x40) # "Entered Graveyard"
-    save_context.write_bits(0x0EEB, 0x20) # "Entered Jabu-Jabu's Belly"
-    save_context.write_bits(0x0EEB, 0x10) # "Entered Lon Lon Ranch"
-    save_context.write_bits(0x0EEB, 0x08) # "Entered Gerudo's Fortress"
-    save_context.write_bits(0x0EEB, 0x04) # "Entered Gerudo Valley"
-    save_context.write_bits(0x0EEB, 0x02) # "Entered Lake Hylia"
-    save_context.write_bits(0x0EEB, 0x01) # "Entered Dodongo's Cavern"
-    save_context.write_bits(0x0F08, 0x08) # "Entered Hyrule Castle"
+    save_context.write_bits(0x0EE8, 0x01)  # "Entered Deku Tree"
+    save_context.write_bits(0x0EE9, 0x80)  # "Entered Temple of Time"
+    save_context.write_bits(0x0EE9, 0x40)  # "Entered Goron City"
+    save_context.write_bits(0x0EE9, 0x20)  # "Entered Hyrule Castle"
+    save_context.write_bits(0x0EE9, 0x10)  # "Entered Zora's Domain"
+    save_context.write_bits(0x0EE9, 0x08)  # "Entered Kakariko Village"
+    save_context.write_bits(0x0EE9, 0x02)  # "Entered Death Mountain Trail"
+    save_context.write_bits(0x0EE9, 0x01)  # "Entered Hyrule Field"
+    save_context.write_bits(0x0EEA, 0x04)  # "Entered Ganon's Castle (Exterior)"
+    save_context.write_bits(0x0EEA, 0x02)  # "Entered Death Mountain Crater"
+    save_context.write_bits(0x0EEA, 0x01)  # "Entered Desert Colossus"
+    save_context.write_bits(0x0EEB, 0x80)  # "Entered Zora's Fountain"
+    save_context.write_bits(0x0EEB, 0x40)  # "Entered Graveyard"
+    save_context.write_bits(0x0EEB, 0x20)  # "Entered Jabu-Jabu's Belly"
+    save_context.write_bits(0x0EEB, 0x10)  # "Entered Lon Lon Ranch"
+    save_context.write_bits(0x0EEB, 0x08)  # "Entered Gerudo's Fortress"
+    save_context.write_bits(0x0EEB, 0x04)  # "Entered Gerudo Valley"
+    save_context.write_bits(0x0EEB, 0x02)  # "Entered Lake Hylia"
+    save_context.write_bits(0x0EEB, 0x01)  # "Entered Dodongo's Cavern"
+    save_context.write_bits(0x0F08, 0x08)  # "Entered Hyrule Castle"
 
     if world.dungeon_mq['Shadow Temple']:
-        save_context.write_bits(0x019F, 0x80) # "Turn On Clear Wall Blocking Hover Boots Room"
+        save_context.write_bits(0x019F, 0x80)  # "Turn On Clear Wall Blocking Hover Boots Room"
 
     # Set the number of chickens to collect
     rom.write_byte(0x00E1E523, world.settings.chicken_count)
@@ -1294,7 +1294,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Make the Kakariko Gate not open with the MS
     if world.settings.open_kakariko != 'open':
-        rom.write_int32(0xDD3538, 0x34190000) # li t9, 0
+        rom.write_int32(0xDD3538, 0x34190000)  # li t9, 0
     if world.settings.open_kakariko != 'closed':
         rom.write_byte(rom.sym('OPEN_KAKARIKO'), 1)
 
@@ -1351,27 +1351,26 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         save_context.write_bits(0x00D4 + 0x5F * 0x1C + 0x04 + 0x3, 0x10) # "Moved crates to access the courtyard"
     if world.skip_child_zelda or "Zeldas Letter" in world.distribution.starting_items.keys():
         if world.settings.open_kakariko != 'closed':
-            save_context.write_bits(0x0F07, 0x40) # "Spoke to Gate Guard About Mask Shop"
+            save_context.write_bits(0x0F07, 0x40)  # "Spoke to Gate Guard About Mask Shop"
         if world.settings.complete_mask_quest:
-            save_context.write_bits(0x0F07, 0x80) # "Soldier Wears Keaton Mask"
-            save_context.write_bits(0x0EF6, 0x8F) # "Sold Masks & Unlocked Masks" / "Obtained Mask of Truth"
-            save_context.write_bits(0x0EE4, 0xF0) # "Paid Back Mask Fees"
+            save_context.write_bits(0x0F07, 0x80)  # "Soldier Wears Keaton Mask"
+            save_context.write_bits(0x0EF6, 0x8F)  # "Sold Masks & Unlocked Masks" / "Obtained Mask of Truth"
+            save_context.write_bits(0x0EE4, 0xF0)  # "Paid Back Mask Fees"
 
     if world.settings.zora_fountain == 'open':
-        save_context.write_bits(0x0EDB, 0x08) # "Moved King Zora"
+        save_context.write_bits(0x0EDB, 0x08)  # "Moved King Zora"
     elif world.settings.zora_fountain == 'adult':
         rom.write_byte(rom.sym('MOVED_ADULT_KING_ZORA'), 1)
 
     # Make all chest opening animations fast
     rom.write_byte(rom.sym('FAST_CHESTS'), int(world.settings.fast_chests))
 
-
     # Set up Rainbow Bridge conditions
     symbol = rom.sym('RAINBOW_BRIDGE_CONDITION')
     count_symbol = rom.sym('RAINBOW_BRIDGE_COUNT')
     if world.settings.bridge == 'open':
         rom.write_int32(symbol, 0)
-        save_context.write_bits(0xEDC, 0x20) # "Rainbow Bridge Built by Sages"
+        save_context.write_bits(0xEDC, 0x20)  # "Rainbow Bridge Built by Sages"
     elif world.settings.bridge == 'medallions':
         rom.write_int32(symbol, 1)
         rom.write_int16(count_symbol, world.settings.bridge_medallions)
@@ -1443,10 +1442,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_int32(symbol, 0)
 
     if world.settings.open_forest == 'open':
-        save_context.write_bits(0xED5, 0x10) # "Showed Mido Sword & Shield"
+        save_context.write_bits(0xED5, 0x10)  # "Showed Mido Sword & Shield"
 
     if world.settings.open_door_of_time:
-        save_context.write_bits(0xEDC, 0x08) # "Opened the Door of Time"
+        save_context.write_bits(0xEDC, 0x08)  # "Opened the Door of Time"
 
     # "fast-ganon" stuff
     symbol = rom.sym('NO_ESCAPE_SEQUENCE')
@@ -1457,35 +1456,35 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     else:
         rom.write_byte(symbol, 0x00)
     if world.skipped_trials['Forest']:
-        save_context.write_bits(0x0EEA, 0x08) # "Completed Forest Trial"
+        save_context.write_bits(0x0EEA, 0x08)  # "Completed Forest Trial"
     if world.skipped_trials['Fire']:
-        save_context.write_bits(0x0EEA, 0x40) # "Completed Fire Trial"
+        save_context.write_bits(0x0EEA, 0x40)  # "Completed Fire Trial"
     if world.skipped_trials['Water']:
-        save_context.write_bits(0x0EEA, 0x10) # "Completed Water Trial"
+        save_context.write_bits(0x0EEA, 0x10)  # "Completed Water Trial"
     if world.skipped_trials['Spirit']:
-        save_context.write_bits(0x0EE8, 0x20) # "Completed Spirit Trial"
+        save_context.write_bits(0x0EE8, 0x20)  # "Completed Spirit Trial"
     if world.skipped_trials['Shadow']:
-        save_context.write_bits(0x0EEA, 0x20) # "Completed Shadow Trial"
+        save_context.write_bits(0x0EEA, 0x20)  # "Completed Shadow Trial"
     if world.skipped_trials['Light']:
-        save_context.write_bits(0x0EEA, 0x80) # "Completed Light Trial"
+        save_context.write_bits(0x0EEA, 0x80)  # "Completed Light Trial"
     if world.settings.trials == 0:
-        save_context.write_bits(0x0EED, 0x08) # "Dispelled Ganon's Tower Barrier"
+        save_context.write_bits(0x0EED, 0x08)  # "Dispelled Ganon's Tower Barrier"
 
     # open gerudo fortress
     if world.settings.gerudo_fortress == 'open':
         if not world.settings.shuffle_gerudo_card:
-            save_context.write_bits(0x00A5, 0x40) # Give Gerudo Card
-        save_context.write_bits(0x0EE7, 0x0F) # Free all 4 carpenters
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x1, 0x0F) # Thieves' Hideout switch flags (started all fights)
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x2, 0x01) # Thieves' Hideout switch flags (heard yells/unlocked doors)
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x3, 0xFE) # Thieves' Hideout switch flags (heard yells/unlocked doors)
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x0C + 0x2, 0xD4) # Thieves' Hideout collection flags (picked up keys, marks fights finished as well)
+            save_context.write_bits(0x00A5, 0x40)  # Give Gerudo Card
+        save_context.write_bits(0x0EE7, 0x0F)  # Free all 4 carpenters
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x1, 0x0F)  # Thieves' Hideout switch flags (started all fights)
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x2, 0x01)  # Thieves' Hideout switch flags (heard yells/unlocked doors)
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x3, 0xFE)  # Thieves' Hideout switch flags (heard yells/unlocked doors)
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x0C + 0x2, 0xD4)  # Thieves' Hideout collection flags (picked up keys, marks fights finished as well)
     elif world.settings.gerudo_fortress == 'fast':
-        save_context.write_bits(0x0EE7, 0x0E) # Free 3 carpenters
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x1, 0x0D) # Thieves' Hideout switch flags (started all fights)
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x2, 0x01) # Thieves' Hideout switch flags (heard yells/unlocked doors)
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x3, 0xDC) # Thieves' Hideout switch flags (heard yells/unlocked doors)
-        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x0C + 0x2, 0xC4) # Thieves' Hideout collection flags (picked up keys, marks fights finished as well)
+        save_context.write_bits(0x0EE7, 0x0E)  # Free 3 carpenters
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x1, 0x0D)  # Thieves' Hideout switch flags (started all fights)
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x2, 0x01)  # Thieves' Hideout switch flags (heard yells/unlocked doors)
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x04 + 0x3, 0xDC)  # Thieves' Hideout switch flags (heard yells/unlocked doors)
+        save_context.write_bits(0x00D4 + 0x0C * 0x1C + 0x0C + 0x2, 0xC4)  # Thieves' Hideout collection flags (picked up keys, marks fights finished as well)
 
     # Add a gate opening guard on the Wasteland side of the Gerudo Fortress' gate
     # Overrides the generic guard at the bottom of the ladder in Gerudo Fortress
@@ -1539,15 +1538,15 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # For Inventory_SwapAgeEquipment going child -> adult:
     # Change range in which items are read from slot instead of items
     # Extended to include hookshot and ocarina
-    rom.write_byte(0xAE5867, 0x07) # >= ITEM_OCARINA_FAIRY
-    rom.write_byte(0xAE5873, 0x0C) # <= ITEM_LONGSHOT
-    rom.write_byte(0xAE587B, 0x14) # >= ITEM_BOTTLE
+    rom.write_byte(0xAE5867, 0x07)  # >= ITEM_OCARINA_FAIRY
+    rom.write_byte(0xAE5873, 0x0C)  # <= ITEM_LONGSHOT
+    rom.write_byte(0xAE587B, 0x14)  # >= ITEM_BOTTLE
 
     # Revert change that Skips the Epona Race
     if not world.settings.no_epona_race:
         rom.write_int32(0xA9E838, 0x03E00008)
     else:
-        save_context.write_bits(0xF0E, 0x01) # Set talked to Malon flag
+        save_context.write_bits(0xF0E, 0x01)  # Set talked to Malon flag
 
     # skip castle guard stealth sequence
     if world.settings.no_guard_stealth:
@@ -1591,11 +1590,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     ### Load Shop File
     # Move shop actor file to free space
-    shop_item_file = File({
-            'Name':'En_GirlA',
-            'Start':'00C004E0',
-            'End':'00C02E00',
-        })
+    shop_item_file = File('En_GirlA', 0x00C004E0, 0x00C02E00)
     shop_item_file.relocate(rom)
 
     # Increase the shop item table size
@@ -1620,19 +1615,15 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     update_dmadata(rom, shop_item_file)
 
     # Create 2nd Bazaar Room
-    bazaar_room_file = File({
-            'Name':'shop1_room_1',
-            'Start':'028E4000',
-            'End':'0290D7B0',
-        })
+    bazaar_room_file = File('shop1_room_1', 0x028E4000, 0x0290D7B0)
     bazaar_room_file.copy(rom)
 
     # Add new Bazaar Room to Bazaar Scene
-    rom.write_int32s(0x28E3030, [0x00010000, 0x02000058])  #reduce position list size
-    rom.write_int32s(0x28E3008, [0x04020000, 0x02000070])  #expand room list size
+    rom.write_int32s(0x28E3030, [0x00010000, 0x02000058])  # reduce position list size
+    rom.write_int32s(0x28E3008, [0x04020000, 0x02000070])  # expand room list size
 
     rom.write_int32s(0x28E3070, [0x028E4000, 0x0290D7B0,
-                                 bazaar_room_file.start, bazaar_room_file.end])  #room list
+                                 bazaar_room_file.start, bazaar_room_file.end])  # room list
     rom.write_int16s(0x28E3080, [0x0000, 0x0001])  # entrance list
     rom.write_int16(0x28E4076, 0x0005) # Change shop to Kakariko Bazaar
     #rom.write_int16(0x3489076, 0x0005) # Change shop to Kakariko Bazaar
@@ -1642,8 +1633,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         sum(f'{shop} Item {idx}' in world.shop_prices for idx in ('7', '5', '8', '6'))
         # number of special deals in this shop
         for shop in (
-        'KF Shop', 'Market Bazaar', 'Market Potion Shop', 'Market Bombchu Shop', 'Kak Bazaar', 'Kak Potion Shop',
-        'GC Shop', 'ZD Shop')
+            'KF Shop', 'Market Bazaar', 'Market Potion Shop', 'Market Bombchu Shop', 'Kak Bazaar', 'Kak Potion Shop',
+            'GC Shop', 'ZD Shop'
+        )
     ])
 
     # Load Message and Shop Data
@@ -1704,10 +1696,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         reward_text = None
     elif location.item.looks_like_item is not None:
         jabu_item = location.item.looks_like_item
-        reward_text = create_fake_name(getHint(getItemGenericName(location.item.looks_like_item), True).text)
+        reward_text = create_fake_name(get_hint(get_item_generic_name(location.item.looks_like_item), True).text)
     else:
         jabu_item = location.item
-        reward_text = getHint(getItemGenericName(location.item), True).text
+        reward_text = get_hint(get_item_generic_name(location.item), True).text
 
     # Update "Princess Ruto got the Spiritual Stone!" text before the midboss in Jabu
     if reward_text is None:
@@ -1746,7 +1738,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_byte(symbol, 0x01)
 
     if world.settings.skip_some_minigame_phases:
-        save_context.write_bits(0x00D4 + 0x48 * 0x1C + 0x08 + 0x3, 0x10) # Beat First Dampe Race (& Chest Spawned)
+        save_context.write_bits(0x00D4 + 0x48 * 0x1C + 0x08 + 0x3, 0x10)  # Beat First Dampe Race (& Chest Spawned)
         rom.write_byte(rom.sym('CHAIN_HBA_REWARDS'), 1)
         # Update the first horseback archery text to make it clear both rewards are available from the start
         update_message_by_id(messages, 0x6040, "Hey newcomer, you have a fine \x01horse!\x04I don't know where you stole \x01it from, but...\x04OK, how about challenging this \x01\x05\x41horseback archery\x05\x40?\x04Once the horse starts galloping,\x01shoot the targets with your\x01arrows. \x04Let's see how many points you \x01can score. You get 20 arrows.\x04If you can score \x05\x411,000 points\x05\x40, I will \x01give you something good! And even \x01more if you score \x05\x411,500 points\x05\x40!\x0B\x02")
@@ -1757,12 +1749,12 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Sets hooks for gossip stone changes
 
-    symbol = rom.sym("GOSSIP_HINT_CONDITION");
+    symbol = rom.sym("GOSSIP_HINT_CONDITION")
 
     if world.settings.hints == 'none':
         rom.write_int32(symbol, 0)
     else:
-        writeGossipStoneHints(spoiler, world, messages)
+        write_gossip_stone_hints(spoiler, world, messages)
 
         if world.settings.hints == 'mask':
             rom.write_int32(symbol, 0)
@@ -1771,16 +1763,15 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         else:
             rom.write_int32(symbol, 1)
 
-
     # build silly ganon lines
     if 'ganondorf' in world.settings.misc_hints:
-        buildGanonText(world, messages)
+        build_ganon_text(world, messages)
 
     # build misc. item hints
-    buildMiscItemHints(world, messages)
+    build_misc_item_hints(world, messages)
 
     # build misc. location hints
-    buildMiscLocationHints(world, messages)
+    build_misc_location_hints(world, messages)
 
     if 'mask_shop' in world.settings.misc_hints:
         rom.write_int32(rom.sym('CFG_MASK_SHOP_HINT'), 1)
@@ -1793,7 +1784,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # Patch freestanding items
     if world.settings.shuffle_freestanding_items:
-    # Get freestanding item locations
+        # Get freestanding item locations
         actor_override_locations = [location for location in world.get_locations() if location.disabled == DisableType.ENABLED and location.type == 'ActorOverride']
         rupeetower_locations = [location for location in world.get_locations() if location.disabled == DisableType.ENABLED and location.type == 'RupeeTower']
 
@@ -1832,7 +1823,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     if len(override_table) >= 1536:
         raise RuntimeError(f'Exceeded override table size: {len(override_table)}')
     rom.write_bytes(rom.sym('cfg_item_overrides'), get_override_table_bytes(override_table))
-    rom.write_byte(rom.sym('PLAYER_ID'), world.id + 1) # Write player ID
+    rom.write_byte(rom.sym('PLAYER_ID'), world.id + 1)  # Write player ID
 
     # Revert Song Get Override Injection
     if not songs_as_items:
@@ -1847,7 +1838,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_int32(0xE09FB0, 0x240F0001)
         # song of time
         rom.write_int32(0xDB532C, 0x24050003)
-
 
     # Set damage multiplier
     if world.settings.damage_multiplier == 'half':
@@ -1888,37 +1878,37 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             rom.write_byte(secondaryaddress, next_song_id)
             if location.name == 'Song from Impa':
                 rom.write_byte(0x0D12ECB, special['item_id'])
-                rom.write_byte(0x2E8E931, special['text_id']) #Fix text box
+                rom.write_byte(0x2E8E931, special['text_id'])  # Fix text box
             elif location.name == 'Song from Malon':
                 rom.write_byte(rom.sym('MALON_TEXT_ID'), special['text_id'])
             elif location.name == 'Song from Royal Familys Tomb':
                 rom.write_int16(0xE09F66, bit_mask_pointer)
-                rom.write_byte(0x332A87D, special['text_id']) #Fix text box
+                rom.write_byte(0x332A87D, special['text_id'])  # Fix text box
             elif location.name == 'Song from Saria':
                 rom.write_byte(0x0E2A02B, special['item_id'])
-                rom.write_byte(0x20B1DBD, special['text_id']) #Fix text box
+                rom.write_byte(0x20B1DBD, special['text_id'])  # Fix text box
             elif location.name == 'Song from Ocarina of Time':
-                rom.write_byte(0x252FC95, special['text_id']) #Fix text box
+                rom.write_byte(0x252FC95, special['text_id'])  # Fix text box
             elif location.name == 'Song from Windmill':
                 rom.write_byte(rom.sym('WINDMILL_SONG_ID'), next_song_id)
                 rom.write_byte(rom.sym('WINDMILL_TEXT_ID'), special['text_id'])
             elif location.name == 'Sheik in Forest':
                 rom.write_byte(0x0C7BAA3, special['item_id'])
-                rom.write_byte(0x20B0815, special['text_id']) #Fix text box
+                rom.write_byte(0x20B0815, special['text_id'])  # Fix text box
             elif location.name == 'Sheik at Temple':
                 rom.write_byte(0x0C805EF, special['item_id'])
-                rom.write_byte(0x2531335, special['text_id']) #Fix text box
+                rom.write_byte(0x2531335, special['text_id'])  # Fix text box
             elif location.name == 'Sheik in Crater':
                 rom.write_byte(0x0C7BC57, special['item_id'])
-                rom.write_byte(0x224D7FD, special['text_id']) #Fix text box
+                rom.write_byte(0x224D7FD, special['text_id'])  # Fix text box
             elif location.name == 'Sheik in Ice Cavern':
                 rom.write_byte(0x0C7BD77, special['item_id'])
-                rom.write_byte(0x2BEC895, special['text_id']) #Fix text box
+                rom.write_byte(0x2BEC895, special['text_id'])  # Fix text box
             elif location.name == 'Sheik in Kakariko':
                 rom.write_byte(0x0AC9A5B, special['item_id'])
-                rom.write_byte(0x2000FED, special['text_id']) #Fix text box
+                rom.write_byte(0x2000FED, special['text_id'])  # Fix text box
             elif location.name == 'Sheik at Colossus':
-                rom.write_byte(0x218C589, special['text_id']) #Fix text box
+                rom.write_byte(0x218C589, special['text_id'])  # Fix text box
         elif location.type == 'Boss' and location.name != 'Links Pocket':
             rom.write_byte(locationaddress, special['item_id'])
             rom.write_byte(secondaryaddress, special['addr2_data'])
@@ -1960,9 +1950,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
 
     # kokiri shop
     shop_locations = [location for location in world.get_region('KF Kokiri Shop').locations if location.type == 'Shop'] # Need to filter because of the freestanding item in KF Shop
-    shop_objs = place_shop_items(rom, world, shop_items, messages,
-        shop_locations, True)
-    shop_objs |= {0x00FC, 0x00B2, 0x0101, 0x0102, 0x00FD, 0x00C5} # Shop objects
+    shop_objs = place_shop_items(rom, world, shop_items, messages, shop_locations, True)
+    shop_objs |= {0x00FC, 0x00B2, 0x0101, 0x0102, 0x00FD, 0x00C5}  # Shop objects
     rom.write_byte(0x2587029, len(shop_objs))
     rom.write_int32(0x258702C, 0x0300F600)
     rom.write_int16s(0x2596600, list(shop_objs))
@@ -1970,7 +1959,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # kakariko bazaar
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('Kak Bazaar').locations)
-    shop_objs |= {0x005B, 0x00B2, 0x00C5, 0x0107, 0x00C9, 0x016B} # Shop objects
+    shop_objs |= {0x005B, 0x00B2, 0x00C5, 0x0107, 0x00C9, 0x016B}  # Shop objects
     rom.write_byte(0x28E4029, len(shop_objs))
     rom.write_int32(0x28E402C, 0x03007A40)
     rom.write_int16s(0x28EBA40, list(shop_objs))
@@ -1978,7 +1967,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # castle town bazaar
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('Market Bazaar').locations)
-    shop_objs |= {0x005B, 0x00B2, 0x00C5, 0x0107, 0x00C9, 0x016B} # Shop objects
+    shop_objs |= {0x005B, 0x00B2, 0x00C5, 0x0107, 0x00C9, 0x016B}  # Shop objects
     rom.write_byte(bazaar_room_file.start + 0x29, len(shop_objs))
     rom.write_int32(bazaar_room_file.start + 0x2C, 0x03007A40)
     rom.write_int16s(bazaar_room_file.start + 0x7A40, list(shop_objs))
@@ -1986,7 +1975,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # goron shop
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('GC Shop').locations)
-    shop_objs |= {0x00C9, 0x00B2, 0x0103, 0x00AF} # Shop objects
+    shop_objs |= {0x00C9, 0x00B2, 0x0103, 0x00AF}  # Shop objects
     rom.write_byte(0x2D33029, len(shop_objs))
     rom.write_int32(0x2D3302C, 0x03004340)
     rom.write_int16s(0x2D37340, list(shop_objs))
@@ -1994,7 +1983,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # zora shop
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('ZD Shop').locations)
-    shop_objs |= {0x005B, 0x00B2, 0x0104, 0x00FE} # Shop objects
+    shop_objs |= {0x005B, 0x00B2, 0x0104, 0x00FE}  # Shop objects
     rom.write_byte(0x2D5B029, len(shop_objs))
     rom.write_int32(0x2D5B02C, 0x03004B40)
     rom.write_int16s(0x2D5FB40, list(shop_objs))
@@ -2002,7 +1991,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # kakariko potion shop
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('Kak Potion Shop Front').locations)
-    shop_objs |= {0x0159, 0x00B2, 0x0175, 0x0122} # Shop objects
+    shop_objs |= {0x0159, 0x00B2, 0x0175, 0x0122}  # Shop objects
     rom.write_byte(0x2D83029, len(shop_objs))
     rom.write_int32(0x2D8302C, 0x0300A500)
     rom.write_int16s(0x2D8D500, list(shop_objs))
@@ -2010,7 +1999,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # market potion shop
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('Market Potion Shop').locations)
-    shop_objs |= {0x0159, 0x00B2, 0x0175, 0x00C5, 0x010C, 0x016B} # Shop objects
+    shop_objs |= {0x0159, 0x00B2, 0x0175, 0x00C5, 0x010C, 0x016B}  # Shop objects
     rom.write_byte(0x2DB0029, len(shop_objs))
     rom.write_int32(0x2DB002C, 0x03004E40)
     rom.write_int16s(0x2DB4E40, list(shop_objs))
@@ -2018,7 +2007,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # bombchu shop
     shop_objs = place_shop_items(rom, world, shop_items, messages,
         world.get_region('Market Bombchu Shop').locations)
-    shop_objs |= {0x0165, 0x00B2} # Shop objects
+    shop_objs |= {0x0165, 0x00B2}  # Shop objects
     rom.write_byte(0x2DD8029, len(shop_objs))
     rom.write_int32(0x2DD802C, 0x03006A40)
     rom.write_int16s(0x2DDEA40, list(shop_objs))
@@ -2032,7 +2021,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_int16s(0x3417400, list(shop_objs))
 
     # Scrub text stuff.
-    def update_scrub_text(message, text_replacement, default_price, price, item_name=None):
+    def update_scrub_text(message: bytearray, text_replacement: List[str], default_price: int, price: int,
+                          item_name: Optional[str] = None) -> bytearray:
         scrub_strip_text = ["some ", "1 piece   ", "5 pieces   ", "30 pieces   "]
         for text in scrub_strip_text:
             message = message.replace(text.encode(), b'')
@@ -2059,8 +2049,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             0x14410004,  # bne v0, at, 0xd8
             0x2463A5D0,  # addiu v1, v1, -0x5a30
             0x94790EF0])  # lhu t9, 0xef0(v1)
-        rom.write_int32(0xDF7CB0,
-            0xA44F0EF0)  # sh t7, 0xef0(v0)
+        rom.write_int32(0xDF7CB0, 0xA44F0EF0)  # sh t7, 0xef0(v0)
 
         # Replace scrub text for 3 default shuffled scrubs.
         for (scrub_item, default_price, text_id, text_replacement) in business_scrubs:
@@ -2115,7 +2104,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             update_message_by_id(messages, 0x405E, "\x1AChomp chomp chomp...\x01We have... \x05\x41a mysterious item\x05\x40! \x01Do you want it...huh? Huh?\x04\x05\x41\x0860 Rupees\x05\x40 and it's yours!\x01Keyahahah!\x01\x1B\x05\x42Yes\x01No\x05\x40\x02")
         else:
             location = world.get_location("ZR Magic Bean Salesman")
-            item_text = getHint(getItemGenericName(location.item), True).text
+            item_text = get_hint(get_item_generic_name(location.item), True).text
             update_message_by_id(messages, 0x405E, "\x1AChomp chomp chomp...We have...\x01\x05\x41" + item_text + "\x05\x40! \x01Do you want it...huh? Huh?\x04\x05\x41\x0860 Rupees\x05\x40 and it's yours!\x01Keyahahah!\x01\x1B\x05\x42Yes\x01No\x05\x40\x02")
         update_message_by_id(messages, 0x4069, "You don't have enough money.\x01I can't sell it to you.\x01Chomp chomp...\x02")
         update_message_by_id(messages, 0x406C, "We hope you like it!\x01Chomp chomp chomp.\x02")
@@ -2129,7 +2118,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             update_message_by_id(messages, 0x6077, "\x06\x41Well Come!\x04I am selling stuff, strange and \x01rare, from all over the world to \x01everybody.\x01Today's special is...\x04A mysterious item! \x01Intriguing! \x01I won't tell you what it is until \x01I see the money....\x04How about \x05\x41200 Rupees\x05\x40?\x01\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
         else:
             location = world.get_location("Wasteland Bombchu Salesman")
-            item_text = getHint(getItemGenericName(location.item), True).text
+            item_text = get_hint(get_item_generic_name(location.item), True).text
             update_message_by_id(messages, 0x6077, "\x06\x41Well Come!\x04I am selling stuff, strange and \x01rare, from all over the world to \x01everybody. Today's special is...\x01\x05\x41"+ item_text + "\x05\x40! \x01\x04How about \x05\x41200 Rupees\x05\x40?\x01\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
         update_message_by_id(messages, 0x6078, "Thank you very much!\x04The mark that will lead you to\x01the Spirit Temple is the \x05\x41flag on\x01the left \x05\x40outside the shop.\x01Be seeing you!\x02")
 
@@ -2141,7 +2130,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             update_message_by_id(messages, 0x304F, "How about buying this cool item for \x01200 Rupees?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
         else:
             location = world.get_location("GC Medigoron")
-            item_text = getHint(getItemGenericName(location.item), True).text
+            item_text = get_hint(get_item_generic_name(location.item), True).text
             update_message_by_id(messages, 0x304F, "For 200 Rupees, how about buying \x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
 
         rom.write_byte(rom.sym('SHUFFLE_GRANNYS_POTION_SHOP'), 0x01)
@@ -2149,7 +2138,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             update_message_by_id(messages, 0x500C, "Mysterious item! How about\x01\x05\x41100 Rupees\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
         else:
             location = world.get_location("Kak Granny Buy Blue Potion")
-            item_text = getHint(getItemGenericName(location.item), True).text
+            item_text = get_hint(get_item_generic_name(location.item), True).text
             update_message_by_id(messages, 0x500C, "How about \x05\x41100 Rupees\x05\x40 for\x01\x05\x41"+ item_text +"\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
 
     new_message = "All right. You don't have to play\x01if you don't want to.\x0B\x02"
@@ -2164,7 +2153,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             update_message_by_id(messages, 0x6D, "I seem to have misplaced my\x01keys, but I have a fun item to\x01sell instead.\x04How about \x05\x4110 Rupees\x05\x40?\x01\x01\x1B\x05\x42Buy\x01Don't Buy\x05\x40\x02")
         else:
             location = world.get_location("Market Treasure Chest Game Salesman")
-            item_text = getHint(getItemGenericName(location.item), True).text
+            item_text = get_hint(get_item_generic_name(location.item), True).text
             update_message_by_id(messages, 0x6D, "I seem to have misplaced my\x01keys, but I have a fun item to\x01sell instead.\x04How about \x05\x4110 Rupees\x05\x40 for\x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't Buy\x05\x40\x02")
         update_message_by_id(messages, 0x908B, "That's OK!\x01More fun for me.\x0B\x02", 0x00)
         update_message_by_id(messages, 0x6E, "Wait, that room was off limits!\x02")
@@ -2303,7 +2292,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
             elif dungeon in ('Bottom of the Well', 'Ice Cavern'):
                 dungeon_name, boss_name, compass_id, map_id = dungeon_list[dungeon]
                 if world.settings.world_count > 1:
-                    map_message = "\x13\x76\x08\x05\x42\x0F\x05\x40 found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x09" % (dungeon_name)
+                    map_message = "\x13\x76\x08\x05\x42\x0F\x05\x40 found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x09" % dungeon_name
                 else:
                     map_message = "\x13\x76\x08You found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x01It\'s %s!\x09" % (dungeon_name, "masterful" if world.dungeon_mq[dungeon] else "ordinary")
 
@@ -2326,7 +2315,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
                 update_message_by_id(messages, compass_id, compass_message)
                 if world.settings.mq_dungeons_mode == 'random' or world.settings.mq_dungeons_count != 0 and world.settings.mq_dungeons_count != 12:
                     if world.settings.world_count > 1:
-                        map_message = "\x13\x76\x08\x05\x42\x0F\x05\x40 found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x09" % (dungeon_name)
+                        map_message = "\x13\x76\x08\x05\x42\x0F\x05\x40 found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x09" % dungeon_name
                     else:
                         map_message = "\x13\x76\x08You found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x01It\'s %s!\x09" % (dungeon_name, "masterful" if world.dungeon_mq[dungeon] else "ordinary")
                     update_message_by_id(messages, map_id, map_message)
@@ -2334,7 +2323,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # Set hints on the altar inside ToT
     rom.write_int16(0xE2ADB2, 0x707A)
     rom.write_int16(0xE2ADB6, 0x7057)
-    buildAltarHints(world, messages, include_rewards='altar' in world.settings.misc_hints and not world.settings.enhance_map_compass, include_wincons='altar' in world.settings.misc_hints)
+    build_altar_hints(world, messages,
+                      include_rewards='altar' in world.settings.misc_hints and not world.settings.enhance_map_compass,
+                      include_wincons='altar' in world.settings.misc_hints)
 
     # Fix Dead Hand spawn coordinates in vanilla shadow temple and bottom of the well to be the exact centre of the room
     # This prevents the extremely small possibility of Dead Hand spawning outside of collision
@@ -2353,7 +2344,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     rom.write_int16(0xB6EC52, 999)
     tycoon_message = "\x08\x13\x57You got a \x05\x43Tycoon's Wallet\x05\x40!\x01Now you can hold\x01up to \x05\x46999\x05\x40 \x05\x46Rupees\x05\x40."
     if world.settings.world_count > 1:
-       tycoon_message = make_player_message(tycoon_message)
+        tycoon_message = make_player_message(tycoon_message)
     update_message_by_id(messages, 0x00F8, tycoon_message, 0x23)
 
     write_shop_items(rom, shop_item_file.start + 0x1DEC, shop_items)
@@ -2364,11 +2355,11 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         text_codes = []
         chars_in_section = 1
         for code in get_message_by_id(messages, message_id).text_codes:
-            if code.code == 0x04: # box-break
-                text_codes.append(Text_Code(0x0c, 80 + chars_in_section))
+            if code.code == 0x04:  # box-break
+                text_codes.append(TextCode(0x0c, 80 + chars_in_section))
                 chars_in_section = 1
-            elif code.code == 0x02: # end
-                text_codes.append(Text_Code(0x0e, 80 + chars_in_section))
+            elif code.code == 0x02:  # end
+                text_codes.append(TextCode(0x0e, 80 + chars_in_section))
                 text_codes.append(code)
             else:
                 chars_in_section += 1
@@ -2387,10 +2378,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     update_warp_song_text(messages, world)
 
     if world.settings.blue_fire_arrows:
-        rom.write_byte(0xC230C1, 0x29) #Adds AT_TYPE_OTHER to arrows to allow collision with red ice
-        rom.write_byte(0xDB38FE, 0xEF) #disables ice arrow collision on secondary cylinder for red ice crystals
-        rom.write_byte(0xC9F036, 0x10) #enable ice arrow collision on mud walls
-        #increase cylinder radius/height for red ice sheets
+        rom.write_byte(0xC230C1, 0x29)  # Adds AT_TYPE_OTHER to arrows to allow collision with red ice
+        rom.write_byte(0xDB38FE, 0xEF)  # disables ice arrow collision on secondary cylinder for red ice crystals
+        rom.write_byte(0xC9F036, 0x10) # enable ice arrow collision on mud walls
+        # increase cylinder radius/height for red ice sheets
         rom.write_byte(0xDB391B, 0x50)
         rom.write_byte(0xDB3927, 0x5A)
 
@@ -2402,7 +2393,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         with open(data_path('blue_fire_arrow_item_name_eng.ia4'), 'rb') as stream:
             bfa_name_bytes = stream.read()
             rom.write_bytes(0x8a1c00, bfa_name_bytes)
-
 
     repack_messages(rom, messages, permutation)
 
@@ -2431,8 +2421,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
         rom.write_byte(symbol, 0x01)
 
         # Autocollect incoming_item_id for magic jars are swapped in vanilla code
-        rom.write_int16(0xA88066, 0x0044) # Change GI_MAGIC_SMALL to GI_MAGIC_LARGE
-        rom.write_int16(0xA88072, 0x0043) # Change GI_MAGIC_LARGE to GI_MAGIC_SMALL
+        rom.write_int16(0xA88066, 0x0044)  # Change GI_MAGIC_SMALL to GI_MAGIC_LARGE
+        rom.write_int16(0xA88072, 0x0043)  # Change GI_MAGIC_LARGE to GI_MAGIC_SMALL
     else:
         # Remove deku shield drop from spirit pot because it's "vanilla behavior"
         # Replace actor parameters in scene 06, room 27 actor list
@@ -2442,10 +2432,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     # available number of skulls in the world instead of 100.
     rom.write_int16(0xBB340E, world.available_tokens)
 
-    replace_songs(world, rom,
-        frog=world.settings.ocarina_songs in ('frog', 'all'),
-        warp=world.settings.ocarina_songs in ('warp', 'all'),
-    )
+    replace_songs(world, rom, frog=world.settings.ocarina_songs in ('frog', 'all'),
+                  warp=world.settings.ocarina_songs in ('warp', 'all'))
 
     # Sets the torch count to open the entrance to Shadow Temple
     if world.settings.easier_fire_arrow_entry:
@@ -2530,8 +2518,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> None:
     return rom
 
 
-NUM_VANILLA_OBJECTS = 0x192
-def add_to_extended_object_table(rom, object_id, start_adddress, end_address):
+NUM_VANILLA_OBJECTS: int = 0x192
+
+
+def add_to_extended_object_table(rom: Rom, object_id: int, start_adddress: int, end_address: int) -> None:
     extended_id = object_id - NUM_VANILLA_OBJECTS - 1
     extended_object_table = rom.sym('EXTENDED_OBJECT_TABLE')
     rom.write_int32s(extended_object_table + extended_id * 8, [start_adddress, end_address])
@@ -2543,45 +2533,51 @@ item_row_fields = [
     'upgrade_fn', 'effect_fn', 'effect_arg1', 'effect_arg2', 'collectible', 'alt_text_fn',
 ]
 
-def read_rom_item(rom, item_id):
+
+def read_rom_item(rom: Rom, item_id: int) -> Dict[str, Any]:
     addr = rom.sym('item_table') + (item_id * item_row_struct.size)
     row_bytes = rom.read_bytes(addr, item_row_struct.size)
     row = item_row_struct.unpack(row_bytes)
     return { item_row_fields[i]: row[i] for i in range(len(item_row_fields)) }
 
-def write_rom_item(rom, item_id, item):
+
+def write_rom_item(rom: Rom, item_id: int, item: Dict[str, Any]) -> None:
     addr = rom.sym('item_table') + (item_id * item_row_struct.size)
     row = [item[f] for f in item_row_fields]
     row_bytes = item_row_struct.pack(*row)
     rom.write_bytes(addr, row_bytes)
 
 
-texture_struct = struct.Struct('>HBxxxxxII') # Match texture_t in textures.c
-texture_fields = ['texture_id', 'file_buf', 'file_vrom_start', 'file_size']
+texture_struct = struct.Struct('>HBxxxxxII')  # Match texture_t in textures.c
+texture_fields: List[str] = ['texture_id', 'file_buf', 'file_vrom_start', 'file_size']
 
-def read_rom_texture(rom, texture_id):
+
+def read_rom_texture(rom: Rom, texture_id: int) -> Dict[str, Any]:
     addr = rom.sym('texture_table') + (texture_id * texture_struct.size)
     row_bytes = rom.read_bytes(addr, texture_struct.size)
     row = texture_struct.unpack(row_bytes)
     return {texture_fields[i]: row[i] for i in range(len(texture_fields))}
 
-def write_rom_texture(rom, texture_id, texture):
+
+def write_rom_texture(rom: Rom, texture_id: int, texture: Dict[str, Any]) -> None:
     addr = rom.sym('texture_table') + (texture_id * texture_struct.size)
     row = [texture[f] for f in texture_fields]
     row_bytes = texture_struct.pack(*row)
     rom.write_bytes(addr, row_bytes)
 
 
-def get_override_table(world):
-    return list(filter(lambda val: val != None, map(get_override_entry, world.get_filled_locations())))
+def get_override_table(world: World):
+    return list(filter(lambda val: val is not None, map(get_override_entry, world.get_filled_locations())))
 
 
-override_struct = struct.Struct('>BBHxxxxHBxHxx') # match override_t in get_items.c
+override_struct = struct.Struct('>BBHxxxxHBxHxx')  # match override_t in get_items.c
+
+
 def get_override_table_bytes(override_table):
     return b''.join(sorted(itertools.starmap(override_struct.pack, override_table)))
 
 
-def get_override_entry(location):
+def get_override_entry(location: Location) -> Optional[OverrideEntry]:
     scene = location.scene
     default = location.default
     item_id = location.item.index
@@ -2626,47 +2622,48 @@ def get_override_entry(location):
     else:
         return None
 
-    return (scene, type, default, item_id, player_id, looks_like_item_id)
+    return scene, type, default, item_id, player_id, looks_like_item_id
 
 
-def check_location_dupes(world):
+def check_location_dupes(world: World) -> None:
     locations = list(world.get_filled_locations())
     for i in range(0, len(locations)):
         for j in range(0, len(locations)):
             check_i = locations[i]
             check_j = locations[j]
-            if(check_i.name == check_j.name and i != j):
+            if check_i.name == check_j.name and i != j:
                 raise Exception(f'Discovered duplicate location: {check_i.name}')
 
 
-chestTypeMap = {
-        #    small   big     boss
-    0x0000: [0x5000, 0x0000, 0x2000], #Large
-    0x1000: [0x7000, 0x1000, 0x1000], #Large, Appears, Clear Flag
-    0x2000: [0x5000, 0x0000, 0x2000], #Boss Key’s Chest
-    0x3000: [0x8000, 0x3000, 0x3000], #Large, Falling, Switch Flag
-    0x4000: [0x6000, 0x4000, 0x4000], #Large, Invisible
-    0x5000: [0x5000, 0x0000, 0x2000], #Small
-    0x6000: [0x6000, 0x4000, 0x4000], #Small, Invisible
-    0x7000: [0x7000, 0x1000, 0x1000], #Small, Appears, Clear Flag
-    0x8000: [0x8000, 0x3000, 0x3000], #Small, Falling, Switch Flag
-    0x9000: [0x9000, 0x9000, 0x9000], #Large, Appears, Zelda's Lullaby
-    0xA000: [0xA000, 0xA000, 0xA000], #Large, Appears, Sun's Song Triggered
-    0xB000: [0xB000, 0xB000, 0xB000], #Large, Appears, Switch Flag
-    0xC000: [0x5000, 0x0000, 0x2000], #Large
-    0xD000: [0x5000, 0x0000, 0x2000], #Large
-    0xE000: [0x5000, 0x0000, 0x2000], #Large
-    0xF000: [0x5000, 0x0000, 0x2000], #Large
+chestTypeMap: Dict[int, List[int]] = {
+    #         small   big     boss
+    0x0000: [0x5000, 0x0000, 0x2000],  # Large
+    0x1000: [0x7000, 0x1000, 0x1000],  # Large, Appears, Clear Flag
+    0x2000: [0x5000, 0x0000, 0x2000],  # Boss Key’s Chest
+    0x3000: [0x8000, 0x3000, 0x3000],  # Large, Falling, Switch Flag
+    0x4000: [0x6000, 0x4000, 0x4000],  # Large, Invisible
+    0x5000: [0x5000, 0x0000, 0x2000],  # Small
+    0x6000: [0x6000, 0x4000, 0x4000],  # Small, Invisible
+    0x7000: [0x7000, 0x1000, 0x1000],  # Small, Appears, Clear Flag
+    0x8000: [0x8000, 0x3000, 0x3000],  # Small, Falling, Switch Flag
+    0x9000: [0x9000, 0x9000, 0x9000],  # Large, Appears, Zelda's Lullaby
+    0xA000: [0xA000, 0xA000, 0xA000],  # Large, Appears, Sun's Song Triggered
+    0xB000: [0xB000, 0xB000, 0xB000],  # Large, Appears, Switch Flag
+    0xC000: [0x5000, 0x0000, 0x2000],  # Large
+    0xD000: [0x5000, 0x0000, 0x2000],  # Large
+    0xE000: [0x5000, 0x0000, 0x2000],  # Large
+    0xF000: [0x5000, 0x0000, 0x2000],  # Large
 }
 
 
-def room_get_actors(rom, actor_func, room_data, scene, alternate=None):
+def room_get_actors(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any], room_data: int, scene: int,
+                    alternate: Optional[int] = None) -> Dict[int, Any]:
     actors = {}
     room_start = alternate if alternate else room_data
     command = 0
-    while command != 0x14: # 0x14 = end header
+    while command != 0x14:  # 0x14 = end header
         command = rom.read_byte(room_data)
-        if command == 0x01: # actor list
+        if command == 0x01:  # actor list
             actor_count = rom.read_byte(room_data + 1)
             actor_list = room_start + (rom.read_int32(room_data + 4) & 0x00FFFFFF)
             for _ in range(0, actor_count):
@@ -2675,9 +2672,9 @@ def room_get_actors(rom, actor_func, room_data, scene, alternate=None):
                 if entry:
                     actors[actor_list] = entry
                 actor_list = actor_list + 16
-        if command == 0x18: # Alternate header list
+        if command == 0x18:  # Alternate header list
             header_list = room_start + (rom.read_int32(room_data + 4) & 0x00FFFFFF)
-            for alt_id in range(0,3):
+            for alt_id in range(0, 3):
                 header_data = room_start + (rom.read_int32(header_list) & 0x00FFFFFF)
                 if header_data != 0 and not alternate:
                     actors.update(room_get_actors(rom, actor_func, header_data, scene, room_start))
@@ -2686,25 +2683,26 @@ def room_get_actors(rom, actor_func, room_data, scene, alternate=None):
     return actors
 
 
-def scene_get_actors(rom, actor_func, scene_data, scene, alternate=None, processed_rooms=None):
-    if processed_rooms == None:
+def scene_get_actors(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any], scene_data: int, scene: int,
+                     alternate: Optional[int] = None, processed_rooms: Optional[List[int]] = None) -> Dict[int, Any]:
+    if processed_rooms is None:
         processed_rooms = []
     actors = {}
     scene_start = alternate if alternate else scene_data
     command = 0
-    while command != 0x14: # 0x14 = end header
+    while command != 0x14:  # 0x14 = end header
         command = rom.read_byte(scene_data)
-        if command == 0x04: #room list
+        if command == 0x04:  # room list
             room_count = rom.read_byte(scene_data + 1)
             room_list = scene_start + (rom.read_int32(scene_data + 4) & 0x00FFFFFF)
             for _ in range(0, room_count):
-                room_data = rom.read_int32(room_list);
+                room_data = rom.read_int32(room_list)
 
-                if not room_data in processed_rooms:
+                if room_data not in processed_rooms:
                     actors.update(room_get_actors(rom, actor_func, room_data, scene))
                     processed_rooms.append(room_data)
                 room_list = room_list + 8
-        if command == 0x0E: #transition actor list
+        if command == 0x0E:  # transition actor list
             actor_count = rom.read_byte(scene_data + 1)
             actor_list = scene_start + (rom.read_int32(scene_data + 4) & 0x00FFFFFF)
             for _ in range(0, actor_count):
@@ -2713,9 +2711,9 @@ def scene_get_actors(rom, actor_func, scene_data, scene, alternate=None, process
                 if entry:
                     actors[actor_list] = entry
                 actor_list = actor_list + 16
-        if command == 0x18: # Alternate header list
+        if command == 0x18:  # Alternate header list
             header_list = scene_start + (rom.read_int32(scene_data + 4) & 0x00FFFFFF)
-            for alt_id in range(0,3):
+            for alt_id in range(0, 3):
                 header_data = scene_start + (rom.read_int32(header_list) & 0x00FFFFFF)
                 if header_data != 0 and not alternate:
                     actors.update(scene_get_actors(rom, actor_func, header_data, scene, scene_start, processed_rooms))
@@ -2725,36 +2723,38 @@ def scene_get_actors(rom, actor_func, scene_data, scene, alternate=None, process
     return actors
 
 
-def get_actor_list(rom, actor_func):
+def get_actor_list(rom: Rom, actor_func: Callable[[Rom, int, int, int], Any]) -> Dict[int, Any]:
     actors = {}
     scene_table = 0x00B71440
     for scene in range(0x00, 0x65):
-        scene_data = rom.read_int32(scene_table + (scene * 0x14));
+        scene_data = rom.read_int32(scene_table + (scene * 0x14))
         actors.update(scene_get_actors(rom, actor_func, scene_data, scene))
     return actors
 
 
-def get_override_itemid(override_table, scene, type, flags):
+def get_override_itemid(override_table: Iterable[OverrideEntry], scene: int, type: int, flags: int) -> Optional[int]:
     for entry in override_table:
         if entry[0] == scene and (entry[1] & 0x07) == type and entry[2] == flags:
             return entry[4]
     return None
 
-def remove_entrance_blockers(rom):
-    def remove_entrance_blockers_do(rom, actor_id, actor, scene):
+
+def remove_entrance_blockers(rom: Rom) -> None:
+    def remove_entrance_blockers_do(rom: Rom, actor_id: int, actor: int, scene: int) -> None:
         if actor_id == 0x014E and scene == 97:
-            actor_var = rom.read_int16(actor + 14);
+            actor_var = rom.read_int16(actor + 14)
             if actor_var == 0xFF01:
                 rom.write_int16(actor + 14, 0x0700)
     get_actor_list(rom, remove_entrance_blockers_do)
 
-def set_cow_id_data(rom, world):
-    def set_cow_id(rom, actor_id, actor, scene):
+
+def set_cow_id_data(rom: Rom, world: World) -> None:
+    def set_cow_id(rom: Rom, actor_id: int, actor: int, scene: int) -> None:
         nonlocal last_scene
         nonlocal cow_count
         nonlocal last_actor
 
-        if actor_id == 0x01C6: #Cow
+        if actor_id == 0x01C6:  # Cow
             if scene == last_scene and last_actor != actor:
                 cow_count += 1
             else:
@@ -2762,8 +2762,8 @@ def set_cow_id_data(rom, world):
 
             last_scene = scene
             last_actor = actor
-            if world.dungeon_mq['Jabu Jabus Belly'] and scene == 2: #If its an MQ jabu cow
-                rom.write_int16(actor + 0x8, 1 if cow_count == 17 else 0) #Give all wall cows ID 0, and set cow 11's ID to 1
+            if world.dungeon_mq['Jabu Jabus Belly'] and scene == 2:  # If it's an MQ jabu cow
+                rom.write_int16(actor + 0x8, 1 if cow_count == 17 else 0)  # Give all wall cows ID 0, and set cow 11's ID to 1
             else:
                 rom.write_int16(actor + 0x8, cow_count)
 
@@ -2774,9 +2774,9 @@ def set_cow_id_data(rom, world):
     get_actor_list(rom, set_cow_id)
 
 
-def set_grotto_shuffle_data(rom, world):
-    def override_grotto_data(rom, actor_id, actor, scene):
-        if actor_id == 0x009B: #Grotto
+def set_grotto_shuffle_data(rom: Rom, world: World) -> None:
+    def override_grotto_data(rom: Rom, actor_id: int, actor: int, scene: int) -> None:
+        if actor_id == 0x009B:  # Grotto
             actor_zrot = rom.read_int16(actor + 12)
             actor_var = rom.read_int16(actor + 14)
             grotto_type = (actor_var >> 8) & 0x0F
@@ -2798,9 +2798,9 @@ def set_grotto_shuffle_data(rom, world):
     get_actor_list(rom, override_grotto_data)
 
 
-def set_deku_salesman_data(rom):
-    def set_deku_salesman(rom, actor_id, actor, scene):
-        if actor_id == 0x0195: #Salesman
+def set_deku_salesman_data(rom: Rom) -> None:
+    def set_deku_salesman(rom: Rom, actor_id: int, actor: int, scene: int) -> None:
+        if actor_id == 0x0195:  # Salesman
             actor_var = rom.read_int16(actor + 14)
             if actor_var == 6:
                 rom.write_int16(actor + 14, 0x0003)
@@ -2808,8 +2808,8 @@ def set_deku_salesman_data(rom):
     get_actor_list(rom, set_deku_salesman)
 
 
-def set_jabu_stone_actors(rom, jabu_actor_type):
-    def set_jabu_stone_actor(rom, actor_id, actor, scene):
+def set_jabu_stone_actors(rom: Rom, jabu_actor_type: int) -> None:
+    def set_jabu_stone_actor(rom: Rom, actor_id: int, actor: int, scene: int) -> None:
         if scene == 2 and actor_id == 0x008B: # Demo_Effect in Jabu Jabu
             actor_type = rom.read_byte(actor + 15)
             if actor_type == 0x15:
@@ -2818,9 +2818,9 @@ def set_jabu_stone_actors(rom, jabu_actor_type):
     get_actor_list(rom, set_jabu_stone_actor)
 
 
-def set_spirit_shortcut_actors(rom):
-    def set_spirit_shortcut(rom, actor_id, actor, scene):
-        if actor_id == 0x018e and scene == 6: # raise initial elevator height
+def set_spirit_shortcut_actors(rom: Rom) -> None:
+    def set_spirit_shortcut(rom: Rom, actor_id: int, actor: int, scene: int) -> None:
+        if actor_id == 0x018e and scene == 6:  # raise initial elevator height
             rom.write_int16(actor + 4, 0x015E)
 
     get_actor_list(rom, set_spirit_shortcut)
@@ -2848,8 +2848,8 @@ def move_fado_in_lost_woods(rom):
 # If boss keys are set to remove, returns boss key doors
 # If ganons boss key is set to remove, returns ganons boss key doors
 # If pot/crate shuffle is enabled, returns the first ganon's boss key door so that it can be unlocked separately to allow access to the room w/ the pots..
-def get_doors_to_unlock(rom, world):
-    def get_door_to_unlock(rom, actor_id, actor, scene):
+def get_doors_to_unlock(rom: Rom, world: World) -> Dict[int, List[int]]:
+    def get_door_to_unlock(rom: Rom, actor_id: int, actor: int, scene: int) -> List[int]:
         actor_var = rom.read_int16(actor + 14)
         door_type = actor_var >> 6
         switch_flag = actor_var & 0x003F
@@ -2873,7 +2873,7 @@ def get_doors_to_unlock(rom, world):
     return get_actor_list(rom, get_door_to_unlock)
 
 
-def create_fake_name(name):
+def create_fake_name(name: str) -> str:
     vowels = 'aeiou'
     list_name = list(name)
     vowel_indexes = [i for i,c in enumerate(list_name) if c in vowels]
@@ -2891,11 +2891,11 @@ def create_fake_name(name):
     return new_name
 
 
-def place_shop_items(rom, world, shop_items, messages, locations, init_shop_id=False):
+def place_shop_items(rom: Rom, world: World, shop_items, messages, locations, init_shop_id: bool = False) -> Set[int]:
     if init_shop_id:
         place_shop_items.shop_id = 0x32
 
-    shop_objs = { 0x0148 } # "Sold Out" object
+    shop_objs = {0x0148}  # "Sold Out" object
     for location in locations:
         if (location.item.type == 'Shop' or
            (location.type == 'MaskShop' and
@@ -2911,7 +2911,7 @@ def place_shop_items(rom, world, shop_items, messages, locations, init_shop_id=F
                 item_display = location.item
 
             # bottles in shops should look like empty bottles
-            # so that that are different than normal shop refils
+            # so that they are different than normal shop refills
             if 'shop_object' in item_display.special:
                 rom_item = read_rom_item(rom, item_display.special['shop_object'])
             else:
@@ -2966,7 +2966,7 @@ def place_shop_items(rom, world, shop_items, messages, locations, init_shop_id=F
                     description_text = '\x08\x05\x41%s  %d Rupees\x01%s\x01\x05\x40Special deal! ONE LEFT!\x01Get it while it lasts!\x09\x0A\x02' % (split_item_name[0], shop_item.price, split_item_name[1])
                 purchase_text = '\x08%s  %d Rupees\x09\x01%s\x01\x1B\x05\x42Buy\x01Don\'t buy\x05\x40\x02' % (split_item_name[0], shop_item.price, split_item_name[1])
             else:
-                shop_item_name = getSimpleHintNoPrefix(item_display)
+                shop_item_name = get_simple_hint_no_prefix(item_display)
                 if location.item.name == 'Ice Trap':
                     shop_item_name = create_fake_name(shop_item_name)
 
@@ -2984,7 +2984,7 @@ def place_shop_items(rom, world, shop_items, messages, locations, init_shop_id=F
     return shop_objs
 
 
-def boss_reward_index(item):
+def boss_reward_index(item: Item) -> int:
     code = item.special['item_id']
     if code >= 0x6C:
         return code - 0x6C
@@ -2992,7 +2992,7 @@ def boss_reward_index(item):
         return 3 + code - 0x66
 
 
-def configure_dungeon_info(rom, world):
+def configure_dungeon_info(rom: Rom, world: World) -> None:
     mq_enable = (world.settings.mq_dungeons_mode == 'random' or world.settings.mq_dungeons_count != 0 and world.settings.mq_dungeons_count != 12)
     enhance_map_compass = world.settings.enhance_map_compass
 
@@ -3025,7 +3025,7 @@ def configure_dungeon_info(rom, world):
 
 
 # Overwrite an actor in rom w/ the actor data from LocationList
-def patch_actor_override(location, rom: Rom):
+def patch_actor_override(location: Location, rom: Rom) -> None:
     addresses = location.address
     patch = location.address2
     if addresses is not None and patch is not None:
@@ -3035,7 +3035,7 @@ def patch_actor_override(location, rom: Rom):
 
 # Patch rupee towers (circular patterns of rupees) to include their flag in their actor initialization data z rotation.
 # Also used for goron pot, shadow spinning pots
-def patch_rupee_tower(location, rom: Rom):
+def patch_rupee_tower(location: Location, rom: Rom) -> None:
     if isinstance(location.default, tuple):
         room, scene_setup, flag = location.default
     elif isinstance(location.default, list):
@@ -3050,7 +3050,7 @@ def patch_rupee_tower(location, rom: Rom):
 
 
 # Patch the first boss key door in ganons tower that leads to the room w/ the pots
-def patch_ganons_tower_bk_door(rom: Rom, flag):
+def patch_ganons_tower_bk_door(rom: Rom, flag: int) -> None:
     var = (0x05 << 6) + (flag & 0x3F)
     bytes = [(var & 0xFF00) >> 8, var & 0xFF]
     rom.write_bytes(0x2EE30FE, bytes)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -12,15 +12,14 @@ from EntranceShuffle import EntranceShuffleError, change_connections, confirm_re
 from Hints import HintArea, gossipLocations, GossipText
 from Item import ItemFactory, ItemInfo, ItemIterator, IsItem
 from ItemPool import item_groups, get_junk_item, song_list, trade_items, child_trade_items
-from Location import LocationIterator, LocationFactory, IsLocation
+from Location import LocationIterator, LocationFactory
 from LocationList import location_groups, location_table
 from Search import Search
 from Spoiler import HASH_ICONS
 from version import __version__
-from Utils import random_choices
 from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
 import StartingItems
-from SettingsList import build_close_match, validate_settings, setting_infos
+from SettingsList import build_close_match, validate_settings
 
 
 class InvalidFileException(Exception):
@@ -477,7 +476,7 @@ class WorldDistribution(object):
             ]  # Only allow items to be candidates if they haven't been set to 0
             if len(candidates) == 0:
                 raise RuntimeError("Unknown item, or item set to 0 in the item pool could not be added: " + repr(item_name) + ". " + build_close_match(item_name, 'item'))
-            added_items = random_choices(candidates, k=count)
+            added_items = random.choices(candidates, k=count)
         else:
             if not IsItem(item_name):
                 raise RuntimeError("Unknown item could not be added: " + repr(item_name) + ". " + build_close_match(item_name, 'item'))
@@ -783,7 +782,7 @@ class WorldDistribution(object):
 
             valid_items = self.get_valid_items_from_record(prizepool, used_items, record)
             if valid_items:  # Choices still available in the item pool, choose one, mark it as a used item
-                record.item = random_choices(valid_items)[0]
+                record.item = random.choices(valid_items)[0]
                 if used_items is not None:
                     used_items.append(record.item)
 
@@ -856,9 +855,9 @@ class WorldDistribution(object):
                         if item in limited_items or item in item_groups['Bottle'] or item in item_groups['AdultTrade'] or item in item_groups['ChildTrade']:
                             continue
                         allowed_choices.append(item)
-                    record.item = random_choices(allowed_choices)[0]
+                    record.item = random.choices(allowed_choices)[0]
             else:  # Choices still available in item pool, choose one, mark it as a used item
-                record.item = random_choices(valid_items)[0]
+                record.item = random.choices(valid_items)[0]
                 if used_items is not None and record.item[0] != '#':
                     used_items.append(record.item)
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -798,10 +798,9 @@ class WorldDistribution(object):
             world.push_item(boss, reward, True)
         return count
 
-    def fill(self, window, worlds, location_pools, item_pools):
+    def fill(self, worlds, location_pools, item_pools):
         """Fills the world with restrictions defined in a plandomizer JSON distribution file.
 
-        :param window:
         :param worlds: A list of the world objects that define the rules of each game world.
         :param location_pools: A list containing all of the location pools.
             0: Shop Locations
@@ -895,8 +894,6 @@ class WorldDistribution(object):
                 search = Search.max_explore([world.state for world in worlds], itertools.chain.from_iterable(item_pools))
                 if not search.can_beat_game(False):
                     raise FillError('%s in world %d is not reachable without %s in world %d!' % (location.name, self.id + 1, item.name, player_id + 1))
-            window.fillcount += 1
-            window.update_progress(5 + ((window.fillcount / window.locationcount) * 30))
 
     def get_item(self, ignore_pools, item_pools, location, player_id, record, worlds):
         """Get or create the item specified by the record and replace something in the item pool with it
@@ -1172,13 +1169,13 @@ class Distribution(object):
                 print('Cannot place item at excluded location because it already has an item defined in the Distribution.')
 
 
-    def fill(self, window, worlds, location_pools, item_pools):
+    def fill(self, worlds, location_pools, item_pools):
         search = Search.max_explore([world.state for world in worlds], itertools.chain.from_iterable(item_pools))
         if not search.can_beat_game(False):
             raise FillError('Item pool does not contain items required to beat game!')
 
         for world_dist in self.world_dists:
-            world_dist.fill(window, worlds, location_pools, item_pools)
+            world_dist.fill(worlds, location_pools, item_pools)
 
 
     def cloak(self, worlds, location_pools, model_pools):

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -51,9 +51,10 @@ per_world_keys = (
 
 
 class Record:
-    def __init__(self, properties: Dict[str, Any] = None, src_dict: Dict[str, Any] = None) -> None:
+    def __init__(self, properties: Optional[Dict[str, Any]] = None, src_dict: Optional[Dict[str, Any]] = None) -> None:
         self.properties: Dict[str, Any] = properties if properties is not None else getattr(self, "properties")
-        self.update(src_dict, update_all=True)
+        if src_dict is not None:
+            self.update(src_dict, update_all=True)
 
     def update(self, src_dict: Dict[str, Any], update_all: bool = False) -> None:
         if src_dict is None:
@@ -117,13 +118,13 @@ class GossipRecord(Record):
             self.colors = CollapseList(self.colors)
         if self.hinted_locations is not None:
             self.hinted_locations = CollapseList(self.hinted_locations)
-        if self.hinted_locations is not None:
+        if self.hinted_items is not None:
             self.hinted_items = CollapseList(self.hinted_items)
         return CollapseDict(super().to_json())
 
 
 class ItemPoolRecord(Record):
-    def __init__(self, src_dict: int = 1) -> None:
+    def __init__(self, src_dict: Union[int, Dict[str, int]] = 1) -> None:
         self.type: str = 'set'
         self.count: int = 1
 

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -631,7 +631,7 @@ class WorldDistribution:
     def collect_starters(self, state: State) -> None:
         for (name, record) in self.starting_items.items():
             for _ in range(record.count):
-                item = ItemFactory("Bottle" if name == "Bottle with Milk (Half)" else name)
+                item = ItemFactory("Bottle" if name == "Bottle with Milk (Half)" else name, state.world)
                 state.collect(item)
 
     def pool_replace_item(self, item_pools: list[list[Item]], item_group: str, player_id: int, new_item: str, worlds: list[World]) -> Item:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -3,25 +3,30 @@ import json
 import math
 import re
 import random
-
-from functools import reduce
 from collections import defaultdict
-from typing import Any, Mapping, MutableMapping, Optional, Sequence, MutableSequence, Union
+from functools import reduce
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Sequence, Iterable, Callable, Optional, Union
 
-from Fill import FillError
+import StartingItems
 from Entrance import Entrance
 from EntranceShuffle import EntranceShuffleError, change_connections, confirm_replacement, validate_world, check_entrances_compatibility
+from Fill import FillError
 from Hints import HintArea, gossipLocations, GossipText
-from Item import ItemFactory, ItemInfo, ItemIterator, IsItem, Item
+from Item import ItemFactory, ItemInfo, ItemIterator, is_item, Item
 from ItemPool import item_groups, get_junk_item, song_list, trade_items, child_trade_items
-from Location import LocationIterator, LocationFactory
+from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
+from Location import Location, LocationIterator, LocationFactory
 from LocationList import location_groups, location_table
 from Search import Search
-from Spoiler import HASH_ICONS
-from version import __version__
-from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
-import StartingItems
 from SettingsList import build_close_match, validate_settings
+from Spoiler import Spoiler, HASH_ICONS
+from version import __version__
+
+if TYPE_CHECKING:
+    from SaveContext import SaveContext
+    from Settings import Settings
+    from State import State
+    from World import World
 
 
 class InvalidFileException(Exception):
@@ -46,11 +51,11 @@ per_world_keys = (
 
 
 class Record:
-    def __init__(self, properties: Mapping[str, Any] = None, src_dict: Mapping[str, Any] = None) -> None:
-        self.properties: Mapping[str, Any] = properties if properties is not None else getattr(self, "properties")
+    def __init__(self, properties: Dict[str, Any] = None, src_dict: Dict[str, Any] = None) -> None:
+        self.properties: Dict[str, Any] = properties if properties is not None else getattr(self, "properties")
         self.update(src_dict, update_all=True)
 
-    def update(self, src_dict: Mapping[str, Any], update_all: bool = False) -> None:
+    def update(self, src_dict: Dict[str, Any], update_all: bool = False) -> None:
         if src_dict is None:
             src_dict = {}
         if isinstance(src_dict, list):
@@ -59,7 +64,7 @@ class Record:
             if update_all or k in src_dict:
                 setattr(self, k, src_dict.get(k, p))
 
-    def to_json(self) -> MutableMapping[str, Any]:
+    def to_json(self) -> Dict[str, Any]:
         return {k: getattr(self, k) for (k, d) in self.properties.items() if getattr(self, k) != d}
 
     def __str__(self) -> str:
@@ -67,14 +72,15 @@ class Record:
 
 
 class DungeonRecord(Record):
-    mapping: Mapping[str, Optional[bool]] = {
+    mapping: Dict[str, Optional[bool]] = {
         'random': None,
         'mq': True,
         'vanilla': False,
     }
 
-    def __init__(self, src_dict: Union[str, Mapping[str, Optional[bool]]] = 'random') -> None:
+    def __init__(self, src_dict: Union[str, Dict[str, Optional[bool]]] = 'random') -> None:
         self.mq: Optional[bool] = None
+
         if isinstance(src_dict, str):
             src_dict = {'mq': self.mapping.get(src_dict, None)}
         super().__init__({'mq': None}, src_dict)
@@ -86,8 +92,9 @@ class DungeonRecord(Record):
 
 
 class EmptyDungeonRecord(Record):
-    def __init__(self, src_dict: Union[Optional[bool], str, Mapping[str, Optional[bool]]] = 'random') -> None:
+    def __init__(self, src_dict: Union[Optional[bool], str, Dict[str, Optional[bool]]] = 'random') -> None:
         self.empty: Optional[bool] = None
+
         if src_dict == 'random':
             src_dict = {'empty': None}
         elif isinstance(src_dict, bool):
@@ -99,13 +106,13 @@ class EmptyDungeonRecord(Record):
 
 
 class GossipRecord(Record):
-    def __init__(self, src_dict: Mapping[str, Any]) -> None:
+    def __init__(self, src_dict: Dict[str, Any]) -> None:
         self.colors: Optional[Sequence[str]] = None
         self.hinted_locations: Optional[Sequence[str]] = None
         self.hinted_items: Optional[Sequence[str]] = None
         super().__init__({'text': None, 'colors': None, 'hinted_locations': None, 'hinted_items': None}, src_dict)
 
-    def to_json(self) -> Mapping[str, Any]:
+    def to_json(self) -> Dict[str, Any]:
         if self.colors is not None:
             self.colors = CollapseList(self.colors)
         if self.hinted_locations is not None:
@@ -119,6 +126,7 @@ class ItemPoolRecord(Record):
     def __init__(self, src_dict: int = 1) -> None:
         self.type: str = 'set'
         self.count: int = 1
+
         if isinstance(src_dict, int):
             src_dict = {'count': src_dict}
         super().__init__({'type': 'set', 'count': 1}, src_dict)
@@ -129,7 +137,7 @@ class ItemPoolRecord(Record):
         else:
             return CollapseDict(super().to_json())
 
-    def update(self, src_dict: Mapping[str, Any], update_all: bool = False) -> None:
+    def update(self, src_dict: Dict[str, Any], update_all: bool = False) -> None:
         super().update(src_dict, update_all)
         if self.count < 0:
             raise ValueError("Count cannot be negative in a ItemPoolRecord.")
@@ -138,8 +146,10 @@ class ItemPoolRecord(Record):
 
 
 class LocationRecord(Record):
-    def __init__(self, src_dict: Union[Mapping[str, Any], str]) -> None:
-        self.item: Optional[str] = None
+    def __init__(self, src_dict: Union[Dict[str, Any], str]) -> None:
+        self.item: Optional[Union[str, List[str]]] = None
+        self.player: Optional[int] = None
+
         if isinstance(src_dict, str):
             src_dict = {'item': src_dict}
         super().__init__({'item': None, 'player': None, 'price': None, 'model': None}, src_dict)
@@ -167,9 +177,10 @@ class LocationRecord(Record):
 
 
 class EntranceRecord(Record):
-    def __init__(self, src_dict: Union[Mapping[str, Optional[str]], str]) -> None:
+    def __init__(self, src_dict: Union[Dict[str, Optional[str]], str]) -> None:
         self.region: Optional[str] = None
         self.origin: Optional[str] = None
+
         if isinstance(src_dict, str):
             src_dict = {'region': src_dict}
         if 'from' in src_dict:
@@ -201,6 +212,7 @@ class EntranceRecord(Record):
 class StarterRecord(Record):
     def __init__(self, src_dict: int = 1) -> None:
         self.count: int = 1
+
         if isinstance(src_dict, int):
             src_dict = {'count': src_dict}
         super().__init__({'count': 1}, src_dict)
@@ -213,14 +225,15 @@ class StarterRecord(Record):
 
 
 class TrialRecord(Record):
-    mapping: Mapping[str, Optional[bool]] = {
+    mapping: Dict[str, Optional[bool]] = {
         'random': None,
         'active': True,
         'inactive': False,
     }
 
-    def __init__(self, src_dict: Union[str, Mapping[str, Optional[bool]]] = 'random') -> None:
+    def __init__(self, src_dict: Union[str, Dict[str, Optional[bool]]] = 'random') -> None:
         self.active: Optional[bool] = None
+
         if isinstance(src_dict, str):
             src_dict = {'active': self.mapping.get(src_dict, None)}
         super().__init__({'active': None}, src_dict)
@@ -232,42 +245,44 @@ class TrialRecord(Record):
 
 
 class SongRecord(Record):
-    def __init__(self, src_dict: Union[Optional[str], Mapping[str, Optional[str]]] = None) -> None:
+    def __init__(self, src_dict: Union[Optional[str], Dict[str, Optional[str]]] = None) -> None:
         self.notes: Optional[str] = None
+
         if src_dict is None or isinstance(src_dict, str):
             src_dict = {'notes': src_dict}
         super().__init__({'notes': None}, src_dict)
 
-    def to_json(self):
+    def to_json(self) -> str:
         return self.notes
 
 
 class WorldDistribution:
-    def __init__(self, distribution, id, src_dict=None):
-        self.randomized_settings = None
-        self.dungeons = None
-        self.empty_dungeons = None
-        self.trials = None
-        self.songs = None
-        self.item_pool = None
-        self.entrances = None
-        self.locations = None
-        self.woth_locations = None
-        self.goal_locations = None
-        self.barren_regions = None
-        self.gossip_stones = None
+    def __init__(self, distribution: 'Distribution', id: int, src_dict: Optional[Dict[str, Any]] = None) -> None:
+        self.randomized_settings: Optional[Dict[str, Any]] = None
+        self.dungeons: Optional[Dict[str, DungeonRecord]] = None
+        self.empty_dungeons: Optional[Dict[str, EmptyDungeonRecord]] = None
+        self.trials: Optional[Dict[str, TrialRecord]] = None
+        self.songs: Optional[Dict[str, SongRecord]] = None
+        self.item_pool: Optional[Dict[str, ItemPoolRecord]] = None
+        self.entrances: Optional[Dict[str, EntranceRecord]] = None
+        self.locations: Optional[Dict[str, Union[LocationRecord, List[LocationRecord]]]] = None
+        self.woth_locations: Optional[Dict[str, LocationRecord]] = None
+        self.goal_locations: Optional[Dict[str, Dict[str, Dict[str, Union[LocationRecord, Dict[str, LocationRecord]]]]]] = None
+        self.barren_regions: Optional[List[str]] = None
+        self.gossip_stones: Optional[Dict[str, GossipRecord]] = None
+
+        self.distribution: 'Distribution' = distribution
+        self.id: int = id
+        self.base_pool: List[str] = []
+        self.major_group: List[str] = []
+        self.song_as_items: bool = False
+        self.skipped_locations: List[Location] = []
+        self.effective_starting_items: Dict[str, StarterRecord] = {}
 
         src_dict = {} if src_dict is None else src_dict
-        self.distribution = distribution
-        self.id = id
-        self.base_pool = []
-        self.major_group = []
-        self.song_as_items = False
-        self.skipped_locations = []
-        self.effective_starting_items = {}
         self.update(src_dict, update_all=True)
 
-    def update(self, src_dict, update_all=False):
+    def update(self, src_dict: Dict[str, Any], update_all: bool = False) -> None:
         update_dict = {
             'randomized_settings': {name: record for (name, record) in src_dict.get('randomized_settings', {}).items()},
             'dungeons': {name: DungeonRecord(record) for (name, record) in src_dict.get('dungeons', {}).items()},
@@ -298,7 +313,7 @@ class WorldDistribution:
                     else:
                         setattr(self, k, None)
 
-    def to_json(self):
+    def to_json(self) -> Dict[str, Any]:
         return {
             'randomized_settings': self.randomized_settings,
             'dungeons': {name: record.to_json() for (name, record) in self.dungeons.items()},
@@ -315,10 +330,10 @@ class WorldDistribution:
             'gossip_stones': SortedDict({name: [rec.to_json() for rec in record] if is_pattern(name) else record.to_json() for (name, record) in self.gossip_stones.items()}),
         }
 
-    def __str__(self):
+    def __str__(self) -> str:
         return dump_obj(self.to_json())
 
-    def pattern_matcher(self, pattern):
+    def pattern_matcher(self, pattern: Union[str, List[str]]) -> Callable[[str], bool]:
         if isinstance(pattern, list):
             pattern_list = []
             for pattern_item in pattern:
@@ -394,14 +409,14 @@ class WorldDistribution:
                 return lambda s: invert != (s == pattern)
 
     # adds the location entry only if there is no record for that location already
-    def add_location(self, new_location, new_item):
+    def add_location(self, new_location: str, new_item: str) -> None:
         for (location, record) in self.locations.items():
             pattern = self.pattern_matcher(location)
             if pattern(new_location):
                 raise KeyError('Cannot add location that already exists')
         self.locations[new_location] = LocationRecord(new_item)
 
-    def configure_dungeons(self, world, mq_dungeon_pool, empty_dungeon_pool):
+    def configure_dungeons(self, world: "World", mq_dungeon_pool: List[str], empty_dungeon_pool: List[str]) -> Tuple[int, int]:
         dist_num_mq, dist_num_empty = 0, 0
         for (name, record) in self.dungeons.items():
             if record.mq is not None:
@@ -417,7 +432,7 @@ class WorldDistribution:
                     world.empty_dungeons[name].empty = True
         return dist_num_mq, dist_num_empty
 
-    def configure_trials(self, trial_pool):
+    def configure_trials(self, trial_pool: List[str]) -> List[str]:
         dist_chosen = []
         for (name, record) in self.trials.items():
             if record.active is not None:
@@ -426,7 +441,7 @@ class WorldDistribution:
                     dist_chosen.append(name)
         return dist_chosen
 
-    def configure_songs(self):
+    def configure_songs(self) -> Dict[str, str]:
         dist_notes = {}
         for (name, record) in self.songs.items():
             if record.notes is not None:
@@ -434,7 +449,7 @@ class WorldDistribution:
         return dist_notes
 
     # Add randomized_settings defined in distribution to world's randomized settings list
-    def configure_randomized_settings(self, world):
+    def configure_randomized_settings(self, world: "World") -> None:
         settings = world.settings
         for name, record in self.randomized_settings.items():
             if not hasattr(settings, name):
@@ -443,7 +458,8 @@ class WorldDistribution:
             if name not in world.randomized_list:
                 world.randomized_list.append(name)
 
-    def pool_remove_item(self, pools, item_name, count, world_id=None, use_base_pool=True):
+    def pool_remove_item(self, pools: List[List[Union[str, Item]]], item_name: str, count: int,
+                         world_id: Optional[int] = None, use_base_pool: bool = True) -> List[Union[str, Item]]:
         removed_items = []
 
         base_remove_matcher = self.pattern_matcher(item_name)
@@ -457,7 +473,7 @@ class WorldDistribution:
             removed_item = pull_random_element(pools, predicate)
             if removed_item is None:
                 if not use_base_pool:
-                    if IsItem(item_name):
+                    if is_item(item_name):
                         raise KeyError('No remaining items matching "%s" to be removed.' % (item_name))
                     else:
                         raise KeyError('No items matching "%s"' % (item_name))
@@ -473,7 +489,7 @@ class WorldDistribution:
 
         return removed_items
 
-    def pool_add_item(self, pool, item_name, count):
+    def pool_add_item(self, pool: List[str], item_name: str, count: int) -> List[str]:
         if item_name == '#Junk':
             added_items = get_junk_item(count, pool=pool, plando_pool=self.item_pool)
         elif is_pattern(item_name):
@@ -486,7 +502,7 @@ class WorldDistribution:
                 raise RuntimeError("Unknown item, or item set to 0 in the item pool could not be added: " + repr(item_name) + ". " + build_close_match(item_name, 'item'))
             added_items = random.choices(candidates, k=count)
         else:
-            if not IsItem(item_name):
+            if not is_item(item_name):
                 raise RuntimeError("Unknown item could not be added: " + repr(item_name) + ". " + build_close_match(item_name, 'item'))
             added_items = [item_name] * count
 
@@ -495,7 +511,7 @@ class WorldDistribution:
 
         return added_items
 
-    def alter_pool(self, world, pool):
+    def alter_pool(self, world: "World", pool: List[str]) -> List[str]:
         self.base_pool = list(pool)
         pool_size = len(pool)
         bottle_matcher = self.pattern_matcher("#Bottle")
@@ -583,7 +599,7 @@ class WorldDistribution:
                         self.pool_remove_item([pool], "Chicken", record.count)
                 except KeyError:
                     raise KeyError('Tried to start with a Weird Egg or Chicken but could not remove it from the item pool. Are both Weird Egg and the Chicken shuffled?')
-            elif IsItem(item_name):
+            elif is_item(item_name):
                 try:
                     self.pool_remove_item([pool], item_name, record.count)
                 except KeyError:
@@ -599,7 +615,7 @@ class WorldDistribution:
 
         return pool
 
-    def set_complete_itempool(self, pool):
+    def set_complete_itempool(self, pool: List[Item]) -> None:
         self.item_pool = {}
         for item in pool:
             if item.dungeonitem or item.type in ('Drop', 'Event', 'DungeonReward'):
@@ -609,13 +625,13 @@ class WorldDistribution:
             else:
                 self.item_pool[item.name] = ItemPoolRecord()
 
-    def collect_starters(self, state):
+    def collect_starters(self, state: "State") -> None:
         for (name, record) in self.starting_items.items():
             for _ in range(record.count):
                 item = ItemFactory("Bottle" if name == "Bottle with Milk (Half)" else name)
                 state.collect(item)
 
-    def pool_replace_item(self, item_pools, item_group, player_id, new_item, worlds):
+    def pool_replace_item(self, item_pools: List[List[Item]], item_group: str, player_id: int, new_item: str, worlds: "List[World]") -> Item:
         removed_item = self.pool_remove_item(item_pools, item_group, 1, world_id=player_id)[0]
         item_matcher = lambda item: self.pattern_matcher(new_item)(item.name)
         if self.item_pool[removed_item.name].count > 1:
@@ -629,7 +645,8 @@ class WorldDistribution:
                 return ItemFactory(get_junk_item(1))[0]
         return random.choice(list(ItemIterator(item_matcher, worlds[player_id])))
 
-    def set_shuffled_entrances(self, worlds, entrance_pools, target_entrance_pools, locations_to_ensure_reachable, itempool):
+    def set_shuffled_entrances(self, worlds: "List[World]", entrance_pools: Dict[str, List[Entrance]], target_entrance_pools: Dict[str, List[Entrance]],
+                               locations_to_ensure_reachable: Iterable[Location], itempool: List[Item]) -> None:
         for (name, record) in self.entrances.items():
             if record.region is None:
                 continue
@@ -647,7 +664,7 @@ class WorldDistribution:
                     continue
 
                 entrance_found = True
-                if matched_entrance.connected_region != None:
+                if matched_entrance.connected_region is not None:
                     if matched_entrance.type == 'Overworld':
                         continue
                     else:
@@ -672,7 +689,7 @@ class WorldDistribution:
                     matched_target = matched_targets_to_region[0]
                     target_parent = matched_target.parent_region.name
 
-                if matched_target.connected_region == None:
+                if matched_target.connected_region is None:
                     raise RuntimeError('Entrance leading to %s from %s is already shuffled in world %d' %
                                             (target_region, target_parent, self.id + 1))
 
@@ -689,7 +706,7 @@ class WorldDistribution:
             if not entrance_found:
                 raise RuntimeError('Entrance does not belong to a pool of shuffled entrances in world %d: %s' % (self.id + 1, name))
 
-    def pattern_dict_items(self, pattern_dict):
+    def pattern_dict_items(self, pattern_dict: Dict[str, Any]) -> Iterable[Tuple[str, Any]]:
         """Retrieve a location by pattern.
 
         :param pattern_dict: the location dictionary. Capable of containing a pattern.
@@ -708,7 +725,7 @@ class WorldDistribution:
             else:
                 yield key, value
 
-    def get_valid_items_from_record(self, itempool, used_items, record):
+    def get_valid_items_from_record(self, itempool: List[Item], used_items: List[str], record: LocationRecord) -> List[str]:
         """Gets items that are valid for placement.
 
         :param itempool: a list of the item pool to search through for the record
@@ -744,7 +761,7 @@ class WorldDistribution:
 
         return valid_items
 
-    def pull_item_or_location(self, pools, world, name, remove=True):
+    def pull_item_or_location(self, pools: List[List[Union[Item, Location]]], world: "World", name: str, remove: bool = True) -> Optional[Union[Item, Location]]:
         """Finds and removes (unless told not to do so) an item or location matching the criteria from a list of pools.
 
         :param pools: the item pools to pull from
@@ -761,7 +778,7 @@ class WorldDistribution:
         else:
             return pull_first_element(pools, lambda e: e.world is world and e.name == name, remove)
 
-    def fill_bosses(self, world, prize_locs, prizepool):
+    def fill_bosses(self, world: "World", prize_locs: List[Location], prizepool: List[Item]) -> int:
         count = 0
         used_items = []
         for (name, record) in self.pattern_dict_items(self.locations):
@@ -789,7 +806,7 @@ class WorldDistribution:
             if reward is None:
                 if record.item not in item_groups['DungeonReward']:
                     raise RuntimeError('Cannot place non-dungeon reward %s in world %d on location %s.' % (record.item, self.id + 1, name))
-                if IsItem(record.item):
+                if is_item(record.item):
                     raise RuntimeError('Reward already placed in world %d: %s' % (world.id + 1, record.item))
                 else:
                     raise RuntimeError('Reward unknown in world %d: %s' % (world.id + 1, record.item))
@@ -797,15 +814,15 @@ class WorldDistribution:
             world.push_item(boss, reward, True)
         return count
 
-    def fill(self, worlds, location_pools, item_pools):
+    def fill(self, worlds: "List[World]", location_pools: List[List[Location]], item_pools: List[List[Item]]) -> None:
         """Fills the world with restrictions defined in a plandomizer JSON distribution file.
 
         :param worlds: A list of the world objects that define the rules of each game world.
-        :param location_pools: A list containing all of the location pools.
+        :param location_pools: A list containing all the location pools.
             0: Shop Locations
             1: Song Locations
             2: Fill locations
-        :param item_pools: A list containing all of the item pools.
+        :param item_pools: A list containing all the item pools.
             0: Shop Items
             1: Dungeon Items
             2: Songs
@@ -819,6 +836,7 @@ class WorldDistribution:
         if self.locations:
             locations = {loc: self.locations[loc] for loc in random.sample(sorted(self.locations), len(self.locations))}
         used_items = []
+        record: LocationRecord
         for (location_name, record) in self.pattern_dict_items(locations):
             if record.item is None:
                 continue
@@ -864,7 +882,7 @@ class WorldDistribution:
             if record.item in item_groups['DungeonReward']:
                 raise RuntimeError('Cannot place dungeon reward %s in world %d in location %s.' % (record.item, self.id + 1, location_name))
 
-            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song' and not any(name in song_list and record.count for name, record in world.settings.starting_items.items()):
+            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song' and not any(name in song_list and r.count for name, r in world.settings.starting_items.items()):
                 record.item = '#JunkSong'
 
             ignore_pools = None
@@ -894,11 +912,12 @@ class WorldDistribution:
                 if not search.can_beat_game(False):
                     raise FillError('%s in world %d is not reachable without %s in world %d!' % (location.name, self.id + 1, item.name, player_id + 1))
 
-    def get_item(self, ignore_pools, item_pools, location, player_id, record, worlds):
+    def get_item(self, ignore_pools: List[int], item_pools: List[List[Item]], location: Location, player_id: int,
+                 record: LocationRecord, worlds: "List[World]") -> Item:
         """Get or create the item specified by the record and replace something in the item pool with it
 
         :param ignore_pools: Pools to not replace items in
-        :param item_pools: A list containing all of the item pools.
+        :param item_pools: A list containing all the item pools.
         :param location: Location record currently being assigned an item
         :param player_id: Integer representing the current player's ID number
         :param record: Item record from the distribution file to assign to a location
@@ -975,7 +994,7 @@ class WorldDistribution:
                 item_pools[i] = new_pool
         return item
 
-    def cloak(self, worlds, location_pools, model_pools):
+    def cloak(self, worlds: "List[World]", location_pools: List[List[Location]], model_pools: List[List[Item]]) -> None:
         for (name, record) in self.pattern_dict_items(self.locations):
             if record.model is None:
                 continue
@@ -999,20 +1018,20 @@ class WorldDistribution:
             if can_cloak(location.item, model):
                 location.item.looks_like_item = model
 
-    def configure_gossip(self, spoiler, stoneIDs):
+    def configure_gossip(self, spoiler: Spoiler, stone_ids: List[int]) -> None:
         for (name, record) in self.pattern_dict_items(self.gossip_stones):
             matcher = self.pattern_matcher(name)
-            stoneID = pull_random_element([stoneIDs], lambda id: matcher(gossipLocations[id].name))
-            if stoneID is None:
+            stone_id = pull_random_element([stone_ids], lambda id: matcher(gossipLocations[id].name))
+            if stone_id is None:
                 # Allow planning of explicit textids
                 match = re.match(r"^(?:\$|x|0x)?([0-9a-f]{4})$", name, flags=re.IGNORECASE)
                 if match:
-                    stoneID = int(match[1], base=16)
+                    stone_id = int(match[1], base=16)
                 else:
                     raise RuntimeError('Gossip stone unknown or already assigned in world %d: %r. %s' % (self.id + 1, name, build_close_match(name, 'stone')))
-            spoiler.hints[self.id][stoneID] = GossipText(text=record.text, colors=record.colors, prefix='')
+            spoiler.hints[self.id][stone_id] = GossipText(text=record.text, colors=record.colors, prefix='')
 
-    def give_items(self, world, save_context):
+    def give_items(self, world: "World", save_context: "SaveContext") -> None:
         # copy Triforce pieces to all worlds
         triforce_count = sum(
             world_dist.effective_starting_items['Triforce Piece'].count
@@ -1027,7 +1046,7 @@ class WorldDistribution:
                 continue
             save_context.give_item(world, name, record.count)
 
-    def get_starting_item(self, item):
+    def get_starting_item(self, item: str) -> int:
         items = self.starting_items
         if item in items:
             return items[item].count
@@ -1035,7 +1054,7 @@ class WorldDistribution:
             return 0
 
     @property
-    def starting_items(self):
+    def starting_items(self) -> Dict[str, StarterRecord]:
         data = defaultdict(lambda: StarterRecord(0))
         world_names = ['World %d' % (i + 1) for i in range(len(self.distribution.world_dists))]
 
@@ -1052,7 +1071,7 @@ class WorldDistribution:
 
         return data
 
-    def configure_effective_starting_items(self, worlds, world):
+    def configure_effective_starting_items(self, worlds: "List[World]", world: "World") -> None:
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
 
         if world.settings.start_with_rupees:
@@ -1120,11 +1139,15 @@ class WorldDistribution:
         self.effective_starting_items = items
 
 
-class Distribution(object):
-    def __init__(self, settings, src_dict=None):
-        self.src_dict = src_dict or {}
-        self.settings = settings
-        self.search_groups = {
+class Distribution:
+    def __init__(self, settings: "Settings", src_dict: Optional[Dict[str, Any]] = None) -> None:
+        self.file_hash: Optional[List[str]] = None
+        self.playthrough: Optional[Dict[str, Dict[str, LocationRecord]]] = None
+        self.entrance_playthrough: Optional[Dict[str, Dict[str, EntranceRecord]]] = None
+
+        self.src_dict: Dict[str, Any] = src_dict or {}
+        self.settings: "Settings" = settings
+        self.search_groups: Dict[str, Sequence[str]] = {
             **location_groups,
             **item_groups,
         }
@@ -1134,7 +1157,7 @@ class Distribution(object):
             if 'starting_items' in self.src_dict:
                 raise ValueError('"starting_items" at the top level is no longer supported, please move it into "settings"')
 
-        self.world_dists = [WorldDistribution(self, id) for id in range(settings.world_count)]
+        self.world_dists: List[WorldDistribution] = [WorldDistribution(self, id) for id in range(settings.world_count)]
         # One-time init
         update_dict = {
             'file_hash': (self.src_dict.get('file_hash', []) + [None, None, None, None, None])[0:5],
@@ -1161,14 +1184,14 @@ class Distribution(object):
         self.reset()
 
     # adds the location entry only if there is no record for that location already
-    def add_location(self, new_location, new_item):
+    def add_location(self, new_location: str, new_item: str) -> None:
         for world_dist in self.world_dists:
             try:
                 world_dist.add_location(new_location, new_item)
             except KeyError:
                 print('Cannot place item at excluded location because it already has an item defined in the Distribution.')
 
-    def fill(self, worlds, location_pools, item_pools):
+    def fill(self, worlds: "List[World]", location_pools: List[List[Location]], item_pools: List[List[Item]]) -> None:
         search = Search.max_explore([world.state for world in worlds], itertools.chain.from_iterable(item_pools))
         if not search.can_beat_game(False):
             raise FillError('Item pool does not contain items required to beat game!')
@@ -1176,11 +1199,11 @@ class Distribution(object):
         for world_dist in self.world_dists:
             world_dist.fill(worlds, location_pools, item_pools)
 
-    def cloak(self, worlds, location_pools, model_pools):
+    def cloak(self, worlds: "List[World]", location_pools: List[List[Location]], model_pools: List[List[Item]]) -> None:
         for world_dist in self.world_dists:
             world_dist.cloak(worlds, location_pools, model_pools)
 
-    def configure_triforce_hunt(self, worlds):
+    def configure_triforce_hunt(self, worlds: "List[World]") -> None:
         total_count = 0
         total_starting_count = 0
         for world in worlds:
@@ -1201,7 +1224,7 @@ class Distribution(object):
         for world in worlds:
             world.total_starting_triforce_count = total_starting_count # used later in Rules.py
 
-    def reset(self):
+    def reset(self) -> None:
         for world in self.world_dists:
             world.update({}, update_all=True)
 
@@ -1228,7 +1251,7 @@ class Distribution(object):
 
         # normalize starting items to use the dictionary format
         starting_items = itertools.chain(self.settings.starting_equipment, self.settings.starting_songs, self.settings.starting_inventory)
-        data = defaultdict(lambda: StarterRecord(0))
+        data: Dict[str, Union[StarterRecord, Dict[str, StarterRecord]]] = defaultdict(lambda: StarterRecord(0))
         if isinstance(self.settings.starting_items, dict) and self.settings.starting_items:
             world_names = ['World %d' % (i + 1) for i in range(len(self.world_dists))]
             for name, record in self.settings.starting_items.items():
@@ -1242,14 +1265,14 @@ class Distribution(object):
             if itemsetting in StartingItems.everything:
                 item = StartingItems.everything[itemsetting]
                 if not item.special:
-                    add_starting_item_with_ammo(data, item.itemname)
+                    add_starting_item_with_ammo(data, item.item_name)
                 else:
-                    if item.itemname == 'Rutos Letter' and self.settings.zora_fountain != 'open':
+                    if item.item_name == 'Rutos Letter' and self.settings.zora_fountain != 'open':
                         data['Rutos Letter'].count += 1
-                    elif item.itemname in ['Bottle', 'Rutos Letter']:
+                    elif item.item_name in ['Bottle', 'Rutos Letter']:
                         data['Bottle'].count += 1
                     else:
-                        raise KeyError("invalid special item: {}".format(item.itemname))
+                        raise KeyError("invalid special item: {}".format(item.item_name))
             else:
                 raise KeyError("invalid starting item: {}".format(itemsetting))
         self.settings.starting_equipment = []
@@ -1270,7 +1293,7 @@ class Distribution(object):
                 data['Heart Container'].count += math.floor(num_hearts_to_collect / 2)
         self.settings.starting_items = data
 
-    def to_json(self, include_output=True, spoiler=True):
+    def to_json(self, include_output: bool = True, spoiler: bool = True) -> Dict[str, Any]:
         self_dict = {
             ':version': __version__,
             'file_hash': CollapseList(self.file_hash),
@@ -1311,13 +1334,13 @@ class Distribution(object):
             self_dict['settings'] = dict(self._settings)
         return self_dict
 
-    def to_str(self, include_output_only=True, spoiler=True):
+    def to_str(self, include_output_only: bool = True, spoiler: bool = True) -> str:
         return dump_obj(self.to_json(include_output_only, spoiler))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return dump_obj(self.to_json())
 
-    def update_spoiler(self, spoiler, output_spoiler):
+    def update_spoiler(self, spoiler: Spoiler, output_spoiler: bool) -> None:
         self.file_hash = [HASH_ICONS[icon] for icon in spoiler.file_hash]
 
         if not output_spoiler:
@@ -1392,7 +1415,7 @@ class Distribution(object):
                     ent_rec_sphere[entrance_key] = EntranceRecord.from_entrance(entrance)
 
     @staticmethod
-    def from_file(settings, filename):
+    def from_file(settings: "Settings", filename: str) -> 'Distribution':
         if any(map(filename.endswith, ['.z64', '.n64', '.v64'])):
             raise InvalidFileException("Your Ocarina of Time ROM doesn't belong in the plandomizer setting. If you don't know what plandomizer is, or don't plan to use it, leave that setting blank and try again.")
 
@@ -1403,28 +1426,28 @@ class Distribution(object):
             raise InvalidFileException(f"Invalid Plandomizer File. Make sure the file is a valid JSON file. Failure reason: {str(e)}") from None
         return Distribution(settings, src_dict)
 
-    def to_file(self, filename, output_spoiler):
+    def to_file(self, filename: str, output_spoiler: bool) -> None:
         json = self.to_str(spoiler=output_spoiler)
         with open(filename, 'w', encoding='utf-8') as outfile:
             outfile.write(json)
 
 
-def add_starting_ammo(starting_items):
+def add_starting_ammo(starting_items: Dict[str, StarterRecord]) -> None:
     for item in StartingItems.inventory.values():
-        if item.itemname in starting_items and item.ammo:
+        if item.item_name in starting_items and item.ammo:
             for ammo, qty in item.ammo.items():
                 # Add ammo to starter record, but not overriding existing count if present
                 if ammo not in starting_items:
                     starting_items[ammo] = StarterRecord(0)
-                    starting_items[ammo].count = qty[starting_items[item.itemname].count - 1]
+                    starting_items[ammo].count = qty[starting_items[item.item_name].count - 1]
 
 
-def add_starting_item_with_ammo(starting_items, item_name, count=1):
+def add_starting_item_with_ammo(starting_items: Dict[str, StarterRecord], item_name: str, count: int = 1) -> None:
     if item_name not in starting_items:
         starting_items[item_name] = StarterRecord(0)
     starting_items[item_name].count += count
     for item in StartingItems.inventory.values():
-        if item.itemname == item_name and item.ammo:
+        if item.item_name == item_name and item.ammo:
             for ammo, qty in item.ammo.items():
                 if ammo not in starting_items:
                     starting_items[ammo] = StarterRecord(0)
@@ -1432,7 +1455,7 @@ def add_starting_item_with_ammo(starting_items, item_name, count=1):
             break
 
 
-def strip_output_only(obj):
+def strip_output_only(obj: Union[list, dict]) -> None:
     if isinstance(obj, list):
         for elem in obj:
             strip_output_only(elem)
@@ -1444,19 +1467,19 @@ def strip_output_only(obj):
             strip_output_only(elem)
 
 
-def can_cloak(actual_item, model):
-    return actual_item.index == 0x7C # Ice Trap
+def can_cloak(actual_item: Item, model: Item) -> bool:
+    return actual_item.index == 0x7C  # Ice Trap
 
 
-def is_output_only(pattern):
+def is_output_only(pattern: str) -> bool:
     return pattern.startswith(':')
 
 
-def is_pattern(pattern):
+def is_pattern(pattern: str) -> bool:
     return pattern.startswith('!') or pattern.startswith('*') or pattern.startswith('#') or pattern.endswith('*')
 
 
-def pull_first_element(pools, predicate=lambda k:True, remove=True):
+def pull_first_element(pools: List[List[Any]], predicate: Callable[[Any], bool] = lambda k: True, remove: bool = True) -> Optional[Any]:
     for pool in pools:
         for element in pool:
             if predicate(element):
@@ -1466,7 +1489,7 @@ def pull_first_element(pools, predicate=lambda k:True, remove=True):
     return None
 
 
-def pull_random_element(pools, predicate=lambda k:True, remove=True):
+def pull_random_element(pools: List[List[Any]], predicate: Callable[[Any], bool] = lambda k: True, remove: bool = True) -> Optional[Any]:
     candidates = [(element, pool) for pool in pools for element in pool if predicate(element)]
     if len(candidates) == 0:
         return None
@@ -1476,7 +1499,7 @@ def pull_random_element(pools, predicate=lambda k:True, remove=True):
     return element
 
 
-def pull_all_elements(pools, predicate=lambda k:True, remove=True):
+def pull_all_elements(pools: List[List[Any]], predicate: Callable[[Any], bool] = lambda k: True, remove: bool = True) -> Optional[List[Any]]:
     elements = []
     for pool in pools:
         for element in pool:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ It is strongly suggested users use the web generator from here:
 https://ootrandomizer.com
 
 If you wish to run the script raw, clone this repository and either run ```Gui.py``` for a
-graphical interface or ```OoTRandomizer.py``` for the command line version. They both require Python 3.7+. This will be fully featured,
-but the seeds you generate will have different random factors than the bundled release.
+graphical interface or ```OoTRandomizer.py``` for the command line version. They both require Python 3.8+.
 To use the GUI, [NodeJS](https://nodejs.org/download/release/v18.12.1/) (v18 LTS, with npm) will additionally need to be installed. NodeJS v14.14.0 and earlier are no longer supported.
 The first time ```Gui.py``` is run it will need to install necessary components, which could take a few minutes. Subsequent instances will run much quicker.
 Supported output formats are .z64 (N64/Emulator), .wad (Wii VC, channel IDs NICE/NRKE recommended), Uncompressed ROM (for developmental purposes, offline build only)
@@ -174,7 +173,7 @@ issue. You should always Hard Reset to avoid this issue entirely.
 * Junk items being sent to another world will now float up into the air to indicate this.
 * An unnecessary polygon check function is skipped to increase game performance.
 * In Triforce Hunt, your current and goal number of triforce pieces are now displayed on the file select screen.
-* Python 3.6 is no longer supported.
+* Python 3.6 and 3.7 are no longer supported.
 
 #### New Speedups
 * Various cutscenes removed or shortened, such as Water Temple and Gerudo Fortress gates and scarecrow spawn cutscenes.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is strongly suggested users use the web generator from here:
 https://ootrandomizer.com
 
 If you wish to run the script raw, clone this repository and either run ```Gui.py``` for a
-graphical interface or ```OoTRandomizer.py``` for the command line version. They both require Python 3.6+. This will be fully featured,
+graphical interface or ```OoTRandomizer.py``` for the command line version. They both require Python 3.7+. This will be fully featured,
 but the seeds you generate will have different random factors than the bundled release.
 To use the GUI, [NodeJS](https://nodejs.org/download/release/v18.12.1/) (v18 LTS, with npm) will additionally need to be installed. NodeJS v14.14.0 and earlier are no longer supported.
 The first time ```Gui.py``` is run it will need to install necessary components, which could take a few minutes. Subsequent instances will run much quicker.
@@ -174,6 +174,7 @@ issue. You should always Hard Reset to avoid this issue entirely.
 * Junk items being sent to another world will now float up into the air to indicate this.
 * An unnecessary polygon check function is skipped to increase game performance.
 * In Triforce Hunt, your current and goal number of triforce pieces are now displayed on the file select screen.
+* Python 3.6 is no longer supported.
 
 #### New Speedups
 * Various cutscenes removed or shortened, such as Water Temple and Gerudo Fortress gates and scarecrow spawn cutscenes.

--- a/Region.py
+++ b/Region.py
@@ -62,7 +62,7 @@ class Region:
         new_region.exits = [entrance.copy(copy_dict=copy_dict) for entrance in self.exits]
         new_region.locations = [location.copy(copy_dict=copy_dict) for location in self.locations]
 
-        # TODO: Why does this not work?
+        # Why does this not work properly?
         # new_region.entrances = [entrance.copy(copy_dict=copy_dict) for entrance in self.entrances]
 
         if self.dungeon:

--- a/Region.py
+++ b/Region.py
@@ -1,53 +1,56 @@
 from enum import Enum, unique
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from Dungeon import Dungeon
+    from Entrance import Entrance
+    from Hints import HintArea
+    from Item import Item
+    from Location import Location
+    from World import World
 
 
 @unique
 class RegionType(Enum):
-
     Overworld = 1
     Interior = 2
     Dungeon = 3
     Grotto = 4
 
-
     @property
-    def is_indoors(self):
+    def is_indoors(self) -> bool:
         """Shorthand for checking if Interior or Dungeon"""
         return self in (RegionType.Interior, RegionType.Dungeon, RegionType.Grotto)
 
 
 # Pretends to be an enum, but when the values are raw ints, it's much faster
-class TimeOfDay(object):
-    NONE = 0
-    DAY = 1
-    DAMPE = 2
-    ALL = DAY | DAMPE
+class TimeOfDay:
+    NONE: int = 0
+    DAY: int = 1
+    DAMPE: int = 2
+    ALL: int = DAY | DAMPE
 
 
-class Region(object):
+class Region:
+    def __init__(self, world: "World", name: str, region_type: RegionType = RegionType.Overworld) -> None:
+        self.world: "World" = world
+        self.name: str = name
+        self.type: RegionType = region_type
+        self.entrances: "List[Entrance]" = []
+        self.exits: "List[Entrance]" = []
+        self.locations: "List[Location]" = []
+        self.dungeon: "Optional[Dungeon]" = None
+        self.hint_name: Optional[str] = None
+        self.alt_hint_name: Optional[str] = None
+        self.price: Optional[int] = None
+        self.time_passes: bool = False
+        self.provides_time: int = TimeOfDay.NONE
+        self.scene: Optional[str] = None
+        self.is_boss_room: bool = False
+        self.savewarp: "Optional[Entrance]" = None
 
-    def __init__(self, name, type=RegionType.Overworld):
-        self.name = name
-        self.type = type
-        self.entrances = []
-        self.exits = []
-        self.locations = []
-        self.dungeon = None
-        self.world = None
-        self.hint_name = None
-        self.alt_hint_name = None
-        self.price = None
-        self.world = None
-        self.time_passes = False
-        self.provides_time = TimeOfDay.NONE
-        self.scene = None
-        self.is_boss_room = False
-        self.savewarp = None
-
-
-    def copy(self, new_world):
-        new_region = Region(self.name, self.type)
-        new_region.world = new_world
+    def copy(self, new_world: "World") -> 'Region':
+        new_region = Region(new_world, self.name, self.type)
         new_region.price = self.price
         new_region.hint_name = self.hint_name
         new_region.alt_hint_name = self.alt_hint_name
@@ -63,9 +66,8 @@ class Region(object):
 
         return new_region
 
-
     @property
-    def hint(self):
+    def hint(self) -> "HintArea":
         from Hints import HintArea
 
         if self.hint_name is not None:
@@ -74,14 +76,13 @@ class Region(object):
             return self.dungeon.hint
 
     @property
-    def alt_hint(self):
+    def alt_hint(self) -> "HintArea":
         from Hints import HintArea
 
         if self.alt_hint_name is not None:
             return HintArea[self.alt_hint_name]
 
-
-    def can_fill(self, item, manual=False):
+    def can_fill(self, item: "Item", manual: bool = False) -> bool:
         if not manual and self.world.settings.empty_dungeons_mode != 'none' and item.dungeonitem:
             # An empty dungeon can only store its own dungeon items
             if self.dungeon and self.dungeon.world.empty_dungeons[self.dungeon.name].empty:
@@ -135,8 +136,7 @@ class Region(object):
 
         return True
 
-
-    def get_scene(self):
+    def get_scene(self) -> Optional[str]:
         if self.scene:
             return self.scene
         elif self.dungeon:
@@ -144,11 +144,8 @@ class Region(object):
         else:
             return None
 
-
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.__unicode__())
 
-
-    def __unicode__(self):
+    def __unicode__(self) -> str:
         return '%s' % self.name
-

--- a/Region.py
+++ b/Region.py
@@ -67,7 +67,7 @@ class Region:
         return new_region
 
     @property
-    def hint(self) -> "HintArea":
+    def hint(self) -> "Optional[HintArea]":
         from Hints import HintArea
 
         if self.hint_name is not None:
@@ -76,13 +76,15 @@ class Region:
             return self.dungeon.hint
 
     @property
-    def alt_hint(self) -> "HintArea":
+    def alt_hint(self) -> "Optional[HintArea]":
         from Hints import HintArea
 
         if self.alt_hint_name is not None:
             return HintArea[self.alt_hint_name]
 
     def can_fill(self, item: "Item", manual: bool = False) -> bool:
+        from Hints import HintArea
+
         if not manual and self.world.settings.empty_dungeons_mode != 'none' and item.dungeonitem:
             # An empty dungeon can only store its own dungeon items
             if self.dungeon and self.dungeon.world.empty_dungeons[self.dungeon.name].empty:
@@ -91,8 +93,6 @@ class Region:
             for dungeon in item.world.dungeons:
                 if item.world.empty_dungeons[dungeon.name].empty and dungeon.is_dungeon_item(item):
                     return False
-
-        from Hints import HintArea
 
         is_self_dungeon_restricted = False
         is_self_region_restricted = None

--- a/Region.py
+++ b/Region.py
@@ -101,7 +101,7 @@ class Region:
         is_dungeon_restricted = False
         is_overworld_restricted = False
 
-        if item.type in ['Map', 'Compass', 'SmallKey', 'HideoutSmallKey', 'TCGSmallKey', 'BossKey', 'GanonBossKey','SilverRupee']:
+        if item.type in ['Map', 'Compass', 'SmallKey', 'HideoutSmallKey', 'TCGSmallKey', 'BossKey', 'GanonBossKey', 'SilverRupee']:
             shuffle_setting = (self.world.settings.shuffle_mapcompass if item.type in ['Map', 'Compass'] else
                                self.world.settings.shuffle_smallkeys if item.type == 'SmallKey' else
                                self.world.settings.shuffle_hideoutkeys if item.type == 'HideoutSmallKey' else

--- a/Region.py
+++ b/Region.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 from enum import Enum, unique
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from Dungeon import Dungeon
@@ -32,14 +33,14 @@ class TimeOfDay:
 
 
 class Region:
-    def __init__(self, world: "World", name: str, region_type: RegionType = RegionType.Overworld) -> None:
-        self.world: "World" = world
+    def __init__(self, world: World, name: str, region_type: RegionType = RegionType.Overworld) -> None:
+        self.world: World = world
         self.name: str = name
         self.type: RegionType = region_type
-        self.entrances: "List[Entrance]" = []
-        self.exits: "List[Entrance]" = []
-        self.locations: "List[Location]" = []
-        self.dungeon: "Optional[Dungeon]" = None
+        self.entrances: list[Entrance] = []
+        self.exits: list[Entrance] = []
+        self.locations: list[Location] = []
+        self.dungeon: Optional[Dungeon] = None
         self.hint_name: Optional[str] = None
         self.alt_hint_name: Optional[str] = None
         self.price: Optional[int] = None
@@ -47,9 +48,9 @@ class Region:
         self.provides_time: int = TimeOfDay.NONE
         self.scene: Optional[str] = None
         self.is_boss_room: bool = False
-        self.savewarp: "Optional[Entrance]" = None
+        self.savewarp: Optional[Entrance] = None
 
-    def copy(self, new_world: "World") -> 'Region':
+    def copy(self, new_world: World) -> Region:
         new_region = Region(new_world, self.name, self.type)
         new_region.price = self.price
         new_region.hint_name = self.hint_name
@@ -67,7 +68,7 @@ class Region:
         return new_region
 
     @property
-    def hint(self) -> "Optional[HintArea]":
+    def hint(self) -> Optional[HintArea]:
         from Hints import HintArea
 
         if self.hint_name is not None:
@@ -76,13 +77,13 @@ class Region:
             return self.dungeon.hint
 
     @property
-    def alt_hint(self) -> "Optional[HintArea]":
+    def alt_hint(self) -> Optional[HintArea]:
         from Hints import HintArea
 
         if self.alt_hint_name is not None:
             return HintArea[self.alt_hint_name]
 
-    def can_fill(self, item: "Item", manual: bool = False) -> bool:
+    def can_fill(self, item: Item, manual: bool = False) -> bool:
         from Hints import HintArea
 
         if not manual and self.world.settings.empty_dungeons_mode != 'none' and item.dungeonitem:

--- a/Rom.py
+++ b/Rom.py
@@ -1,41 +1,39 @@
-import io
-import itertools
 import json
-import logging
 import os
 import platform
 import struct
 import subprocess
-import random
 import copy
-from Utils import is_bundled, subprocess_args, local_path, data_path, default_output_path, get_version_bytes
-from ntype import BigStream, uint32
+from typing import Sequence, MutableSequence, Tuple, Optional
+
+from Utils import is_bundled, subprocess_args, local_path, data_path, get_version_bytes
+from ntype import BigStream
 from crc import calculate_crc
 from Models import restrictiveBytes
 from version import base_version, branch_identifier, supplementary_version
 
 DMADATA_START = 0x7430
 
+
 class Rom(BigStream):
+    def __init__(self, file: str = None) -> None:
+        super().__init__(bytearray())
 
-    def __init__(self, file=None):
-        super().__init__([])
-
-        self.original = None
-        self.changed_address = {}
-        self.changed_dma = {}
-        self.force_patch = []
+        self.original: Rom
+        self.changed_address: dict[int, int] = {}
+        self.changed_dma: dict[int, Tuple[int, int, int]] = {}
+        self.force_patch: MutableSequence[int] = []
 
         if file is None:
             return
 
-        decomp_file = local_path('ZOOTDEC.z64')
+        decomp_file: str = local_path('ZOOTDEC.z64')
 
         os.chdir(local_path())
 
         with open(data_path('generated/symbols.json'), 'r') as stream:
             symbols = json.load(stream)
-            self.symbols = { name: int(addr, 16) for name, addr in symbols.items() }
+            self.symbols: dict[str, int] = {name: int(addr, 16) for name, addr in symbols.items()}
 
         if file == '':
             # if not specified, try to read from the previously decompressed rom
@@ -58,32 +56,30 @@ class Rom(BigStream):
         # Add version number to header.
         self.write_version_bytes()
 
-
-    def copy(self):
-        new_rom = Rom()
+    def copy(self) -> 'Rom':
+        new_rom: Rom = Rom()
         new_rom.buffer = copy.copy(self.buffer)
         new_rom.changed_address = copy.copy(self.changed_address)
         new_rom.changed_dma = copy.copy(self.changed_dma)
         new_rom.force_patch = copy.copy(self.force_patch)
         return new_rom
 
-
-    def decompress_rom_file(self, file, decomp_file, verify_crc=True):
-        validCRC = [
+    def decompress_rom_file(self, input_file: str, output_file: str, verify_crc: bool = True) -> None:
+        valid_crc = [
             [0xEC, 0x70, 0x11, 0xB7, 0x76, 0x16, 0xD7, 0x2B], # Compressed
             [0x70, 0xEC, 0xB7, 0x11, 0x16, 0x76, 0x2B, 0xD7], # Byteswap compressed
             [0x93, 0x52, 0x2E, 0x7B, 0xE5, 0x06, 0xD4, 0x27], # Decompressed
         ]
 
         # Validate ROM file
-        file_name = os.path.splitext(file)
-        romCRC = list(self.buffer[0x10:0x18])
-        if verify_crc and romCRC not in validCRC:
+        file_name = os.path.splitext(input_file)
+        rom_crc = list(self.buffer[0x10:0x18])
+        if verify_crc and rom_crc not in valid_crc:
             # Bad CRC validation
-            raise RuntimeError('ROM file %s is not a valid OoT 1.0 US ROM.' % file)
-        elif len(self.buffer) < 0x2000000 or len(self.buffer) > (0x4000000) or file_name[1].lower() not in ['.z64', '.n64']:
+            raise RuntimeError('ROM file %s is not a valid OoT 1.0 US ROM.' % input_file)
+        elif len(self.buffer) < 0x2000000 or len(self.buffer) > 0x4000000 or file_name[1].lower() not in ['.z64', '.n64']:
             # ROM is too big, or too small, or not a bad type
-            raise RuntimeError('ROM file %s is not a valid OoT 1.0 US ROM.' % file)
+            raise RuntimeError('ROM file %s is not a valid OoT 1.0 US ROM.' % input_file)
         elif len(self.buffer) == 0x2000000:
             # If Input ROM is compressed, then Decompress it
             subcall = []
@@ -92,55 +88,53 @@ class Rom(BigStream):
 
             if platform.system() == 'Windows':
                 if platform.machine() == 'AMD64':
-                    subcall = [sub_dir + "Decompress.exe", file, decomp_file]
+                    subcall = [sub_dir + "Decompress.exe", input_file, output_file]
                 elif platform.machine() == 'ARM64':
-                    subcall = [sub_dir + "Decompress_ARM64.exe", file, decomp_file]
+                    subcall = [sub_dir + "Decompress_ARM64.exe", input_file, output_file]
                 else:
-                    subcall = [sub_dir + "Decompress32.exe", file, decomp_file]
+                    subcall = [sub_dir + "Decompress32.exe", input_file, output_file]
             elif platform.system() == 'Linux':
                 if platform.machine() in ['arm64', 'aarch64', 'aarch64_be', 'armv8b', 'armv8l']:
-                    subcall = [sub_dir + "Decompress_ARM64", file, decomp_file]
+                    subcall = [sub_dir + "Decompress_ARM64", input_file, output_file]
                 elif platform.machine() in ['arm', 'armv7l', 'armhf']:
-                    subcall = [sub_dir + "Decompress_ARM32", file, decomp_file]
+                    subcall = [sub_dir + "Decompress_ARM32", input_file, output_file]
                 else:
-                    subcall = [sub_dir + "Decompress", file, decomp_file]
+                    subcall = [sub_dir + "Decompress", input_file, output_file]
             elif platform.system() == 'Darwin':
                 if platform.machine() == 'arm64':
-                    subcall = [sub_dir + "Decompress_ARM64.out", file, decomp_file]
+                    subcall = [sub_dir + "Decompress_ARM64.out", input_file, output_file]
                 else:
-                    subcall = [sub_dir + "Decompress.out", file, decomp_file]
+                    subcall = [sub_dir + "Decompress.out", input_file, output_file]
             else:
                 raise RuntimeError('Unsupported operating system for decompression. Please supply an already decompressed ROM.')
 
             subprocess.call(subcall, **subprocess_args())
-            self.read_rom(decomp_file)
+            self.read_rom(output_file)
         else:
             # ROM file is a valid and already uncompressed
             pass
 
-
-    def write_byte(self, address, value):
+    def write_byte(self, address: int, value: int) -> None:
         super().write_byte(address, value)
         self.changed_address[self.last_address-1] = value
 
-    def write_bytes_restrictive(self, start, size, values):
+    def write_bytes_restrictive(self, start: int, size: int, values: Sequence[int]) -> None:
         for i in range(size):
             address = start + i
             should_write = True
             for restrictiveBlock in restrictiveBytes:
                 # If i is between the start of restrictive zone [0] and start + size [1]
-                if restrictiveBlock[0] <= address and address < restrictiveBlock[0] + restrictiveBlock[1]:
+                if restrictiveBlock[0] <= address < restrictiveBlock[0] + restrictiveBlock[1]:
                     should_write = False
                     break
             if should_write:
                 self.write_byte(address, values[i])
 
-    def write_bytes(self, address, values):
+    def write_bytes(self, address: int, values: Sequence[int]) -> None:
         super().write_bytes(address, values)
-        self.changed_address.update(zip(range(address, address+len(values)), values))
+        self.changed_address.update(zip(range(address, address + len(values)), values))
 
-
-    def restore(self):
+    def restore(self) -> None:
         self.buffer = copy.copy(self.original.buffer)
         self.changed_address = {}
         self.changed_dma = {}
@@ -148,31 +142,26 @@ class Rom(BigStream):
         self.last_address = None
         self.write_version_bytes()
 
-
-    def sym(self, symbol_name):
+    def sym(self, symbol_name: str) -> int:
         return self.symbols.get(symbol_name)
 
-
-    def write_to_file(self, file):
+    def write_to_file(self, file: str) -> None:
         self.verify_dmadata()
         self.update_header()
         with open(file, 'wb') as outfile:
             outfile.write(self.buffer)
 
-
-    def update_header(self):
+    def update_header(self) -> None:
         crc = calculate_crc(self)
         self.write_bytes(0x10, crc)
 
-
-    def write_version_bytes(self):
+    def write_version_bytes(self) -> None:
         version_bytes = get_version_bytes(base_version, branch_identifier, supplementary_version)
         self.write_bytes(0x19, version_bytes)
         self.write_bytes(0x35, version_bytes[:3])
         self.force_patch.extend([0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x35, 0x36, 0x37])
 
-
-    def read_version_bytes(self):
+    def read_version_bytes(self) -> bytearray:
         version_bytes = self.read_bytes(0x19, 5)
         secondary_version_bytes = self.read_bytes(0x35, 3)
         for i in range(3):
@@ -180,8 +169,7 @@ class Rom(BigStream):
                 return secondary_version_bytes
         return version_bytes
 
-
-    def read_rom(self, file):
+    def read_rom(self, file: str) -> None:
         # "Reads rom into bytearray"
         try:
             with open(file, 'rb') as stream:
@@ -189,17 +177,15 @@ class Rom(BigStream):
         except FileNotFoundError as ex:
             raise FileNotFoundError('Invalid path to Base ROM: "' + file + '"')
 
-
     # dmadata/file management helper functions
 
-    def _get_dmadata_record(self, cur):
+    def _get_dmadata_record(self, cur: int) -> Tuple[int, int, int]:
         start = self.read_int32(cur)
         end = self.read_int32(cur+0x04)
         size = end-start
         return start, end, size
 
-
-    def get_dmadata_record_by_key(self, key):
+    def get_dmadata_record_by_key(self, key: int) -> Optional[Tuple[int, int, int]]:
         cur = DMADATA_START
         dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
         while True:
@@ -210,8 +196,7 @@ class Rom(BigStream):
             cur += 0x10
             dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
 
-
-    def verify_dmadata(self):
+    def verify_dmadata(self) -> None:
         cur = DMADATA_START
         overlapping_records = []
         dma_data = []
@@ -241,10 +226,9 @@ class Rom(BigStream):
             raise Exception("Overlapping DMA Data Records!\n%s" % \
                 '\n-------------------------------------\n'.join(overlapping_records))
 
-
     # update dmadata record with start vrom address "key"
     # if key is not found, then attempt to add a new dmadata entry
-    def update_dmadata_record(self, key, start, end, from_file=None):
+    def update_dmadata_record(self, key: int, start: int, end: int, from_file: int = None) -> None:
         cur, dma_data_end = self.get_dma_table_range()
         dma_index = 0
         dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
@@ -260,15 +244,14 @@ class Rom(BigStream):
             raise Exception('dmadata update failed: key {0:x} not found in dmadata and dma table is full.'.format(key))
         else:
             self.write_int32s(cur, [start, end, start, 0])
-            if from_file == None:
-                if key == None:
+            if from_file is None:
+                if key is None:
                     from_file = -1
                 else:
                     from_file = key
             self.changed_dma[dma_index] = (from_file, start, end - start)
 
-
-    def get_dma_table_range(self):
+    def get_dma_table_range(self) -> Tuple[int, int]:
         cur = DMADATA_START
         dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
         while True:
@@ -276,25 +259,22 @@ class Rom(BigStream):
                 raise Exception('Bad DMA Table: DMA Table entry missing.')
 
             if dma_start == DMADATA_START:
-                return (DMADATA_START, dma_end)
+                return DMADATA_START, dma_end
 
             cur += 0x10
             dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
 
-
     # This will scan for any changes that have been made to the DMA table
     # By default, this assumes any changes here are new files, so this should only be called
     # after patching in the new files, but before vanilla files are repointed
-    def scan_dmadata_update(self, preserve_from_file=False, assume_move=False):
+    def scan_dmadata_update(self, preserve_from_file: bool = False, assume_move: bool = False) -> None:
         cur = DMADATA_START
-        dma_data_end = None
         dma_index = 0
         dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
         old_dma_start, old_dma_end, old_dma_size = self.original._get_dmadata_record(cur)
 
         while True:
-            if (dma_start == 0 and dma_end == 0) and \
-            (old_dma_start == 0 and old_dma_end == 0):
+            if (dma_start == 0 and dma_end == 0) and (old_dma_start == 0 and old_dma_end == 0):
                 break
 
             # If the entries do not match, the flag the changed entry
@@ -311,9 +291,8 @@ class Rom(BigStream):
             dma_start, dma_end, dma_size = self._get_dmadata_record(cur)
             old_dma_start, old_dma_end, old_dma_size = self.original._get_dmadata_record(cur)
 
-
     # This will rescan the entire ROM, compare to original ROM, and repopulate changed_address.
-    def rescan_changed_bytes(self):
+    def rescan_changed_bytes(self) -> None:
         self.changed_address = {}
         size = len(self.buffer)
         original_size = len(self.original.buffer)
@@ -327,9 +306,8 @@ class Rom(BigStream):
         if size < original_size:
             self.changed_address.update(zip(range(size, original_size-1), [0]*(original_size-size)))
 
-
     # gets the last used byte of rom defined in the DMA table
-    def free_space(self):
+    def free_space(self) -> int:
         cur = DMADATA_START
         max_end = 0
 

--- a/Rom.py
+++ b/Rom.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
 import copy
 import json
 import os
 import platform
 import subprocess
-from typing import List, Tuple, Sequence, Iterator, Optional
+from collections.abc import Iterator, Sequence
+from typing import Optional
 
 from Models import restrictiveBytes
 from Utils import is_bundled, subprocess_args, local_path, data_path, get_version_bytes
@@ -21,9 +23,9 @@ class Rom(BigStream):
 
         self.original: Rom = self
         self.changed_address: dict[int, int] = {}
-        self.changed_dma: dict[int, Tuple[int, int, int]] = {}
-        self.force_patch: List[int] = []
-        self.dma: 'DMAIterator' = DMAIterator(self, DMADATA_START, DMADATA_INDEX)
+        self.changed_dma: dict[int, tuple[int, int, int]] = {}
+        self.force_patch: list[int] = []
+        self.dma: DMAIterator = DMAIterator(self, DMADATA_START, DMADATA_INDEX)
 
         if file is None:
             return
@@ -53,7 +55,7 @@ class Rom(BigStream):
         # Add version number to header.
         self.write_version_bytes()
 
-    def copy(self) -> 'Rom':
+    def copy(self) -> Rom:
         new_rom: Rom = Rom()
         new_rom.buffer = copy.copy(self.buffer)
         new_rom.changed_address = copy.copy(self.changed_address)
@@ -273,7 +275,7 @@ class DMAEntry:
     def size(self) -> int:
         return self.end - self.start
 
-    def as_tuple(self) -> Tuple[int, int, int]:
+    def as_tuple(self) -> tuple[int, int, int]:
         start, end = self.start, self.end
         return start, end, end - start
 

--- a/RuleParser.py
+++ b/RuleParser.py
@@ -84,9 +84,9 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                 keywords=[])
         elif node.id in self.world.__dict__:
             return ast.parse('%r' % self.world.__dict__[node.id], mode='eval').body
-        elif node.id in self.world.settings.__dict__:
+        elif node.id in self.world.settings.settings_dict:
             # Settings are constant
-            return ast.parse('%r' % self.world.settings.__dict__[node.id], mode='eval').body
+            return ast.parse('%r' % self.world.settings.settings_dict[node.id], mode='eval').body
         elif node.id in State.__dict__:
             return self.make_call(node, node.id, [], [])
         elif node.id in kwarg_defaults or node.id in special_globals:
@@ -142,7 +142,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
 
         if isinstance(count, ast.Name):
             # Must be a settings constant
-            count = ast.parse('%r' % self.world.settings.__dict__[count.id], mode='eval').body
+            count = ast.parse('%r' % self.world.settings.settings_dict[count.id], mode='eval').body
 
         if item.id not in ItemInfo.solver_ids:
             self.events.add(item.id.replace('_', ' '))
@@ -192,7 +192,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                             ctx=ast.Load()),
                         attr=child.id,
                         ctx=ast.Load())
-                elif child.id in self.world.settings.__dict__:
+                elif child.id in self.world.settings.settings_dict:
                     child = ast.Attribute(
                         value=ast.Attribute(
                             value=ast.Attribute(
@@ -247,7 +247,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
         if (len(node.ops) == 1 and isinstance(node.ops[0], ast.Eq)
                 and isinstance(node.left, ast.Name) and isinstance(node.comparators[0], ast.Name)
                 and node.left.id not in self.world.__dict__ and node.comparators[0].id not in self.world.__dict__
-                and node.left.id not in self.world.settings.__dict__ and node.comparators[0].id not in self.world.settings.__dict__):
+                and node.left.id not in self.world.settings.settings_dict and node.comparators[0].id not in self.world.settings.settings_dict):
             return ast.NameConstant(node.left.id == node.comparators[0].id)
 
         node.left = escape_or_string(node.left)
@@ -299,7 +299,7 @@ class Rule_AST_Transformer(ast.NodeTransformer):
                 items.add(escape_name(elt.s))
             elif (isinstance(elt, ast.Name) and elt.id not in rule_aliases
                     and elt.id not in self.world.__dict__
-                    and elt.id not in self.world.settings.__dict__
+                    and elt.id not in self.world.settings.settings_dict
                     and elt.id not in dir(self)
                     and elt.id not in State.__dict__):
                 items.add(elt.id)

--- a/Rules.py
+++ b/Rules.py
@@ -1,11 +1,19 @@
 import logging
+from typing import TYPE_CHECKING, Collection, Iterable, Callable, Union
+
 from ItemPool import song_list
-from Location import DisableType
+from Location import Location, DisableType
+from RulesCommon import AccessRule
 from Search import Search
 from State import State
 
+if TYPE_CHECKING:
+    from Entrance import Entrance
+    from Item import Item
+    from World import World
 
-def set_rules(world):
+
+def set_rules(world: "World") -> None:
     logger = logging.getLogger('')
 
     # ganon can only carry triforce
@@ -76,8 +84,8 @@ def set_rules(world):
             logger.debug('Tried to disable location that does not exist: %s' % location)
 
 
-def create_shop_rule(location):
-    def required_wallets(price):
+def create_shop_rule(location: Location) -> AccessRule:
+    def required_wallets(price: int) -> int:
         if price > 500:
             return 3
         if price > 200:
@@ -88,26 +96,26 @@ def create_shop_rule(location):
     return location.world.parser.parse_rule('(Progressive_Wallet, %d)' % required_wallets(location.price))
 
 
-def set_rule(spot, rule):
+def set_rule(spot: "Union[Location, Entrance]", rule: AccessRule) -> None:
     spot.access_rule = rule
 
 
-def add_item_rule(spot, rule):
+def add_item_rule(spot: Location, rule: "Callable[[Location, Item], bool]") -> None:
     old_rule = spot.item_rule
     spot.item_rule = lambda location, item: rule(location, item) and old_rule(location, item)
 
 
-def forbid_item(location, item_name):
+def forbid_item(location: Location, item_name: str) -> None:
     old_rule = location.item_rule
     location.item_rule = lambda loc, item: item.name != item_name and old_rule(loc, item)
 
 
-def limit_to_itemset(location, itemset):
+def limit_to_itemset(location: Location, itemset: "Collection[Item]"):
     old_rule = location.item_rule
     location.item_rule = lambda loc, item: item.name in itemset and old_rule(loc, item)
 
 
-def item_in_locations(state, item, locations):
+def item_in_locations(state: State, item: "Item", locations: Iterable[Location]) -> bool:
     for location in locations:
         if state.item_name(location) == item:
             return True
@@ -120,7 +128,7 @@ def item_in_locations(state, item, locations):
 # accessible when all items are obtained and every shop item is not.
 # This function should also be called when a world is copied if the original world
 # had called this function because the world.copy does not copy the rules
-def set_shop_rules(world):
+def set_shop_rules(world: "World"):
     found_bombchus = world.parser.parse_rule('found_bombchus')
     wallet = world.parser.parse_rule('Progressive_Wallet')
     wallet2 = world.parser.parse_rule('(Progressive_Wallet, 2)')
@@ -147,16 +155,15 @@ def set_shop_rules(world):
                                       'Buy Red Potion for 30 Rupees',
                                       'Buy Red Potion for 40 Rupees',
                                       'Buy Red Potion for 50 Rupees',
-                                      'Buy Fairy\'s Spirit']:
+                                      "Buy Fairy's Spirit"]:
                 location.add_rule(State.has_bottle)
             if location.item.name in ['Buy Bombchu (10)', 'Buy Bombchu (20)', 'Buy Bombchu (5)']:
                 location.add_rule(found_bombchus)
 
 
-# This function should be ran once after setting up entrances and before placing items
+# This function should be run once after setting up entrances and before placing items
 # The goal is to automatically set item rules based on age requirements in case entrances were shuffled
-def set_entrances_based_rules(worlds):
-
+def set_entrances_based_rules(worlds: "Collection[World]") -> None:
     # Use the states with all items available in the pools for this seed
     complete_itempool = [item for world in worlds for item in world.get_itempool_with_dungeon_items()]
     search = Search([world.state for world in worlds])

--- a/RulesCommon.py
+++ b/RulesCommon.py
@@ -1,21 +1,14 @@
 from __future__ import annotations
 import re
-import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Protocol, Any
 
 if TYPE_CHECKING:
     from State import State
 
-# The better way to type hint the access rule requires Python 3.8.
-if sys.version_info >= (3, 8):
-    from typing import Protocol
 
-    class AccessRule(Protocol):
-        def __call__(self, state: State, **kwargs) -> bool:
-            ...
-else:
-    from typing import Callable
-    AccessRule = Callable[["State"], bool]
+class AccessRule(Protocol):
+    def __call__(self, state: State, **kwargs) -> bool:
+        ...
 
 
 # Variable names and values used by rule execution,

--- a/RulesCommon.py
+++ b/RulesCommon.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 import re
 import sys
-from typing import TYPE_CHECKING, Dict, Pattern, Callable, Any
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from State import State
@@ -10,18 +11,19 @@ if sys.version_info >= (3, 8):
     from typing import Protocol
 
     class AccessRule(Protocol):
-        def __call__(self, state: "State", **kwargs) -> bool:
+        def __call__(self, state: State, **kwargs) -> bool:
             ...
 else:
+    from typing import Callable
     AccessRule = Callable[["State"], bool]
 
 
 # Variable names and values used by rule execution,
 # will be automatically filled by Items
-allowed_globals: Dict[str, Any] = {}
+allowed_globals: dict[str, Any] = {}
 
 
-_escape: Pattern[str] = re.compile(r'[\'()[\]-]')
+_escape: re.Pattern[str] = re.compile(r'[\'()[\]-]')
 
 
 def escape_name(name: str) -> str:

--- a/RulesCommon.py
+++ b/RulesCommon.py
@@ -1,12 +1,29 @@
 import re
+import sys
+from typing import TYPE_CHECKING, Dict, Pattern, Callable, Any
+
+if TYPE_CHECKING:
+    from State import State
+
+# The better way to type hint the access rule requires Python 3.8.
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+
+    class AccessRule(Protocol):
+        def __call__(self, state: "State", **kwargs):
+            ...
+else:
+    from Utils import TypeAlias
+    AccessRule: TypeAlias = Callable[["State"], bool]
+
 
 # Variable names and values used by rule execution,
 # will be automatically filled by Items
-allowed_globals = {}
+allowed_globals: Dict[str, Any] = {}
 
 
-_escape = re.compile(r'[\'()[\]-]')
+_escape: Pattern[str] = re.compile(r'[\'()[\]-]')
 
-def escape_name(name):
+
+def escape_name(name: str) -> str:
     return _escape.sub('', name.replace(' ', '_'))
-

--- a/RulesCommon.py
+++ b/RulesCommon.py
@@ -10,11 +10,10 @@ if sys.version_info >= (3, 8):
     from typing import Protocol
 
     class AccessRule(Protocol):
-        def __call__(self, state: "State", **kwargs):
+        def __call__(self, state: "State", **kwargs) -> bool:
             ...
 else:
-    from Utils import TypeAlias
-    AccessRule: TypeAlias = Callable[["State"], bool]
+    AccessRule = Callable[["State"], bool]
 
 
 # Variable names and values used by rule execution,

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -1,8 +1,13 @@
+import sys
 from enum import IntEnum
 from typing import TYPE_CHECKING, Dict, List, Iterable, Callable, Optional, Union, Any
 
 from ItemPool import IGNORE_LOCATION
-from Utils import TypeAlias
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    TypeAlias = str
 
 if TYPE_CHECKING:
     from Rom import Rom
@@ -46,7 +51,7 @@ class FlagType(IntEnum):
 
 
 class Address:
-    prev_address: Optional[int] = None
+    prev_address: int = 0
     EXTENDED_CONTEXT_START = 0x1450
 
     def __init__(self, address: Optional[int] = None, extended: bool = False, size: int = 4, mask: int = 0xFFFFFFFF,

--- a/SaveContext.py
+++ b/SaveContext.py
@@ -1,6 +1,15 @@
-from itertools import chain
 from enum import IntEnum
+from typing import TYPE_CHECKING, Dict, List, Iterable, Callable, Optional, Union, Any
+
 from ItemPool import IGNORE_LOCATION
+from Utils import TypeAlias
+
+if TYPE_CHECKING:
+    from Rom import Rom
+    from World import World
+
+AddressesDict: TypeAlias = 'Dict[str, Union[Address, Dict[str, Union[Address, Dict[str, Address]]]]]'
+
 
 class Scenes(IntEnum):
     # Dungeons
@@ -25,6 +34,7 @@ class Scenes(IntEnum):
     DEATH_MOUNTAIN_CRATER = 0x61
     GORON_CITY = 0x62
 
+
 class FlagType(IntEnum):
     CHEST = 0x00
     SWITCH = 0x01
@@ -34,42 +44,36 @@ class FlagType(IntEnum):
     VISITED_ROOM = 0x05
     VISITED_FLOOR = 0x06
 
-class Address():
-    prev_address = None
+
+class Address:
+    prev_address: Optional[int] = None
     EXTENDED_CONTEXT_START = 0x1450
 
-    def __init__(self, address=None, extended=False, size=4, mask=0xFFFFFFFF, max=None, choices=None, value=None):
-        if address is None:
-            self.address = Address.prev_address
-        else:
-            self.address = address
+    def __init__(self, address: Optional[int] = None, extended: bool = False, size: int = 4, mask: int = 0xFFFFFFFF,
+                 max: Optional[int] = None, choices: Optional[Dict[str, int]] = None, value: Optional[str] = None) -> None:
+        self.address: int = Address.prev_address if address is None else address
         if extended and address is not None:
             self.address += Address.EXTENDED_CONTEXT_START
-        self.value = value
-        self.size = size
-        self.choices = choices
-        self.mask = mask
+        self.value: Optional[Union[str, int]] = value
+        self.size: int = size
+        self.choices: Optional[Dict[str, int]] = choices
+        self.mask: int = mask
 
         Address.prev_address = self.address + self.size
 
-        self.bit_offset = 0
+        self.bit_offset: int = 0
         while mask & 1 == 0:
             mask = mask >> 1
             self.bit_offset += 1
 
-        if max is None:
-            self.max = mask
-        else:
-            self.max = max
+        self.max: int = mask if max is None else max
 
-
-    def get_value(self, default=0):
+    def get_value(self, default: Union[str, int] = 0) -> Union[str, int]:
         if self.value is None:
             return default
         return self.value
 
-
-    def get_value_raw(self):
+    def get_value_raw(self) -> Optional[int]:
         if self.value is None:
             return None
 
@@ -87,8 +91,7 @@ class Address():
         value = (value << self.bit_offset) & self.mask
         return value
 
-
-    def set_value_raw(self, value):
+    def set_value_raw(self, value: int) -> None:
         if value is None:
             self.value = None
             return
@@ -108,8 +111,7 @@ class Address():
 
         self.value = value
 
-
-    def get_writes(self, save_context):
+    def get_writes(self, save_context: 'SaveContext') -> None:
         if self.value is None:
             return
 
@@ -128,8 +130,8 @@ class Address():
             else:
                 save_context.write_bits(self.address + i, byte, mask=mask)
 
-
-    def to_bytes(value, size):
+    @staticmethod
+    def to_bytes(value: int, size: int) -> List[int]:
         ret = []
         for _ in range(size):
             ret.insert(0, value & 0xFF)
@@ -137,15 +139,14 @@ class Address():
         return ret
 
 
-class SaveContext():
+class SaveContext:
     def __init__(self):
-        self.save_bits = {}
-        self.save_bytes = {}
-        self.addresses = self.get_save_context_addresses()
-
+        self.save_bits: Dict[int, int] = {}
+        self.save_bytes: Dict[int, int] = {}
+        self.addresses: AddressesDict = self.get_save_context_addresses()
 
     # will set the bits of value to the offset in the save (or'ing them with what is already there)
-    def write_bits(self, address, value, mask=None, predicate=None):
+    def write_bits(self, address: int, value: int, mask: Optional[int] = None, predicate: Optional[Callable[[int], bool]] = None) -> None:
         if predicate and not predicate(value):
             return
 
@@ -165,9 +166,8 @@ class SaveContext():
         else:
             self.save_bits[address] = value
 
-
     # will overwrite the byte at offset with the given value
-    def write_byte(self, address, value, predicate=None):
+    def write_byte(self, address: int, value: int, predicate: Optional[Callable[[int], bool]] = None) -> None:
         if predicate and not predicate(value):
             return
 
@@ -176,14 +176,12 @@ class SaveContext():
 
         self.save_bytes[address] = value
 
-
     # will overwrite the byte at offset with the given value
-    def write_bytes(self, address, bytes, predicate=None):
+    def write_bytes(self, address: int, bytes: Iterable[int], predicate: Optional[Callable[[int], bool]] = None) -> None:
         for i, value in enumerate(bytes):
             self.write_byte(address + i, value, predicate)
 
-
-    def write_save_entry(self, address):
+    def write_save_entry(self, address: Address) -> None:
         if isinstance(address, dict):
             for name, sub_address in address.items():
                 self.write_save_entry(sub_address)
@@ -193,7 +191,7 @@ class SaveContext():
         else:
             address.get_writes(self)
 
-    def write_permanent_flag(self, scene, type, byte_offset, bit_values):
+    def write_permanent_flag(self, scene: int, type: int, byte_offset: int, bit_values: int) -> None:
         # Save format is described here: https://wiki.cloudmodding.com/oot/Save_Format
         # Permanent flags start at offset 0x00D4. Each scene has 7 types of flags, one
         # of which is unused. Each flag type is 4 bytes wide per-scene, thus each scene
@@ -203,11 +201,11 @@ class SaveContext():
         self.write_bits(0x00D4 + scene * 0x1C + type * 0x04 + byte_offset, bit_values)
 
     # write all flags (int32) of a given type at once
-    def write_permanent_flags(self, scene, type, value):
+    def write_permanent_flags(self, scene: Scenes, flag_type: FlagType, value: int) -> None:
         byte_value = value.to_bytes(4, byteorder='big', signed=False)
-        self.write_bytes(0x00D4 + scene * 0x1C + type * 0x04, byte_value)
+        self.write_bytes(0x00D4 + scene * 0x1C + flag_type * 0x04, byte_value)
 
-    def set_ammo_max(self):
+    def set_ammo_max(self) -> None:
         ammo_maxes = {
             'stick'     : ('stick_upgrade', [10,  10,  20,  30]),
             'nut'       : ('nut_upgrade',   [20,  20,  30,  40]),
@@ -228,9 +226,8 @@ class SaveContext():
             else:
                 self.addresses['ammo'][ammo].max = ammo_max
 
-
     # will overwrite the byte at offset with the given value
-    def write_save_table(self, rom):
+    def write_save_table(self, rom: "Rom") -> None:
         self.set_ammo_max()
         for name, address in self.addresses.items():
             self.write_save_entry(address)
@@ -262,8 +259,7 @@ class SaveContext():
             raise Exception("The Initial Extended Save Table has exceeded its maximum capacity: 0x%03X/0x100" % extended_table_len)
         rom.write_bytes(rom.sym('EXTENDED_INITIAL_SAVE_DATA'), extended_table)
 
-
-    def give_bottle(self, item, count):
+    def give_bottle(self, item: str, count: int) -> None:
         for bottle_id in range(4):
             item_slot = 'bottle_%d' % (bottle_id + 1)
             if self.addresses['item_slot'][item_slot].get_value(0xFF) != 0xFF:
@@ -275,8 +271,7 @@ class SaveContext():
             if count == 0:
                 return
 
-
-    def give_health(self, health):
+    def give_health(self, health: float):
         health += self.addresses['health_capacity'].get_value(0x30) / 0x10
         health += self.addresses['quest']['heart_pieces'].get_value() / 4
 
@@ -284,8 +279,7 @@ class SaveContext():
         self.addresses['health'].value                = int(health) * 0x10
         self.addresses['quest']['heart_pieces'].value = int((health % 1) * 4) * 0x10
 
-
-    def give_item(self, world, item, count=1):
+    def give_item(self, world: "World", item: str, count: int = 1) -> None:
         if item.endswith(')'):
             item_base, implicit_count = item[:-1].split(' (', 1)
             if implicit_count.isdigit():
@@ -424,6 +418,7 @@ class SaveContext():
 
                 address_value = self.addresses
                 prev_sub_address = 'Save Context'
+                sub_address = None
                 for sub_address in address.split('.'):
                     if sub_address not in address_value:
                         raise ValueError('Unknown key %s in %s of SaveContext' % (sub_address, prev_sub_address))
@@ -434,7 +429,7 @@ class SaveContext():
                     address_value = address_value[sub_address]
                     prev_sub_address = sub_address
                 if not isinstance(address_value, Address):
-                    raise ValueError('%s does not resolve to an Address in SaveContext' % (sub_address))
+                    raise ValueError('%s does not resolve to an Address in SaveContext' % sub_address)
 
                 if isinstance(value, int) and value < address_value.get_value():
                     continue
@@ -443,20 +438,16 @@ class SaveContext():
         else:
             raise ValueError("Cannot give unknown starting item %s" % item)
 
-
-    def give_bombchu_item(self, world):
+    def give_bombchu_item(self, world: "World") -> None:
         self.give_item(world, "Bombchus", 0)
 
-
-    def equip_default_items(self, age):
+    def equip_default_items(self, age: str) -> None:
         self.equip_items(age, 'equips_' + age)
 
-
-    def equip_current_items(self, age):
+    def equip_current_items(self, age: str) -> None:
         self.equip_items(age, 'equips')
 
-
-    def equip_items(self, age, equip_type):
+    def equip_items(self, age: str, equip_type: str) -> None:
         if age not in ['child', 'adult']:
             raise ValueError("Age must be 'adult' or 'child', not %s" % age)
 
@@ -485,8 +476,8 @@ class SaveContext():
                         self.addresses[equip_type]['button_items']['b'].value = item
                     break
 
-
-    def get_save_context_addresses(self):
+    @staticmethod
+    def get_save_context_addresses() -> AddressesDict:
         return {
             'entrance_index'             : Address(0x0000, size=4),
             'link_age'                   : Address(size=4, max=1),
@@ -890,8 +881,7 @@ class SaveContext():
             }
         }
 
-
-    item_id_map = {
+    item_id_map: Dict[str, int] = {
         'none'                : 0xFF,
         'stick'               : 0x00,
         'nut'                 : 0x01,
@@ -1015,8 +1005,7 @@ class SaveContext():
         'small_key'           : 0x67,
     }
 
-
-    slot_id_map = {
+    slot_id_map: Dict[str, int] = {
         'stick'               : 0x00,
         'nut'                 : 0x01,
         'bomb'                : 0x02,
@@ -1043,8 +1032,7 @@ class SaveContext():
         'child_trade'         : 0x17,
     }
 
-
-    bottle_types = {
+    bottle_types: Dict[str, str] = {
         "Bottle"                   : 'bottle',
         "Bottle with Red Potion"   : 'red_potion',
         "Bottle with Green Potion" : 'green_potion',
@@ -1060,11 +1048,10 @@ class SaveContext():
         "Bottle with Poe"          : 'poe',
     }
 
-
-    save_writes_table = {
+    save_writes_table: Dict[str, Dict[str, Any]] = {
         "Deku Stick Capacity": {
             'item_slot.stick'            : 'stick',
-            'upgrades.stick_upgrade'     : [2,3],
+            'upgrades.stick_upgrade'     : [2, 3],
         },
         "Deku Stick": {
             'item_slot.stick'            : 'stick',
@@ -1078,7 +1065,7 @@ class SaveContext():
         },
         "Deku Nut Capacity": {
             'item_slot.nut'              : 'nut',
-            'upgrades.nut_upgrade'       : [2,3],
+            'upgrades.nut_upgrade'       : [2, 3],
         },
         "Deku Nuts": {
             'item_slot.nut'              : 'nut',
@@ -1305,8 +1292,8 @@ class SaveContext():
         'Silver Rupee (Ganons Castle Shadow Trial)':           {'silver_rupee_counts.trials_shadow': None},
         'Silver Rupee (Ganons Castle Water Trial)':            {'silver_rupee_counts.trials_water': None},
         'Silver Rupee (Ganons Castle Forest Trial)':           {'silver_rupee_counts.trials_forest': None},
-        #HACK: the following counts aren't used since exact counts based on whether the dungeon is MQ are defined above,
-        # but the entries need to be there for key rings and silver rupee pouches to be valid starting items
+        # HACK: these counts aren't used since exact counts based on whether the dungeon is MQ are defined above,
+        # but the entries need to be there for key rings to be valid starting items
         "Small Key Ring (Forest Temple)"          : {
             'keys.forest': 6,
             'total_keys.forest': 6,
@@ -1371,8 +1358,7 @@ class SaveContext():
         'Silver Rupee Pouch (Ganons Castle Forest Trial)':           {'silver_rupee_counts.trials_forest': 5},
     }
 
-
-    equipable_items = {
+    equipable_items: Dict[str, Dict[str, List[str]]] = {
         'equips_adult' : {
             'items': [
                 'hookshot',

--- a/SceneFlags.py
+++ b/SceneFlags.py
@@ -1,6 +1,10 @@
 from math import ceil
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
-from LocationList import location_table
+if TYPE_CHECKING:
+    from Location import Location
+    from World import World
+
 
 # Create a dict of dicts of the format:
 # {
@@ -10,25 +14,23 @@ from LocationList import location_table
 # }
 # where room_setup_number defines the room + scene setup as ((setup << 6) + room) for scene n
 # and max_flags is the highest used enemy flag for that setup/room
-def get_collectible_flag_table(world):
+def get_collectible_flag_table(world: "World") -> "Tuple[Dict[int, Dict[int, int]], List[Tuple[Location, Tuple[int, int, int], Tuple[int, int, int]]]]":
     scene_flags = {}
     alt_list = []
     for i in range(0, 101):
-        max_room_num = 0
-        max_enemy_flag = 0
         scene_flags[i] = {}
         for location in world.get_locations():
-            if(location.scene == i and location.type in ["Freestanding", "Pot", "FlyingPot", "Crate", "SmallCrate", "Beehive", "RupeeTower", "SilverRupee"]):
+            if location.scene == i and location.type in ["Freestanding", "Pot", "FlyingPot", "Crate", "SmallCrate", "Beehive", "RupeeTower", "SilverRupee"]:
                 default = location.default
-                if(isinstance(default, list)): #List of alternative room/setup/flag to use
+                if isinstance(default, list):  # List of alternative room/setup/flag to use
                     primary_tuple = default[0]
-                    for c in range(1,len(default)):
+                    for c in range(1, len(default)):
                         alt_list.append((location, default[c], primary_tuple))
-                    default = location.default[0] #Use the first tuple as the primary tuple
-                if(isinstance(default, tuple)):
+                    default = location.default[0]  # Use the first tuple as the primary tuple
+                if isinstance(default, tuple):
                     room, setup, flag = default
                     room_setup = room + (setup << 6)
-                    if(room_setup in scene_flags[i].keys()):
+                    if room_setup in scene_flags[i].keys():
                         curr_room_max_flag = scene_flags[i][room_setup]
                         if flag > curr_room_max_flag:
                             scene_flags[i][room_setup] = flag
@@ -36,11 +38,11 @@ def get_collectible_flag_table(world):
                         scene_flags[i][room_setup] = flag
         if len(scene_flags[i].keys()) == 0:
             del scene_flags[i]
-        #scene_flags.append((i, max_enemy_flag))
-    return (scene_flags, alt_list)
+    return scene_flags, alt_list
+
 
 # Create a byte array from the scene flag table created by get_collectible_flag_table
-def get_collectible_flag_table_bytes(scene_flag_table):
+def get_collectible_flag_table_bytes(scene_flag_table: Dict[int, Dict[int, int]]) -> Tuple[bytearray, int]:
     num_flag_bytes = 0
     bytes = bytearray()
     bytes.append(len(scene_flag_table.keys()))
@@ -57,7 +59,8 @@ def get_collectible_flag_table_bytes(scene_flag_table):
 
     return bytes, num_flag_bytes
 
-def get_alt_list_bytes(alt_list):
+
+def get_alt_list_bytes(alt_list: "List[Tuple[Location, Tuple[int, int, int], Tuple[int, int, int]]]") -> bytearray:
     bytes = bytearray()
     for entry in alt_list:
         location, alt, primary = entry

--- a/SceneFlags.py
+++ b/SceneFlags.py
@@ -26,7 +26,7 @@ def get_collectible_flag_table(world: "World") -> "Tuple[Dict[int, Dict[int, int
                     primary_tuple = default[0]
                     for c in range(1, len(default)):
                         alt_list.append((location, default[c], primary_tuple))
-                    default = location.default[0]  # Use the first tuple as the primary tuple
+                    default = primary_tuple  # Use the first tuple as the primary tuple
                 if isinstance(default, tuple):
                     room, setup, flag = default
                     room_setup = room + (setup << 6)
@@ -65,6 +65,9 @@ def get_alt_list_bytes(alt_list: "List[Tuple[Location, Tuple[int, int, int], Tup
     for entry in alt_list:
         location, alt, primary = entry
         room, scene_setup, flag = alt
+        if location.scene is None:
+            continue
+
         alt_override = (room << 8) + (scene_setup << 14) + flag
         room, scene_setup, flag = primary
         primary_override = (room << 8) + (scene_setup << 14) + flag

--- a/SceneFlags.py
+++ b/SceneFlags.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 from math import ceil
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from Location import Location
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 # }
 # where room_setup_number defines the room + scene setup as ((setup << 6) + room) for scene n
 # and max_flags is the highest used enemy flag for that setup/room
-def get_collectible_flag_table(world: "World") -> "Tuple[Dict[int, Dict[int, int]], List[Tuple[Location, Tuple[int, int, int], Tuple[int, int, int]]]]":
+def get_collectible_flag_table(world: World) -> tuple[dict[int, dict[int, int]], list[tuple[Location, tuple[int, int, int], tuple[int, int, int]]]]:
     scene_flags = {}
     alt_list = []
     for i in range(0, 101):
@@ -42,7 +43,7 @@ def get_collectible_flag_table(world: "World") -> "Tuple[Dict[int, Dict[int, int
 
 
 # Create a byte array from the scene flag table created by get_collectible_flag_table
-def get_collectible_flag_table_bytes(scene_flag_table: Dict[int, Dict[int, int]]) -> Tuple[bytearray, int]:
+def get_collectible_flag_table_bytes(scene_flag_table: dict[int, dict[int, int]]) -> tuple[bytearray, int]:
     num_flag_bytes = 0
     bytes = bytearray()
     bytes.append(len(scene_flag_table.keys()))
@@ -60,7 +61,7 @@ def get_collectible_flag_table_bytes(scene_flag_table: Dict[int, Dict[int, int]]
     return bytes, num_flag_bytes
 
 
-def get_alt_list_bytes(alt_list: "List[Tuple[Location, Tuple[int, int, int], Tuple[int, int, int]]]") -> bytearray:
+def get_alt_list_bytes(alt_list: list[tuple[Location, tuple[int, int, int], tuple[int, int, int]]]) -> bytearray:
     bytes = bytearray()
     for entry in alt_list:
         location, alt, primary = entry

--- a/Search.py
+++ b/Search.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
 import copy
 import itertools
 import sys
-from typing import TYPE_CHECKING, Dict, List, Tuple, Iterable, Set, Callable, Union, Optional
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
 
 from Region import Region, TimeOfDay
 from State import State
@@ -17,20 +20,34 @@ if TYPE_CHECKING:
     from Location import Location
     from Goals import GoalCategory
 
-ValidGoals: TypeAlias = Dict[str, Union[bool, Dict[str, Union[List[int], Dict[int, List[str]]]]]]
-SearchCache: TypeAlias = "Dict[str, Union[List[Entrance], Set[Location], Dict[Region, int]]]"
+ValidGoals: TypeAlias = "dict[str, bool | dict[str, list[int] | dict[int, list[str]]]]"
+
+
+@dataclass
+class SearchCache:
+    child_queue: list[Entrance] = field(default_factory=list)
+    adult_queue: list[Entrance] = field(default_factory=list)
+    visited_locations: set[Location] = field(default_factory=set)
+    child_regions: dict[Region, int] = field(default_factory=dict)
+    adult_regions: dict[Region, int] = field(default_factory=dict)
+
+    def copy(self) -> SearchCache:
+        new = type(self)()
+        for name, value in self.__dict__.items():
+            setattr(new, name, copy.copy(value))
+        return new
 
 
 class Search:
-    def __init__(self, state_list: "Iterable[State]", initial_cache: Optional[SearchCache] = None) -> None:
-        self.state_list: List[State] = [state.copy() for state in state_list]
+    def __init__(self, state_list: Iterable[State], initial_cache: Optional[SearchCache] = None) -> None:
+        self.state_list: list[State] = [state.copy() for state in state_list]
 
         # Let the states reference this search.
         for state in self.state_list:
             state.search = self
 
         self._cache: SearchCache
-        self.cached_spheres: List[SearchCache]
+        self.cached_spheres: list[SearchCache]
         if initial_cache:
             self._cache = initial_cache
             self.cached_spheres = [self._cache]
@@ -41,34 +58,33 @@ class Search:
             #    values are lazily-determined tod flags (see TimeOfDay).
             #  child_queue, adult_queue: queue of Entrance, all the exits to try next sphere
             #  visited_locations: set of Locations visited in or before that sphere.
-            self._cache = {
-                'child_queue': list(exit for region in root_regions for exit in region.exits),
-                'adult_queue': list(exit for region in root_regions for exit in region.exits),
-                'visited_locations': set(),
-                'child_regions': {region: TimeOfDay.NONE for region in root_regions},
-                'adult_regions': {region: TimeOfDay.NONE for region in root_regions},
-            }
+            self._cache = SearchCache(
+                child_queue=list(exit for region in root_regions for exit in region.exits),
+                adult_queue=list(exit for region in root_regions for exit in region.exits),
+                visited_locations=set(),
+                child_regions={region: TimeOfDay.NONE for region in root_regions},
+                adult_regions={region: TimeOfDay.NONE for region in root_regions},
+            )
             self.cached_spheres = [self._cache]
             self.next_sphere()
 
-    def copy(self) -> 'Search':
+    def copy(self) -> Search:
         # we only need to copy the top sphere since that's what we're starting with and we don't go back
-        new_cache = {k: copy.copy(v) for k,v in self._cache.items()}
         # copy always makes a nonreversible instance
-        return Search(self.state_list, initial_cache=new_cache)
+        return Search(self.state_list, initial_cache=self._cache.copy())
 
-    def collect_all(self, itempool: "Iterable[Item]") -> None:
+    def collect_all(self, itempool: Iterable[Item]) -> None:
         for item in itempool:
             if item.solver_id is not None and item.world is not None:
                 self.state_list[item.world.id].collect(item)
 
-    def collect(self, item: "Item") -> None:
+    def collect(self, item: Item) -> None:
         if item.world is None:
             raise Exception(f"Item '{item.name}' cannot be collected as it does not have a world.")
         self.state_list[item.world.id].collect(item)
 
     @classmethod
-    def max_explore(cls, state_list: Iterable[State], itempool: "Optional[Iterable[Item]]" = None) -> 'Search':
+    def max_explore(cls, state_list: Iterable[State], itempool: Optional[Iterable[Item]] = None) -> Search:
         p = cls(state_list)
         if itempool:
             p.collect_all(itempool)
@@ -76,7 +92,7 @@ class Search:
         return p
 
     @classmethod
-    def with_items(cls, state_list: Iterable[State], itempool: "Optional[Iterable[Item]]" = None) -> 'Search':
+    def with_items(cls, state_list: Iterable[State], itempool: Optional[Iterable[Item]] = None) -> Search:
         p = cls(state_list)
         if itempool:
             p.collect_all(itempool)
@@ -91,12 +107,12 @@ class Search:
     # Locations never visited in this Search are assumed to have been visited
     # in sphere 0, so unvisiting them will discard the entire cache.
     # Not safe to call during iteration.
-    def unvisit(self, location: "Location") -> None:
+    def unvisit(self, location: Location) -> None:
         raise Exception('Unimplemented for Search. Perhaps you want RewindableSearch.')
 
     # Drops the item from its respective state.
     # Has no effect on cache!
-    def uncollect(self, item: "Item") -> None:
+    def uncollect(self, item: Item) -> None:
         if item.world is None:
             raise Exception(f"Item '{item.name}' cannot be uncollected as it does not have a world.")
         self.state_list[item.world.id].remove(item)
@@ -110,7 +126,7 @@ class Search:
     # Internal to the iteration. Modifies the exit_queue, regions.
     # Returns a queue of the exits whose access rule failed,
     # as a cache for the exits to try on the next iteration.
-    def _expand_regions(self, exit_queue: "List[Entrance]", regions: Dict[Region, int], age: Optional[str]) -> "List[Entrance]":
+    def _expand_regions(self, exit_queue: list[Entrance], regions: dict[Region, int], age: Optional[str]) -> list[Entrance]:
         failed = []
         for exit in exit_queue:
             if exit.world and exit.connected_region and exit.connected_region not in regions:
@@ -129,7 +145,7 @@ class Search:
                     failed.append(exit)
         return failed
 
-    def _expand_tod_regions(self, regions: Dict[Region, int], goal_region: Region, age: Optional[str], tod: int) -> bool:
+    def _expand_tod_regions(self, regions: dict[Region, int], goal_region: Region, age: Optional[str], tod: int) -> bool:
         # grab all the exits from the regions with the given tod in the same world as our goal.
         # we want those that go to existing regions without the tod, until we reach the goal.
         has_tod_world = lambda regtod: regtod[1] & tod and regtod[0].world == goal_region.world
@@ -150,18 +166,16 @@ class Search:
     # the regions accessible as adult, and the set of visited locations.
     # These are references to the new entry in the cache, so they can be modified
     # directly.
-    def next_sphere(self) -> "Tuple[Dict[Region, int], Dict[Region, int], Set[Location]]":
+    def next_sphere(self) -> tuple[dict[Region, int], dict[Region, int], set[Location]]:
         # Use the queue to iteratively add regions to the accessed set,
         # until we are stuck or out of regions.
-        self._cache.update({
-            # Replace the queues (which have been modified) with just the
-            # failed exits that we can retry next time.
-            'adult_queue': self._expand_regions(
-                self._cache['adult_queue'], self._cache['adult_regions'], 'adult'),
-            'child_queue': self._expand_regions(
-                self._cache['child_queue'], self._cache['child_regions'], 'child'),
-        })
-        return self._cache['child_regions'], self._cache['adult_regions'], self._cache['visited_locations']
+
+        # Replace the queues (which have been modified) with just the
+        # failed exits that we can retry next time.
+        self._cache.adult_queue = self._expand_regions(self._cache.adult_queue, self._cache.adult_regions, 'adult')
+        self._cache.child_queue = self._expand_regions(self._cache.child_queue, self._cache.child_regions, 'child')
+
+        return self._cache.child_regions, self._cache.adult_regions, self._cache.visited_locations
 
     # Yields every reachable location, by iteratively deepening explored sets of regions
     # (one as child, one as adult) and invoking access rules.
@@ -171,7 +185,7 @@ class Search:
     # Inside the loop, the caller usually wants to collect items at these
     # locations to see if the game is beatable. Collection should be done
     # using internal State (recommended to just call search.collect).
-    def iter_reachable_locations(self, item_locations: "Iterable[Location]") -> "Iterable[Location]":
+    def iter_reachable_locations(self, item_locations: Iterable[Location]) -> Iterable[Location]:
         had_reachable_locations = True
         # will loop as long as any visits were made, and at least once
         while had_reachable_locations:
@@ -201,20 +215,20 @@ class Search:
     # This collects all item locations available in the state list given that
     # the states have collected items. The purpose is that it will search for
     # all new items that become accessible with a new item set.
-    def collect_locations(self, item_locations: "Optional[Iterable[Location]]" = None) -> None:
+    def collect_locations(self, item_locations: Optional[Iterable[Location]] = None) -> None:
         item_locations = item_locations or self.progression_locations()
         for location in self.iter_reachable_locations(item_locations):
             # Collect the item for the state world it is for
             self.collect(location.item)
 
     # A shorthand way to iterate over locations without collecting items.
-    def visit_locations(self, locations: "Optional[Iterable[Location]]" = None) -> None:
+    def visit_locations(self, locations: Optional[Iterable[Location]] = None) -> None:
         locations = locations or self.progression_locations()
         for _ in self.iter_reachable_locations(locations):
             pass
 
     # Retrieve all item locations in the worlds that have progression items
-    def progression_locations(self) -> "List[Location]":
+    def progression_locations(self) -> list[Location]:
         return [location for state in self.state_list for location in state.world.get_locations() if location.item and location.item.advancement]
 
     # This returns True if every state is beatable. It's important to ensure
@@ -244,7 +258,7 @@ class Search:
         else:
             return False
 
-    def beatable_goals_fast(self, goal_categories: "Dict[str, GoalCategory]", world_filter: Optional[int] = None) -> ValidGoals:
+    def beatable_goals_fast(self, goal_categories: dict[str, GoalCategory], world_filter: Optional[int] = None) -> ValidGoals:
         valid_goals = self.test_category_goals(goal_categories, world_filter)
         if all(map(State.won, self.state_list)):
             valid_goals['way of the hero'] = True
@@ -252,7 +266,7 @@ class Search:
             valid_goals['way of the hero'] = False
         return valid_goals
 
-    def beatable_goals(self, goal_categories: "Dict[str, GoalCategory]") -> ValidGoals:
+    def beatable_goals(self, goal_categories: dict[str, GoalCategory]) -> ValidGoals:
         # collect all available items
         # make a new search since we might be iterating over one already
         search = self.copy()
@@ -264,7 +278,7 @@ class Search:
             valid_goals['way of the hero'] = False
         return valid_goals
 
-    def test_category_goals(self, goal_categories: "Dict[str, GoalCategory]", world_filter: Optional[int] = None) -> ValidGoals:
+    def test_category_goals(self, goal_categories: dict[str, GoalCategory], world_filter: Optional[int] = None) -> ValidGoals:
         valid_goals: ValidGoals = {}
         for category_name, category in goal_categories.items():
             valid_goals[category_name] = {}
@@ -292,12 +306,12 @@ class Search:
                         valid_goals[category_name]['stateReverse'][state.world.id].append(goal.name)
         return valid_goals
 
-    def iter_pseudo_starting_locations(self) -> "Iterable[Location]":
+    def iter_pseudo_starting_locations(self) -> Iterable[Location]:
         for state in self.state_list:
             for location in state.world.distribution.skipped_locations:
                 # We need to use the locations in the current world
                 location = state.world.get_location(location.name)
-                self._cache['visited_locations'].add(location)
+                self._cache.visited_locations.add(location)
                 yield location
 
     def collect_pseudo_starting_items(self) -> None:
@@ -310,14 +324,14 @@ class Search:
     def can_reach(self, region: Region, age: Optional[str] = None, tod: int = TimeOfDay.NONE) -> bool:
         if age == 'adult':
             if tod:
-                return region in self._cache['adult_regions'] and (self._cache['adult_regions'][region] & tod or self._expand_tod_regions(self._cache['adult_regions'], region, age, tod))
+                return region in self._cache.adult_regions and (self._cache.adult_regions[region] & tod or self._expand_tod_regions(self._cache.adult_regions, region, age, tod))
             else:
-                return region in self._cache['adult_regions']
+                return region in self._cache.adult_regions
         elif age == 'child':
             if tod:
-                return region in self._cache['child_regions'] and (self._cache['child_regions'][region] & tod or self._expand_tod_regions(self._cache['child_regions'], region, age, tod))
+                return region in self._cache.child_regions and (self._cache.child_regions[region] & tod or self._expand_tod_regions(self._cache.child_regions, region, age, tod))
             else:
-                return region in self._cache['child_regions']
+                return region in self._cache.child_regions
         elif age == 'both':
             return self.can_reach(region, age='adult', tod=tod) and self.can_reach(region, age='child', tod=tod)
         else:
@@ -330,21 +344,21 @@ class Search:
 
     # Use the cache in the search to determine location reachability.
     # Only works for locations that had progression items...
-    def visited(self, location: "Location") -> bool:
-        return location in self._cache['visited_locations']
+    def visited(self, location: Location) -> bool:
+        return location in self._cache.visited_locations
 
     # Use the cache in the search to get all reachable regions.
-    def reachable_regions(self, age: Optional[str] = None) -> Set[Region]:
+    def reachable_regions(self, age: Optional[str] = None) -> set[Region]:
         if age == 'adult':
-            return set(self._cache['adult_regions'].keys())
+            return set(self._cache.adult_regions.keys())
         elif age == 'child':
-            return set(self._cache['child_regions'].keys())
+            return set(self._cache.child_regions.keys())
         else:
-            return set(self._cache['adult_regions'].keys()).union(self._cache['child_regions'].keys())
+            return set(self._cache.adult_regions.keys()).union(self._cache.child_regions.keys())
 
     # Returns whether the given age can access the spot at this age and tod,
     # by checking whether the search has reached the containing region, and evaluating the spot's access rule.
-    def spot_access(self, spot: "Union[Location, Entrance]", age: Optional[str] = None, tod: int = TimeOfDay.NONE) -> bool:
+    def spot_access(self, spot: Location | Entrance, age: Optional[str] = None, tod: int = TimeOfDay.NONE) -> bool:
         if age == 'adult' or age == 'child':
             return (self.can_reach(spot.parent_region, age=age, tod=tod)
                     and spot.access_rule(self.state_list[spot.world.id], spot=spot, age=age, tod=tod))
@@ -360,16 +374,16 @@ class Search:
 
 
 class RewindableSearch(Search):
-    def unvisit(self, location: "Location") -> None:
+    def unvisit(self, location: Location) -> None:
         # A location being unvisited is either:
         # in the top two caches (if it's the first being unvisited for a sphere)
         # in the topmost cache only (otherwise)
         # After we unvisit every location in a sphere, the top two caches have identical visited locations.
-        assert location in self.cached_spheres[-1]['visited_locations']
-        if location in self.cached_spheres[-2]['visited_locations']:
+        assert location in self.cached_spheres[-1].visited_locations
+        if location in self.cached_spheres[-2].visited_locations:
             self.cached_spheres.pop()
             self._cache = self.cached_spheres[-1]
-        self._cache['visited_locations'].discard(location)
+        self._cache.visited_locations.discard(location)
 
     def reset(self) -> None:
         self._cache = self.cached_spheres[0]
@@ -378,7 +392,5 @@ class RewindableSearch(Search):
     # Adds a new layer to the sphere cache, as a copy of the previous.
     def checkpoint(self) -> None:
         # Save the current data into the cache.
-        self.cached_spheres.append({
-            k: copy.copy(v) for k, v in self._cache.items()
-        })
+        self.cached_spheres.append(self._cache.copy())
         self._cache = self.cached_spheres[-1]

--- a/SettingTypes.py
+++ b/SettingTypes.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
 import math
 import operator
-from typing import Dict, Optional, Union, Any
+from typing import Optional, Any
 
 
 # holds the info for a single setting
 class SettingInfo:
     def __init__(self, setting_type: type, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
-                 choices: Optional[Union[dict, list]] = None, default: Any = None, disabled_default: Any = None,
+                 choices: Optional[dict | list] = None, default: Any = None, disabled_default: Any = None,
                  disable: Optional[dict] = None, gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None,
                  cosmetic: bool = False) -> None:
         self.type: type = setting_type  # type of the setting's value, used to properly convert types to setting strings
@@ -15,7 +16,7 @@ class SettingInfo:
         self.gui_text: Optional[str] = gui_text
         self.gui_type: Optional[str] = gui_type
         self.gui_tooltip: Optional[str] = "" if gui_tooltip is None else gui_tooltip
-        self.gui_params: Dict[str, Any] = {} if gui_params is None else gui_params  # additional parameters that the randomizer uses for the gui
+        self.gui_params: dict[str, Any] = {} if gui_params is None else gui_params  # additional parameters that the randomizer uses for the gui
         self.disable: Optional[dict] = disable  # dictionary of settings this setting disabled
         self.dependency = None  # lambda that determines if this is disabled. Generated later
 
@@ -130,7 +131,7 @@ class SettingInfoBool(SettingInfo):
 
 class SettingInfoStr(SettingInfo):
     def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool = False,
-                 choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+                 choices: Optional[dict | list] = None, default: Optional[str] = None,
                  disabled_default: Optional[str] = None, disable: Optional[dict] = None,
                  gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(setting_type=str, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
@@ -151,7 +152,7 @@ class SettingInfoStr(SettingInfo):
 
 class SettingInfoInt(SettingInfo):
     def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
-                 choices: Optional[Union[dict, list]] = None, default: Optional[int] = None,
+                 choices: Optional[dict | list] = None, default: Optional[int] = None,
                  disabled_default: Optional[int] = None, disable: Optional[dict] = None,
                  gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(setting_type=int, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
@@ -172,7 +173,7 @@ class SettingInfoInt(SettingInfo):
 
 class SettingInfoList(SettingInfo):
     def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
-                 choices: Optional[Union[dict, list]] = None, default: Optional[list] = None,
+                 choices: Optional[dict | list] = None, default: Optional[list] = None,
                  disabled_default: Optional[list] = None, disable: Optional[dict] = None,
                  gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(setting_type=list, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
@@ -193,7 +194,7 @@ class SettingInfoList(SettingInfo):
 
 class SettingInfoDict(SettingInfo):
     def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
-                 choices: Optional[Union[dict, list]] = None, default: Optional[dict] = None,
+                 choices: Optional[dict | list] = None, default: Optional[dict] = None,
                  disabled_default: Optional[dict] = None, disable: Optional[dict] = None,
                  gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(setting_type=dict, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
@@ -234,7 +235,7 @@ class Checkbutton(SettingInfoBool):
 
 
 class Combobox(SettingInfoStr):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[str],
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list], default: Optional[str],
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='Combobox', shared=shared, choices=choices, default=default,
@@ -243,7 +244,7 @@ class Combobox(SettingInfoStr):
 
 
 class Radiobutton(SettingInfoStr):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[str],
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list], default: Optional[str],
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='Radiobutton', shared=shared, choices=choices, default=default,
@@ -252,7 +253,7 @@ class Radiobutton(SettingInfoStr):
 
 
 class Fileinput(SettingInfoStr):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list] = None, default: Optional[str] = None,
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='Fileinput', shared=shared, choices=choices, default=default,
@@ -261,7 +262,7 @@ class Fileinput(SettingInfoStr):
 
 
 class Directoryinput(SettingInfoStr):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list] = None, default: Optional[str] = None,
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='Directoryinput', shared=shared, choices=choices, default=default,
@@ -270,7 +271,7 @@ class Directoryinput(SettingInfoStr):
 
 
 class Textinput(SettingInfoStr):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list] = None, default: Optional[str] = None,
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='Textinput', shared=shared, choices=choices, default=default,
@@ -279,7 +280,7 @@ class Textinput(SettingInfoStr):
 
 
 class ComboboxInt(SettingInfoInt):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[int],
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list], default: Optional[int],
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[int] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='Combobox', shared=shared, choices=choices, default=default,
@@ -324,7 +325,7 @@ class Numberinput(SettingInfoInt):
 
 
 class MultipleSelect(SettingInfoList):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[list],
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list], default: Optional[list],
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[list] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='MultipleSelect', shared=shared, choices=choices, default=default,
@@ -333,7 +334,7 @@ class MultipleSelect(SettingInfoList):
 
 
 class SearchBox(SettingInfoList):
-    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[list],
+    def __init__(self, gui_text: Optional[str], choices: Optional[dict | list], default: Optional[list],
                  gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[list] = None,
                  shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         super().__init__(gui_text=gui_text, gui_type='SearchBox', shared=shared, choices=choices, default=default,

--- a/SettingTypes.py
+++ b/SettingTypes.py
@@ -64,7 +64,10 @@ class SettingInfo:
         self.name = name
 
     def __get__(self, obj, obj_type=None) -> Any:
-        return obj.settings_dict.get(self.name, self.default)
+        value = obj.settings_dict.get(self.name, self.default)
+        if value is None:
+            return self.default
+        return value
 
     def __set__(self, obj, value: Any) -> None:
         obj.settings_dict[self.name] = value

--- a/SettingTypes.py
+++ b/SettingTypes.py
@@ -1,0 +1,264 @@
+import math
+import operator
+from typing import Any, Optional
+
+
+# holds the info for a single setting
+class SettingInfo:
+    def __init__(self, setting_type: type, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        self.type: type = setting_type  # type of the setting's value, used to properly convert types to setting strings
+        self.shared: bool = shared  # whether the setting is one that should be shared, used in converting settings to a string
+        self.cosmetic: bool = cosmetic  # whether the setting should be included in the cosmetic log
+        self.gui_text: Optional[str] = gui_text
+        self.gui_type: Optional[str] = gui_type
+        self.gui_tooltip: Optional[str] = "" if gui_tooltip is None else gui_tooltip
+        self.gui_params: dict = {} if gui_params is None else gui_params  # additional parameters that the randomizer uses for the gui
+        self.disable: dict = disable  # dictionary of settings this setting disabled
+        self.dependency = None  # lambda that determines if this is disabled. Generated later
+
+        # dictionary of options to their text names
+        choices = {} if choices is None else choices
+        if isinstance(choices, list):
+            self.choices: dict = {k: k for k in choices}
+            self.choice_list: list = list(choices)
+        else:
+            self.choices: dict = dict(choices)
+            self.choice_list: list = list(choices.keys())
+        self.reverse_choices: dict = {v: k for k, v in self.choices.items()}
+
+        # number of bits needed to store the setting, used in converting settings to a string
+        if shared:
+            if self.gui_params.get('min') and self.gui_params.get('max') and not choices:
+                self.bitwidth = math.ceil(math.log(self.gui_params.get('max') - self.gui_params.get('min') + 1, 2))
+            else:
+                self.bitwidth = self.calc_bitwidth(choices)
+        else:
+            self.bitwidth = 0
+
+        # default value if undefined/unset
+        self.default = default
+        if self.default is None:
+            if self.type == bool:
+                self.default = False
+            elif self.type == str:
+                self.default = ""
+            elif self.type == int:
+                self.default = 0
+            elif self.type == list:
+                self.default = []
+            elif self.type == dict:
+                self.default = {}
+
+        # default value if disabled
+        self.disabled_default = self.default if disabled_default is None else disabled_default
+
+        # used to when random options are set for this setting
+        if 'distribution' not in self.gui_params:
+            self.gui_params['distribution'] = [(choice, 1) for choice in self.choice_list]
+
+    def __set_name__(self, owner, name: str) -> None:
+        self.name = name
+
+    def __get__(self, obj, obj_type=None) -> Any:
+        return obj.settings_dict.get(self.name, self.default)
+
+    def __set__(self, obj, value: Any) -> None:
+        obj.settings_dict[self.name] = value
+
+    def __delete__(self, obj) -> None:
+        del obj.settings_dict[self.name]
+
+    def calc_bitwidth(self, choices) -> int:
+        count = len(choices)
+        if count > 0:
+            if self.type == list:
+                # Need two special values for terminating additive and subtractive lists
+                count = count + 2
+            return math.ceil(math.log(count, 2))
+        return 0
+
+    def create_dependency(self, disabling_setting: 'SettingInfo', option, negative: bool = False) -> None:
+        op = operator.__ne__ if negative else operator.__eq__
+        if self.dependency is None:
+            self.dependency = lambda settings: op(getattr(settings, disabling_setting.name), option)
+        else:
+            old_dependency = self.dependency
+            self.dependency = lambda settings: op(getattr(settings, disabling_setting.name), option) or old_dependency(settings)
+
+
+class SettingInfoNone(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], gui_tooltip=None, gui_params=None) -> None:
+        super().__init__(type(None), gui_text, gui_type, False, None, None, None, None, gui_tooltip, gui_params, False)
+
+    def __get__(self, obj, obj_type=None) -> None:
+        raise Exception(f"{self.name} is not a setting and cannot be retrieved.")
+
+    def __set__(self, obj, value: str) -> None:
+        raise Exception(f"{self.name} is not a setting and cannot be set.")
+
+
+class SettingInfoBool(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        choices = {
+            True:  'checked',
+            False: 'unchecked',
+        }
+
+        super().__init__(bool, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> bool:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, bool):
+            value = bool(value)
+        return value
+
+    def __set__(self, obj, value: bool) -> None:
+        if not isinstance(value, bool):
+            value = bool(value)
+        super().__set__(obj, value)
+
+
+class SettingInfoStr(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool = False, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(str, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> str:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, str):
+            value = str(value)
+        return value
+
+    def __set__(self, obj, value: str) -> None:
+        if not isinstance(value, str):
+            value = str(value)
+        super().__set__(obj, value)
+
+
+class SettingInfoInt(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(int, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> int:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, int):
+            value = int(value)
+        return value
+
+    def __set__(self, obj, value: int) -> None:
+        if not isinstance(value, int):
+            value = int(value)
+        super().__set__(obj, value)
+
+
+class SettingInfoList(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(list, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> list:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, list):
+            value = list(value)
+        return value
+
+    def __set__(self, obj, value: list) -> None:
+        if not isinstance(value, list):
+            value = list(value)
+        super().__set__(obj, value)
+
+
+class SettingInfoDict(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(dict, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> dict:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, dict):
+            value = dict(value)
+        return value
+
+    def __set__(self, obj, value: dict) -> None:
+        if not isinstance(value, dict):
+            value = dict(value)
+        super().__set__(obj, value)
+
+
+class Button(SettingInfoNone):
+    def __init__(self, gui_text: Optional[str], gui_tooltip=None, gui_params=None) -> None:
+        super().__init__(gui_text, "Button", gui_tooltip, gui_params)
+
+
+class Textbox(SettingInfoNone):
+    def __init__(self, gui_text: Optional[str], gui_tooltip=None, gui_params=None) -> None:
+        super().__init__(gui_text, "Textbox", gui_tooltip, gui_params)
+
+
+class Checkbutton(SettingInfoBool):
+    def __init__(self, gui_text: Optional[str], gui_tooltip: Optional[str] = None, disable=None, disabled_default=None, default=False, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Checkbutton', shared, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Combobox(SettingInfoStr):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Radiobutton(SettingInfoStr):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Radiobutton', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Fileinput(SettingInfoStr):
+    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Fileinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Directoryinput(SettingInfoStr):
+    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Directoryinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Textinput(SettingInfoStr):
+    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Textinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class ComboboxInt(SettingInfoInt):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Scale(SettingInfoInt):
+    def __init__(self, gui_text, default, minimum, maximum, step=1, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        choices = {
+            i: str(i) for i in range(minimum, maximum+1, step)
+        }
+
+        if gui_params is None:
+            gui_params = {}
+        gui_params['min'] = minimum
+        gui_params['max'] = maximum
+        gui_params['step'] = step
+
+        super().__init__(gui_text, 'Scale', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Numberinput(SettingInfoInt):
+    def __init__(self, gui_text, default, minimum=None, maximum=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        if gui_params is None:
+            gui_params = {}
+        if minimum is not None:
+            gui_params['min'] = minimum
+        if maximum is not None:
+            gui_params['max'] = maximum
+
+        super().__init__(gui_text, 'Numberinput', shared, None, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class MultipleSelect(SettingInfoList):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'MultipleSelect', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class SearchBox(SettingInfoList):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'SearchBox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)

--- a/SettingTypes.py
+++ b/SettingTypes.py
@@ -1,19 +1,22 @@
 import math
 import operator
-from typing import Any, Optional
+from typing import Dict, Optional, Union, Any
 
 
 # holds the info for a single setting
 class SettingInfo:
-    def __init__(self, setting_type: type, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+    def __init__(self, setting_type: type, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
+                 choices: Optional[Union[dict, list]] = None, default: Any = None, disabled_default: Any = None,
+                 disable: Optional[dict] = None, gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None,
+                 cosmetic: bool = False) -> None:
         self.type: type = setting_type  # type of the setting's value, used to properly convert types to setting strings
         self.shared: bool = shared  # whether the setting is one that should be shared, used in converting settings to a string
         self.cosmetic: bool = cosmetic  # whether the setting should be included in the cosmetic log
         self.gui_text: Optional[str] = gui_text
         self.gui_type: Optional[str] = gui_type
         self.gui_tooltip: Optional[str] = "" if gui_tooltip is None else gui_tooltip
-        self.gui_params: dict = {} if gui_params is None else gui_params  # additional parameters that the randomizer uses for the gui
-        self.disable: dict = disable  # dictionary of settings this setting disabled
+        self.gui_params: Dict[str, Any] = {} if gui_params is None else gui_params  # additional parameters that the randomizer uses for the gui
+        self.disable: Optional[dict] = disable  # dictionary of settings this setting disabled
         self.dependency = None  # lambda that determines if this is disabled. Generated later
 
         # dictionary of options to their text names
@@ -87,8 +90,11 @@ class SettingInfo:
 
 
 class SettingInfoNone(SettingInfo):
-    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], gui_tooltip=None, gui_params=None) -> None:
-        super().__init__(type(None), gui_text, gui_type, False, None, None, None, None, gui_tooltip, gui_params, False)
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], gui_tooltip: Optional[str] = None,
+                 gui_params: Optional[dict] = None) -> None:
+        super().__init__(setting_type=type(None), gui_text=gui_text, gui_type=gui_type, shared=False, choices=None,
+                         default=None, disabled_default=None, disable=None, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=False)
 
     def __get__(self, obj, obj_type=None) -> None:
         raise Exception(f"{self.name} is not a setting and cannot be retrieved.")
@@ -98,13 +104,17 @@ class SettingInfoNone(SettingInfo):
 
 
 class SettingInfoBool(SettingInfo):
-    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, default: Optional[bool] = None,
+                 disabled_default: Optional[bool] = None, disable: Optional[dict] = None, gui_tooltip: Optional[str] = None,
+                 gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         choices = {
             True:  'checked',
             False: 'unchecked',
         }
 
-        super().__init__(bool, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+        super().__init__(setting_type=bool, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
+                         default=default, disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
     def __get__(self, obj, obj_type=None) -> bool:
         value = super().__get__(obj, obj_type)
@@ -119,8 +129,13 @@ class SettingInfoBool(SettingInfo):
 
 
 class SettingInfoStr(SettingInfo):
-    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool = False, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
-        super().__init__(str, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool = False,
+                 choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+                 disabled_default: Optional[str] = None, disable: Optional[dict] = None,
+                 gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(setting_type=str, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
+                         default=default, disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
     def __get__(self, obj, obj_type=None) -> str:
         value = super().__get__(obj, obj_type)
@@ -135,8 +150,13 @@ class SettingInfoStr(SettingInfo):
 
 
 class SettingInfoInt(SettingInfo):
-    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
-        super().__init__(int, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
+                 choices: Optional[Union[dict, list]] = None, default: Optional[int] = None,
+                 disabled_default: Optional[int] = None, disable: Optional[dict] = None,
+                 gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(setting_type=int, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
+                         default=default, disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
     def __get__(self, obj, obj_type=None) -> int:
         value = super().__get__(obj, obj_type)
@@ -151,8 +171,13 @@ class SettingInfoInt(SettingInfo):
 
 
 class SettingInfoList(SettingInfo):
-    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
-        super().__init__(list, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
+                 choices: Optional[Union[dict, list]] = None, default: Optional[list] = None,
+                 disabled_default: Optional[list] = None, disable: Optional[dict] = None,
+                 gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(setting_type=list, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
+                         default=default, disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
     def __get__(self, obj, obj_type=None) -> list:
         value = super().__get__(obj, obj_type)
@@ -167,8 +192,13 @@ class SettingInfoList(SettingInfo):
 
 
 class SettingInfoDict(SettingInfo):
-    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
-        super().__init__(dict, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool,
+                 choices: Optional[Union[dict, list]] = None, default: Optional[dict] = None,
+                 disabled_default: Optional[dict] = None, disable: Optional[dict] = None,
+                 gui_tooltip: Optional[str] = None, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(setting_type=dict, gui_text=gui_text, gui_type=gui_type, shared=shared, choices=choices,
+                         default=default, disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
     def __get__(self, obj, obj_type=None) -> dict:
         value = super().__get__(obj, obj_type)
@@ -183,52 +213,84 @@ class SettingInfoDict(SettingInfo):
 
 
 class Button(SettingInfoNone):
-    def __init__(self, gui_text: Optional[str], gui_tooltip=None, gui_params=None) -> None:
-        super().__init__(gui_text, "Button", gui_tooltip, gui_params)
+    def __init__(self, gui_text: Optional[str], gui_tooltip: Optional[str] = None,
+                 gui_params: Optional[dict] = None) -> None:
+        super().__init__(gui_text=gui_text, gui_type="Button", gui_tooltip=gui_tooltip, gui_params=gui_params)
 
 
 class Textbox(SettingInfoNone):
-    def __init__(self, gui_text: Optional[str], gui_tooltip=None, gui_params=None) -> None:
-        super().__init__(gui_text, "Textbox", gui_tooltip, gui_params)
+    def __init__(self, gui_text: Optional[str], gui_tooltip: Optional[str] = None,
+                 gui_params: Optional[dict] = None) -> None:
+        super().__init__(gui_text=gui_text, gui_type="Textbox", gui_tooltip=gui_tooltip, gui_params=gui_params)
 
 
 class Checkbutton(SettingInfoBool):
-    def __init__(self, gui_text: Optional[str], gui_tooltip: Optional[str] = None, disable=None, disabled_default=None, default=False, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Checkbutton', shared, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], gui_tooltip: Optional[str] = None, disable: Optional[dict] = None,
+                 disabled_default: Optional[bool] = None, default: bool = False, shared: bool = False,
+                 gui_params: Optional[dict] = None, cosmetic: bool = False):
+        super().__init__(gui_text=gui_text, gui_type='Checkbutton', shared=shared, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Combobox(SettingInfoStr):
-    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[str],
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='Combobox', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Radiobutton(SettingInfoStr):
-    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Radiobutton', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[str],
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='Radiobutton', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Fileinput(SettingInfoStr):
-    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Fileinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='Fileinput', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Directoryinput(SettingInfoStr):
-    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Directoryinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='Directoryinput', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Textinput(SettingInfoStr):
-    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Textinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]] = None, default: Optional[str] = None,
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[str] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='Textinput', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class ComboboxInt(SettingInfoInt):
-    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[int],
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[int] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='Combobox', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Scale(SettingInfoInt):
-    def __init__(self, gui_text, default, minimum, maximum, step=1, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+    def __init__(self, gui_text: Optional[str], default: Optional[int], minimum: int, maximum: int, step: int = 1,
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[int] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
         choices = {
             i: str(i) for i in range(minimum, maximum+1, step)
         }
@@ -239,11 +301,16 @@ class Scale(SettingInfoInt):
         gui_params['max'] = maximum
         gui_params['step'] = step
 
-        super().__init__(gui_text, 'Scale', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+        super().__init__(gui_text=gui_text, gui_type='Scale', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class Numberinput(SettingInfoInt):
-    def __init__(self, gui_text, default, minimum=None, maximum=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+    def __init__(self, gui_text: Optional[str], default: Optional[int], minimum: Optional[int] = None,
+                 maximum: Optional[int] = None, gui_tooltip: Optional[str] = None, disable: Optional[dict] = None,
+                 disabled_default: Optional[int] = None, shared: bool = False, gui_params: Optional[dict] = None,
+                 cosmetic: bool = False) -> None:
         if gui_params is None:
             gui_params = {}
         if minimum is not None:
@@ -251,14 +318,24 @@ class Numberinput(SettingInfoInt):
         if maximum is not None:
             gui_params['max'] = maximum
 
-        super().__init__(gui_text, 'Numberinput', shared, None, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+        super().__init__(gui_text=gui_text, gui_type='Numberinput', shared=shared, choices=None, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class MultipleSelect(SettingInfoList):
-    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'MultipleSelect', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[list],
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[list] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='MultipleSelect', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)
 
 
 class SearchBox(SettingInfoList):
-    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
-        super().__init__(gui_text, 'SearchBox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __init__(self, gui_text: Optional[str], choices: Optional[Union[dict, list]], default: Optional[list],
+                 gui_tooltip: Optional[str] = None, disable: Optional[dict] = None, disabled_default: Optional[list] = None,
+                 shared: bool = False, gui_params: Optional[dict] = None, cosmetic: bool = False) -> None:
+        super().__init__(gui_text=gui_text, gui_type='SearchBox', shared=shared, choices=choices, default=default,
+                         disabled_default=disabled_default, disable=disable, gui_tooltip=gui_tooltip,
+                         gui_params=gui_params, cosmetic=cosmetic)

--- a/Settings.py
+++ b/Settings.py
@@ -5,18 +5,20 @@ import hashlib
 import json
 import logging
 import os
+import random
 import re
 import string
 import sys
 import textwrap
 
 from version import __version__
-from Utils import random_choices, local_path, data_path
+from Utils import local_path, data_path
 from SettingsList import setting_infos, get_setting_info, validate_settings
 from Plandomizer import Distribution
 import StartingItems
 
 LEGACY_STARTING_ITEM_SETTINGS = {'starting_equipment': StartingItems.equipment, 'starting_items': StartingItems.inventory, 'starting_songs': StartingItems.songs}
+
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 
@@ -206,7 +208,7 @@ class Settings:
     def update_seed(self, seed):
         if seed is None or seed == '':
             # https://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python
-            self.seed = ''.join(random_choices(string.ascii_uppercase + string.digits, k=10))
+            self.seed = ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
         else:
             self.seed = seed
         self.sanitize_seed()
@@ -299,7 +301,7 @@ class Settings:
             if self.__dict__[info.gui_params['randomize_key']] and not_in_dist:
                 randomize_keys_enabled.add(info.gui_params['randomize_key'])
                 choices, weights = zip(*info.gui_params['distribution'])
-                self.__dict__[info.name] = random_choices(choices, weights=weights)[0]
+                self.__dict__[info.name] = random.choices(choices, weights=weights)[0]
 
         # Second pass to make sure disabled settings are set properly.
         # Stupid hack: disable randomize keys, then re-enable.

--- a/Settings.py
+++ b/Settings.py
@@ -10,13 +10,13 @@ import re
 import string
 import sys
 import textwrap
-from typing import TYPE_CHECKING, Dict, List, Tuple, Set, Any, Optional
+from typing import Dict, List, Tuple, Set, Any, Optional
 
+import StartingItems
 from version import __version__
 from Utils import local_path, data_path
 from SettingsList import SettingInfos, validate_settings
 from Plandomizer import Distribution
-import StartingItems
 
 LEGACY_STARTING_ITEM_SETTINGS: Dict[str, Dict[str, StartingItems.Entry]] = {
     'starting_equipment': StartingItems.equipment,
@@ -27,8 +27,9 @@ LEGACY_STARTING_ITEM_SETTINGS: Dict[str, Dict[str, StartingItems.Entry]] = {
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 
-    def _get_help_string(self, action):
-        return textwrap.dedent(action.help)
+    def _get_help_string(self, action) -> Optional[str]:
+        if  action.help is not None:
+            return textwrap.dedent(action.help)
 
 
 # 32 characters

--- a/Settings.py
+++ b/Settings.py
@@ -10,6 +10,7 @@ import re
 import string
 import sys
 import textwrap
+from typing import TYPE_CHECKING, Dict, List, Tuple, Set, Any, Optional
 
 from version import __version__
 from Utils import local_path, data_path
@@ -17,7 +18,11 @@ from SettingsList import SettingInfos, validate_settings
 from Plandomizer import Distribution
 import StartingItems
 
-LEGACY_STARTING_ITEM_SETTINGS = {'starting_equipment': StartingItems.equipment, 'starting_inventory': StartingItems.inventory, 'starting_songs': StartingItems.songs}
+LEGACY_STARTING_ITEM_SETTINGS: Dict[str, Dict[str, StartingItems.Entry]] = {
+    'starting_equipment': StartingItems.equipment,
+    'starting_inventory': StartingItems.inventory,
+    'starting_songs': StartingItems.songs,
+}
 
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
@@ -27,12 +32,12 @@ class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 
 
 # 32 characters
-letters = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
-index_to_letter = { i: letters[i] for i in range(32) }
-letter_to_index = { v: k for k, v in index_to_letter.items() }
+letters: str = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+index_to_letter: Dict[int, str] = {i: letters[i] for i in range(32)}
+letter_to_index: Dict[str, int] = {v: k for k, v in index_to_letter.items()}
 
 
-def bit_string_to_text(bits):
+def bit_string_to_text(bits: List[int]) -> str:
     # pad the bits array to be multiple of 5
     if len(bits) % 5 > 0:
         bits += [0] * (5 - len(bits) % 5)
@@ -47,7 +52,7 @@ def bit_string_to_text(bits):
     return result
 
 
-def text_to_bit_string(text):
+def text_to_bit_string(text: str) -> List[int]:
     bits = []
     for c in text:
         index = letter_to_index[c]
@@ -56,7 +61,7 @@ def text_to_bit_string(text):
     return bits
 
 
-def get_preset_files():
+def get_preset_files() -> List[str]:
     return [data_path('presets_default.json')] + sorted(
             os.path.join(data_path('Presets'), fn)
             for fn in os.listdir(data_path('Presets'))
@@ -65,7 +70,40 @@ def get_preset_files():
 
 # holds the particular choices for a run's settings
 class Settings(SettingInfos):
-    def get_settings_display(self):
+    # add the settings as fields, and calculate information based on them
+    def __init__(self, settings_dict: Dict[str, Any], strict: bool = False) -> None:
+        super().__init__()
+        self.numeric_seed: Optional[int] = None
+        if settings_dict.get('compress_rom', None):
+            # Old compress_rom setting is set, so set the individual output settings using it.
+            settings_dict['create_patch_file'] = settings_dict['compress_rom'] == 'Patch' or settings_dict.get('create_patch_file', False)
+            settings_dict['create_compressed_rom'] = settings_dict['compress_rom'] == 'True' or settings_dict.get('create_compressed_rom', False)
+            settings_dict['create_uncompressed_rom'] = settings_dict['compress_rom'] == 'False' or settings_dict.get('create_uncompressed_rom', False)
+            del settings_dict['compress_rom']
+        if strict:
+            validate_settings(settings_dict)
+        self.settings_dict.update(settings_dict)
+        for info in self.setting_infos.values():
+            if info.name not in self.settings_dict:
+                self.settings_dict[info.name] = info.default
+
+        if self.world_count < 1:
+            self.world_count = 1
+        if self.world_count > 255:
+            self.world_count = 255
+
+        self._disabled: Set[str] = set()
+        self.settings_string: str = self.get_settings_string()
+        self.distribution: Distribution = Distribution(self)
+        self.update_seed(self.seed)
+        self.custom_seed: bool = False
+
+    def copy(self) -> 'Settings':
+        settings = copy.copy(self)
+        settings.settings_dict = copy.deepcopy(settings.settings_dict)
+        return settings
+
+    def get_settings_display(self) -> str:
         padding = 0
         for setting in filter(lambda s: s.shared, self.setting_infos.values()):
             padding = max(len(setting.name), padding)
@@ -80,7 +118,7 @@ class Settings(SettingInfos):
             output += name + val + '\n'
         return output
 
-    def get_settings_string(self):
+    def get_settings_string(self) -> str:
         bits = []
         for setting in filter(lambda s: s.shared and s.bitwidth > 0, self.setting_infos.values()):
             value = self.settings_dict[setting.name]
@@ -89,12 +127,12 @@ class Settings(SettingInfos):
                 items = LEGACY_STARTING_ITEM_SETTINGS[setting.name]
                 value = []
                 for entry in items.values():
-                    if entry.itemname in self.starting_items:
-                        count = self.starting_items[entry.itemname]
+                    if entry.item_name in self.starting_items:
+                        count = self.starting_items[entry.item_name]
                         if not isinstance(count, int):
                             count = count.count
                         if count > entry.i:
-                            value.append(entry.settingname)
+                            value.append(entry.setting_name)
             if setting.type == bool:
                 i_bits = [ 1 if value else 0 ]
             elif setting.type == str:
@@ -143,7 +181,7 @@ class Settings(SettingInfos):
             bits += i_bits
         return bit_string_to_text(bits)
 
-    def update_with_settings_string(self, text):
+    def update_with_settings_string(self, text: str) -> None:
         bits = text_to_bit_string(text)
 
         for setting in filter(lambda s: s.shared and s.bitwidth > 0, self.setting_infos.values()):
@@ -185,21 +223,22 @@ class Settings(SettingInfos):
 
             self.settings_dict[setting.name] = value
 
+        self.settings_dict['starting_items'] = {}  # Settings string contains the GUI format, so clear the current value of the dict format.
         self.distribution.reset()  # convert starting_items
         self.settings_string = self.get_settings_string()
         self.numeric_seed = self.get_numeric_seed()
 
-    def get_numeric_seed(self):
+    def get_numeric_seed(self) -> int:
         # salt seed with the settings, and hash to get a numeric seed
         distribution = json.dumps(self.distribution.to_json(include_output=False), sort_keys=True)
         full_string = self.settings_string + distribution + __version__ + self.seed
         return int(hashlib.sha256(full_string.encode('utf-8')).hexdigest(), 16)
 
-    def sanitize_seed(self):
+    def sanitize_seed(self) -> None:
         # leave only alphanumeric and some punctuation
         self.seed = re.sub(r'[^a-zA-Z0-9_-]', '', self.seed, re.UNICODE)
 
-    def update_seed(self, seed):
+    def update_seed(self, seed: str) -> None:
         if seed is None or seed == '':
             # https://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python
             self.seed = ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
@@ -208,11 +247,11 @@ class Settings(SettingInfos):
         self.sanitize_seed()
         self.numeric_seed = self.get_numeric_seed()
 
-    def update(self):
+    def update(self) -> None:
         self.settings_string = self.get_settings_string()
         self.numeric_seed = self.get_numeric_seed()
 
-    def load_distribution(self):
+    def load_distribution(self) -> None:
         if self.enable_distribution_file:
             if self.distribution_file:
                 try:
@@ -233,18 +272,16 @@ class Settings(SettingInfos):
 
         self.numeric_seed = self.get_numeric_seed()
 
-
-    def reset_distribution(self):
+    def reset_distribution(self) -> None:
         self.distribution.reset()
 
         for location in self.disabled_locations:
             self.distribution.add_location(location, '#Junk')
 
-
-    def check_dependency(self, setting_name, check_random=True):
+    def check_dependency(self, setting_name: str, check_random: bool = True) -> bool:
         return self.get_dependency(setting_name, check_random) is None
 
-    def get_dependency(self, setting_name, check_random=True):
+    def get_dependency(self, setting_name: str, check_random: bool = True) -> Any:
         info = SettingInfos.setting_infos[setting_name]
         not_in_dist = '_settings' not in self.distribution.src_dict or info.name not in self.distribution.src_dict['_settings'].keys()
         if check_random and 'randomize_key' in info.gui_params and self.settings_dict[info.gui_params['randomize_key']] and not_in_dist:
@@ -254,7 +291,7 @@ class Settings(SettingInfos):
         else:
             return None
 
-    def remove_disabled(self):
+    def remove_disabled(self) -> None:
         for info in self.setting_infos.values():
             if info.dependency is not None:
                 new_value = self.get_dependency(info.name)
@@ -265,7 +302,7 @@ class Settings(SettingInfos):
         self.settings_string = self.get_settings_string()
         self.numeric_seed = self.get_numeric_seed()
 
-    def resolve_random_settings(self, cosmetic, randomize_key=None):
+    def resolve_random_settings(self, cosmetic: bool, randomize_key: Optional[str] = None) -> None:
         sorted_infos = list(self.setting_infos.values())
         sort_key = lambda info: 0 if info.dependency is None else 1
         sorted_infos.sort(key=sort_key)
@@ -307,54 +344,21 @@ class Settings(SettingInfos):
         for randomize_keys in randomize_keys_enabled:
             self.settings_dict[randomize_keys] = True
 
-    # add the settings as fields, and calculate information based on them
-    def __init__(self, settings_dict, strict=False):
-        super().__init__()
-        self.numeric_seed = None
-        if settings_dict.get('compress_rom', None):
-            # Old compress_rom setting is set, so set the individual output settings using it.
-            settings_dict['create_patch_file'] = settings_dict['compress_rom'] == 'Patch' or settings_dict.get('create_patch_file', False)
-            settings_dict['create_compressed_rom'] = settings_dict['compress_rom'] == 'True' or settings_dict.get('create_compressed_rom', False)
-            settings_dict['create_uncompressed_rom'] = settings_dict['compress_rom'] == 'False' or settings_dict.get('create_uncompressed_rom', False)
-            del settings_dict['compress_rom']
-        if strict:
-            validate_settings(settings_dict)
-        self.settings_dict.update(settings_dict)
-        for info in self.setting_infos.values():
-            if info.name not in self.settings_dict:
-                self.settings_dict[info.name] = info.default
-
-        if self.world_count < 1:
-            self.world_count = 1
-        if self.world_count > 255:
-            self.world_count = 255
-
-        self._disabled = set()
-        self.settings_string = self.get_settings_string()
-        self.distribution = Distribution(self)
-        self.update_seed(self.seed)
-        self.custom_seed = False
-
-    def copy(self) -> 'Settings':
-        settings = copy.copy(self)
-        settings.settings_dict = copy.deepcopy(settings.settings_dict)
-        return settings
-
-    def to_json(self, *, legacy_starting_items=False):
+    def to_json(self, *, legacy_starting_items: bool = False) -> Dict[str, Any]:
         if legacy_starting_items:
             settings = self.copy()
             for setting_name, items in LEGACY_STARTING_ITEM_SETTINGS.items():
                 settings.settings_dict[setting_name] = []
                 for entry in items.values():
-                    if entry.itemname in self.starting_items:
-                        count = self.starting_items[entry.itemname]
+                    if entry.item_name in self.starting_items:
+                        count = self.starting_items[entry.item_name]
                         if not isinstance(count, int):
                             count = count.count
                         if count > entry.i:
-                            settings.settings_dict[setting_name].append(entry.settingname)
+                            settings.settings_dict[setting_name].append(entry.setting_name)
         else:
             settings = self
-        return {
+        return {  # TODO: This should be done in a way that is less insane than a double-digit line dictionary comprehension.
             setting.name: (
                 {name: (
                     {name: record.to_json() for name, record in record.items()} if isinstance(record, dict) else record.to_json()
@@ -370,14 +374,15 @@ class Settings(SettingInfos):
             )
             # Don't want to include list starting equipment and songs, these are consolidated into starting_items
             and (legacy_starting_items or not (setting.name in LEGACY_STARTING_ITEM_SETTINGS))
+            and (setting.name != 'starting_items' or not legacy_starting_items)
         }
 
-    def to_json_cosmetics(self):
+    def to_json_cosmetics(self) -> Dict[str, Any]:
         return {setting.name: self.settings_dict[setting.name] for setting in self.setting_infos.values() if setting.cosmetic}
 
 
 # gets the randomizer settings, whether to open the gui, and the logger level from command line arguments
-def get_settings_from_command_line_args():
+def get_settings_from_command_line_args() -> Tuple[Settings, bool, str, bool, str]:
     parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('--gui', help='Launch the GUI', action='store_true')

--- a/Settings.py
+++ b/Settings.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 import argparse
-from collections.abc import Iterable
 import copy
 import hashlib
 import json
@@ -10,7 +10,8 @@ import re
 import string
 import sys
 import textwrap
-from typing import Dict, List, Tuple, Set, Any, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import StartingItems
 from version import __version__
@@ -18,7 +19,7 @@ from Utils import local_path, data_path
 from SettingsList import SettingInfos, validate_settings
 from Plandomizer import Distribution
 
-LEGACY_STARTING_ITEM_SETTINGS: Dict[str, Dict[str, StartingItems.Entry]] = {
+LEGACY_STARTING_ITEM_SETTINGS: dict[str, dict[str, StartingItems.Entry]] = {
     'starting_equipment': StartingItems.equipment,
     'starting_inventory': StartingItems.inventory,
     'starting_songs': StartingItems.songs,
@@ -34,11 +35,11 @@ class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 
 # 32 characters
 letters: str = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
-index_to_letter: Dict[int, str] = {i: letters[i] for i in range(32)}
-letter_to_index: Dict[str, int] = {v: k for k, v in index_to_letter.items()}
+index_to_letter: dict[int, str] = {i: letters[i] for i in range(32)}
+letter_to_index: dict[str, int] = {v: k for k, v in index_to_letter.items()}
 
 
-def bit_string_to_text(bits: List[int]) -> str:
+def bit_string_to_text(bits: list[int]) -> str:
     # pad the bits array to be multiple of 5
     if len(bits) % 5 > 0:
         bits += [0] * (5 - len(bits) % 5)
@@ -53,7 +54,7 @@ def bit_string_to_text(bits: List[int]) -> str:
     return result
 
 
-def text_to_bit_string(text: str) -> List[int]:
+def text_to_bit_string(text: str) -> list[int]:
     bits = []
     for c in text:
         index = letter_to_index[c]
@@ -62,7 +63,7 @@ def text_to_bit_string(text: str) -> List[int]:
     return bits
 
 
-def get_preset_files() -> List[str]:
+def get_preset_files() -> list[str]:
     return [data_path('presets_default.json')] + sorted(
             os.path.join(data_path('Presets'), fn)
             for fn in os.listdir(data_path('Presets'))
@@ -72,7 +73,7 @@ def get_preset_files() -> List[str]:
 # holds the particular choices for a run's settings
 class Settings(SettingInfos):
     # add the settings as fields, and calculate information based on them
-    def __init__(self, settings_dict: Dict[str, Any], strict: bool = False) -> None:
+    def __init__(self, settings_dict: dict[str, Any], strict: bool = False) -> None:
         super().__init__()
         self.numeric_seed: Optional[int] = None
         if settings_dict.get('compress_rom', None):
@@ -93,13 +94,13 @@ class Settings(SettingInfos):
         if self.world_count > 255:
             self.world_count = 255
 
-        self._disabled: Set[str] = set()
+        self._disabled: set[str] = set()
         self.settings_string: str = self.get_settings_string()
         self.distribution: Distribution = Distribution(self)
         self.update_seed(self.seed)
         self.custom_seed: bool = False
 
-    def copy(self) -> 'Settings':
+    def copy(self) -> Settings:
         settings = copy.copy(self)
         settings.settings_dict = copy.deepcopy(settings.settings_dict)
         return settings
@@ -345,7 +346,7 @@ class Settings(SettingInfos):
         for randomize_keys in randomize_keys_enabled:
             self.settings_dict[randomize_keys] = True
 
-    def to_json(self, *, legacy_starting_items: bool = False) -> Dict[str, Any]:
+    def to_json(self, *, legacy_starting_items: bool = False) -> dict[str, Any]:
         if legacy_starting_items:
             settings = self.copy()
             for setting_name, items in LEGACY_STARTING_ITEM_SETTINGS.items():
@@ -378,12 +379,12 @@ class Settings(SettingInfos):
             and (setting.name != 'starting_items' or not legacy_starting_items)
         }
 
-    def to_json_cosmetics(self) -> Dict[str, Any]:
+    def to_json_cosmetics(self) -> dict[str, Any]:
         return {setting.name: self.settings_dict[setting.name] for setting in self.setting_infos.values() if setting.cosmetic}
 
 
 # gets the randomizer settings, whether to open the gui, and the logger level from command line arguments
-def get_settings_from_command_line_args() -> Tuple[Settings, bool, str, bool, str]:
+def get_settings_from_command_line_args() -> tuple[Settings, bool, str, bool, str]:
     parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('--gui', help='Launch the GUI', action='store_true')

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 import difflib
 import json
-from typing import TYPE_CHECKING, Dict, List, Iterable, Union, Optional, Any
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Optional, Any
 
 import Colors
 from Hints import hint_dist_list, hint_dist_tips, gossipLocations
@@ -4897,11 +4899,11 @@ class SettingInfos:
         }
     )
 
-    setting_infos: Dict[str, SettingInfo] = {}
+    setting_infos: dict[str, SettingInfo] = {}
     setting_map: dict = {}
 
     def __init__(self) -> None:
-        self.settings_dict: Dict[str, Any] = {}
+        self.settings_dict: dict[str, Any] = {}
 
 
 def get_settings_from_section(section_name: str) -> Iterable[str]:
@@ -4932,7 +4934,7 @@ def is_mapped(setting_name: str) -> bool:
 
 # When a string isn't found in the source list, attempt to get the closest match from the list
 # ex. Given "Recovery Hart" returns "Did you mean 'Recovery Heart'?"
-def build_close_match(name: str, value_type: str, source_list: "Optional[Union[List[str], Dict[str, List[Entrance]]]]" = None) -> str:
+def build_close_match(name: str, value_type: str, source_list: Optional[list[str] | dict[str, list[Entrance]]] = None) -> str:
     source = []
     if value_type == 'item':
         source = ItemInfo.items.keys()
@@ -4955,7 +4957,7 @@ def build_close_match(name: str, value_type: str, source_list: "Optional[Union[L
     return ""  # No matches
 
 
-def validate_settings(settings_dict: Dict[str, Any], *, check_conflicts: bool = True) -> None:
+def validate_settings(settings_dict: dict[str, Any], *, check_conflicts: bool = True) -> None:
     for setting, choice in settings_dict.items():
         # Ensure the supplied setting name is a real setting
         if setting not in SettingInfos.setting_infos:
@@ -4993,7 +4995,7 @@ def validate_settings(settings_dict: Dict[str, Any], *, check_conflicts: bool = 
                             validate_disabled_setting(settings_dict, setting, choice, other_setting)
 
 
-def validate_disabled_setting(settings_dict: Dict[str, Any], setting: str, choice, other_setting: str) -> None:
+def validate_disabled_setting(settings_dict: dict[str, Any], setting: str, choice, other_setting: str) -> None:
     if other_setting in settings_dict:
         if settings_dict[other_setting] != SettingInfos.setting_infos[other_setting].disabled_default:
             raise ValueError(f'The {other_setting!r} setting cannot be used since {setting!r} is set to {choice!r}')

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4932,7 +4932,7 @@ def is_mapped(setting_name: str) -> bool:
 
 # When a string isn't found in the source list, attempt to get the closest match from the list
 # ex. Given "Recovery Hart" returns "Did you mean 'Recovery Heart'?"
-def build_close_match(name: str, value_type: str, source_list: "Optional[Union[List[str]], Dict[str, List[Entrance]]]" = None) -> str:
+def build_close_match(name: str, value_type: str, source_list: "Optional[Union[List[str], Dict[str, List[Entrance]]]]" = None) -> str:
     source = []
     if value_type == 'item':
         source = ItemInfo.items.keys()

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1,54 +1,43 @@
-import argparse
 import difflib
-from itertools import chain
-import re
-import math
 import json
+import math
 import operator
-import os
+from typing import Any, Optional, Dict
 
-from Colors import get_tunic_color_options, get_navi_color_options, get_sword_trail_color_options, \
-    get_bombchu_trail_color_options, get_boomerang_trail_color_options, get_gauntlet_color_options, \
-    get_magic_color_options, get_heart_color_options, get_shield_frame_color_options, get_a_button_color_options,\
-    get_b_button_color_options, get_c_button_color_options, get_start_button_color_options
+import Colors
 from Hints import HintDistList, HintDistTips, gossipLocations
 from Item import ItemInfo
 from Location import LocationIterator
 from LocationList import location_table
 from Models import get_model_choices
-import Sounds as sfx
+from SettingsListTricks import logic_tricks
+import Sounds
 import StartingItems
 from Utils import data_path
 
+
 # holds the info for a single setting
-class Setting_Info():
-
-    def __init__(self, name, type, gui_text, gui_type, shared, choices, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic=False):
-        self.name = name # name of the setting, used as a key to retrieve the setting's value everywhere
-        self.type = type # type of the setting's value, used to properly convert types to setting strings
-        self.shared = shared # whether or not the setting is one that should be shared, used in converting settings to a string
-        self.cosmetic = cosmetic # whether or not the setting should be included in the cosmetic log
-        self.gui_text = gui_text
-        self.gui_type = gui_type
-        if gui_tooltip is None:
-            self.gui_tooltip = ""
-        else:
-            self.gui_tooltip = gui_tooltip
-
-        if gui_params == None:
-            gui_params = {}
-        self.gui_params = gui_params # additional parameters that the randomizer uses for the gui
-        self.disable = disable # dictionary of settings this this setting disabled
-        self.dependency = None # lambda the determines if this is disabled. Generated later
+class SettingInfo:
+    def __init__(self, setting_type: type, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        self.type: type = setting_type  # type of the setting's value, used to properly convert types to setting strings
+        self.shared: bool = shared  # whether the setting is one that should be shared, used in converting settings to a string
+        self.cosmetic: bool = cosmetic  # whether the setting should be included in the cosmetic log
+        self.gui_text: Optional[str] = gui_text
+        self.gui_type: Optional[str] = gui_type
+        self.gui_tooltip: Optional[str] = "" if gui_tooltip is None else gui_tooltip
+        self.gui_params: dict = {} if gui_params is None else gui_params  # additional parameters that the randomizer uses for the gui
+        self.disable: dict = disable  # dictionary of settings this setting disabled
+        self.dependency = None  # lambda that determines if this is disabled. Generated later
 
         # dictionary of options to their text names
+        choices = {} if choices is None else choices
         if isinstance(choices, list):
-            self.choices = {k: k for k in choices}
-            self.choice_list = list(choices)
+            self.choices: dict = {k: k for k in choices}
+            self.choice_list: list = list(choices)
         else:
-            self.choices = dict(choices)
-            self.choice_list = list(choices.keys())
-        self.reverse_choices = {v: k for k, v in self.choices.items()}
+            self.choices: dict = dict(choices)
+            self.choice_list: list = list(choices.keys())
+        self.reverse_choices: dict = {v: k for k, v in self.choices.items()}
 
         # number of bits needed to store the setting, used in converting settings to a string
         if shared:
@@ -60,29 +49,37 @@ class Setting_Info():
             self.bitwidth = 0
 
         # default value if undefined/unset
-        if default != None:
-            self.default = default
-        elif self.type == bool:
-            self.default = False
-        elif self.type == str:
-            self.default = ""
-        elif self.type == int:
-            self.default = 0
-        elif self.type == list:
-            self.default = []
-        elif self.type == dict:
-            self.default = {}
+        self.default = default
+        if self.default is None:
+            if self.type == bool:
+                self.default = False
+            elif self.type == str:
+                self.default = ""
+            elif self.type == int:
+                self.default = 0
+            elif self.type == list:
+                self.default = []
+            elif self.type == dict:
+                self.default = {}
 
         # default value if disabled
-        if disabled_default == None:
-            self.disabled_default = self.default
-        else:
-            self.disabled_default = disabled_default
+        self.disabled_default = self.default if disabled_default is None else disabled_default
 
         # used to when random options are set for this setting
-        if 'distribution' not in gui_params:
+        if 'distribution' not in self.gui_params:
             self.gui_params['distribution'] = [(choice, 1) for choice in self.choice_list]
 
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, obj, obj_type=None) -> Any:
+        return obj.settings_dict.get(self.name, self.default)
+
+    def __set__(self, obj, value: Any) -> None:
+        obj.settings_dict[self.name] = value
+
+    def __delete__(self, obj):
+        del obj.settings_dict[self.name]
 
     def calc_bitwidth(self, choices):
         count = len(choices)
@@ -94,1700 +91,259 @@ class Setting_Info():
         return 0
 
 
-class Checkbutton(Setting_Info):
+class SettingInfoNone(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], gui_tooltip=None, gui_params=None) -> None:
+        super().__init__(type(None), gui_text, gui_type, False, None, None, None, None, gui_tooltip, gui_params, False)
 
-    def __init__(self, name, gui_text, gui_tooltip=None, disable=None,
-            disabled_default=None, default=False, shared=False, gui_params=None, cosmetic=False):
+    def __get__(self, obj, obj_type=None) -> None:
+        raise Exception(f"{self.name} is not a setting and cannot be retrieved.")
 
+    def __set__(self, obj, value: str) -> None:
+        raise Exception(f"{self.name} is not a setting and cannot be set.")
+
+
+class SettingInfoBool(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
         choices = {
             True:  'checked',
             False: 'unchecked',
         }
 
-        super().__init__(name, bool, gui_text, 'Checkbutton', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+        super().__init__(bool, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> bool:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, bool):
+            value = bool(value)
+        return value
+
+    def __set__(self, obj, value: bool) -> None:
+        if not isinstance(value, bool):
+            value = bool(value)
+        super().__set__(obj, value)
 
 
-class Combobox(Setting_Info):
+class SettingInfoStr(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool = False, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(str, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
-    def __init__(self, name, gui_text, choices, default, gui_tooltip=None, disable=None,
-            disabled_default=None, shared=False, gui_params=None, cosmetic=False, multiple_select=False):
+    def __get__(self, obj, obj_type=None) -> str:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, str):
+            value = str(value)
+        return value
 
-        gui_type = 'Combobox' if not multiple_select else 'MultipleSelect'
-        type = str if not multiple_select else list
-        super().__init__(name, type, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+    def __set__(self, obj, value: str) -> None:
+        if not isinstance(value, str):
+            value = str(value)
+        super().__set__(obj, value)
 
 
-class Scale(Setting_Info):
+class SettingInfoInt(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(int, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
-    def __init__(self, name, gui_text, min, max, default, step=1,
-            gui_tooltip=None, disable=None, disabled_default=None,
-            shared=False, gui_params=None, cosmetic=False):
+    def __get__(self, obj, obj_type=None) -> int:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, int):
+            value = int(value)
+        return value
 
+    def __set__(self, obj, value: int) -> None:
+        if not isinstance(value, int):
+            value = int(value)
+        super().__set__(obj, value)
+
+
+class SettingInfoList(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(list, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> list:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, list):
+            value = list(value)
+        return value
+
+    def __set__(self, obj, value: list) -> None:
+        if not isinstance(value, list):
+            value = list(value)
+        super().__set__(obj, value)
+
+
+class SettingInfoDict(SettingInfo):
+    def __init__(self, gui_text: Optional[str], gui_type: Optional[str], shared: bool, choices=None, default=None, disabled_default=None, disable=None, gui_tooltip=None, gui_params=None, cosmetic: bool = False) -> None:
+        super().__init__(dict, gui_text, gui_type, shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+    def __get__(self, obj, obj_type=None) -> dict:
+        value = super().__get__(obj, obj_type)
+        if not isinstance(value, dict):
+            value = dict(value)
+        return value
+
+    def __set__(self, obj, value: dict) -> None:
+        if not isinstance(value, dict):
+            value = dict(value)
+        super().__set__(obj, value)
+
+
+class Button(SettingInfoNone):
+    def __init__(self, gui_text: Optional[str], gui_tooltip=None, gui_params=None) -> None:
+        super().__init__(gui_text, "Button", gui_tooltip, gui_params)
+
+
+class Textbox(SettingInfoNone):
+    def __init__(self, gui_text: Optional[str], gui_tooltip=None, gui_params=None) -> None:
+        super().__init__(gui_text, "Textbox", gui_tooltip, gui_params)
+
+
+class Checkbutton(SettingInfoBool):
+    def __init__(self, gui_text: Optional[str], gui_tooltip: Optional[str] = None, disable=None, disabled_default=None, default=False, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Checkbutton', shared, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Combobox(SettingInfoStr):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Radiobutton(SettingInfoStr):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Radiobutton', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Fileinput(SettingInfoStr):
+    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Fileinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Directoryinput(SettingInfoStr):
+    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Directoryinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Textinput(SettingInfoStr):
+    def __init__(self, gui_text, choices=None, default=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Textinput', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class ComboboxInt(SettingInfoInt):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'Combobox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+
+
+class Scale(SettingInfoInt):
+    def __init__(self, gui_text, default, minimum, maximum, step=1, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
         choices = {
-            i: str(i) for i in range(min, max+1, step)
+            i: str(i) for i in range(minimum, maximum+1, step)
         }
-        if gui_params == None:
+
+        if gui_params is None:
             gui_params = {}
-        gui_params['min']    = min
-        gui_params['max']    = max
-        gui_params['step']   = step
+        gui_params['min'] = minimum
+        gui_params['max'] = maximum
+        gui_params['step'] = step
 
-        super().__init__(name, int, gui_text, 'Scale', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
+        super().__init__(gui_text, 'Scale', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
-# Below is the list of possible glitchless tricks.
-# The order they are listed in is also the order in which
-# they appear to the user in the GUI, so a sensible order was chosen
 
-logic_tricks = {
+class Numberinput(SettingInfoInt):
+    def __init__(self, gui_text, default, minimum=None, maximum=None, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        if gui_params is None:
+            gui_params = {}
+        if minimum is not None:
+            gui_params['min'] = minimum
+        if maximum is not None:
+            gui_params['max'] = maximum
 
-    # General tricks
+        super().__init__(gui_text, 'Numberinput', shared, None, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
-    'Pass Through Visible One-Way Collisions': {
-        'name'    : 'logic_visible_collisions',
-        'tags'    : ("General", "Entrance Shuffle", "Kakariko Village", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    Allows climbing through the platform to reach
-                    Impa's House Back as adult with no items and
-                    going through the Kakariko Village Gate as child
-                    when coming from the Mountain Trail side.
-                    '''},
-    'Hidden Grottos without Stone of Agony': {
-        'name'    : 'logic_grottos_without_agony',
-        'tags'    : ("General", "Entrance Shuffle", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    Allows entering hidden grottos without the
-                    Stone of Agony.
-                    '''},
-    'Fewer Tunic Requirements': {
-        'name'    : 'logic_fewer_tunic_requirements',
-        'tags'    : ("General", "Fire Temple", "Fire Temple MQ", "Water Temple", "Water Temple MQ", "Gerudo Training Ground", "Gerudo Training Ground MQ",
-                    "Ganon's Castle", "Ganon's Castle MQ", "Zora's Fountain", "Death Mountain Crater", "Master Quest", "Overworld", "Vanilla Dungeons",
-                    "Child", "Adult",),
-        'tooltip' : '''\
-                    Allows the following possible without Tunics:
-                    - Enter Fire Temple as adult.
-                    - Zora's Fountain bottom Freestandings. You
-                    might not have enough time to resurface, and
-                    you may need to make multiple trips.
-                    - Traverse the first floor of the Fire Temple,
-                    except the elevator room and Volvagia.
-                    - Go underwater in the Water Temple. (The area
-                    below the central pillar always requires Zora
-                    Tunic.)
-                    - Gerudo Training Ground Underwater Silver
-                    Rupees. You may need to make multiple trips.
-                    - Collecting some Silver Rupees in the Fire
-                    Trial. You may need to make multiple trips.
-                    - All instances also apply in Master Quest.
-                    '''},
-    'Beehives with Bombchus' : {
-        'name'    : 'logic_beehives_bombchus',
-        'tags'    : ("General", "Beehives", "Overworld", "Zora's Fountain", "Child", "Adult",),
-        'tooltip' : '''\
-                    Puts breaking beehives with bombchus into logic.
-                    Using bombs is already expected on beehives that
-                    that are low enough that a bomb throw will reach.
-                    '''},
-    'Hammer Rusted Switches Through Walls': {
-        'name'    : 'logic_rusted_switches',
-        'tags'    : ("General", "Fire Temple", "Fire Temple MQ", "Ganon's Castle MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Applies to:
-                    - Fire Temple Highest Goron Chest.
-                    - MQ Fire Temple Lizalfos Maze.
-                    - MQ Spirit Trial.
-                    '''},
 
-    # Overworld tricks
+class MultipleSelect(SettingInfoList):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'MultipleSelect', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
-    'Adult Kokiri Forest GS with Hover Boots': {
-        'name'    : 'logic_adult_kokiri_gs',
-        'tags'    : ("Kokiri Forest", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Can be obtained without Hookshot by using the Hover
-                    Boots off of one of the roots.
-                    '''},
-    'Jump onto the Lost Woods Bridge as Adult with Nothing': {
-        'name'    : 'logic_lost_woods_bridge',
-        'tags'    : ("Lost Woods", "Entrance Shuffle", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    With very precise movement it's possible for
-                    adult to jump onto the bridge without needing
-                    Longshot, Hover Boots, or Bean.
-                    '''},
-    'Backflip over Mido as Adult': {
-        'name'    : 'logic_mido_backflip',
-        'tags'    : ("Lost Woods", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    With a specific position and angle, you can
-                    backflip over Mido.
-                    '''},
-    'Lost Woods Adult GS without Bean': {
-        'name'    : 'logic_lost_woods_gs_bean',
-        'tags'    : ("Lost Woods", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    You can collect the token with a precise
-                    Hookshot use, as long as you can kill the
-                    Skulltula somehow first. It can be killed
-                    using Longshot, Bow, Bombchus or Din's Fire.
-                    '''},
-    'Hyrule Castle Storms Grotto GS with Just Boomerang': {
-        'name'    : 'logic_castle_storms_gs',
-        'tags'    : ("Hyrule Castle", "Gold Skulltulas", "Overworld", "Child",),
-        'tooltip' : '''\
-                    With precise throws, the Boomerang alone can
-                    kill the Skulltula and collect the token,
-                    without first needing to blow up the wall.
-                    '''},
-    'Man on Roof without Hookshot': {
-        'name'    : 'logic_man_on_roof',
-        'tags'    : ("Kakariko Village", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    Can be reached by side-hopping off
-                    the watchtower as either age, or by
-                    jumping onto the potion shop's roof
-                    from the ledge as adult.
-                    '''},
-    'Kakariko Tower GS with Jump Slash': {
-        'name'    : 'logic_kakariko_tower_gs',
-        'tags'    : ("Kakariko Village", "Gold Skulltulas", "Overworld", "Child",),
-        'tooltip' : '''\
-                    Climb the tower as high as you can without
-                    touching the Gold Skulltula, then let go and
-                    jump slash immediately. By jump-slashing from
-                    as low on the ladder as possible to still
-                    hit the Skulltula, this trick can be done
-                    without taking fall damage.
-                    '''},
-    'Windmill PoH as Adult with Nothing': {
-        'name'    : 'logic_windmill_poh',
-        'tags'    : ("Kakariko Village", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Can jump up to the spinning platform from
-                    below as adult.
-                    '''},
-    'Kakariko Rooftop GS with Hover Boots': {
-        'name'    : 'logic_kakariko_rooftop_gs',
-        'tags'    : ("Kakariko Village", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Take the Hover Boots from the entrance to Impa's
-                    House over to the rooftop of Skulltula House. From
-                    there, a precise Hover Boots backwalk with backflip
-                    can be used to get onto a hill above the side of
-                    the village. And then from there you can Hover onto
-                    Impa's rooftop to kill the Skulltula and backflip
-                    into the token.
-                    '''},
-    'Graveyard Freestanding PoH with Boomerang': {
-        'name'    : 'logic_graveyard_poh',
-        'tags'    : ("Graveyard", "Overworld", "Child",),
-        'tooltip' : '''\
-                    Using a precise moving setup you can obtain
-                    the Piece of Heart by having the Boomerang
-                    interact with it along the return path.
-                    '''},
-    'Second Dampe Race as Child': {
-        'name'    : 'logic_child_dampe_race_poh',
-        'tags'    : ("Graveyard", "Entrance Shuffle", "Overworld", "Child",),
-        'tooltip' : '''\
-                    It is possible to complete the second dampe
-                    race as child in under a minute, but it is
-                    a strict time limit.
-                    '''},
-    'Shadow Temple Entry with Fire Arrows': {
-        'name'    : 'logic_shadow_fire_arrow_entry',
-        'tags'    : ("Graveyard", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    It is possible to light all of the torches to
-                    open the Shadow Temple entrance with just Fire
-                    Arrows, but you must be very quick, precise,
-                    and strategic with how you take your shots.
-                    '''},
-    'Death Mountain Trail Soil GS without Destroying Boulder': {
-        'name'    : 'logic_dmt_soil_gs',
-        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Child",),
-        'tooltip' : '''\
-                    Bugs will go into the soft soil even while the boulder is
-                    still blocking the entrance.
-                    Then, using a precise moving setup you can kill the Gold
-                    Skulltula and obtain the token by having the Boomerang
-                    interact with it along the return path.
-                    '''},
-    'Death Mountain Trail Chest with Strength': {
-        'name'    : 'logic_dmt_bombable',
-        'tags'    : ("Death Mountain Trail", "Overworld", "Child",),
-        'tooltip' : '''\
-                    Child Link can blow up the wall using a nearby bomb
-                    flower. You must backwalk with the flower and then
-                    quickly throw it toward the wall.
-                    '''},
-    'Death Mountain Trail Lower Red Rock GS with Hookshot': {
-        'name'    : 'logic_trail_gs_lower_hookshot',
-        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    After killing the Skulltula, the token can be fished
-                    out of the rock without needing to destroy it, by
-                    using the Hookshot in the correct way.
-                    '''},
-    'Death Mountain Trail Lower Red Rock GS with Hover Boots': {
-        'name'    : 'logic_trail_gs_lower_hovers',
-        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    After killing the Skulltula, the token can be
-                    collected without needing to destroy the rock by
-                    backflipping down onto it with the Hover Boots.
-                    First use the Hover Boots to stand on a nearby
-                    fence, and go for the Skulltula Token from there.
-                    '''},
-    'Death Mountain Trail Lower Red Rock GS with Magic Bean': {
-        'name'    : 'logic_trail_gs_lower_bean',
-        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    After killing the Skulltula, the token can be
-                    collected without needing to destroy the rock by
-                    jumping down onto it from the bean plant,
-                    midflight, with precise timing and positioning.
-                    '''},
-    'Death Mountain Trail Climb with Hover Boots': {
-        'name'    : 'logic_dmt_climb_hovers',
-        'tags'    : ("Death Mountain Trail", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    It is possible to use the Hover Boots to bypass
-                    needing to destroy the boulders blocking the path
-                    to the top of Death Mountain.
-                    '''},
-    'Death Mountain Trail Upper Red Rock GS without Hammer': {
-        'name'    : 'logic_trail_gs_upper',
-        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    After killing the Skulltula, the token can be collected
-                    by backflipping into the rock at the correct angle.
-                    '''},
-    'Deliver Eye Drops with Bolero of Fire': {
-        'name'    : 'logic_biggoron_bolero',
-        'tags'    : ("Death Mountain Trail", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Playing a warp song normally causes a trade item to
-                    spoil immediately, however, it is possible use Bolero
-                    to reach Biggoron and still deliver the Eye Drops
-                    before they spoil. If you do not wear the Goron Tunic,
-                    the heat timer inside the crater will override the trade
-                    item's timer. When you exit to Death Mountain Trail you
-                    will have one second to show the Eye Drops before they
-                    expire. You can get extra time to show the Eye Drops if
-                    you warp immediately upon receiving them. If you don't
-                    have many hearts, you may have to reset the heat timer
-                    by quickly dipping in and out of Darunia's chamber or
-                    quickly equipping and unequipping the Goron Tunic.
-                    This trick does not apply if "Randomize Warp Song
-                    Destinations" is enabled, or if the settings are such
-                    that trade items do not need to be delivered within a
-                    time limit.
-                    '''},
-    'Goron City Spinning Pot PoH with Bombchu': {
-        'name'    : 'logic_goron_city_pot',
-        'tags'    : ("Goron City", "Overworld", "Child",),
-        'tooltip' : '''\
-                    A Bombchu can be used to stop the spinning
-                    pot, but it can be quite finicky to get it
-                    to work.
-                    '''},
-    'Goron City Spinning Pot PoH with Strength': {
-        'name'    : 'logic_goron_city_pot_with_strength',
-        'tags'    : ("Goron City", "Overworld", "Child",),
-        'tooltip' : '''\
-                    Allows for stopping the Goron City Spinning
-                    Pot using a bomb flower alone, requiring
-                    strength in lieu of inventory explosives.
-                    '''},
-    'Rolling Goron (Hot Rodder Goron) as Child with Strength': {
-        'name'    : 'logic_child_rolling_with_strength',
-        'tags'    : ("Goron City", "Overworld", "Child",),
-        'tooltip' : '''\
-                    Use the bombflower on the stairs or near Medigoron.
-                    Timing is tight, especially without backwalking.
-                    '''},
-    'Stop Link the Goron with Din\'s Fire': {
-        'name'    : 'logic_link_goron_dins',
-        'tags'    : ("Goron City", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    The timing is quite awkward.
-                    '''},
-    'Goron City Maze Left Chest with Hover Boots': {
-        'name'    : 'logic_goron_city_leftmost',
-        'tags'    : ("Goron City", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    A precise backwalk starting from on top of the
-                    crate and ending with a precisely-timed backflip
-                    can reach this chest without needing either
-                    the Hammer or Silver Gauntlets.
-                    '''},
-    'Goron City Grotto with Hookshot While Taking Damage': {
-        'name'    : 'logic_goron_grotto',
-        'tags'    : ("Goron City", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    It is possible to reach the Goron City Grotto by
-                    quickly using the Hookshot while in the midst of
-                    taking damage from the lava floor. This trick will
-                    not be expected on OHKO or quadruple damage.
-                    '''},
-    'Crater\'s Bean PoH with Hover Boots': {
-        'name'    : 'logic_crater_bean_poh_with_hovers',
-        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Hover from the base of the bridge
-                    near Goron City and walk up the
-                    very steep slope.
-                    '''},
-    'Death Mountain Crater Jump to Bolero': {
-        'name'    : 'logic_crater_bolero_jump',
-        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    As Adult , using a shield to drop a pot while you have
-                    the perfect speed and position, the pot can
-                    push you that little extra distance you
-                    need to jump across the gap in the bridge.
-                    '''},
-    'Death Mountain Crater Upper to Lower with Hammer': {
-        'name'    : 'logic_crater_boulder_jumpslash',
-        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    With the Hammer, you can jump slash the rock twice
-                    in the same jump in order to destroy it before you
-                    fall into the lava.
-                    '''},
-    'Death Mountain Crater Upper to Lower Boulder Skip': {
-        'name'    : 'logic_crater_boulder_skip',
-        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    As adult, With careful positioning, you can jump to the ledge
-                    where the boulder is, then use repeated ledge grabs
-                    to shimmy to a climbable ledge. This trick supersedes
-                    "Death Mountain Crater Upper to Lower with Hammer".
-                    '''},
-    'Zora\'s River Lower Freestanding PoH as Adult with Nothing': {
-        'name'    : 'logic_zora_river_lower',
-        'tags'    : ("Zora's River", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Adult can reach this PoH with a precise jump,
-                    no Hover Boots required.
-                    '''},
-    'Zora\'s River Upper Freestanding PoH as Adult with Nothing': {
-        'name'    : 'logic_zora_river_upper',
-        'tags'    : ("Zora's River", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Adult can reach this PoH with a precise jump,
-                    no Hover Boots required.
-                    '''},
-    'Zora\'s Domain Entry with Cucco': {
-        'name'    : 'logic_zora_with_cucco',
-        'tags'    : ("Zora's River", "Overworld", "Child",),
-        'tooltip' : '''\
-                    You can fly behind the waterfall with
-                    a Cucco as child.
-                    '''},
-    'Zora\'s Domain Entry with Hover Boots': {
-        'name'    : 'logic_zora_with_hovers',
-        'tags'    : ("Zora's River", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Can hover behind the waterfall as adult.
-                    '''},
-    'Zora\'s River Rupees with Jump Dive': {
-        'name'    : 'logic_zora_river_rupees',
-        'tags'    : ("Zora's River", "Freestandings", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    You can jump down onto them from
-                    above to skip needing Iron Boots.
-                    '''},
-    'Skip King Zora as Adult with Nothing': {
-        'name'    : 'logic_king_zora_skip',
-        'tags'    : ("Zora's Domain", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    With a precise jump as adult, it is possible to
-                    get on the fence next to King Zora from the front
-                    to access Zora's Fountain.
-                    '''},
-    'Zora\'s Domain GS with No Additional Items': {
-        'name'    : 'logic_domain_gs',
-        'tags'    : ("Zora's Domain", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    A precise jump slash can kill the Skulltula and
-                    recoil back onto the top of the frozen waterfall.
-                    To kill it, the logic normally guarantees one of
-                    Hookshot, Bow, or Magic.
-                    '''},
-    'Lake Hylia Lab Wall GS with Jump Slash': {
-        'name'    : 'logic_lab_wall_gs',
-        'tags'    : ("Lake Hylia", "Gold Skulltulas", "Overworld", "Child",),
-        'tooltip' : '''\
-                    The jump slash to actually collect the
-                    token is somewhat precise.
-                    '''},
-    'Lake Hylia Lab Dive without Gold Scale': {
-        'name'    : 'logic_lab_diving',
-        'tags'    : ("Lake Hylia", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Remove the Iron Boots in the midst of
-                    Hookshotting the underwater crate.
-                    '''},
-    'Water Temple Entry without Iron Boots using Hookshot': {
-        'name'    : 'logic_water_hookshot_entry',
-        'tags'    : ("Lake Hylia", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    When entering Water Temple using Gold Scale instead
-                    of Iron Boots, the Longshot is usually used to be
-                    able to hit the switch and open the gate. But, by
-                    standing in a particular spot, the switch can be hit
-                    with only the reach of the Hookshot.
-                    '''},
-    'Gerudo Valley Crate PoH as Adult with Hover Boots': {
-        'name'    : 'logic_valley_crate_hovers',
-        'tags'    : ("Gerudo Valley", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    From the far side of Gerudo Valley, a precise
-                    Hover Boots movement and jump-slash recoil can
-                    allow adult to reach the ledge with the crate
-                    PoH without needing Longshot. You will take
-                    fall damage.
-                    '''},
-    'Thieves\' Hideout "Kitchen" with No Additional Items': {
-        'name'    : 'logic_gerudo_kitchen',
-        'tags'    : ("Thieves' Hideout", "Gerudo's Fortress", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    Allows passing through the kitchen by avoiding being
-                    seen by the guards. The logic normally guarantees
-                    Bow or Hookshot to stun them from a distance, or
-                    Hover Boots to cross the room without needing to
-                    deal with the guards.
-                    '''},
-    'Gerudo\'s Fortress Ledge Jumps': {
-        'name'    : 'logic_gf_jump',
-        'tags'    : ("Gerudo's Fortress", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    Allows both ages to use a jump to reach the second
-                    floor of the fortress from the southern roof with
-                    the guard, and adult to jump to the top roof from
-                    there, without going through the interiors of the
-                    Thieves' Hideout.
-                    '''},
-    'Wasteland Crossing without Hover Boots or Longshot': {
-        'name'    : 'logic_wasteland_crossing',
-        'tags'    : ("Haunted Wasteland", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    You can beat the quicksand by backwalking across it
-                    in a specific way.
-                    Note that jumping to the carpet merchant as child
-                    typically requires a fairly precise jump slash.
-                    '''},
-    'Lensless Wasteland': {
-        'name'    : 'logic_lens_wasteland',
-        'tags'    : ("Lens of Truth", "Haunted Wasteland", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    By memorizing the path, you can travel through the
-                    Wasteland without using the Lens of Truth to see
-                    the Poe.
-                    The equivalent trick for going in reverse through
-                    the Wasteland is "Reverse Wasteland".
-                    '''},
-    'Reverse Wasteland': {
-        'name'    : 'logic_reverse_wasteland',
-        'tags'    : ("Haunted Wasteland", "Overworld", "Child", "Adult",),
-        'tooltip' : '''\
-                    By memorizing the path, you can travel through the
-                    Wasteland in reverse.
-                    Note that jumping to the carpet merchant as child
-                    typically requires a fairly precise jump slash.
-                    The equivalent trick for going forward through the
-                    Wasteland is "Lensless Wasteland".
-                    To cross the river of sand with no additional items,
-                    be sure to also enable "Wasteland Crossing without
-                    Hover Boots or Longshot".
-                    Unless Thieves' Hideout entrances or all overworld
-                    entrances are randomized, child Link will not be
-                    expected to do anything at Gerudo's Fortress.
-                    '''},
-    'Colossus Hill GS with Hookshot': {
-        'name'    : 'logic_colossus_gs',
-        'tags'    : ("Desert Colossus", "Gold Skulltulas", "Overworld", "Adult",),
-        'tooltip' : '''\
-                    Somewhat precise. If you kill enough Leevers
-                    you can get enough of a break to take some time
-                    to aim more carefully.
-                    '''},
 
-    # Dungeons
+class SearchBox(SettingInfoList):
+    def __init__(self, gui_text, choices, default, gui_tooltip=None, disable=None, disabled_default=None, shared=False, gui_params=None, cosmetic=False):
+        super().__init__(gui_text, 'SearchBox', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
-    'Deku Tree Basement Vines GS with Jump Slash': {
-        'name'    : 'logic_deku_basement_gs',
-        'tags'    : ("Deku Tree", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    Can be defeated by doing a precise jump slash.
-                    '''},
-    'Deku Tree Basement without Slingshot': {
-        'name'    : 'logic_deku_b1_skip',
-        'tags'    : ("Deku Tree", "Deku Tree MQ", "Master Quest", "Vanilla Dungeons", "Child"),
-        'tooltip' : '''\
-                    A precise jump can be used to skip
-                    needing to use the Slingshot to go
-                    around B1 of the Deku Tree. If used
-                    with the "Closed Forest" setting, a
-                    Slingshot will not be guaranteed to
-                    exist somewhere inside the Forest.
-                    This trick applies to both Vanilla
-                    and Master Quest.
-                    '''},
-    'Deku Tree Basement Web to Gohma with Bow': {
-        'name'    : 'logic_deku_b1_webs_with_bow',
-        'tags'    : ("Deku Tree", "Entrance Shuffle", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    All spider web walls in the Deku Tree basement can be burnt
-                    as adult with just a bow by shooting through torches. This
-                    trick only applies to the circular web leading to Gohma;
-                    the two vertical webs are always in logic.
 
-                    Backflip onto the chest near the torch at the bottom of
-                    the vine wall. With precise positioning you can shoot
-                    through the torch to the right edge of the circular web.
+class SettingInfos:
+    # Internal & Non-GUI Settings
+    cosmetics_only = Checkbutton(None)
+    check_version = Checkbutton(None)
+    checked_version = SettingInfoStr(None, None)
+    output_settings = Checkbutton(None)
+    patch_without_output = Checkbutton(None)
+    generating_patch_file = Checkbutton(None)
+    output_file = SettingInfoStr(None, None)
+    seed = SettingInfoStr(None, None)
 
-                    This allows completion of adult Deku Tree with no fire source.
-                    '''},
-    'Deku Tree MQ Compass Room GS Boulders with Just Hammer': {
-        'name'    : 'logic_deku_mq_compass_gs',
-        'tags'    : ("Deku Tree MQ", "Gold Skulltulas", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Climb to the top of the vines, then let go
-                    and jump slash immediately to destroy the
-                    boulders using the Hammer, without needing
-                    to spawn a Song of Time block.
-                    '''},
-    'Deku Tree MQ Roll Under the Spiked Log': {
-        'name'    : 'logic_deku_mq_log',
-        'tags'    : ("Deku Tree MQ", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    You can get past the spiked log by rolling
-                    to briefly shrink your hitbox. As adult,
-                    the timing is a bit more precise.
-                    '''},
-    'Dodongo\'s Cavern Scarecrow GS with Armos Statue': {
-        'name'    : 'logic_dc_scarecrow_gs',
-        'tags'    : ("Dodongo's Cavern", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    You can jump off an Armos Statue to reach the
-                    alcove with the Gold Skulltula. It takes quite
-                    a long time to pull the statue the entire way.
-                    The jump to the alcove can be a bit picky when
-                    done as child.
-                    '''},
-    'Dodongo\'s Cavern Vines GS from Below with Longshot': {
-        'name'    : 'logic_dc_vines_gs',
-        'tags'    : ("Dodongo's Cavern", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The vines upon which this Skulltula rests are one-
-                    sided collision. You can use the Longshot to get it
-                    from below, by shooting it through the vines,
-                    bypassing the need to lower the staircase.
-                    '''},
-    'Dodongo\'s Cavern Staircase with Bow': {
-        'name'    : 'logic_dc_staircase',
-        'tags'    : ("Dodongo's Cavern", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The Bow can be used to knock down the stairs
-                    with two well-timed shots.
-                    '''},
-    'Dodongo\'s Cavern Child Slingshot Skips': {
-        'name'    : 'logic_dc_slingshot_skip',
-        'tags'    : ("Dodongo's Cavern", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    With precise platforming, child can cross the
-                    platforms while the flame circles are there.
-                    When enabling this trick, it's recommended that
-                    you also enable the Adult variant: "Dodongo's
-                    Cavern Spike Trap Room Jump without Hover Boots".
-                    '''},
-    'Dodongo\'s Cavern Two Scrub Room with Strength': {
-        'name'    : 'logic_dc_scrub_room',
-        'tags'    : ("Dodongo's Cavern", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    With help from a conveniently-positioned block,
-                    Adult can quickly carry a bomb flower over to
-                    destroy the mud wall blocking the room with two
-                    Deku Scrubs.
-                    '''},
-    'Dodongo\'s Cavern Spike Trap Room Jump without Hover Boots': {
-        'name'    : 'logic_dc_jump',
-        'tags'    : ("Dodongo's Cavern", "Dodongo's Cavern MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The jump is adult Link only. Applies to both Vanilla and MQ.
-                    '''},
-    'Dodongo\'s Cavern Smash the Boss Lobby Floor': {
-        'name'    : 'logic_dc_hammer_floor',
-        'tags'    : ("Dodongo's Cavern", "Dodongo's Cavern MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The bombable floor before King Dodongo can be destroyed
-                    with Hammer if hit in the very center. This is only
-                    relevant with Shuffle Boss Entrances or if Dodongo's Cavern
-                    is MQ and either variant of "Dodongo's Cavern MQ Light the
-                    Eyes with Strength" is on.
-                    '''},
-    'Dodongo\'s Cavern MQ Early Bomb Bag Area as Child': {
-        'name'    : 'logic_dc_mq_child_bombs',
-        'tags'    : ("Dodongo's Cavern MQ", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    With a precise jump slash from above, you
-                    can reach the Bomb Bag area as only child
-                    without needing a Slingshot. You will
-                    take fall damage.
-                    '''},
-    'Dodongo\'s Cavern MQ Light the Eyes with Strength as Adult': {
-        'name'    : 'logic_dc_mq_eyes_adult',
-        'tags'    : ("Dodongo's Cavern MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    If you move very quickly, it is possible to use
-                    the bomb flower at the top of the room to light
-                    the eyes.
-                    '''},
-    'Dodongo\'s Cavern MQ Light the Eyes with Strength as Child': {
-        'name'    : 'logic_dc_mq_eyes_child',
-        'tags'    : ("Dodongo's Cavern MQ", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    If you move very quickly, it is possible to use
-                    the bomb flower at the top of the room to light
-                    the eyes. To perform this trick as child is
-                    significantly more difficult than adult. The
-                    player is also expected to complete the DC back
-                    area without explosives, including getting past
-                    the Armos wall to the switch for the boss door.
-                    '''},
-    'Jabu Underwater Alcove as Adult with Jump Dive': {
-        'name'    : 'logic_jabu_alcove_jump_dive',
-        'tags'    : ("Jabu Jabu's Belly", "Jabu Jabu's Belly MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Standing above the underwater tunnel leading to the scrub,
-                    jump down and swim through the tunnel. This allows adult to
-                    access the alcove with no Scale or Iron Boots. In vanilla Jabu,
-                    this alcove has a business scrub. In MQ Jabu, it has the compass
-                    chest and a door switch for the main floor.
-                    '''},
-    'Jabu Near Boss Room with Hover Boots': {
-        'name'    : 'logic_jabu_boss_hover',
-        'tags'    : ("Jabu Jabu's Belly", "Gold Skulltulas", "Entrance Shuffle", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A box for the blue switch can be carried over
-                    by backwalking with one while the elevator is
-                    at its peak. Alternatively, you can skip
-                    transporting a box by quickly rolling from the
-                    switch and opening the door before it closes.
-                    However, the timing for this is very tight.
-                    '''},
-    'Jabu Near Boss Ceiling Switch/GS without Boomerang or Explosives': {
-        'name'    : 'logic_jabu_near_boss_ranged',
-        'tags'    : ("Jabu Jabu's Belly", "Jabu Jabu's Belly MQ", "Gold Skulltulas", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    Vanilla Jabu: From near the entrance into the room, you can
-                    hit the switch that opens the door to the boss room using a
-                    precisely-aimed use of the Slingshot, Bow, or Longshot. As well,
-                    if you climb to the top of the vines you can stand on the right
-                    edge of the platform and shoot around the glass. From this
-                    distance, even the Hookshot can reach the switch. This trick is
-                    only relevant if "Shuffle Boss Entrances" is enabled.
+    # GUI Only Buttons/Text
 
-                    MQ Jabu: A Gold Skulltula Token can be collected with the
-                    Hookshot or Longshot using the same methods as hitting the switch
-                    in vanilla. This trick is usually only relevant if Jabu dungeon
-                    shortcuts are enabled.
-                    '''},
-    'Jabu Near Boss Ceiling Switch with Explosives': {
-        'name'    : 'logic_jabu_near_boss_explosives',
-        'tags'    : ("Jabu Jabu's Belly", "Entrance Shuffle", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    You can hit the switch that opens the door to the boss
-                    room using a precisely-aimed Bombchu. Also, using the
-                    Hover Boots, adult can throw a Bomb at the switch. This
-                    trick is only relevant if "Shuffle Boss Entrances" is
-                    enabled.
-                    '''},
-    'Jabu MQ without Lens of Truth': {
-        'name'    : 'logic_lens_jabu_mq',
-        'tags'    : ("Lens of Truth", "Jabu Jabu's Belly MQ", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Jabu MQ.
-                    '''},
-    'Jabu MQ Compass Chest with Boomerang': {
-        'name'    : 'logic_jabu_mq_rang_jump',
-        'tags'    : ("Jabu Jabu's Belly MQ", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    Boomerang can reach the cow switch to spawn the chest by
-                    targeting the cow, jumping off of the ledge where the
-                    chest spawns, and throwing the Boomerang in midair. This
-                    is only relevant with Jabu Jabu's Belly dungeon shortcuts
-                    enabled.
-                    '''},
-    'Jabu MQ Song of Time Block GS with Boomerang': {
-        'name'    : 'logic_jabu_mq_sot_gs',
-        'tags'    : ("Jabu Jabu's Belly MQ", "Gold Skulltulas", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    Allow the Boomerang to return to you through
-                    the Song of Time block to grab the token.
-                    '''},
-    'Bottom of the Well without Lens of Truth': {
-        'name'    : 'logic_lens_botw',
-        'tags'    : ("Lens of Truth", "Bottom of the Well", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Bottom of the Well.
-                    '''},
-    'Child Dead Hand without Kokiri Sword': {
-        'name'    : 'logic_child_deadhand',
-        'tags'    : ("Bottom of the Well", "Bottom of the Well MQ", "Vanilla Dungeons", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    Requires 9 sticks or 5 jump slashes.
-                    '''},
-    'Bottom of the Well Map Chest with Strength & Sticks': {
-        'name'    : 'logic_botw_basement',
-        'tags'    : ("Bottom of the Well", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    The chest in the basement can be reached with
-                    strength by doing a jump slash with a lit
-                    stick to access the bomb flowers.
-                    '''},
-    'Bottom of the Well MQ Jump Over the Pits': {
-        'name'    : 'logic_botw_mq_pits',
-        'tags'    : ("Bottom of the Well MQ", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    While the pits in Bottom of the Well don't allow you to
-                    jump just by running straight at them, you can still get
-                    over them by side-hopping or backflipping across. With
-                    explosives, this allows you to access the central areas
-                    without Zelda's Lullaby. With Zelda's Lullaby, it allows
-                    you to access the west inner room without explosives.
-                    '''},
-    'Bottom of the Well MQ Dead Hand Freestanding Key with Boomerang': {
-        'name'    : 'logic_botw_mq_dead_hand_key',
-        'tags'    : ("Bottom of the Well MQ", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    Boomerang can fish the item out of the rubble without
-                    needing explosives to blow it up.
-                    '''},
-    'Forest Temple First Room GS with Difficult-to-Use Weapons': {
-        'name'    : 'logic_forest_first_gs',
-        'tags'    : ("Forest Temple", "Entrance Shuffle", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    Allows killing this Skulltula with Sword or Sticks by
-                    jump slashing it as you let go from the vines. You can
-                    avoid taking fall damage by recoiling onto the tree.
-                    Also allows killing it as Child with a Bomb throw. It's
-                    much more difficult to use a Bomb as child due to
-                    Child Link's shorter height.
-                    '''},
-    'Forest Temple East Courtyard GS with Boomerang': {
-        'name'    : 'logic_forest_outdoor_east_gs',
-        'tags'    : ("Forest Temple", "Entrance Shuffle", "Gold Skulltulas", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    Precise Boomerang throws can allow child to
-                    kill the Skulltula and collect the token.
-                    '''},
-    'Forest Temple East Courtyard Vines with Hookshot': {
-        'name'    : 'logic_forest_vines',
-        'tags'    : ("Forest Temple", "Forest Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The vines in Forest Temple leading to where the well
-                    drain switch is in the standard form can be barely
-                    reached with just the Hookshot. Applies to MQ also.
-                    '''},
-    'Forest Temple NE Outdoors Ledge with Hover Boots': {
-        'name'    : 'logic_forest_outdoors_ledge',
-        'tags'    : ("Forest Temple", "Forest Temple MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    With precise Hover Boots movement you can fall down
-                    to this ledge from upper balconies. If done precisely
-                    enough, it is not necessary to take fall damage.
-                    In MQ, this skips a Longshot requirement.
-                    In Vanilla, this can skip a Hookshot requirement in
-                    entrance randomizer.
-                    '''},
-    'Forest Temple East Courtyard Door Frame with Hover Boots': {
-        'name'    : 'logic_forest_door_frame',
-        'tags'    : ("Forest Temple", "Forest Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A precise Hover Boots movement from the upper
-                    balconies in this courtyard can be used to get on
-                    top of the door frame. Applies to both Vanilla and
-                    Master Quest. In Vanilla, from on top the door
-                    frame you can summon Pierre, allowing you to access
-                    the falling ceiling room early. In Master Quest,
-                    this allows you to obtain the GS on the door frame
-                    as adult without Hookshot or Song of Time.
-                    '''},
-    'Forest Temple Outside Backdoor with Jump Slash': {
-        'name'    : 'logic_forest_outside_backdoor',
-        'tags'    : ("Forest Temple", "Forest Temple MQ", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    A jump slash recoil can be used to reach the
-                    ledge in the block puzzle room that leads to
-                    the west courtyard. This skips a potential
-                    Hover Boots requirement in vanilla, and it
-                    can sometimes apply in MQ as well. This trick
-                    can be performed as both ages.
-                    '''},
-    'Swim Through Forest Temple MQ Well with Hookshot': {
-        'name'    : 'logic_forest_well_swim',
-        'tags'    : ("Forest Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Shoot the vines in the well as low and as far to
-                    the right as possible, and then immediately swim
-                    under the ceiling to the right. This can only be
-                    required if Forest Temple is in its Master Quest
-                    form.
-                    '''},
-    'Skip Forest Temple MQ Block Puzzle with Bombchu': {
-        'name'    : 'logic_forest_mq_block_puzzle',
-        'tags'    : ("Forest Temple MQ", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    Send the Bombchu straight up the center of the
-                    wall directly to the left upon entering the room.
-                    '''},
-    'Forest Temple MQ Twisted Hallway Switch with Jump Slash': {
-        'name'    : 'logic_forest_mq_hallway_switch_jumpslash',
-        'tags'    : ("Forest Temple MQ", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    The switch to twist the hallway can be hit with
-                    a jump slash through the glass block. To get in
-                    front of the switch, either use the Hover Boots
-                    or hit the shortcut switch at the top of the
-                    room and jump from the glass blocks that spawn.
-                    Sticks can be used as child, but the Kokiri
-                    Sword is too short to reach through the glass.
-                    '''},
-    #'Forest Temple MQ Twisted Hallway Switch with Hookshot': {
-    #    'name'    : 'logic_forest_mq_hallway_switch_hookshot',
-    #    'tags'    : ("Forest Temple MQ", "Master Quest", "Adult",),
-    #    'tooltip' : '''\
-    #                There's a very small gap between the glass block
-    #                and the wall. Through that gap you can hookshot
-    #                the target on the ceiling.
-    #                '''},
-    'Forest Temple MQ Twisted Hallway Switch with Boomerang': {
-        'name'    : 'logic_forest_mq_hallway_switch_boomerang',
-        'tags'    : ("Forest Temple MQ", "Entrance Shuffle", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    The Boomerang can return to Link through walls,
-                    allowing child to hit the hallway switch. This
-                    can be used to allow adult to pass through later,
-                    or in conjuction with "Forest Temple Outside
-                    Backdoor with Jump Slash".
-                    '''},
-    'Fire Temple Boss Door without Hover Boots or Pillar': {
-        'name'    : 'logic_fire_boss_door_jump',
-        'tags'    : ("Fire Temple", "Fire Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The Fire Temple Boss Door can be reached as adult with a precise
-                    jump. You must be touching the side wall of the room so
-                    that Link will grab the ledge from farther away than
-                    is normally possible.
-                    '''},
-    'Fire Temple Song of Time Room GS without Song of Time': {
-        'name'    : 'logic_fire_song_of_time',
-        'tags'    : ("Fire Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A precise jump can be used to reach this room.
-                    '''},
-    'Fire Temple Climb without Strength': {
-        'name'    : 'logic_fire_strength',
-        'tags'    : ("Fire Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A precise jump can be used to skip
-                    pushing the block.
-                    '''},
-    'Fire Temple East Tower without Scarecrow\'s Song': {
-        'name'    : 'logic_fire_scarecrow',
-        'tags'    : ("Fire Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Also known as "Pixelshot".
-                    The Longshot can reach the target on the elevator
-                    itself, allowing you to skip needing to spawn the
-                    scarecrow.
-                    '''},
-    'Fire Temple Flame Wall Maze Skip': {
-        'name'    : 'logic_fire_flame_maze',
-        'tags'    : ("Fire Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    If you move quickly you can sneak past the edge of
-                    a flame wall before it can rise up to block you.
-                    To do it without taking damage is more precise.
-                    Allows you to progress without needing either a
-                    Small Key or Hover Boots.
-                    '''},
-    'Fire Temple MQ Chest Near Boss without Breaking Crate': {
-        'name'    : 'logic_fire_mq_near_boss',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    The hitbox for the torch extends a bit outside of the crate.
-                    Shoot a flaming arrow at the side of the crate to light the
-                    torch without needing to get over there and break the crate.
-                    '''},
-    'Fire Temple MQ Big Lava Room Blocked Door without Hookshot': {
-        'name'    : 'logic_fire_mq_blocked_chest',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    There is a gap between the hitboxes of the flame
-                    wall in the big lava room. If you know where this
-                    gap is located, you can jump through it and skip
-                    needing to use the Hookshot. To do this without
-                    taking damage is more precise.
-                    '''},
-    'Fire Temple MQ Boss Key Chest without Bow': {
-        'name'    : 'logic_fire_mq_bk_chest',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    It is possible to light both of the timed torches
-                    to unbar the door to the boss key chest's room
-                    with just Din's Fire if you move very quickly
-                    between the two torches. It is also possible to
-                    unbar the door with just Din's by abusing an
-                    oversight in the way the game counts how many
-                    torches have been lit.
-                    '''},
-    'Fire Temple MQ Climb without Fire Source': {
-        'name'    : 'logic_fire_mq_climb',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    You can use the Hover Boots to hover around to
-                    the climbable wall, skipping the need to use a
-                    fire source and spawn a Hookshot target.
-                    '''},
-    'Fire Temple MQ Lizalfos Maze Side Room without Box': {
-        'name'    : 'logic_fire_mq_maze_side_room',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    You can walk from the blue switch to the door and
-                    quickly open the door before the bars reclose. This
-                    skips needing to reach the upper sections of the
-                    maze to get a box to place on the switch.
-                    '''},
-    'Fire Temple MQ Lower to Upper Lizalfos Maze with Hover Boots': {
-        'name'    : 'logic_fire_mq_maze_hovers',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Use the Hover Boots off of a crate to
-                    climb to the upper maze without needing
-                    to spawn and use the Hookshot targets.
-                    '''},
-    'Fire Temple MQ Lower to Upper Lizalfos Maze with Precise Jump': {
-        'name'    : 'logic_fire_mq_maze_jump',
-        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    A precise jump off of a crate can be used to
-                    climb to the upper maze without needing to spawn
-                    and use the Hookshot targets. This trick
-                    supersedes both "Fire Temple MQ Lower to Upper
-                    Lizalfos Maze with Hover Boots" and "Fire Temple
-                    MQ Lizalfos Maze Side Room without Box".
-                    '''},
-    'Fire Temple MQ Above Flame Wall Maze GS from Below with Longshot': {
-        'name'    : 'logic_fire_mq_above_maze_gs',
-        'tags'    : ("Fire Temple MQ", "Gold Skulltulas", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    The floor of the room that contains this Skulltula
-                    is only solid from above. From the maze below, the
-                    Longshot can be shot through the ceiling to obtain
-                    the token with two fewer small keys than normal.
-                    '''},
-    'Fire Temple MQ Flame Wall Maze Skip': {
-        'name'    : 'logic_fire_mq_flame_maze',
-        'tags'    : ("Fire Temple MQ", "Gold Skulltulas", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    If you move quickly you can sneak past the edge of
-                    a flame wall before it can rise up to block you.
-                    To do it without taking damage is more precise.
-                    Allows you to reach the side room GS without needing
-                    Song of Time or Hover Boots. If either of "Fire Temple
-                    MQ Lower to Upper Lizalfos Maze with Hover Boots" or
-                    "with Precise Jump" are enabled, this also allows you
-                    to progress deeper into the dungeon without Hookshot.
-                    '''},
-    'Water Temple Torch Longshot': {
-        'name'    : 'logic_water_temple_torch_longshot',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Stand on the eastern side of the central pillar and longshot
-                    the torches on the bottom level. Swim through the corridor
-                    and float up to the top level. This allows access to this
-                    area and lower water levels without Iron Boots.
-                    The majority of the tricks that allow you to skip Iron Boots
-                    in the Water Temple are not going to be relevant unless this
-                    trick is first enabled.
-                    '''},
-    'Water Temple Cracked Wall with Hover Boots': {
-        'name'    : 'logic_water_cracked_wall_hovers',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    With a midair side-hop while wearing the Hover
-                    Boots, you can reach the cracked wall without
-                    needing to raise the water up to the middle level.
-                    '''},
-    'Water Temple Cracked Wall with No Additional Items': {
-        'name'    : 'logic_water_cracked_wall_nothing',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A precise jump slash (among other methods) will
-                    get you to the cracked wall without needing the
-                    Hover Boots or to raise the water to the middle
-                    level. This trick supersedes "Water Temple
-                    Cracked Wall with Hover Boots".
-                    '''},
-    'Water Temple Boss Key Region with Hover Boots': {
-        'name'    : 'logic_water_boss_key_region',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    With precise Hover Boots movement it is possible
-                    to reach the boss key chest's region without
-                    needing the Longshot. It is not necessary to take
-                    damage from the spikes. The Gold Skulltula Token
-                    in the following room can also be obtained with
-                    just the Hover Boots.
-                    '''},
-    'Water Temple North Basement Ledge with Precise Jump': {
-        'name'    : 'logic_water_north_basement_ledge_jump',
-        'tags'    : ("Water Temple", "Water Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    In the northern basement there's a ledge from where, in
-                    vanilla Water Temple, boulders roll out into the room.
-                    Normally to jump directly to this ledge logically
-                    requires the Hover Boots, but with precise jump, it can
-                    be done without them. This trick applies to both
-                    Vanilla and Master Quest.
-                    '''},
-    'Water Temple Boss Key Jump Dive': {
-        'name'    : 'logic_water_bk_jump_dive',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Stand on the very edge of the raised corridor leading from the
-                    push block room to the rolling boulder corridor. Face the
-                    gold skulltula on the waterfall and jump over the boulder
-                    corridor floor into the pool of water, swimming right once
-                    underwater. This allows access to the boss key room without
-                    Iron boots.
-                    '''},
-    'Water Temple Central Pillar GS with Farore\'s Wind': {
-        'name'    : 'logic_water_central_gs_fw',
-        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    If you set Farore's Wind inside the central pillar
-                    and then return to that warp point after raising
-                    the water to the highest level, you can obtain this
-                    Skulltula Token with Hookshot or Boomerang.
-                    '''},
-    'Water Temple Central Pillar GS with Iron Boots': {
-        'name'    : 'logic_water_central_gs_irons',
-        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    After opening the middle water level door into the
-                    central pillar, the door will stay unbarred so long
-                    as you do not leave the room -- even if you were to
-                    raise the water up to the highest level. With the
-                    Iron Boots to go through the door after the water has
-                    been raised, you can obtain the Skulltula Token with
-                    the Hookshot.
-                    '''},
-    'Water Temple Central Bow Target without Longshot or Hover Boots': {
-        'name'    : 'logic_water_central_bow',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    A very precise Bow shot can hit the eye
-                    switch from the floor above. Then, you
-                    can jump down into the hallway and make
-                    through it before the gate closes.
-                    It can also be done as child, using the
-                    Slingshot instead of the Bow.
-                    '''},
-    'Water Temple Falling Platform Room GS with Hookshot': {
-        'name'    : 'logic_water_falling_platform_gs_hookshot',
-        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    If you stand on the very edge of the platform, this
-                    Gold Skulltula can be obtained with only the Hookshot.
-                    '''},
-    'Water Temple Falling Platform Room GS with Boomerang': {
-        'name'    : 'logic_water_falling_platform_gs_boomerang',
-        'tags'    : ("Water Temple", "Gold Skulltulas", "Entrance Shuffle", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    If you stand on the very edge of the platform, this
-                    Gold Skulltula can be obtained with only the Boomerang.
-                    '''},
-    'Water Temple River GS without Iron Boots': {
-        'name'    : 'logic_water_river_gs',
-        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Standing on the exposed ground toward the end of
-                    the river, a precise Longshot use can obtain the
-                    token. The Longshot cannot normally reach far
-                    enough to kill the Skulltula, however. You'll
-                    first have to find some other way of killing it.
-                    '''},
-    'Water Temple Dragon Statue Jump Dive': {
-        'name'    : 'logic_water_dragon_jump_dive',
-        'tags'    : ("Water Temple", "Water Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    If you come into the dragon statue room from the
-                    serpent river, you can jump down from above and get
-                    into the tunnel without needing either Iron Boots
-                    or a Scale. This trick applies to both Vanilla and
-                    Master Quest. In Vanilla, you must shoot the switch
-                    from above with the Bow, and then quickly get
-                    through the tunnel before the gate closes.
-                    '''},
-    'Water Temple Dragon Statue Switch from Above the Water as Adult': {
-        'name'    : 'logic_water_dragon_adult',
-        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Normally you need both Hookshot and Iron Boots to hit the
-                    switch and swim through the tunnel to get to the chest. But
-                    by hitting the switch from dry land, using one of Bombchus,
-                    Hookshot, or Bow, it is possible to skip one or both of
-                    those requirements. After the gate has been opened, besides
-                    just using the Iron Boots, a well-timed dive with at least
-                    the Silver Scale could be used to swim through the tunnel. If
-                    coming from the serpent river, a jump dive can also be used
-                    to get into the tunnel.
-                    '''},
-    'Water Temple Dragon Statue Switch from Above the Water as Child': {
-        'name'    : 'logic_water_dragon_child',
-        'tags'    : ("Water Temple", "Entrance Shuffle", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    It is possible for child to hit the switch from dry land
-                    using one of Bombchus, Slingshot or Boomerang. Then, to
-                    get to the chest, child can dive through the tunnel using
-                    at least the Silver Scale. The timing and positioning of
-                    this dive needs to be perfect to actually make it under the
-                    gate, and it all needs to be done very quickly to be able to
-                    get through before the gate closes. Be sure to enable "Water
-                    Temple Dragon Statue Switch from Above the Water as Adult"
-                    for adult's variant of this trick.
-                    '''},
-    'Water Temple MQ Central Pillar with Fire Arrows': {
-        'name'    : 'logic_water_mq_central_pillar',
-        'tags'    : ("Water Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Slanted torches have misleading hitboxes. Whenever
-                    you see a slanted torch jutting out of the wall,
-                    you can expect most or all of its hitbox is actually
-                    on the other side that wall. This can make slanted
-                    torches very finicky to light when using arrows. The
-                    torches in the central pillar of MQ Water Temple are
-                    a particularly egregious example. Logic normally
-                    expects Din's Fire and Song of Time.
-                    '''},
-    'Water Temple MQ North Basement GS without Small Key': {
-        'name'    : 'logic_water_mq_locked_gs',
-        'tags'    : ("Water Temple MQ", "Gold Skulltulas", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    There is an invisible Hookshot target that can be used
-                    to get over the gate that blocks you from going to this
-                    Skulltula early, skipping a small key as well as
-                    needing Hovers or Scarecrow to reach the locked door.
-                    '''},
-    'Shadow Temple Stationary Objects without Lens of Truth': {
-        'name'    : 'logic_lens_shadow',
-        'tags'    : ("Lens of Truth", "Shadow Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Shadow Temple for most areas in the dungeon
-                    except for crossing the moving platform in the huge
-                    pit room and for fighting Bongo Bongo.
-                    '''},
-    'Shadow Temple Invisible Moving Platform without Lens of Truth': {
-        'name'    : 'logic_lens_shadow_platform',
-        'tags'    : ("Lens of Truth", "Shadow Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Shadow Temple to cross the invisible moving
-                    platform in the huge pit room in either direction.
-                    '''},
-    'Shadow Temple Bongo Bongo without Lens of Truth': {
-        'name'    : 'logic_lens_bongo',
-        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    Bongo Bongo can be defeated without the use of
-                    Lens of Truth, as the hands give a pretty good
-                    idea of where the eye is.
-                    '''},
-    'Shadow Temple Stone Umbrella Skip': {
-        'name'    : 'logic_shadow_umbrella',
-        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A very precise Hover Boots movement
-                    from off of the lower chest can get you
-                    on top of the crushing spikes without
-                    needing to pull the block. Applies to
-                    both Vanilla and Master Quest.
-                    '''},
-    'Shadow Temple Falling Spikes GS with Hover Boots': {
-        'name'    : 'logic_shadow_umbrella_gs',
-        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Gold Skulltulas", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    After killing the Skulltula, a very precise Hover Boots
-                    movement from off of the lower chest can get you on top
-                    of the crushing spikes without needing to pull the block.
-                    From there, another very precise Hover Boots movement can
-                    be used to obtain the token without needing the Hookshot.
-                    Applies to both Vanilla and Master Quest. For obtaining
-                    the chests in this room with just Hover Boots, be sure to
-                    enable "Shadow Temple Stone Umbrella Skip".
-                    '''},
-    'Shadow Temple Freestanding Key with Bombchu': {
-        'name'    : 'logic_shadow_freestanding_key',
-        'tags'    : ("Shadow Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Release the Bombchu with good timing so that
-                    it explodes near the bottom of the pot.
-                    '''},
-    'Shadow Temple River Statue with Bombchu': {
-        'name'    : 'logic_shadow_statue',
-        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    By sending a Bombchu around the edge of the
-                    gorge, you can knock down the statue without
-                    needing a Bow.
-                    Applies in both vanilla and MQ Shadow.
-                    '''},
-    'Shadow Temple Bongo Bongo without projectiles': {
-        'name'    : 'logic_shadow_bongo',
-        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Entrance Shuffle", "Vanilla Dungeons", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    Using precise sword slashes, Bongo Bongo can be
-                    defeated without using projectiles. This is
-                    only relevant in conjunction with Shadow Temple
-                    dungeon shortcuts or shuffled boss entrances.
-                    '''},
-    'Shadow Temple MQ Stationary Objects without Lens of Truth': {
-        'name'    : 'logic_lens_shadow_mq',
-        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Shadow Temple MQ for most areas in the dungeon.
-                    See "Shadow Temple MQ Invisible Moving Platform
-                    without Lens of Truth", "Shadow Temple MQ Invisible
-                    Blades Silver Rupees without Lens of Truth",
-                    "Shadow Temple MQ 2nd Dead Hand without Lens of Truth",
-                    and "Shadow Temple Bongo Bongo without Lens of Truth"
-                    for exceptions.
-                    '''},
-    'Shadow Temple MQ Invisible Blades Silver Rupees without Lens of Truth': {
-        'name'    : 'logic_lens_shadow_mq_invisible_blades',
-        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Silver Rupees", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirement for the Lens of Truth or
-                    Nayru's Love in Shadow Temple MQ for the Invisible
-                    Blades room silver rupee collection.
-                    '''},
-    'Shadow Temple MQ Invisible Moving Platform without Lens of Truth': {
-        'name'    : 'logic_lens_shadow_mq_platform',
-        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Shadow Temple MQ to cross the invisible moving
-                    platform in the huge pit room in either direction.
-                    '''},
-    'Shadow Temple MQ 2nd Dead Hand without Lens of Truth': {
-        'name'    : 'logic_lens_shadow_mq_dead_hand',
-        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Dead Hand spawns in a random spot within the room.
-                    Having Lens removes the hassle of having to comb
-                    the room looking for his spawn location.
-                    '''},
-    'Shadow Temple MQ Truth Spinner Gap with Longshot': {
-        'name'    : 'logic_shadow_mq_gap',
-        'tags'    : ("Shadow Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    You can Longshot a torch and jump-slash recoil onto
-                    the tongue. It works best if you Longshot the right
-                    torch from the left side of the room.
-                    '''},
-    'Shadow Temple MQ Invisible Blades without Song of Time': {
-        'name'    : 'logic_shadow_mq_invisible_blades',
-        'tags'    : ("Shadow Temple MQ", "Master Quest", "Silver Rupees", "Freestandings", "Adult",),
-        'tooltip' : '''\
-                    The Like Like can be used to boost you into the
-                    silver rupee or recovery hearts that normally
-                    require Song of Time. This cannot be performed
-                    on OHKO since the Like Like does not boost you
-                    high enough if you die.
-                    '''},
-    'Shadow Temple MQ Lower Huge Pit without Fire Source': {
-        'name'    : 'logic_shadow_mq_huge_pit',
-        'tags'    : ("Shadow Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Normally a frozen eye switch spawns some platforms
-                    that you can use to climb down, but there's actually
-                    a small piece of ground that you can stand on that
-                    you can just jump down to.
-                    '''},
-    'Shadow Temple MQ Windy Walkway Reverse without Hover Boots': {
-        'name'    : 'logic_shadow_mq_windy_walkway',
-        'tags'    : ("Shadow Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    With shadow dungeon shortcuts enabled, it is possible
-                    to jump from the alcove in the windy hallway to the
-                    middle platform. There are two methods: wait out the fan
-                    opposite the door and hold forward, or jump to the right
-                    to be pushed by the fan there towards the platform ledge.
-                    Note that jumps of this distance are inconsistent, but
-                    still possible.
-                    '''},
-    'Spirit Temple without Lens of Truth': {
-        'name'    : 'logic_lens_spirit',
-        'tags'    : ("Lens of Truth", "Spirit Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Spirit Temple.
-                    '''},
-    'Spirit Temple Child Side Bridge with Bombchu': {
-        'name'    : 'logic_spirit_child_bombchu',
-        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    A carefully-timed Bombchu can hit the switch.
-                    '''},
-    'Spirit Temple Collect Metal Fence GS Through the Fence': {
-        'name'    : 'logic_spirit_fence_gs',
-        'tags'    : ("Spirit Temple", "Silver Rupees", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    After killing the Skulltula through the fence, the token
-                    can be collected from the wrong side of the fence by
-                    moving against the fence in a certain way. Also, the
-                    Skulltula can be defeated using the Kokiri Sword, by
-                    jump slashing into it after letting go from the fence.
-                    This trick is only relevant if Silver Rupees are shuffled.
-                    '''},
-    'Spirit Temple Main Room GS with Boomerang': {
-        'name'    : 'logic_spirit_lobby_gs',
-        'tags'    : ("Spirit Temple", "Gold Skulltulas", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    Standing on the highest part of the arm of the statue, a
-                    precise Boomerang throw can kill and obtain this Gold
-                    Skulltula. You must throw the Boomerang slightly off to
-                    the side so that it curves into the Skulltula, as aiming
-                    directly at it will clank off of the wall in front.
-                    '''},
-    'Spirit Temple Lower Adult Switch with Bombs': {
-        'name'    : 'logic_spirit_lower_adult_switch',
-        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A bomb can be used to hit the switch on the ceiling,
-                    but it must be thrown from a particular distance
-                    away and with precise timing.
-                    '''},
-    'Spirit Temple Main Room Jump from Hands to Upper Ledges': {
-        'name'    : 'logic_spirit_lobby_jump',
-        'tags'    : ("Spirit Temple", "Spirit Temple MQ", "Gold Skulltulas", "Pots", "Master Quest", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    A precise jump to obtain the following as adult
-                    without needing one of Hover Boots, or Hookshot
-                    (in vanilla) or Song of Time (in MQ):
-                    - Spirit Temple Statue Room Northeast Chest
-                    - Spirit Temple GS Lobby
-                    - Spirit Temple MQ Central Chamber Top Left Pot (Left)
-                    - Spirit Temple MQ Central Chamber Top Left Pot (Right)
-                    '''},
-    'Spirit Temple Main Room Hookshot to Boss Platform': {
-        'name'    : 'logic_spirit_platform_hookshot',
-        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Precise hookshot aiming at the platform chains can be
-                    used to reach the boss platform from the middle landings.
-                    Using a jump slash immediately after reaching a chain
-                    makes aiming more lenient. Relevant only when Spirit
-                    Temple boss shortcuts are on.
-                    '''},
-    'Spirit Temple Map Chest with Bow': {
-        'name'    : 'logic_spirit_map_chest',
-        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    To get a line of sight from the upper torch to
-                    the map chest torches, you must pull an Armos
-                    statue all the way up the stairs.
-                    '''},
-    'Spirit Temple Sun Block Room Chest with Bow': {
-        'name'    : 'logic_spirit_sun_chest_bow',
-        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Using the blocks in the room as platforms you can
-                    get lines of sight to all three torches. The timer
-                    on the torches is quite short so you must move
-                    quickly in order to light all three.
-                    '''},
-    'Spirit Temple Sun Block Room Chest with Sticks without Silver Rupees': {
-        'name'    : 'logic_spirit_sun_chest_no_rupees',
-        'tags'    : ("Spirit Temple", "Silver Rupees", "Vanilla Dungeons", "Child",),
-        'tooltip' : '''\
-                    With lightning fast movement, the chest can
-                    be spawned using a lit stick brought in from
-                    the main room. This trick is only relevant
-                    if Silver Rupees are shuffled.
-                    '''},
-    'Spirit Temple Shifting Wall with No Additional Items': {
-        'name'    : 'logic_spirit_wall',
-        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    Logic normally guarantees a way of dealing with both
-                    the Beamos and the Walltula before climbing the wall.
-                    '''},
-    'Spirit Temple MQ without Lens of Truth': {
-        'name'    : 'logic_lens_spirit_mq',
-        'tags'    : ("Lens of Truth", "Spirit Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Spirit Temple MQ.
-                    '''},
-    'Spirit Temple MQ Sun Block Room as Child without Song of Time': {
-        'name'    : 'logic_spirit_mq_sun_block_sot',
-        'tags'    : ("Spirit Temple MQ", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    While adult can easily jump directly to the switch that
-                    unbars the door to the sun block room, child Link cannot
-                    make the jump without spawning a Song of Time block to
-                    jump from. You can skip this by throwing the crate down
-                    onto the switch from above, which does unbar the door,
-                    however the crate immediately breaks, so you must move
-                    quickly to get through the door before it closes back up.
-                    '''},
-    'Spirit Temple MQ Sun Block Room GS with Boomerang': {
-        'name'    : 'logic_spirit_mq_sun_block_gs',
-        'tags'    : ("Spirit Temple MQ", "Gold Skulltulas", "Master Quest", "Child",),
-        'tooltip' : '''\
-                    Throw the Boomerang in such a way that it
-                    curves through the side of the glass block
-                    to hit the Gold Skulltula.
-                    '''},
-    'Spirit Temple MQ Lower Adult without Fire Arrows': {
-        'name'    : 'logic_spirit_mq_lower_adult',
-        'tags'    : ("Spirit Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    By standing in a precise position it is possible to
-                    light two of the torches with a single use of Din\'s
-                    Fire. This saves enough time to be able to light all
-                    three torches with only Din\'s.
-                    '''},
-    'Spirit Temple MQ Frozen Eye Switch without Fire': {
-        'name'    : 'logic_spirit_mq_frozen_eye',
-        'tags'    : ("Spirit Temple MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    You can melt the ice by shooting an arrow through a
-                    torch. The only way to find a line of sight for this
-                    shot is to first spawn a Song of Time block, and then
-                    stand on the very edge of it.
-                    '''},
-    'Ice Cavern Block Room GS with Hover Boots': {
-        'name'    : 'logic_ice_block_gs',
-        'tags'    : ("Ice Cavern", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
-        'tooltip' : '''\
-                    The Hover Boots can be used to get in front of the
-                    Skulltula to kill it with a jump slash. Then, the
-                    Hover Boots can again be used to obtain the Token,
-                    all without Hookshot or Boomerang.
-                    '''},
-    'Ice Cavern MQ Red Ice GS without Song of Time': {
-        'name'    : 'logic_ice_mq_red_ice_gs',
-        'tags'    : ("Ice Cavern MQ", "Gold Skulltulas", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    If you side-hop into the perfect position, you
-                    can briefly stand on the platform with the red
-                    ice just long enough to dump some blue fire.
-                    '''},
-    'Ice Cavern MQ Scarecrow GS with No Additional Items': {
-        'name'    : 'logic_ice_mq_scarecrow',
-        'tags'    : ("Ice Cavern MQ", "Gold Skulltulas", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    As adult a precise jump can be used to reach this alcove.
-                    '''},
-    'Gerudo Training Ground without Lens of Truth': {
-        'name'    : 'logic_lens_gtg',
-        'tags'    : ("Lens of Truth", "Gerudo Training Ground", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Gerudo Training Ground.
-                    '''},
-    'Gerudo Training Ground Highest Underwater Rupee with Gold Scale': {
-        'name'    : 'logic_gtg_underwater_highest',
-        'tags'    : ("Gerudo Training Ground", "Vanilla Dungeons", "Silver Rupees", "Child", "Adult",),
-        'tooltip' : '''\
-                    The camera is a menance while attempting to do this,
-                    though, as least as Adult, you will be automatically
-                    pulled by the current into the rupee. This trick is
-                    only relevant if Silver Rupees are shuffled.
-                    '''},
-    'Gerudo Training Ground Left Side Ceiling Silver Rupee without Hookshot': {
-        'name'    : 'logic_gtg_without_hookshot',
-        'tags'    : ("Gerudo Training Ground", "Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    The Silver Rupee on the ceiling can be reached by being pulled
-                    up into it by the Wallmaster. If Silver Rupees are not shuffled,
-                    you can save this rupee for last to unbar the door to the next
-                    room. In MQ, this trick is a bit more difficult since the
-                    Wallmaster will not track you to directly beneath the rupee, so
-                    you must inch forward after it begins its attempt to grab you.
-                    This trick is relevant if Silver Rupees are shuffled, or if GTG
-                    is in its MQ form, or if "Gerudo Training Ground Boulder Room
-                    Flame Wall Skip" is also enabled. This trick supersedes "Gerudo
-                    Training Ground MQ Left Side Ceiling Silver Rupee with Hookshot".
-                    '''},
-    'Gerudo Training Ground Boulder Room Flame Wall Skip': {
-        'name'    : 'logic_gtg_flame_wall',
-        'tags'    : ("Gerudo Training Ground", "Vanilla Dungeons", "Silver Rupees", "Child", "Adult",),
-        'tooltip' : '''\
-                    If you move quickly you can sneak past the edge of a flame wall
-                    before it can rise up to block you. To do so without taking damage
-                    is more precise. This trick is only relevant if Silver Rupees are
-                    shuffled, or if "Gerudo Training Ground Left Side Ceiling Silver
-                    Rupee without Hookshot" is also enabled.
-                    '''},
-    'Reach Gerudo Training Ground Fake Wall Ledge with Hover Boots': {
-        'name'    : 'logic_gtg_fake_wall',
-        'tags'    : ("Gerudo Training Ground", "Gerudo Training Ground MQ", "Master Quest", "Vanilla Dungeons", "Silver Rupees", "Adult",),
-        'tooltip' : '''\
-                    A precise Hover Boots use from the top of the chest can allow you
-                    to grab the ledge without needing the usual requirements. In Master
-                    Quest, this always skips a Song of Time requirement. In Vanilla,
-                    this can skip a Hookshot requirement, but it is only relevant if
-                    Silver Rupees are shuffled, or if "Gerudo Training Ground Left Side
-                    Ceiling Silver Rupee without Hookshot" is enabled.
-                    '''},
-    'Gerudo Training Ground MQ without Lens of Truth': {
-        'name'    : 'logic_lens_gtg_mq',
-        'tags'    : ("Lens of Truth", "Gerudo Training Ground MQ", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Gerudo Training Ground MQ.
-                    '''},
-    'Gerudo Training Ground MQ Left Side Ceiling Silver Rupee with Hookshot': {
-        'name'    : 'logic_gtg_mq_with_hookshot',
-        'tags'    : ("Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    The highest Silver Rupee can be obtained by
-                    hookshotting the target and then immediately jump
-                    slashing toward the rupee.
-                    '''},
-    'Gerudo Training Ground MQ Eye Statue Room Switch with Jump Slash': {
-        'name'    : 'logic_gtg_mq_eye_statue_jumpslash',
-        'tags'    : ("Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    The switch that unbars the door to the Ice Arrows chest
-                    can be hit with a precise jump slash. This trick is
-                    only relevant if Silver Rupees are shuffled, or if
-                    "Gerudo Training Ground Left Side Ceiling Silver Rupee
-                    without Hookshot" is also enabled.
-                    '''},
-    'Gerudo Training Ground MQ Central Maze Right to Dinolfos Room with Hookshot': {
-        'name'    : 'logic_gtg_mq_maze_right',
-        'tags'    : ("Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    You can stand next to the flame circle to the right of
-                    the entrance into the lava room from central maze right.
-                    From there, Hookshot can reach the torch to access the
-                    Dinolfos room without Bow. This trick is only relevant
-                    if Silver Rupees are shuffled or if one of the two tricks
-                    to collect the ceiling Silver Rupee without Longshot
-                    is enabled.
-                    '''},
-    'Ganon\'s Castle without Lens of Truth': {
-        'name'    : 'logic_lens_castle',
-        'tags'    : ("Lens of Truth", "Ganon's Castle", "Vanilla Dungeons", "Child", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Ganon's Castle.
-                    '''},
-    'Fire Trial Torch Slug Silver Rupee as Child': {
-        'name'    : 'logic_fire_trial_slug_rupee',
-        'tags'    : ("Ganon's Castle", "Entrance Shuffle", "Vanilla Dungeons", "Silver Rupees", "Child"),
-        'tooltip' : '''\
-                    To jump to the platform with the Torch Slug as child requires
-                    that the sinking platform be almost as high as possible. This
-                    trick is only relevant if Silver Rupees and the Ganon's Castle
-                    entrance are both shuffled, and the Fewer Tunic Requirements
-                    trick is also enabled.
-                    '''},
-    'Spirit Trial Ceiling Silver Rupee without Hookshot': {
-        'name'    : 'logic_spirit_trial_hookshot',
-        'tags'    : ("Ganon's Castle", "Vanilla Dungeons", "Silver Rupees", "Child", "Adult",),
-        'tooltip' : '''\
-                    The highest rupee can be obtained as either age by performing
-                    a precise jump and a well-timed jumpslash off of an Armos.
-                    '''},
-    'Ganon\'s Castle MQ without Lens of Truth': {
-        'name'    : 'logic_lens_castle_mq',
-        'tags'    : ("Lens of Truth", "Ganon's Castle MQ", "Master Quest", "Child", "Adult",),
-        'tooltip' : '''\
-                    Removes the requirements for the Lens of Truth
-                    in Ganon's Castle MQ.
-                    '''},
-    'Fire Trial MQ with Hookshot': {
-        'name'    : 'logic_fire_trial_mq',
-        'tags'    : ("Ganon's Castle MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    It's possible to hook the target at the end of
-                    fire trial with just Hookshot, but it requires
-                    precise aim and perfect positioning. The main
-                    difficulty comes from getting on the very corner
-                    of the obelisk without falling into the lava.
-                    '''},
-    'Shadow Trial MQ Torch with Bow': {
-        'name'    : 'logic_shadow_trial_mq',
-        'tags'    : ("Ganon's Castle MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    You can light the torch in this room without a fire
-                    source by shooting an arrow through the lit torch
-                    at the beginning of the room. Because the room is
-                    so dark and the unlit torch is so far away, it can
-                    be difficult to aim the shot correctly.
-                    '''},
-    'Light Trial MQ without Hookshot': {
-        'name'    : 'logic_light_trial_mq',
-        'tags'    : ("Ganon's Castle MQ", "Master Quest", "Adult",),
-        'tooltip' : '''\
-                    If you move quickly you can sneak past the edge of
-                    a flame wall before it can rise up to block you.
-                    In this case to do it without taking damage is
-                    especially precise.
-                    '''},
-}
+    output_types = Textbox(
+        gui_text = "Output Types",
+    )
 
-# Below is the list of possible settings.
-# They are mostly listed in the order in which they appear in the GUI
-# (with the exception of major settings like ALR, Rainbow Bridge, Ganon's Boss Key, Triforce Hunt).
-# This makes the Spoiler Log more readable for Support and users.
+    open_output_dir = Button(
+        gui_text   = "Open Output Directory",
+        gui_params = {
+            'function':      "openOutputDir",
+            'no_line_break': True,
+        },
+    )
 
-setting_infos = [
+    open_python_dir = Button(
+        gui_text   = "Open App Directory",
+        gui_params = {
+            'function':      "openPythonDir",
+        },
+    )
+
+    tricks_list_msg = Textbox(
+        gui_text   = "Your current logic setting does not support the enabling of tricks.",
+        gui_params = {
+            "hide_when_disabled": True,
+        },
+    )
+
+    model_unavailable_msg = Textbox(
+        gui_text   = "Models can only be customized when patching.",
+        gui_params = {
+            "hide_when_disabled": True,
+        },
+    )
+
+    sfx_link_unavailable_msg = Textbox(
+        gui_text   = "Link's Voice can only be customized when patching.",
+        gui_params = {
+            "hide_when_disabled": True
+        },
+    )
+
     # Web Only Settings
-    Setting_Info(
-        name        = 'web_wad_file',
-        type        = str,
+
+    web_wad_file = Fileinput(
         gui_text    = "WAD File",
-        gui_type    = "Fileinput",
-        shared      = False,
-        choices     = {},
         gui_tooltip = "Your original OoT 1.2 NTSC-U / NTSC-J WAD file (.wad)",
         gui_params  = {
             "file_types": [
                 {
                   "name": "WAD Files",
-                  "extensions": [ "wad" ]
+                  "extensions": ["wad"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
             "hide_when_disabled": True,
-        }
-    ),
-    Setting_Info(
-        name        = 'web_common_key_file',
-        type        = str,
+        },
+    )
+
+    web_common_key_file = Fileinput(
         gui_text    = "Wii Common Key File",
-        gui_type    = "Fileinput",
-        shared      = False,
-        choices     = {},
         gui_tooltip = """\
             The Wii Common Key is a copyrighted 32 character string needed for WAD encryption.
             Google to find it! Do not ask on Discord!
@@ -1796,167 +352,142 @@ setting_infos = [
             "file_types": [
                 {
                   "name": "BIN Files",
-                  "extensions": [ "bin" ]
+                  "extensions": ["bin"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
             "hide_when_disabled": True,
-        }
-    ),
-    Setting_Info(
-        name        = 'web_common_key_string',
-        type        = str,
+        },
+    )
+
+    web_common_key_string = Textinput(
         gui_text    = "Alternatively Enter Wii Common Key",
-        gui_type    = "Textinput",
-        shared      = False,
-        choices     = {},
         gui_tooltip = """\
             The Wii Common Key is a copyrighted 32 character string needed for WAD encryption.
             Google to find it! Do not ask on Discord!
         """,
         gui_params  = {
-            "size"               : "full",
-            "max_length"         : 32,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info(
-        name        = 'web_wad_channel_id',
-        type        = str,
+            "size":               "full",
+            "max_length":         32,
+            "hide_when_disabled": True,
+        },
+    )
+
+    web_wad_channel_id = Textinput(
         gui_text    = "WAD Channel ID",
-        gui_type    = "Textinput",
-        shared      = False,
-        choices     = {},
         default     = "NICE",
         gui_tooltip = """\
             4 characters, should end with E to ensure Dolphin compatibility.
             Note: If you have multiple OoTR WAD files with different Channel IDs installed, the game can crash on a soft reset. Use a Title Deleter to remove old WADs.
         """,
         gui_params  = {
-            "size"               : "small",
-            "max_length"         : 4,
-            "no_line_break"      : True,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info(
-        name        = 'web_wad_channel_title',
-        type        = str,
+            "size":               "small",
+            "max_length":         4,
+            "no_line_break":      True,
+            "hide_when_disabled": True,
+        },
+    )
+
+    web_wad_channel_title = Textinput(
         gui_text    = "WAD Channel Title",
-        gui_type    = "Textinput",
-        shared      = False,
-        choices     = {},
         default     = "OoTRandomizer",
         gui_tooltip = "20 characters max",
         gui_params  = {
-            "size"               : "medium",
-            "max_length"         : 20,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Checkbutton(
-        name           = 'web_wad_legacy_mode',
+            "size":               "medium",
+            "max_length":         20,
+            "hide_when_disabled": True,
+        },
+    )
+
+    web_wad_legacy_mode = Checkbutton(
         gui_text       = 'WAD Legacy Mode',
-        shared         = False,
         default        = False,
         gui_tooltip    = "Enabling this will avoid any patching of the VC emulator in case your Wii does not have support for it. Recommended to be left unchecked.",
         gui_params  = {
-            "no_line_break"      : False,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info(
-        name       = 'web_output_type',
-        type       = str,
+            "no_line_break":      False,
+            "hide_when_disabled": True,
+        },
+    )
+
+    web_output_type = Radiobutton(
         gui_text   = "Output Type",
-        gui_type   = "Radiobutton",
-        shared     = False,
         choices    = {
-            'z64' : ".z64 (N64/Emulator)",
-            'wad' : ".wad (WiiVC)"
+            'z64': ".z64 (N64/Emulator)",
+            'wad': ".wad (WiiVC)",
         },
         gui_params  = {
-            "hide_when_disabled" : True,
+            "hide_when_disabled": True,
         },
         default    = "z64",
         disable    = {
-            'z64' : {'settings' : [
-                'web_wad_file',
-                'web_common_key_file',
-                'web_common_key_string',
-                'web_wad_channel_id',
-                'web_wad_channel_title',
-                'web_wad_legacy_mode']
-            }
-        }
-    ),
-    Checkbutton(
-        name           = 'web_persist_in_cache',
+            'z64': {
+                'settings': [
+                    'web_wad_file', 'web_common_key_file', 'web_common_key_string',
+                    'web_wad_channel_id', 'web_wad_channel_title', 'web_wad_legacy_mode',
+                ],
+            },
+        },
+    )
+
+    web_persist_in_cache = Checkbutton(
         gui_text       = 'Persist Files in Cache',
         default        = True,
-        shared         = False,
-    ),
+    )
 
-    # Non-GUI Settings
-    Checkbutton('cosmetics_only', None),
-    Checkbutton('check_version', None),
-    Checkbutton('output_settings', None),
-    Checkbutton('patch_without_output', None),
-    Checkbutton('generating_patch_file', None),
-    Checkbutton(
-        name           = 'generate_from_file',
+    # General Settings
+
+    generate_from_file = Checkbutton(
         gui_text       = 'Generate From Patch File',
         default        = False,
         disable        = {
-            True : {
-                'tabs' : ['main_tab', 'detailed_tab', 'starting_tab', 'other_tab'],
-                'sections' : ['preset_section'],
-                'settings' : ['count', 'create_spoiler', 'world_count', 'enable_distribution_file', 'distribution_file', 'create_patch_file', 'show_seed_info', 'user_message'],
+            True: {
+                'tabs':     ['main_tab', 'detailed_tab', 'starting_tab', 'other_tab'],
+                'sections': ['preset_section'],
+                'settings': ['count', 'create_spoiler', 'world_count', 'enable_distribution_file', 'distribution_file', 'create_patch_file', 'show_seed_info', 'user_message'],
             },
-            False : {
-                'settings' : ['repatch_cosmetics'],
+            False: {
+                'settings': ['repatch_cosmetics'],
             },
         },
         gui_params     = {
-            'web:disable' : {
-                False : {
-                    'settings' : [
-                        'rom','web_output_type','player_num',
+            'web:disable': {
+                False: {
+                    'settings': [
+                        'rom', 'web_output_type', 'player_num',
                         'web_wad_file', 'web_common_key_file', 'web_common_key_string',
-                        'web_wad_channel_id','web_wad_channel_title', 'web_wad_legacy_mode',
+                        'web_wad_channel_id', 'web_wad_channel_title', 'web_wad_legacy_mode',
                         'model_adult', 'model_child', 'model_adult_filepicker', 'model_child_filepicker',
                         'sfx_link_adult', 'sfx_link_child',
                     ],
                 },
-                True : {
-                    'settings' : [
+                True: {
+                    'settings': [
                         'model_adult', 'model_child', 'model_unavailable_msg',
                         'sfx_link_unavailable_msg',
                     ],
                 },
             },
-            'electron:disable' : {
-                False : {
-                    'settings' : [
+            'electron:disable': {
+                False: {
+                    'settings': [
                         'model_adult_filepicker', 'model_child_filepicker', 'model_unavailable_msg',
                         'sfx_link_unavailable_msg',
                     ],
                 },
-                True : {
-                    'settings' : [
+                True: {
+                    'settings': [
                         'model_adult_filepicker', 'model_child_filepicker', 'model_unavailable_msg',
                         'sfx_link_unavailable_msg',
                     ],
                 },
-            }
+            },
         },
-        shared         = False,
-    ),
-    Checkbutton(
-        name           = 'enable_distribution_file',
+    )
+
+    enable_distribution_file = Checkbutton(
         gui_text       = 'Enable Plandomizer (Advanced)',
         gui_tooltip    = '''\
             Optional. Use a plandomizer JSON file to get
@@ -1967,12 +498,12 @@ setting_infos = [
         },
         default        = False,
         disable        = {
-            False  : {'settings' : ['distribution_file']},
+            False: {'settings': ['distribution_file']},
         },
         shared         = False,
-    ),
-    Checkbutton(
-        name           = 'enable_cosmetic_file',
+    )
+
+    enable_cosmetic_file = Checkbutton(
         gui_text       = 'Enable Cosmetic Plandomizer (Advanced)',
         gui_tooltip    = '''\
             Optional. Use a cosmetic plandomizer JSON file to get
@@ -1980,11 +511,13 @@ setting_infos = [
         ''',
         default        = False,
         disable        = {
-            False  : {'settings' : ['cosmetic_file']},
+            False: {'settings': ['cosmetic_file']},
         },
         shared         = False,
-    ),
-    Setting_Info('distribution_file', str, "Plandomizer File", "Fileinput", False, {},
+    )
+
+    distribution_file = Fileinput(
+        gui_text    = "Plandomizer File",
         gui_tooltip = """\
             Optional. Place a plandomizer JSON file here
             to get total control over the item placement.
@@ -1993,16 +526,19 @@ setting_infos = [
             "file_types": [
                 {
                   "name": "JSON Files",
-                  "extensions": [ "json" ]
+                  "extensions": ["json"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
-            "hide_when_disabled" : True,
-        }),
-    Setting_Info('cosmetic_file', str, "Cosmetic Plandomizer File", "Fileinput", False, {},
+            "hide_when_disabled": True,
+        },
+    )
+
+    cosmetic_file = Fileinput(
+        gui_text    = "Cosmetic Plandomizer File",
         gui_tooltip = """\
             Optional. Use a cosmetic plandomizer JSON file to get
             more control over your cosmetic and sound settings.
@@ -2011,34 +547,39 @@ setting_infos = [
             "file_types": [
                 {
                   "name": "JSON Files",
-                  "extensions": [ "json" ]
+                  "extensions": ["json"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
-            "hide_when_disabled" : True,
-        }),
-    Setting_Info('checked_version',   str, None, None, False, {}),
-    Setting_Info('rom',               str, "Base ROM", "Fileinput", False, {},
+            "hide_when_disabled": True,
+        },
+    )
+
+    rom = Fileinput(
+        gui_text   = "Base ROM",
         gui_params = {
             "file_types": [
                 {
                   "name": "ROM Files",
-                  "extensions": [ "z64", "n64" ]
+                  "extensions": ["z64", "n64"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
-            "web:hide_when_disabled" : True,
-        }),
-    Setting_Info('output_dir',        str, "Output Directory", "Directoryinput", False, {}),
-    Setting_Info('output_file',       str, None, None, False, {}),
-    Checkbutton(
-        name           = 'show_seed_info',
+            "web:hide_when_disabled": True,
+        },
+    )
+
+    output_dir = Directoryinput(
+        gui_text   = "Output Directory",
+    )
+
+    show_seed_info = Checkbutton(
         gui_text       = 'Show Seed Info on File Screen',
         shared         = True,
         gui_tooltip    = '''\
@@ -2047,96 +588,84 @@ setting_infos = [
         ''',
         default        = True,
         disable        = {
-            False : {'settings' : ["user_message"]}
+            False: {'settings': ["user_message"]},
         },
         gui_params = {
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info(
-        name           = 'user_message',
-        type           = str,
+            "hide_when_disabled": True,
+        },
+    )
+
+    user_message = Textinput(
         gui_text       = "User-Configurable Message",
         shared         = True,
-        gui_type       = "Textinput",
-        choices        = {},
         gui_tooltip    = """\
             Add a custom message to the seed info.
         """,
         default        = "",
         gui_params     = {
-            "size"               : "full",
-            "max_length"         : 42,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info('seed',              str, None, None, False, {}),
-    Setting_Info('patch_file',        str, "Patch File", "Fileinput", False, {},
+            "size":               "full",
+            "max_length":         42,
+            "hide_when_disabled": True,
+        },
+    )
+
+    patch_file = Fileinput(
+        gui_text   = "Patch File",
         gui_params = {
             "file_types": [
                 {
                   "name": "Patch File Archive",
-                  "extensions": [ "zpfz", "zpf", "patch" ]
+                  "extensions": ["zpfz", "zpf", "patch"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
-        }),
-    Setting_Info('count',             int, "Generation Count", "Numberinput", False, {},
-        default        = 1,
-        gui_params = {
-            'min' : 1,
-        }
-    ),
-    Setting_Info('world_count',       int, "Player Count", "Numberinput", True, {},
-        default        = 1,
-        gui_params = {
-            'min' : 1,
-            'max' : 255,
-            'no_line_break'     : True,
-            'web:max'           : 15,
-            'web:no_line_break' : True,
-        }
-    ),
-    Setting_Info('player_num',        int, "Player ID", "Numberinput", False, {},
-        default        = 1,
-        gui_params = {
-            'min' : 1,
-            'max' : 255,
-        }
-    ),
+        },
+    )
 
-    # GUI Settings
+    count = Numberinput(
+        gui_text       = "Generation Count",
+        shared         = False,
+        default        = 1,
+        minimum        = 1,
+    )
 
-    # ROM Options
+    world_count = Numberinput(
+        gui_text       = "Player Count",
+        shared         = True,
+        default        = 1,
+        minimum        = 1,
+        maximum        = 255,
+        gui_params     = {
+            'no_line_break':     True,
+            'web:max':           15,
+            'web:no_line_break': True,
+        },
+    )
 
-    Setting_Info('open_output_dir',   str, "Open Output Directory", "Button", False, {},
-        gui_params = {
-            'function' : "openOutputDir",
-            'no_line_break' : True,
-        }
-    ),
-    Setting_Info('open_python_dir',   str, "Open App Directory", "Button", False, {},
-        gui_params = {
-            'function' : "openPythonDir",
-        }
-    ),
-    Checkbutton(
-        name           = 'repatch_cosmetics',
+    player_num = Numberinput(
+        gui_text       = "Player ID",
+        shared         = False,
+        default        = 1,
+        minimum        = 1,
+        maximum        = 255,
+    )
+
+    repatch_cosmetics = Checkbutton(
         gui_text       = 'Override Original Cosmetics',
         default        = True,
         disable        = {
-            False : {
-                'tabs': ['cosmetics_tab','sfx_tab'],
-                'settings' : ['create_cosmetics_log', 'enable_cosmetic_file', 'cosmetic_file'],
+            False: {
+                'tabs':     ['cosmetics_tab', 'sfx_tab'],
+                'settings': ['create_cosmetics_log', 'enable_cosmetic_file', 'cosmetic_file'],
             },
         },
         shared         = False,
-    ),
-    Checkbutton(
-        name           = 'create_spoiler',
+    )
+
+    create_spoiler = Checkbutton(
         gui_text       = 'Create Spoiler Log',
         gui_tooltip    = '''\
                          Enabling this will change the seed.
@@ -2144,30 +673,22 @@ setting_infos = [
                          ''',
         default        = True,
         gui_params     = {
-            'no_line_break' : True,
-            'web:no_line_break' : False,
+            'no_line_break':     True,
+            'web:no_line_break': False,
         },
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'create_cosmetics_log',
-        gui_text       = 'Create Cosmetics Log',
-        gui_tooltip='''\
+    )
+
+    create_cosmetics_log = Checkbutton(
+        gui_text         = 'Create Cosmetics Log',
+        gui_tooltip      = '''\
                  Cosmetics Logs are only output if one of the output types below are enabled.
                  ''',
-        default        = True,
+        default          = True,
         disabled_default = False,
-    ),
-    Setting_Info(
-        name           = 'output_types',
-        type           = str,
-        gui_text       = "Output Types",
-        gui_type       = "Textbox",
-        shared         = False,
-        choices        = {},
-    ),
-    Checkbutton(
-        name           = 'create_patch_file',
+    )
+
+    create_patch_file = Checkbutton(
         gui_text       = '.zpf (Patch File)',
         gui_tooltip    = '''\
             Patch files are used to send the patched data to other
@@ -2177,9 +698,9 @@ setting_infos = [
         gui_params     = {
             "no_line_break": True,
         },
-    ),
-    Checkbutton(
-        name           = 'create_compressed_rom',
+    )
+
+    create_compressed_rom = Checkbutton(
         gui_text       = '.z64 (N64/Emulator)',
         default        = True,
         gui_tooltip    = '''\
@@ -2190,23 +711,23 @@ setting_infos = [
         gui_params     = {
             "no_line_break": True,
         },
-    ),
-    Checkbutton(
-        name           = 'create_wad_file',
+    )
+
+    create_wad_file = Checkbutton(
         gui_text       = '.wad (Wii VC)',
         gui_tooltip    = '''\
             .wad files are used to play on Wii Virtual Console or Dolphin Emulator.
         ''',
         shared         = False,
         disable        = {
-            False: {'settings' : ['wad_file', 'wad_channel_title', 'wad_channel_id']},
+            False: {'settings': ['wad_file', 'wad_channel_title', 'wad_channel_id']},
         },
         gui_params     = {
             "no_line_break": True,
         },
-    ),
-    Checkbutton(
-        name           = 'create_uncompressed_rom',
+    )
+
+    create_uncompressed_rom = Checkbutton(
         gui_text       = 'Uncompressed ROM (Development)',
         gui_tooltip    = '''\
             Uncompressed ROMs may be helpful for developers
@@ -2215,64 +736,55 @@ setting_infos = [
             Use a compressed ROM instead.
         ''',
         shared         = False,
-    ),
-    Setting_Info(
-        name        = 'wad_file',
-        type        = str,
+    )
+
+    wad_file = Fileinput(
         gui_text    = "Base WAD File",
-        gui_type    = "Fileinput",
-        shared      = False,
-        choices     = {},
         gui_tooltip = "Your original OoT 1.2 NTSC-U / NTSC-J WAD file (.wad)",
         gui_params  = {
             "file_types": [
                 {
                   "name": "WAD Files",
-                  "extensions": [ "wad" ]
+                  "extensions": ["wad"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
             "hide_when_disabled": True,
-        }
-    ),
-    Setting_Info(
-        name        = 'wad_channel_id',
-        type        = str,
+        },
+    )
+
+    wad_channel_id = Textinput(
         gui_text    = "WAD Channel ID",
-        gui_type    = "Textinput",
-        shared      = False,
-        choices     = {},
         default     = "NICE",
         gui_tooltip = """\
             4 characters, should end with E to ensure Dolphin compatibility.
             Note: If you have multiple OoTR WAD files with different Channel IDs installed, the game can crash on a soft reset. Use a Title Deleter to remove old WADs.
         """,
         gui_params  = {
-            "size"               : "small",
-            "max_length"         : 4,
-            "no_line_break": True,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info(
-        name        = 'wad_channel_title',
-        type        = str,
+            "size":               "small",
+            "max_length":         4,
+            "no_line_break":      True,
+            "hide_when_disabled": True,
+        },
+    )
+
+    wad_channel_title = Textinput(
         gui_text    = "WAD Channel Title",
-        gui_type    = "Textinput",
-        shared      = False,
-        choices     = {},
         default     = "OoTRandomizer",
         gui_tooltip = "20 characters max",
         gui_params  = {
-            "size"               : "medium",
-            "max_length"         : 20,
-            "hide_when_disabled" : True,
-        }
-    ),
-    Setting_Info('presets',           str, "", "Presetinput", False, {},
+            "size":               "medium",
+            "max_length":         20,
+            "hide_when_disabled": True,
+        },
+    )
+
+    presets = SettingInfoStr(
+        gui_text       = "",
+        gui_type       = "Presetinput",
         default        = "[New Preset]",
         gui_tooltip    = '''\
             Select a setting preset to apply.
@@ -2296,12 +808,11 @@ setting_infos = [
             After a preset is loaded, the settings can be viewed/changed in the other tabs before
             generating a seed.
             ''',
-    ),
+    )
 
     # Main Rules (and "Guarantee Reachable Locations")
 
-    Checkbutton(
-        name           = 'randomize_settings',
+    randomize_settings = Checkbutton(
         gui_text       = 'Randomize Main Rule Settings',
         gui_tooltip    = '''\
                          Randomizes all settings on the 'Main Rules' tab, except:
@@ -2317,7 +828,7 @@ setting_infos = [
                          ''',
         default        = False,
         disable        = {
-            True : {
+            True: {
                 'sections': ['shuffle_section'],
                 'settings': [
                     'open_forest', 'open_kakariko', 'open_door_of_time', 'zora_fountain', 'gerudo_fortress', 'dungeon_shortcuts_choice',
@@ -2327,14 +838,14 @@ setting_infos = [
                     'shuffle_bosses', 'shuffle_overworld_entrances', 'shuffle_gerudo_valley_river_exit', 'owl_drops', 'warp_songs', 'spawn_positions',
                     'triforce_hunt', 'triforce_count_per_world', 'triforce_goal_per_world', 'free_bombchu_drops', 'one_item_per_dungeon',
                     'shuffle_mapcompass', 'shuffle_smallkeys', 'shuffle_hideoutkeys', 'key_rings_choice', 'key_rings',
-                    'shuffle_bosskeys', 'enhance_map_compass'
+                    'shuffle_bosskeys', 'enhance_map_compass',
                 ],
-            }
+            },
         },
         shared         = True,
-    ),
-    Combobox(
-        name           = 'logic_rules',
+    )
+
+    logic_rules = Combobox(
         gui_text       = 'Logic Rules',
         default        = 'glitchless',
         choices        = {
@@ -2358,18 +869,18 @@ setting_infos = [
             considered available. MAY BE IMPOSSIBLE TO BEAT.
         ''',
         disable        = {
-            'glitchless': {'settings' : ['tricks_list_msg']},
-            'glitched'  : {'settings' : ['allowed_tricks', 'shuffle_interior_entrances', 'shuffle_hideout_entrances', 'shuffle_grotto_entrances',
+            'glitchless': {'settings': ['tricks_list_msg']},
+            'glitched':   {'settings': ['allowed_tricks', 'shuffle_interior_entrances', 'shuffle_hideout_entrances', 'shuffle_grotto_entrances',
                                          'shuffle_dungeon_entrances', 'shuffle_overworld_entrances', 'shuffle_gerudo_valley_river_exit', 'owl_drops',
                                          'warp_songs', 'spawn_positions', 'mq_dungeons_mode', 'mq_dungeons_specific',
                                          'mq_dungeons_count', 'shuffle_bosses', 'dungeon_shortcuts', 'deadly_bonks',
                                          'shuffle_freestanding_items', 'shuffle_pots', 'shuffle_crates', 'shuffle_beehives', 'shuffle_silver_rupees']},
-            'none'      : {'settings' : ['allowed_tricks', 'logic_no_night_tokens_without_suns_song', 'reachable_locations']},
+            'none':       {'settings': ['allowed_tricks', 'logic_no_night_tokens_without_suns_song', 'reachable_locations']},
         },
         shared         = True,
-    ),
-    Combobox(
-        name           = 'reachable_locations',
+    )
+
+    reachable_locations = Combobox(
         gui_text       = 'Guarantee Reachable Locations',
         default        = 'all',
         choices        = {
@@ -2394,13 +905,10 @@ setting_infos = [
         gui_params={
             "hide_when_disabled": True,
         },
-        shared         = True
-    ),
+        shared         = True,
+    )
 
-
-
-    Checkbutton(
-        name           = 'triforce_hunt',
+    triforce_hunt = Checkbutton(
         gui_text       = 'Triforce Hunt',
         gui_tooltip    = '''\
             Pieces of the Triforce have been scattered around the world.
@@ -2414,16 +922,16 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
         disable        = {
-            True  : {'settings' : ['shuffle_ganon_bosskey', 'ganon_bosskey_stones', 'ganon_bosskey_medallions', 'ganon_bosskey_rewards', 'ganon_bosskey_tokens', 'ganon_bosskey_hearts']},
-            False : {'settings' : ['triforce_count_per_world', 'triforce_goal_per_world']}
+            True:  {'settings': ['shuffle_ganon_bosskey', 'ganon_bosskey_stones', 'ganon_bosskey_medallions', 'ganon_bosskey_rewards', 'ganon_bosskey_tokens', 'ganon_bosskey_hearts']},
+            False: {'settings': ['triforce_count_per_world', 'triforce_goal_per_world']},
         },
-    ),
-    Scale(
-        name           = 'triforce_count_per_world',
+    )
+
+    triforce_count_per_world = Scale(
         gui_text       = 'Triforces Per World',
         default        = 30,
-        min            = 1,
-        max            = 999,
+        minimum        = 1,
+        maximum        = 999,
         shared         = True,
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces placed in each world.
@@ -2437,16 +945,16 @@ setting_infos = [
         ''',
         gui_params     = {
             "hide_when_disabled": True,
-            'web:max': 200,
-            'electron:max': 200,
+            'web:max':            200,
+            'electron:max':       200,
         },
-    ),
-    Scale(
-        name           = 'triforce_goal_per_world',
+    )
+
+    triforce_goal_per_world = Scale(
         gui_text       = 'Required Triforces Per World',
         default        = 20,
-        min            = 1,
-        max            = 999,
+        minimum        = 1,
+        maximum        = 999,
         shared         = True,
         gui_tooltip    = '''\
             Select the amount of Triforce Pieces required to beat the game.
@@ -2457,12 +965,12 @@ setting_infos = [
         ''',
         gui_params     = {
             "hide_when_disabled": True,
-            'web:max': 100,
-            'electron:max': 100,
+            'web:max':            100,
+            'electron:max':       100,
         },
-    ),
-    Combobox(
-        name           = 'lacs_condition',
+    )
+
+    lacs_condition = Combobox(
         gui_text       = 'LACS Condition',
         default        = 'vanilla',
         choices        = {
@@ -2486,11 +994,11 @@ setting_infos = [
         ''',
         shared         = True,
         disable        = {
-            '!stones':  {'settings': ['lacs_stones']},
-            '!medallions':  {'settings': ['lacs_medallions']},
-            '!dungeons':  {'settings': ['lacs_rewards']},
-            '!tokens':  {'settings': ['lacs_tokens']},
-            '!hearts':  {'settings': ['lacs_hearts']},
+            '!stones':     {'settings': ['lacs_stones']},
+            '!medallions': {'settings': ['lacs_medallions']},
+            '!dungeons':   {'settings': ['lacs_rewards']},
+            '!tokens':     {'settings': ['lacs_tokens']},
+            '!hearts':     {'settings': ['lacs_hearts']},
         },
         gui_params     = {
             'optional': True,
@@ -2501,97 +1009,97 @@ setting_infos = [
                 ('dungeons',   1),
             ],
         },
-    ),
-    Scale(
-        name           = 'lacs_medallions',
-        gui_text       = "Medallions Required for LACS",
-        default        = 6,
-        min            = 1,
-        max            = 6,
-        gui_tooltip    = '''\
+    )
+
+    lacs_medallions = Scale(
+        gui_text         = "Medallions Required for LACS",
+        default          = 6,
+        minimum          = 1,
+        maximum          = 6,
+        gui_tooltip      = '''\
             Select the amount of Medallions required to trigger the Light Arrow Cutscene.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            'optional': True,
+        gui_params       = {
+            'optional':           True,
             "hide_when_disabled": True,
-            'distribution': [(6, 1)],
+            'distribution':       [(6, 1)],
         },
-    ),
-    Scale(
-        name           = 'lacs_stones',
-        gui_text       = "Spiritual Stones Required for LACS",
-        default        = 3,
-        min            = 1,
-        max            = 3,
-        gui_tooltip    = '''\
+    )
+
+    lacs_stones = Scale(
+        gui_text         = "Spiritual Stones Required for LACS",
+        default          = 3,
+        minimum          = 1,
+        maximum          = 3,
+        gui_tooltip      = '''\
             Select the amount of Spiritual Stones required to trigger the Light Arrow Cutscene.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            'optional': True,
+        gui_params       = {
+            'optional':           True,
             "hide_when_disabled": True,
-            'distribution': [(3, 1)],
+            'distribution':       [(3, 1)],
         },
-    ),
-    Scale(
-        name           = 'lacs_rewards',
-        gui_text       = "Dungeon Rewards Required for LACS",
-        default        = 9,
-        min            = 1,
-        max            = 9,
-        gui_tooltip    = '''\
+    )
+
+    lacs_rewards = Scale(
+        gui_text         = "Dungeon Rewards Required for LACS",
+        default          = 9,
+        minimum          = 1,
+        maximum          = 9,
+        gui_tooltip      = '''\
             Select the amount of Dungeon Rewards (Medallions and Spiritual Stones)
             required to trigger the Light Arrow Cutscene.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            'optional': True,
+        gui_params       = {
+            'optional':           True,
             "hide_when_disabled": True,
-            'distribution': [(9, 1)],
+            'distribution':       [(9, 1)],
         },
-    ),
-    Scale(
-        name           = 'lacs_tokens',
-        gui_text       = "Gold Skulltula Tokens Required for LACS",
-        default        = 100,
-        min            = 1,
-        max            = 999,
-        gui_tooltip    = '''\
+    )
+
+    lacs_tokens = Scale(
+        gui_text         = "Gold Skulltula Tokens Required for LACS",
+        default          = 100,
+        minimum          = 1,
+        maximum          = 999,
+        gui_tooltip      = '''\
             Select the amount of Gold Skulltula Tokens
             required to trigger the Light Arrow Cutscene.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            'optional': True,
+        gui_params       = {
+            'optional':           True,
             "hide_when_disabled": True,
-            'web:max': 100,
-            'electron:max': 100,
+            'web:max':            100,
+            'electron:max':       100,
         },
-    ),
-    Scale(
-        name           = 'lacs_hearts',
-        gui_text       = "Hearts Required for LACS",
-        default        = 20,
-        min            = 4,
-        max            = 20,
-        gui_tooltip    = '''\
+    )
+
+    lacs_hearts = Scale(
+        gui_text         = "Hearts Required for LACS",
+        default          = 20,
+        minimum          = 4,
+        maximum          = 20,
+        gui_tooltip      = '''\
             Select the amount of hearts
             required to trigger the Light Arrow Cutscene.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            'optional': True,
+        gui_params       = {
+            'optional':           True,
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name           = 'bridge',
+    )
+
+    bridge = Combobox(
         gui_text       = 'Rainbow Bridge Requirement',
         default        = 'medallions',
         choices        = {
@@ -2632,82 +1140,82 @@ setting_infos = [
                 ('dungeons',   1),
             ],
         },
-    ),
-    Scale(
-        name           = 'bridge_medallions',
-        gui_text       = "Medallions Required for Bridge",
-        default        = 6,
-        min            = 1,
-        max            = 6,
-        gui_tooltip    = '''\
+    )
+
+    bridge_medallions = Scale(
+        gui_text         = "Medallions Required for Bridge",
+        default          = 6,
+        minimum          = 1,
+        maximum          = 6,
+        gui_tooltip      = '''\
             Select the amount of Medallions required to spawn the rainbow bridge.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            "randomize_key": "randomize_settings",
+        gui_params       = {
+            "randomize_key":      "randomize_settings",
             "hide_when_disabled": True,
-            'distribution': [(6, 1)],
+            'distribution':       [(6, 1)],
         },
-    ),
-    Scale(
-        name           = 'bridge_stones',
-        gui_text       = "Spiritual Stones Required for Bridge",
-        default        = 3,
-        min            = 1,
-        max            = 3,
-        gui_tooltip    = '''\
+    )
+
+    bridge_stones = Scale(
+        gui_text         = "Spiritual Stones Required for Bridge",
+        default          = 3,
+        minimum          = 1,
+        maximum          = 3,
+        gui_tooltip      = '''\
             Select the amount of Spiritual Stones required to spawn the rainbow bridge.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            "randomize_key": "randomize_settings",
+        gui_params       = {
+            "randomize_key":      "randomize_settings",
             "hide_when_disabled": True,
-            'distribution': [(3, 1)],
+            'distribution':       [(3, 1)],
         },
-    ),
-    Scale(
-        name           = 'bridge_rewards',
-        gui_text       = "Dungeon Rewards Required for Bridge",
-        default        = 9,
-        min            = 1,
-        max            = 9,
-        gui_tooltip    = '''\
+    )
+
+    bridge_rewards = Scale(
+        gui_text         = "Dungeon Rewards Required for Bridge",
+        default          = 9,
+        minimum          = 1,
+        maximum          = 9,
+        gui_tooltip      = '''\
             Select the amount of Dungeon Rewards (Medallions and Spiritual Stones)
             required to spawn the rainbow bridge.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            "randomize_key": "randomize_settings",
+        gui_params       = {
+            "randomize_key":      "randomize_settings",
             "hide_when_disabled": True,
-            'distribution': [(9, 1)],
+            'distribution':       [(9, 1)],
         },
-    ),
-    Scale(
-        name           = 'bridge_tokens',
-        gui_text       = "Skulltulas Required for Bridge",
-        default        = 100,
-        min            = 1,
-        max            = 999,
-        gui_tooltip    = '''\
+    )
+
+    bridge_tokens = Scale(
+        gui_text         = "Skulltulas Required for Bridge",
+        default          = 100,
+        minimum          = 1,
+        maximum          = 999,
+        gui_tooltip      = '''\
             Select the amount of Gold Skulltula Tokens required to spawn the rainbow bridge.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
+        gui_params       = {
             'hide_when_disabled': True,
-            'web:max': 100,
-            'electron:max': 100,
+            'web:max':            100,
+            'electron:max':       100,
         },
-    ),
-    Scale(
-        name           = 'bridge_hearts',
+    )
+
+    bridge_hearts = Scale(
         gui_text       = "Hearts Required for Bridge",
         default        = 20,
-        min            = 4,
-        max            = 20,
+        minimum        = 4,
+        maximum        = 20,
         gui_tooltip    = '''\
             Select the amount of hearts required to spawn the rainbow bridge.
         ''',
@@ -2716,40 +1224,40 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Checkbutton(
-        name           = 'trials_random',
+    )
+
+    trials_random = Checkbutton(
         gui_text       = 'Random Number of Ganon\'s Trials',
         gui_tooltip    = '''\
             Sets a random number of trials to enter Ganon's Tower.
         ''',
         shared         = True,
         disable        = {
-            True : {'settings' : ['trials']}
+            True: {'settings': ['trials']}
         },
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution':  [
                 (True, 1),
-            ]
+            ],
         },
-    ),
-    Scale(
-        name           = 'trials',
-        gui_text       = "Ganon's Trials Count",
-        default        = 6,
-        min            = 0,
-        max            = 6,
-        gui_tooltip    = '''\
+    )
+
+    trials = Scale(
+        gui_text         = "Ganon's Trials Count",
+        default          = 6,
+        minimum          = 0,
+        maximum          = 6,
+        gui_tooltip      = '''\
             Trials are randomly selected. If hints are
             enabled, then there will be hints for which
             trials need to be completed.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-    ),
-    Combobox(
-        name           = 'shuffle_ganon_bosskey',
+    )
+
+    shuffle_ganon_bosskey = Combobox(
         gui_text       = 'Ganon\'s Boss Key',
         default        = 'dungeon',
         disabled_default = 'triforce',
@@ -2824,98 +1332,98 @@ setting_infos = [
                 ('dungeon',         2),
                 ('vanilla',         2),
                 ('keysanity',       4),
-                ('on_lacs',         1)
+                ('on_lacs',         1),
             ],
         },
-    ),
-    Scale(
-        name           = 'ganon_bosskey_medallions',
-        gui_text       = "Medallions Required for Ganon's BK",
-        default        = 6,
-        min            = 1,
-        max            = 6,
-        gui_tooltip    = '''\
+    )
+
+    ganon_bosskey_medallions = Scale(
+        gui_text         = "Medallions Required for Ganon's BK",
+        default          = 6,
+        minimum          = 1,
+        maximum          = 6,
+        gui_tooltip      = '''\
             Select the amount of Medallions required to receive Ganon's Castle Boss Key.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            "randomize_key": "randomize_settings",
+        gui_params       = {
+            "randomize_key":      "randomize_settings",
             "hide_when_disabled": True,
-            'distribution': [(6, 1)],
+            'distribution':       [(6, 1)],
         },
-    ),
-    Scale(
-        name           = 'ganon_bosskey_stones',
-        gui_text       = "Spiritual Stones Required for Ganon's BK",
-        default        = 3,
-        min            = 1,
-        max            = 3,
-        gui_tooltip    = '''\
+    )
+
+    ganon_bosskey_stones = Scale(
+        gui_text         = "Spiritual Stones Required for Ganon's BK",
+        default          = 3,
+        minimum          = 1,
+        maximum          = 3,
+        gui_tooltip      = '''\
             Select the amount of Spiritual Stones required to receive Ganon's Castle Boss Key.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            "randomize_key": "randomize_settings",
+        gui_params       = {
+            "randomize_key":      "randomize_settings",
             "hide_when_disabled": True,
-            'distribution': [(3, 1)],
+            'distribution':       [(3, 1)],
         },
-    ),
-    Scale(
-        name           = 'ganon_bosskey_rewards',
-        gui_text       = "Dungeon Rewards Required for Ganon's BK",
-        default        = 9,
-        min            = 1,
-        max            = 9,
-        gui_tooltip    = '''\
+    )
+
+    ganon_bosskey_rewards = Scale(
+        gui_text         = "Dungeon Rewards Required for Ganon's BK",
+        default          = 9,
+        minimum          = 1,
+        maximum          = 9,
+        gui_tooltip      = '''\
             Select the amount of Dungeon Rewards (Medallions and Spiritual Stones)
             required to receive Ganon's Castle Boss Key.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
-            "randomize_key": "randomize_settings",
+        gui_params       = {
+            "randomize_key":      "randomize_settings",
             "hide_when_disabled": True,
-            'distribution': [(9, 1)],
+            'distribution':       [(9, 1)],
         },
-    ),
-    Scale(
-        name           = 'ganon_bosskey_tokens',
-        gui_text       = "Gold Skulltula Tokens Required for Ganon's BK",
-        default        = 100,
-        min            = 1,
-        max            = 999,
-        gui_tooltip    = '''\
+    )
+
+    ganon_bosskey_tokens = Scale(
+        gui_text         = "Gold Skulltula Tokens Required for Ganon's BK",
+        default          = 100,
+        minimum          = 1,
+        maximum          = 999,
+        gui_tooltip      = '''\
             Select the amount of Gold Skulltula Tokens
             required to receive Ganon's Castle Boss Key.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
+        gui_params       = {
             "hide_when_disabled": True,
-            'web:max': 100,
-            'electron:max': 100,
+            'web:max':            100,
+            'electron:max':       100,
         },
-    ),
-    Scale(
-        name           = 'ganon_bosskey_hearts',
-        gui_text       = "Hearts Required for Ganon's BK",
-        default        = 20,
-        min            = 4,
-        max            = 20,
-        gui_tooltip    = '''\
+    )
+
+    ganon_bosskey_hearts = Scale(
+        gui_text         = "Hearts Required for Ganon's BK",
+        default          = 20,
+        minimum          = 4,
+        maximum          = 20,
+        gui_tooltip      = '''\
             Select the amount of hearts
             required to receive Ganon's Castle Boss Key.
         ''',
-        shared         = True,
+        shared           = True,
         disabled_default = 0,
-        gui_params     = {
+        gui_params       = {
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name           = 'shuffle_bosskeys',
+    )
+
+    shuffle_bosskeys = Combobox(
         gui_text       = 'Boss Keys',
         default        = 'dungeon',
         choices        = {
@@ -2972,9 +1480,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'shuffle_smallkeys',
+    )
+
+    shuffle_smallkeys = Combobox(
         gui_text       = 'Small Keys',
         default        = 'dungeon',
         choices        = {
@@ -3031,10 +1539,10 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'shuffle_hideoutkeys',
-        gui_text       = 'Thieves\' Hideout Keys',
+    )
+
+    shuffle_hideoutkeys = Combobox(
+        gui_text       = "Thieves' Hideout Keys",
         default        = 'vanilla',
         disabled_default = 'remove',
         choices        = {
@@ -3072,9 +1580,9 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
             'option_remove': ['fortress'],
         },
-    ),
-    Combobox(
-        name           = 'shuffle_tcgkeys',
+    )
+
+    shuffle_tcgkeys = Combobox(
         gui_text       = 'Treasure Chest Game Keys',
         default        = 'vanilla',
         choices        = {
@@ -3111,16 +1619,16 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'key_rings_choice',
+    )
+
+    key_rings_choice = Combobox(
         gui_text       = 'Key Rings Mode',
         default        = 'off',
         choices        = {
             'off':       'Off',
-            'choice':    'Choose dungeons',
-            'all':       'All dungeons',
-            'random':    'Random selection'
+            'choice':    'Choose Dungeons',
+            'all':       'All Dungeons',
+            'random':    'Random Selection'
         },
         gui_tooltip     = '''\
             Selected dungeons will have all of their keys found
@@ -3145,14 +1653,13 @@ setting_infos = [
         ''',
         shared         = True,
         disable={
-            'off': {'settings' : ['key_rings', 'keyring_give_bk']},
-            'all': {'settings' : ['key_rings']},
-            'random': {'settings' : ['key_rings']},
+            'off':    {'settings': ['key_rings', 'keyring_give_bk']},
+            'all':    {'settings': ['key_rings']},
+            'random': {'settings': ['key_rings']},
         },
-    ),
-    Combobox(
-        name            = 'key_rings',
-        multiple_select = True,
+    )
+
+    key_rings = MultipleSelect(
         gui_text        = 'Key Rings',
         choices         = {
             'Thieves Hideout':        "Thieves' Hideout",
@@ -3174,9 +1681,9 @@ setting_infos = [
             Select areas with keyring instead of multiple keys
         ''',
         shared          = True,
-    ),
-    Checkbutton(
-        name           = 'keyring_give_bk',
+    )
+
+    keyring_give_bk = Checkbutton(
         gui_text       = 'Key Rings give Boss Keys',
         gui_tooltip    = '''\
             Boss Keys will be included in the Key Ring for the specific dungeon.
@@ -3187,9 +1694,9 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name           = 'shuffle_silver_rupees',
+    )
+
+    shuffle_silver_rupees = Combobox(
         gui_text       = 'Shuffle Silver Rupees',
         default        = 'vanilla',
         choices        = {
@@ -3246,16 +1753,16 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'silver_rupee_pouches_choice',
+    )
+
+    silver_rupee_pouches_choice = Combobox(
         gui_text       = 'Silver Rupee Pouches Mode',
         default        = 'off',
         choices        = {
             'off':       'Off',
-            'choice':    'Choose puzzles',
-            'all':       'All puzzles',
-            'random':    'Random puzzles'
+            'choice':    'Choose Puzzles',
+            'all':       'All Puzzles',
+            'random':    'Random Puzzles'
         },
         gui_tooltip     = '''\
             Selected silver rupee puzzles will have all of
@@ -3276,10 +1783,9 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name            = 'silver_rupee_pouches',
-        multiple_select = True,
+    )
+
+    silver_rupee_pouches = MultipleSelect(
         gui_text        = 'Silver Rupee Pouches',
         choices         = {
             'Dodongos Cavern Staircase': "Dodongo's Cavern Staircase",
@@ -3314,9 +1820,9 @@ setting_infos = [
             "hide_when_disabled": True,
         },
         shared          = True,
-    ),
-    Combobox(
-        name           = 'shuffle_mapcompass',
+    )
+
+    shuffle_mapcompass = Combobox(
         gui_text       = 'Maps & Compasses',
         default        = 'dungeon',
         choices        = {
@@ -3365,9 +1871,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'enhance_map_compass',
+    )
+
+    enhance_map_compass = Checkbutton(
         gui_text       = 'Maps and Compasses Give Information',
         gui_tooltip    = '''\
             Gives the Map and Compass extra functionality.
@@ -3387,12 +1893,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
+    )
 
-
-
-    Combobox(
-        name           = 'open_forest',
+    open_forest = Combobox(
         gui_text       = 'Forest',
         default        = 'closed',
         choices        = {
@@ -3424,19 +1927,19 @@ setting_infos = [
         ''',
         shared         = True,
         disable        = {
-            'closed' : {'settings' : ['starting_age']}
+            'closed': {'settings': ['starting_age']}
         },
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution': [
-                ('open', 1),
+                ('open',        1),
                 ('closed_deku', 1),
-                ('closed', 1),
+                ('closed',      1),
             ],
         },
-    ),
-    Combobox(
-        name           = 'open_kakariko',
+    )
+
+    open_kakariko = Combobox(
         gui_text       = 'Kakariko Gate',
         default        = 'closed',
         choices        = {
@@ -3465,9 +1968,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'open_door_of_time',
+    )
+
+    open_door_of_time = Checkbutton(
         gui_text       = 'Open Door of Time',
         gui_tooltip    = '''\
             The Door of Time starts opened instead of needing to
@@ -3479,10 +1982,10 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'zora_fountain',
-        gui_text       = 'Zora\'s Fountain',
+    )
+
+    zora_fountain = Combobox(
+        gui_text       = "Zora's Fountain",
         default        = 'closed',
         choices        = {
             'closed': 'Default Behavior (Closed)',
@@ -3506,15 +2009,15 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'gerudo_fortress',
-        gui_text       = 'Gerudo\'s Fortress',
+    )
+
+    gerudo_fortress = Combobox(
+        gui_text       = "Gerudo's Fortress",
         default        = 'normal',
         choices        = {
             'normal': 'Default Behavior',
             'fast':   'Rescue One Carpenter',
-            'open':   'Open Gerudo\'s Fortress',
+            'open':   "Open Gerudo's Fortress",
         },
         gui_tooltip    = '''\
             'Rescue One Carpenter': Only the bottom left carpenter,
@@ -3529,14 +2032,14 @@ setting_infos = [
         ''',
         shared         = True,
         disable        = {
-            'open' : {'settings' : ['shuffle_hideoutkeys']}
+            'open': {'settings': ['shuffle_hideoutkeys']}
         },
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'dungeon_shortcuts_choice',
+    )
+
+    dungeon_shortcuts_choice = Combobox(
         gui_text       = 'Dungeon Boss Shortcuts Mode',
         default        = 'off',
         choices        = {
@@ -3580,15 +2083,14 @@ setting_infos = [
             Random: Random dungeon shortcuts
         ''',
         shared         = True,
-        disable={
-            'off': {'settings' : ['dungeon_shortcuts']},
-            'all': {'settings' : ['dungeon_shortcuts']},
-            'random': {'settings' : ['dungeon_shortcuts']},
+        disable        = {
+            'off':    {'settings': ['dungeon_shortcuts']},
+            'all':    {'settings': ['dungeon_shortcuts']},
+            'random': {'settings': ['dungeon_shortcuts']},
         },
-    ),
-    Combobox(
-        name            = 'dungeon_shortcuts',
-        multiple_select = True,
+    )
+
+    dungeon_shortcuts = MultipleSelect(
         gui_text        = 'Dungeon Boss Shortcuts',
         choices         = {
             'Deku Tree':        "Deku Tree",
@@ -3608,12 +2110,9 @@ setting_infos = [
             Select dungeons with shortcuts
         ''',
         shared          = True,
-    ),
+    )
 
-
-
-    Combobox(
-        name           = 'starting_age',
+    starting_age = Combobox(
         gui_text       = 'Starting Age',
         default        = 'child',
         choices        = {
@@ -3633,13 +2132,13 @@ setting_infos = [
         shared         = True,
         gui_params     = {
             'randomize_key': 'randomize_settings',
-            'distribution': [
+            'distribution':  [
                 ('random', 1),
             ],
-        }
-    ),
-    Combobox(
-        name           = 'mq_dungeons_mode',
+        },
+    )
+
+    mq_dungeons_mode = Combobox(
         gui_text       = 'MQ Dungeon Mode',
         default        = 'vanilla',
         choices        = {
@@ -3669,10 +2168,9 @@ setting_infos = [
                 ('random', 1),
             ],
         },
-    ),
-    Combobox(
-        name            = 'mq_dungeons_specific',
-        multiple_select = True,
+    )
+
+    mq_dungeons_specific = MultipleSelect(
         gui_text        = 'MQ Dungeons',
         choices         = {
             'Deku Tree':              "Deku Tree",
@@ -3699,13 +2197,13 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Scale(
-        name           = 'mq_dungeons_count',
+    )
+
+    mq_dungeons_count = Scale(
         gui_text       = "MQ Dungeon Count",
         default        = 0,
-        min            = 0,
-        max            = 12,
+        minimum        = 0,
+        maximum        = 12,
         gui_tooltip    = '''\
             Specify the number of Master Quest
             dungeons to appear in the game.
@@ -3714,9 +2212,9 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name           = 'empty_dungeons_mode',
+    )
+
+    empty_dungeons_mode = Combobox(
         gui_text       = 'Pre-completed Dungeons Mode',
         default        = 'none',
         choices        = {
@@ -3762,10 +2260,9 @@ setting_infos = [
                 ('none', 1)
             ],
         },
-    ),
-    Combobox(
-        name            = 'empty_dungeons_specific',
-        multiple_select = True,
+    )
+
+    empty_dungeons_specific = MultipleSelect(
         gui_text        = 'Pre-completed Dungeons',
         choices         = {
             'Deku Tree':              "Deku Tree",
@@ -3786,13 +2283,13 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Scale(
-        name           = 'empty_dungeons_count',
+    )
+
+    empty_dungeons_count = Scale(
         gui_text       = "Pre-completed Dungeon Count",
         default        = 2,
-        min            = 1,
-        max            = 8,
+        minimum        = 1,
+        maximum        = 8,
         gui_tooltip    = '''\
             Specify the number of pre-completed
             dungeons to appear in the game.
@@ -3801,9 +2298,9 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name           = 'shuffle_interior_entrances',
+    )
+
+    shuffle_interior_entrances = Combobox(
         gui_text       = 'Shuffle Interior Entrances',
         default        = 'off',
         choices        = {
@@ -3825,20 +2322,20 @@ setting_infos = [
         ''',
         shared         = True,
         disable        = {
-            'off' : {'settings' : ['shuffle_hideout_entrances']},
+            'off': {'settings': ['shuffle_hideout_entrances']},
         },
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution':  [
-                ('off', 2),
+                ('off',    2),
                 ('simple', 1),
-                ('all', 1),
+                ('all',    1),
             ],
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_hideout_entrances',
-        gui_text       = 'Shuffle Thieves\' Hideout Entrances',
+    )
+
+    shuffle_hideout_entrances = Checkbutton(
+        gui_text       = "Shuffle Thieves' Hideout Entrances",
         gui_tooltip    = '''\
             Shuffle the pool of entrances to Thieves' Hideout
             into the pool of interior entrances.
@@ -3855,9 +2352,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_grotto_entrances',
+    )
+
+    shuffle_grotto_entrances = Checkbutton(
         gui_text       = 'Shuffle Grotto Entrances',
         gui_tooltip    = '''\
             Shuffle the pool of grotto entrances, including all graves,
@@ -3868,9 +2365,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'shuffle_dungeon_entrances',
+    )
+
+    shuffle_dungeon_entrances = Combobox(
         gui_text       = 'Shuffle Dungeon Entrances',
         default        = 'off',
         choices        = {
@@ -3894,14 +2391,14 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution': [
-                ('off', 2),
+                ('off',    2),
                 ('simple', 1),
-                ('all', 1),
+                ('all',    1),
             ],
         },
-    ),
-    Combobox(
-        name           = 'shuffle_bosses',
+    )
+
+    shuffle_bosses = Combobox(
         gui_text       = 'Shuffle Boss Entrances',
         gui_tooltip    = '''\
             Shuffle dungeon boss rooms.  This affects the boss rooms of all stone and medallion dungeons.
@@ -3922,9 +2419,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_overworld_entrances',
+    )
+
+    shuffle_overworld_entrances = Checkbutton(
         gui_text       = 'Shuffle Overworld Entrances',
         gui_tooltip    = '''\
             Shuffle the pool of Overworld entrances, which corresponds
@@ -3946,9 +2443,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_gerudo_valley_river_exit',
+    )
+
+    shuffle_gerudo_valley_river_exit = Checkbutton(
         gui_text       = 'Shuffle Gerudo Valley River Exit',
         gui_tooltip    = '''\
             Randomize where the the one-way entrance
@@ -3959,9 +2456,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'owl_drops',
+    )
+
+    owl_drops = Checkbutton(
         gui_text       = 'Randomize Owl Drops',
         gui_tooltip    = '''\
             Randomize where Kaepora Gaebora (the Owl) drops you at
@@ -3973,9 +2470,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'warp_songs',
+    )
+
+    warp_songs = Checkbutton(
         gui_text       = 'Randomize Warp Song Destinations',
         gui_tooltip    = '''\
             Randomize where each of the 6 warp songs leads to.
@@ -3985,11 +2482,10 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'spawn_positions',
+    )
+
+    spawn_positions = MultipleSelect(
         gui_text       = 'Randomize Overworld Spawns',
-        multiple_select = True,
         choices         = {
             'child': 'Child',
             'adult': 'Adult',
@@ -4012,12 +2508,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
+    )
 
-
-
-    Checkbutton(
-        name           = 'free_bombchu_drops',
+    free_bombchu_drops = Checkbutton(
         gui_text       = 'Add Bombchu Bag and Drops',
         gui_tooltip    = '''\
             Bombchus are properly considered in logic.
@@ -4051,9 +2544,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'one_item_per_dungeon',
+    )
+
+    one_item_per_dungeon = Checkbutton(
         gui_text       = 'Dungeons Have One Major Item',
         gui_tooltip    = '''\
             Dungeons have exactly one major item.
@@ -4094,9 +2587,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'shuffle_song_items',
+    )
+
+    shuffle_song_items = Combobox(
         gui_text       = 'Shuffle Songs',
         default        = 'song',
         choices        = {
@@ -4129,15 +2622,15 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution':  [
-                ('song', 2),
+                ('song',    2),
                 ('dungeon', 1),
-                ('any', 1),
+                ('any',     1),
             ],
         },
         shared         = True,
-    ),
-    Combobox(
-        name           = 'shopsanity',
+    )
+
+    shopsanity = Combobox(
         gui_text       = 'Shopsanity',
         default        = 'off',
         choices        = {
@@ -4190,22 +2683,20 @@ setting_infos = [
                 ('random', 1),
             ],
         },
-    ),
-    Combobox(
-        name           = 'shopsanity_prices',
-        gui_text       = 'Shopsanity Prices',
-        default        = 'random',
-        choices        = {
-            'random':          'Random',
-            'random_starting':    'Starting Wallet',
-            'random_adult':   'Adult\'s Wallet',
-            'random_giant':    'Giant\'s Wallet',
-            'random_tycoon':   'Tycoon\'s Wallet',
-            'affordable':      'Affordable',
+    )
+
+    shopsanity_prices = Combobox(
+        gui_text         = 'Shopsanity Prices',
+        default          = 'random',
+        choices          = {
+            'random':          "Random",
+            'random_starting': "Starting Wallet",
+            'random_adult':    "Adult's Wallet",
+            'random_giant':    "Giant's Wallet",
+            'random_tycoon':   "Tycoon's Wallet",
+            'affordable':      "Affordable",
         },
-        disable        = {
-        },
-        gui_tooltip    = '''\
+        gui_tooltip      = '''\
             Controls the randomization of prices for shopsanity items.
             For more control, utilize the plandomizer.
 
@@ -4222,13 +2713,13 @@ setting_infos = [
             fixed to 10 rupees.
         ''',
         disabled_default =  'random',
-        shared         = True,
-        gui_params     = {
+        shared           = True,
+        gui_params       = {
             "hide_when_disabled": True,
         },
-    ),
-    Combobox(
-        name           = 'tokensanity',
+    )
+
+    tokensanity = Combobox(
         gui_text       = 'Tokensanity',
         default        = 'off',
         choices        = {
@@ -4258,9 +2749,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'shuffle_scrubs',
+    )
+
+    shuffle_scrubs = Combobox(
         gui_text       = 'Scrub Shuffle',
         default        = 'off',
         choices        = {
@@ -4294,10 +2785,9 @@ setting_infos = [
                 ('low', 1),
             ],
         },
-    ),
-    Combobox(
-        name           = 'shuffle_child_trade',
-        multiple_select= True,
+    )
+
+    shuffle_child_trade = MultipleSelect(
         gui_text       = 'Shuffled Child Trade Sequence Items',
         default        = [],
         choices        = {
@@ -4320,9 +2810,9 @@ setting_infos = [
             add it as a starting item.
         ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'shuffle_freestanding_items',
+    )
+
+    shuffle_freestanding_items = Combobox(
         gui_text       = 'Shuffle Rupees & Hearts',
         default        = 'off',
         choices        = {
@@ -4345,9 +2835,9 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
         shared         = True,
-    ),
-    Combobox(
-        name           = 'shuffle_pots',
+    )
+
+    shuffle_pots = Combobox(
         gui_text       = 'Shuffle Pots',
         default        = 'off',
         choices        = {
@@ -4375,9 +2865,9 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
         shared         = True,
-    ),
-    Combobox(
-        name           = 'shuffle_crates',
+    )
+
+    shuffle_crates = Combobox(
         gui_text       = 'Shuffle Crates',
         default        = 'off',
         choices        = {
@@ -4400,9 +2890,9 @@ setting_infos = [
             'randomize_key': 'randomize_settings',
         },
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'shuffle_cows',
+    )
+
+    shuffle_cows = Checkbutton(
         gui_text       = 'Shuffle Cows',
         gui_tooltip    = '''\
             Enabling this will let cows give you items
@@ -4414,9 +2904,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_beehives',
+    )
+
+    shuffle_beehives = Checkbutton(
         gui_text       = 'Shuffle Beehives',
         gui_tooltip    = '''\
             Enabling this will let beehives drop items.
@@ -4432,9 +2922,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_kokiri_sword',
+    )
+
+    shuffle_kokiri_sword = Checkbutton(
         gui_text       = 'Shuffle Kokiri Sword',
         gui_tooltip    = '''\
             Enabling this shuffles the Kokiri Sword into the pool.
@@ -4447,9 +2937,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_ocarinas',
+    )
+
+    shuffle_ocarinas = Checkbutton(
         gui_text       = 'Shuffle Ocarinas',
         gui_tooltip    = '''\
             Enabling this shuffles the Fairy Ocarina and the Ocarina
@@ -4463,9 +2953,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_gerudo_card',
+    )
+
+    shuffle_gerudo_card = Checkbutton(
         gui_text       = "Shuffle Gerudo Card",
         gui_tooltip    = '''\
             Enabling this shuffles the Gerudo Card into the item pool.
@@ -4477,9 +2967,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_beans',
+    )
+
+    shuffle_beans = Checkbutton(
         gui_text       = 'Shuffle Magic Beans',
         gui_tooltip    = '''\
             Enabling this adds a pack of 10 beans to the item pool
@@ -4491,9 +2981,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_expensive_merchants',
+    )
+
+    shuffle_expensive_merchants = Checkbutton(
         gui_text       = 'Shuffle Expensive Merchants',
         gui_tooltip    = '''\
             Enabling this adds a Giant's Knife and a pack of Bombchus
@@ -4506,9 +2996,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Checkbutton(
-        name           = 'shuffle_frog_song_rupees',
+    )
+
+    shuffle_frog_song_rupees = Checkbutton(
         gui_text       = 'Shuffle Frog Song Rupees',
         gui_tooltip    = '''\
             Enabling this adds 5 Purple Rupees to the item pool
@@ -4521,9 +3011,9 @@ setting_infos = [
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
-    ),
-    Combobox(
-        name           = 'shuffle_loach_reward',
+    )
+
+    shuffle_loach_reward = Combobox(
         gui_text       = 'Shuffle Hyrule Loach Reward',
         gui_tooltip    = '''\
             Enabling this shuffles the reward for catching the
@@ -4559,13 +3049,12 @@ setting_infos = [
                 ('easy',         1)
             ],
         },
-    ),
+    )
 
     # Detailed Logic (except "Guarantee Reachable Locations")
 
-    Checkbutton(
-        name           = 'logic_no_night_tokens_without_suns_song',
-        gui_text       = 'Nighttime Skulltulas Expect Sun\'s Song',
+    logic_no_night_tokens_without_suns_song = Checkbutton(
+        gui_text       = "Nighttime Skulltulas Expect Sun's Song",
         gui_tooltip    = '''\
             GS Tokens that can only be obtained
             during the night expect you to have Sun's
@@ -4576,12 +3065,10 @@ setting_infos = [
             "hide_when_disabled": True,
         },
         shared         = True,
-    ),
-    Setting_Info(
-        name           = 'disabled_locations',
-        type           = list,
+    )
+
+    disabled_locations = SearchBox(
         gui_text       = "Exclude Locations",
-        gui_type       = "SearchBox",
         shared         = True,
         choices        = [location.name for location in LocationIterator(lambda loc: loc.filter_tags is not None)],
         default        = [],
@@ -4601,12 +3088,10 @@ setting_infos = [
         gui_params     = {
             'filterdata': {location.name: location.filter_tags for location in LocationIterator(lambda loc: loc.filter_tags is not None)},
         }
-    ),
-    Setting_Info(
-        name           = 'allowed_tricks',
-        type           = list,
+    )
+
+    allowed_tricks = SearchBox(
         gui_text       = "Enable Tricks",
-        gui_type       = "SearchBox",
         shared         = True,
         choices        = {
             val['name']: gui_text for gui_text, val in logic_tricks.items()
@@ -4625,26 +3110,14 @@ setting_infos = [
 
             Tricks are only relevant for Glitchless logic.
         '''
-    ),
-    Setting_Info(
-        name           = 'tricks_list_msg',
-        type           = str,
-        gui_text       = "Your current logic setting does not support the enabling of tricks.",
-        gui_type       = "Textbox",
-        shared         = False,
-        gui_params     = {
-            "hide_when_disabled": True
-        },
-        choices        = {},
-    ),
+    )
 
     # Starting Inventory
 
-    Setting_Info(
-        name           = 'starting_equipment',
-        type           = list,
+    starting_items = SettingInfoDict(None, None, True, {})
+
+    starting_equipment = SearchBox(
         gui_text       = "Starting Equipment",
-        gui_type       = "SearchBox",
         shared         = True,
         choices        = {
             key: value.guitext for key, value in StartingItems.equipment.items()
@@ -4653,12 +3126,10 @@ setting_infos = [
         gui_tooltip    = '''\
             Begin the game with the selected equipment.
         ''',
-    ),
-    Setting_Info(
-        name           = 'starting_songs',
-        type           = list,
+    )
+
+    starting_songs = SearchBox(
         gui_text       = "Starting Songs",
-        gui_type       = "SearchBox",
         shared         = True,
         choices        = {
             key: value.guitext for key, value in StartingItems.songs.items()
@@ -4667,12 +3138,10 @@ setting_infos = [
         gui_tooltip    = '''\
             Begin the game with the selected songs already learnt.
         ''',
-    ),
-    Setting_Info(
-        name           = 'starting_items',
-        type           = list,
+    )
+
+    starting_inventory = SearchBox(
         gui_text       = "Starting Items",
-        gui_type       = "SearchBox",
         shared         = True,
         choices        = {
             key: value.guitext for key, value in StartingItems.inventory.items()
@@ -4686,70 +3155,69 @@ setting_infos = [
             If playing with Open Zora's Fountain, the Ruto's Letter
             is converted to a regular Bottle.
         ''',
-    ),
-    Checkbutton(
-        name           = 'start_with_consumables',
+    )
+
+    start_with_consumables = Checkbutton(
         gui_text       = 'Start with Consumables',
         gui_tooltip    = '''\
             Start the game with maxed out Deku Sticks and Deku Nuts.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'start_with_rupees',
+    )
+
+    start_with_rupees = Checkbutton(
         gui_text       = 'Start with Max Rupees',
         gui_tooltip    = '''\
             Start the game with a full wallet.
             Wallet upgrades will also fill the wallet.
         ''',
         shared         = True,
-    ),
-    Scale(
-        name           = 'starting_hearts',
-        gui_text       = "Starting Hearts",
-        default        = 3,
-        min            = 3,
-        max            = 20,
-        gui_tooltip    = '''\
+    )
+
+    starting_hearts = Scale(
+        gui_text         = "Starting Hearts",
+        default          = 3,
+        minimum          = 3,
+        maximum          = 20,
+        gui_tooltip      = '''\
             Start the game with the selected number of hearts.
             Heart Containers and Pieces of Heart are removed
             from the item pool in equal proportion.
         ''',
         disabled_default = 1,
-        shared         = True,
-    ),
+        shared           = True,
+    )
 
     # Other
 
-    Checkbutton(
-        name           = 'no_escape_sequence',
+    no_escape_sequence = Checkbutton(
         gui_text       = 'Skip Tower Escape Sequence',
         gui_tooltip    = '''\
             The tower escape sequence between
             Ganondorf and Ganon will be skipped.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'no_guard_stealth',
+    )
+
+    no_guard_stealth = Checkbutton(
         gui_text       = 'Skip Child Stealth',
         gui_tooltip    = '''\
             The crawlspace into Hyrule Castle goes
             straight to Zelda, skipping the guards.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'no_epona_race',
+    )
+
+    no_epona_race = Checkbutton(
         gui_text       = 'Skip Epona Race',
         gui_tooltip    = '''\
             Epona can be summoned with Epona's Song
             without needing to race Ingo.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'skip_some_minigame_phases',
+    )
+
+    skip_some_minigame_phases = Checkbutton(
         gui_text       = 'Skip Some Minigame Phases',
         gui_tooltip    = '''\
             Awards all eligible prizes after the first attempt for
@@ -4766,18 +3234,18 @@ setting_infos = [
             1500 points in a single attempt.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'complete_mask_quest',
+    )
+
+    complete_mask_quest = Checkbutton(
         gui_text       = 'Complete Mask Quest',
         gui_tooltip    = '''\
             Once the Happy Mask Shop is opened,
             all masks will be available to be borrowed.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'useful_cutscenes',
+    )
+
+    useful_cutscenes = Checkbutton(
         gui_text       = 'Enable Specific Glitch-Useful Cutscenes',
         gui_tooltip    = '''\
             The cutscenes of the Poes in Forest Temple and Darunia in
@@ -4786,9 +3254,9 @@ setting_infos = [
             for glitchless playthroughs.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'fast_chests',
+    )
+
+    fast_chests = Checkbutton(
         gui_text       = 'Fast Chest Cutscenes',
         gui_tooltip    = '''\
             All chest animations are fast. If disabled,
@@ -4796,28 +3264,28 @@ setting_infos = [
         ''',
         default        = True,
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'free_scarecrow',
-        gui_text       = 'Free Scarecrow\'s Song',
+    )
+
+    free_scarecrow = Checkbutton(
+        gui_text       = "Free Scarecrow's Song",
         gui_tooltip    = '''\
             Pulling out the Ocarina near a
             spot at which Pierre can spawn will
             do so, without needing the song.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'fast_bunny_hood',
+    )
+
+    fast_bunny_hood = Checkbutton(
         gui_text       = 'Fast Bunny Hood',
         gui_tooltip    = '''\
             The Bunny Hood mask behaves like it does
             in Majora's Mask and makes you go 1.5× faster.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'plant_beans',
+    )
+
+    plant_beans = Checkbutton(
         gui_text       = 'Plant Magic Beans',
         gui_tooltip    = '''\
             Enabling this plants all 10 magic beans in soft soil
@@ -4826,25 +3294,25 @@ setting_infos = [
         ''',
         default        = False,
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'chicken_count_random',
+    )
+
+    chicken_count_random = Checkbutton(
         gui_text       = 'Random Cucco Count',
         gui_tooltip    = '''\
             Anju will give a reward for collecting a random
             number of Cuccos.
         ''',
         disable        = {
-            True : {'settings' : ['chicken_count']}
+            True: {'settings' : ['chicken_count']},
         },
         shared         = True,
-    ),
-    Scale(
-        name           = 'chicken_count',
+    )
+
+    chicken_count = Scale(
         gui_text       = 'Cucco Count',
         default        = 7,
-        min            = 0,
-        max            = 7,
+        minimum        = 0,
+        maximum        = 7,
         gui_tooltip    = '''\
             Anju will give a reward for turning
             in the chosen number of Cuccos.
@@ -4853,34 +3321,34 @@ setting_infos = [
         gui_params     = {
             'no_line_break': True,
         },
-    ),
-    Checkbutton(
-        name           = 'big_poe_count_random',
+    )
+
+    big_poe_count_random = Checkbutton(
         gui_text       = 'Random Big Poe Target Count',
         gui_tooltip    = '''\
             The Poe buyer will give a reward for turning
             in a random number of Big Poes.
         ''',
         disable        = {
-            True : {'settings' : ['big_poe_count']}
+            True: {'settings' : ['big_poe_count']},
         },
         shared         = True,
-    ),
-    Scale(
-        name           = 'big_poe_count',
-        gui_text       = "Big Poe Target Count",
-        default        = 10,
-        min            = 1,
-        max            = 10,
-        gui_tooltip    = '''\
+    )
+
+    big_poe_count = Scale(
+        gui_text         = "Big Poe Target Count",
+        default          = 10,
+        minimum          = 1,
+        maximum          = 10,
+        gui_tooltip      = '''\
             The Poe buyer will give a reward for turning
             in the chosen number of Big Poes.
         ''',
         disabled_default = 1,
-        shared         = True,
-    ),
-    Checkbutton(
-        name           = 'easier_fire_arrow_entry',
+        shared           = True,
+    )
+
+    easier_fire_arrow_entry = Checkbutton(
         gui_text       = 'Easier Fire Arrow Entry',
         gui_tooltip    = '''\
             It is possible to open the Shadow Temple entrance
@@ -4897,16 +3365,16 @@ setting_infos = [
             in logic.
         ''',
         disable        = {
-            False : {'settings' : ['fae_torch_count']}
+            False: {'settings': ['fae_torch_count']},
         },
         shared         = True,
-    ),
-    Scale(
-        name           = 'fae_torch_count',
+    )
+
+    fae_torch_count = Scale(
         gui_text       = 'Fire Arrow Entry Torch Count',
         default        = 3,
-        min            = 1,
-        max            = 23,
+        minimum        = 1,
+        maximum        = 23,
         gui_tooltip    = '''\
             The entrance to Shadow Temple will open
             after the chosen number of torches are lit.
@@ -4914,13 +3382,10 @@ setting_infos = [
         shared         = True,
         gui_params     = {
             "hide_when_disabled": True,
-        }
-    ),
+        },
+    )
 
-
-
-    Combobox(
-        name           = 'ocarina_songs',
+    ocarina_songs = Combobox(
         gui_text       = 'Randomize Ocarina Song Notes',
         default        = 'off',
         choices        = {
@@ -4936,9 +3401,9 @@ setting_infos = [
             typically more difficult than frog songs.
             ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'correct_chest_appearances',
+    )
+
+    correct_chest_appearances = Combobox(
         gui_text       = 'Chest Appearance Matches Contents',
         default        = 'off',
         choices        = {
@@ -4948,8 +3413,6 @@ setting_infos = [
             'classic': 'Classic'
         },
         gui_tooltip    = '''\
-
-
             If "Texture" is enabled, chest texture will reflect its contents
             regardless of size.  Fancy chests will contain keys,
             Gilded chests will contain major items, shuffled
@@ -4970,11 +3433,11 @@ setting_infos = [
         ''',
         shared         = True,
         disable        = {
-            'off' : {'settings' : ['minor_items_as_major_chest']},
+            'off': {'settings': ['minor_items_as_major_chest']},
         },
-    ),
-    Checkbutton(
-        name           = 'minor_items_as_major_chest',
+    )
+
+    minor_items_as_major_chest = Checkbutton(
         gui_text       = 'Minor Items in Big/Gold chests',
         gui_tooltip    = '''\
             Chests with Hylian Shield, Deku Shield, or
@@ -4988,9 +3451,9 @@ setting_infos = [
         gui_params       = {
             "hide_when_disabled" : True
         },
-    ),
-    Checkbutton(
-        name           = 'invisible_chests',
+    )
+
+    invisible_chests = Checkbutton(
         gui_text       = 'Invisible Chests',
         gui_tooltip    = '''\
             Chests will be only be visible with
@@ -4998,9 +3461,9 @@ setting_infos = [
             required for normally visible chests.
         ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'correct_potcrate_appearances',
+    )
+
+    correct_potcrate_appearances = Combobox(
         gui_text       = 'Pot, Crate, & Beehive Appearance Matches Contents',
         default        = 'textures_unchecked',
         choices        = {
@@ -5028,9 +3491,9 @@ setting_infos = [
             Beehives will wiggle until their item is collected.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'clearer_hints',
+    )
+
+    clearer_hints = Checkbutton(
         gui_text       = 'Clearer Hints',
         gui_tooltip    = '''\
             The hints provided by Gossip Stones will
@@ -5038,9 +3501,9 @@ setting_infos = [
         ''',
         shared         = True,
         default        = True,
-    ),
-    Combobox(
-        name           = 'hints',
+    )
+
+    hints = Combobox(
         gui_text       = 'Gossip Stones',
         default        = 'always',
         choices        = {
@@ -5065,9 +3528,9 @@ setting_infos = [
             required to beat the game.
         ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'hint_dist',
+    )
+
+    hint_dist = Combobox(
         gui_text       = 'Hint Distribution',
         default        = 'balanced',
         choices        = HintDistList(),
@@ -5079,12 +3542,9 @@ setting_infos = [
         disable        = {
             '!bingo' : {'settings' : ['bingosync_url']},
         },
-    ),
-    Setting_Info(
-        name           = "bingosync_url",
-        type           = str,
-        choices        = {},
-        gui_type       = "Textinput",
+    )
+
+    bingosync_url = Textinput(
         gui_text       = "Bingosync URL",
         shared         = False,
         gui_tooltip    = '''\
@@ -5108,19 +3568,18 @@ setting_infos = [
             "size"               : "full",
             "hide_when_disabled" : True,
         },
-    ),
-    Setting_Info(
-        name           = 'item_hints',
-        type           =  list,
+    )
+
+    item_hints = SettingInfoList(
         gui_type       = None,
         gui_text       = None,
         shared         = True,
         choices        = [name for name, item in ItemInfo.items.items() if item.type == 'Item']
-    ),
-    Setting_Info('hint_dist_user',    dict, None, None, True, {}),
-    Combobox(
-        name            = 'misc_hints',
-        multiple_select = True,
+    )
+
+    hint_dist_user = SettingInfoDict(None, None, True, {})
+
+    misc_hints = MultipleSelect(
         gui_text        = 'Misc. Hints',
         choices         = {
             'altar':       'Temple of Time Altar',
@@ -5191,9 +3650,9 @@ setting_infos = [
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],
-    ),
-    Combobox(
-        name           = 'text_shuffle',
+    )
+
+    text_shuffle = Combobox(
         gui_text       = 'Text Shuffle',
         default        = 'none',
         choices        = {
@@ -5212,9 +3671,9 @@ setting_infos = [
             price scrubs, chicken count and poe count.
         ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'damage_multiplier',
+    )
+
+    damage_multiplier = Combobox(
         gui_text       = 'Damage Multiplier',
         default        = 'normal',
         choices        = {
@@ -5230,9 +3689,9 @@ setting_infos = [
             'OHKO': Link dies in one hit.
         ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'deadly_bonks',
+    )
+
+    deadly_bonks = Combobox(
         gui_text       = 'Bonks Do Damage',
         default        = 'none',
         choices        = {
@@ -5249,9 +3708,9 @@ setting_infos = [
             by the damage multiplier setting.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'no_collectible_hearts',
+    )
+
+    no_collectible_hearts = Checkbutton(
         gui_text       = 'Hero Mode',
         gui_tooltip    = '''\
             No recovery hearts will drop from
@@ -5261,9 +3720,9 @@ setting_infos = [
         ''',
         default        = False,
         shared         = True,
-    ),
-    Combobox(
-        name           = 'starting_tod',
+    )
+
+    starting_tod = Combobox(
         gui_text       = 'Starting Time of Day',
         default        = 'default',
         choices        = {
@@ -5285,9 +3744,9 @@ setting_infos = [
             nighttime at 18:00 (6:00 PM).
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'blue_fire_arrows',
+    )
+
+    blue_fire_arrows = Checkbutton(
         gui_text       = 'Blue Fire Arrows',
         gui_tooltip    = '''\
             Ice arrows gain the power of blue fire.
@@ -5296,9 +3755,9 @@ setting_infos = [
         ''',
         default        = False,
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'fix_broken_drops',
+    )
+
+    fix_broken_drops = Checkbutton(
         gui_text       = 'Fix Broken Drops',
         gui_tooltip    = '''\
             Enabling this fixes drops that are broken in the vanilla game.
@@ -5310,12 +3769,9 @@ setting_infos = [
             not always refill your magic in the vanilla game.
         ''',
         shared         = True,
-    ),
+    )
 
-
-
-    Combobox(
-        name           = 'item_pool_value',
+    item_pool_value = Combobox(
         gui_text       = 'Item Pool',
         default        = 'balanced',
         choices        = {
@@ -5349,9 +3805,9 @@ setting_infos = [
         disable        = {
             'ludicrous':  {'settings': ['one_item_per_dungeon']}
         }
-    ),
-    Combobox(
-        name           = 'junk_ice_traps',
+    )
+
+    junk_ice_traps = Combobox(
         gui_text       = 'Ice Traps',
         default        = 'normal',
         choices        = {
@@ -5378,9 +3834,9 @@ setting_infos = [
             base pool.
         ''',
         shared         = True,
-    ),
-    Combobox(
-        name           = 'ice_trap_appearance',
+    )
+
+    ice_trap_appearance = Combobox(
         gui_text       = 'Ice Trap Appearance',
         default        = 'major_only',
         choices        = {
@@ -5402,9 +3858,9 @@ setting_infos = [
             'Anything': Ice Traps may appear as anything.
         ''',
         shared         = True,
-    ),
-    Checkbutton(
-        name           = 'adult_trade_shuffle',
+    )
+
+    adult_trade_shuffle = Checkbutton(
         gui_text       = 'Shuffle All Adult Trade Items',
         gui_tooltip    = '''\
             Shuffle all adult trade sequence items. If disabled,
@@ -5413,10 +3869,9 @@ setting_infos = [
         ''',
         shared         = True,
         default        = False,
-    ),
-    Combobox(
-        name           = 'adult_trade_start',
-        multiple_select= True,
+    )
+
+    adult_trade_start = MultipleSelect(
         gui_text       = 'Adult Trade Sequence Items',
         default        = ['Pocket Egg', 'Pocket Cucco', 'Cojiro', 'Odd Mushroom', 'Odd Potion', 'Poachers Saw',
                           'Broken Sword', 'Prescription', 'Eyeball Frog', 'Eyedrops', 'Claim Check'],
@@ -5437,12 +3892,11 @@ setting_infos = [
             Select the items to shuffle in the adult trade sequence.
         ''',
         shared         = True,
-    ),
+    )
 
     # Cosmetics
 
-    Combobox(
-        name           = 'default_targeting',
+    default_targeting = Combobox(
         gui_text       = 'Default Targeting Option',
         shared         = False,
         cosmetic       = True,
@@ -5451,9 +3905,9 @@ setting_infos = [
             'hold':   'Hold',
             'switch': 'Switch',
         },
-    ),
-    Checkbutton(
-        name           = 'display_dpad',
+    )
+
+    display_dpad = Checkbutton(
         gui_text       = 'Display D-Pad HUD',
         shared         = False,
         cosmetic       = True,
@@ -5462,9 +3916,9 @@ setting_infos = [
             current available options on the D-Pad.
         ''',
         default        = True,
-    ),
-    Checkbutton(
-        name           = 'dpad_dungeon_menu',
+    )
+
+    dpad_dungeon_menu = Checkbutton(
         gui_text       = 'Display D-Pad Dungeon Info',
         shared         = False,
         cosmetic       = True,
@@ -5475,9 +3929,9 @@ setting_infos = [
             one of the D-Pad directions on the pause screen.
         ''',
         default        = True,
-    ),
-    Checkbutton(
-        name           = 'correct_model_colors',
+    )
+
+    correct_model_colors = Checkbutton(
         gui_text       = 'Item Model Colors Match Cosmetics',
         shared         = False,
         cosmetic       = True,
@@ -5490,9 +3944,9 @@ setting_infos = [
             able to discern freestanding Tunics from each other.
         ''',
         default        = True,
-    ),
-    Checkbutton(
-        name           = 'randomize_all_cosmetics',
+    )
+
+    randomize_all_cosmetics = Checkbutton(
         gui_text       = 'Randomize All Cosmetics',
         shared         = False,
         cosmetic       = True,
@@ -5500,13 +3954,12 @@ setting_infos = [
             Randomize all cosmetics settings.
         ''',
         default        = False,
-        disable    = {
-            True : {'sections' : [ "equipment_color_section", "ui_color_section", "misc_color_section" ]
-            }
+        disable        = {
+            True: {'sections': ["equipment_color_section", "ui_color_section", "misc_color_section"]},
         }
-    ),
-    Combobox(
-        name           = 'model_adult',
+    )
+
+    model_adult = Combobox(
         gui_text       = 'Adult Link Model',
         shared         = False,
         cosmetic       = True,
@@ -5525,16 +3978,12 @@ setting_infos = [
         default        = 'Default',
         gui_params     = {
             "hide_when_disabled": True,
-            "dynamic": True,
-        }
-    ),
-    Setting_Info(
-        name        = 'model_adult_filepicker',
-        type        = str,
-        gui_text    = "Adult Link Model",
-        gui_type    = "Fileinput",
-        shared      = False,
-        choices     = {},
+            "dynamic":            True,
+        },
+    )
+
+    model_adult_filepicker = Fileinput(
+        gui_text   = "Adult Link Model",
         gui_tooltip = '''\
             Link's model will be replaced by the model selected.
             Cosmetics options might not be applied when a
@@ -5544,22 +3993,22 @@ setting_infos = [
             for all recorded Racetime races. A note will appear at the top
             of the pause screen if this is the case.
         ''',
-        gui_params  = {
+        gui_params = {
             "file_types": [
                 {
                   "name": "Z64 Model Files",
-                  "extensions": [ "zobj" ]
+                  "extensions": ["zobj"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
             "hide_when_disabled": True,
-        }
-    ),
-    Combobox(
-        name           = 'model_child',
+        },
+    )
+
+    model_child = Combobox(
         gui_text       = 'Child Link Model',
         shared         = False,
         cosmetic       = True,
@@ -5578,16 +4027,12 @@ setting_infos = [
         default        = 'Default',
         gui_params     = {
             "hide_when_disabled": True,
-            "dynamic": True,
-        }
-    ),
-    Setting_Info(
-        name        = 'model_child_filepicker',
-        type        = str,
-        gui_text    = "Child Link Model",
-        gui_type    = "Fileinput",
-        shared      = False,
-        choices     = {},
+            "dynamic":            True,
+        },
+    )
+
+    model_child_filepicker = Fileinput(
+        gui_text   = "Child Link Model",
         gui_tooltip = '''\
             Link's model will be replaced by the model selected.
             Cosmetics options might not be applied when a
@@ -5597,39 +4042,26 @@ setting_infos = [
             for all recorded Racetime races. A note will appear at the top
             of the pause screen if this is the case.
         ''',
-        gui_params  = {
+        gui_params = {
             "file_types": [
                 {
                   "name": "Z64 Model Files",
-                  "extensions": [ "zobj" ]
+                  "extensions": ["zobj"]
                 },
                 {
                   "name": "All Files",
-                  "extensions": [ "*" ]
-                }
+                  "extensions": ["*"]
+                },
             ],
             "hide_when_disabled": True,
-        }
-    ),
-    Setting_Info(
-        name           = 'model_unavailable_msg',
-        type           = str,
-        gui_text       = "Models can only be customized when patching.",
-        gui_type       = "Textbox",
-        shared         = False,
-        gui_params     = {
-            "hide_when_disabled": True
         },
-        choices        = {},
-    ),
-    Setting_Info(
-        name           = 'kokiri_color',
-        type           = str,
+    )
+
+    kokiri_color = Combobox(
         gui_text       = "Kokiri Tunic",
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_tunic_color_options(),
+        choices        = Colors.get_tunic_color_options(),
         default        = 'Kokiri Green',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5639,19 +4071,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'goron_color',
-        type           = str,
+            ],
+        },
+    )
+
+    goron_color = Combobox(
         gui_text       = "Goron Tunic",
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_tunic_color_options(),
+        choices        = Colors.get_tunic_color_options(),
         default        = 'Goron Red',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5661,19 +4091,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'zora_color',
-        type           = str,
+            ],
+        },
+    )
+
+    zora_color = Combobox(
         gui_text       = "Zora Tunic",
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_tunic_color_options(),
+        choices        = Colors.get_tunic_color_options(),
         default        = 'Zora Blue',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5683,19 +4111,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'silver_gauntlets_color',
-        type           = str,
+            ],
+        },
+    )
+
+    silver_gauntlets_color = Combobox(
         gui_text       = 'Silver Gauntlets Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_gauntlet_color_options(),
+        choices        = Colors.get_gauntlet_color_options(),
         default        = 'Silver',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5705,19 +4131,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'golden_gauntlets_color',
-        type           = str,
+            ],
+        },
+    )
+
+    golden_gauntlets_color = Combobox(
         gui_text       = 'Golden Gauntlets Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_gauntlet_color_options(),
+        choices        = Colors.get_gauntlet_color_options(),
         default        = 'Gold',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5727,19 +4151,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'mirror_shield_frame_color',
-        type           = str,
+            ],
+        },
+    )
+
+    mirror_shield_frame_color = Combobox(
         gui_text       = 'Mirror Shield Frame Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_shield_frame_color_options(),
+        choices        = Colors.get_shield_frame_color_options(),
         default        = 'Red',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5749,19 +4171,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'heart_color',
-        type           = str,
+            ],
+        },
+    )
+
+    heart_color = Combobox(
         gui_text       = 'Heart Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_heart_color_options(),
+        choices        = Colors.get_heart_color_options(),
         default        = 'Red',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5771,19 +4191,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'magic_color',
-        type           = str,
+            ],
+        },
+    )
+
+    magic_color = Combobox(
         gui_text       = 'Magic Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_magic_color_options(),
+        choices        = Colors.get_magic_color_options(),
         default        = 'Green',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5793,19 +4211,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'a_button_color',
-        type           = str,
+            ],
+        },
+    )
+
+    a_button_color = Combobox(
         gui_text       = 'A Button Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_a_button_color_options(),
+        choices        = Colors.get_a_button_color_options(),
         default        = 'N64 Blue',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5815,19 +4231,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'b_button_color',
-        type           = str,
+            ],
+        },
+    )
+
+    b_button_color = Combobox(
         gui_text       = 'B Button Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_b_button_color_options(),
+        choices        = Colors.get_b_button_color_options(),
         default        = 'N64 Green',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5837,19 +4251,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'c_button_color',
-        type           = str,
+            ],
+        },
+    )
+
+    c_button_color = Combobox(
         gui_text       = 'C Button Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_c_button_color_options(),
+        choices        = Colors.get_c_button_color_options(),
         default        = 'Yellow',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5859,19 +4271,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'start_button_color',
-        type           = str,
+            ],
+        },
+    )
+
+    start_button_color = Combobox(
         gui_text       = 'Start Button Color',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_start_button_color_options(),
+        choices        = Colors.get_start_button_color_options(),
         default        = 'N64 Red',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5881,19 +4291,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_default_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_default_inner = Combobox(
         gui_text       = "Navi Idle Inner",
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(),
+        choices        = Colors.get_navi_color_options(),
         default        = 'White',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5903,21 +4311,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break': True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_default_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_default_outer = Combobox(
         gui_text       = "Outer",
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(True),
+        choices        = Colors.get_navi_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5928,19 +4334,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_enemy_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_enemy_inner = Combobox(
         gui_text       = 'Navi Targeting Enemy Inner',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(),
+        choices        = Colors.get_navi_color_options(),
         default        = 'Yellow',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5950,21 +4354,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break':  True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_enemy_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_enemy_outer = Combobox(
         gui_text       = 'Outer',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(True),
+        choices        = Colors.get_navi_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5975,19 +4377,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_npc_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_npc_inner = Combobox(
         gui_text       = 'Navi Targeting NPC Inner',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(),
+        choices        = Colors.get_navi_color_options(),
         default        = 'Light Blue',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -5997,21 +4397,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break':  True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_npc_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_npc_outer = Combobox(
         gui_text       = 'Outer',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(True),
+        choices        = Colors.get_navi_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6022,19 +4420,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_prop_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_prop_inner = Combobox(
         gui_text       = 'Navi Targeting Prop Inner',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(),
+        choices        = Colors.get_navi_color_options(),
         default        = 'Green',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6044,21 +4440,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break': True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'navi_color_prop_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    navi_color_prop_outer = Combobox(
         gui_text       = 'Outer',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_navi_color_options(True),
+        choices        = Colors.get_navi_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6069,19 +4463,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'bombchu_trail_color_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    bombchu_trail_color_inner = Combobox(
         gui_text       = 'Bombchu Trail Inner',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_bombchu_trail_color_options(),
+        choices        = Colors.get_bombchu_trail_color_options(),
         default        = 'Red',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6091,21 +4483,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break': True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'bombchu_trail_color_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    bombchu_trail_color_outer = Combobox(
         gui_text       = 'Outer',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_bombchu_trail_color_options(True),
+        choices        = Colors.get_bombchu_trail_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6116,19 +4506,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'boomerang_trail_color_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    boomerang_trail_color_inner = Combobox(
         gui_text       = 'Boomerang Trail Inner',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_boomerang_trail_color_options(),
+        choices        = Colors.get_boomerang_trail_color_options(),
         default        = 'Yellow',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6138,21 +4526,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break': True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'boomerang_trail_color_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    boomerang_trail_color_outer = Combobox(
         gui_text       = 'Outer',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_boomerang_trail_color_options(True),
+        choices        = Colors.get_boomerang_trail_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6163,19 +4549,17 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'sword_trail_color_inner',
-        type           = str,
+            ],
+        },
+    )
+
+    sword_trail_color_inner = Combobox(
         gui_text       = 'Sword Trail Inner',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_sword_trail_color_options(),
+        choices        = Colors.get_sword_trail_color_options(),
         default        = 'White',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6185,21 +4569,19 @@ setting_infos = [
             'Rainbow': Cycle through a color rainbow.
         ''',
         gui_params     = {
-            'no_line_break' : True,
+            'no_line_break': True,
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Setting_Info(
-        name           = 'sword_trail_color_outer',
-        type           = str,
+            ],
+        },
+    )
+
+    sword_trail_color_outer = Combobox(
         gui_text       = 'Outer',
-        gui_type       = "Combobox",
         shared         = False,
         cosmetic       = True,
-        choices        = get_sword_trail_color_options(True),
+        choices        = Colors.get_sword_trail_color_options(True),
         default        = '[Same as Inner]',
         gui_tooltip    = '''\
             'Random Choice': Choose a random
@@ -6210,13 +4592,13 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 ('Completely Random', 1),
-            ]
-        }
-    ),
-    Combobox(
-        name           = 'sword_trail_duration',
+            ],
+        },
+    )
+
+    sword_trail_duration = ComboboxInt(
         gui_text       = 'Sword Trail Duration',
         shared         = False,
         cosmetic       = True,
@@ -6232,19 +4614,18 @@ setting_infos = [
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_cosmetics',
-            'distribution': [
+            'distribution':  [
                 (4, 1),
                 (10, 1),
                 (15, 1),
                 (20, 1)
-            ]
-        }
-    ),
+            ],
+        },
+    )
 
-# SFX
+    # SFX
 
-    Checkbutton(
-        name           = 'randomize_all_sfx',
+    randomize_all_sfx = Checkbutton(
         gui_text       = 'Randomize All Sound Effects',
         shared         = False,
         cosmetic       = True,
@@ -6257,9 +4638,9 @@ setting_infos = [
             'settings' : ["sfx_navi_overworld", "sfx_navi_enemy", "sfx_horse_neigh", "sfx_cucco"]
             }
         }
-    ),
-    Checkbutton(
-        name           = 'disable_battle_music',
+    )
+
+    disable_battle_music = Checkbutton(
         gui_text       = 'Disable Battle Music',
         shared         = False,
         cosmetic       = True,
@@ -6270,9 +4651,9 @@ setting_infos = [
             near enemies.
         ''',
         default        = False,
-    ),
-    Checkbutton(
-        name           = 'speedup_music_for_last_triforce_piece',
+    )
+
+    speedup_music_for_last_triforce_piece = Checkbutton(
         gui_text       = 'Speed Up Music For Last Triforce Piece',
         shared         = False,
         cosmetic       = True,
@@ -6282,9 +4663,9 @@ setting_infos = [
             Does not apply on the standard battle enemy music.
         ''',
         default        = False,
-    ),
-    Combobox(
-        name           = 'background_music',
+    )
+
+    background_music = Combobox(
         gui_text       = 'Background Music',
         shared         = False,
         cosmetic       = True,
@@ -6303,14 +4684,14 @@ setting_infos = [
         ''',
         gui_params  = {
             'randomize_key': 'randomize_all_sfx',
-            'distribution': [
+            'distribution':  [
                 ('random', 1),
             ],
             'web:option_remove': ['random_custom_only'],
         },
-    ),
-    Combobox(
-        name           = 'fanfares',
+    )
+
+    fanfares = Combobox(
         gui_text       = 'Fanfares',
         shared         = False,
         cosmetic       = True,
@@ -6322,7 +4703,7 @@ setting_infos = [
             'random_custom_only':   'Random (Custom Only)',
         },
         disable        = {
-            'normal' : {'settings' : ['ocarina_fanfares']},
+            'normal': {'settings': ['ocarina_fanfares']},
         },
         gui_tooltip    = '''\
             'No Fanfares': No fanfares (short non-looping tracks) are played.
@@ -6337,9 +4718,9 @@ setting_infos = [
             ],
             'web:option_remove': ['random_custom_only'],
         },
-    ),
-    Checkbutton(
-        name           = 'ocarina_fanfares',
+    )
+
+    ocarina_fanfares = Checkbutton(
         gui_text       = 'Ocarina Songs as Fanfares',
         shared         = False,
         cosmetic       = True,
@@ -6354,12 +4735,12 @@ setting_infos = [
             'randomize_key': 'randomize_all_sfx',
             'distribution': [
                 (True, 1),
-            ]
+            ],
         },
         default        = False,
-    ),
-    Combobox(
-        name           = 'sfx_ocarina',
+    )
+
+    sfx_ocarina = Combobox(
         gui_text       = 'Ocarina',
         shared         = False,
         cosmetic       = True,
@@ -6383,30 +4764,30 @@ setting_infos = [
                 ('random-choice', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_bombchu_move',
+    )
+
+    sfx_bombchu_move = Combobox(
         gui_text       = 'Bombchu',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.BOMBCHU_MOVE),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.BOMBCHU_MOVE),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound bombchus make when moving.
         ''',
         gui_params     = {
             'randomize_key': 'randomize_all_sfx',
-            'distribution': [
+            'distribution':  [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_hover_boots',
+    )
+
+    sfx_hover_boots = Combobox(
         gui_text       = "Hover Boots",
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.BOOTS_HOVER),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.BOOTS_HOVER),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of the hover boots when in air.
@@ -6418,13 +4799,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_iron_boots',
+    )
+
+    sfx_iron_boots = Combobox(
         gui_text       = "Iron Boots",
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.BOOTS_IRON),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.BOOTS_IRON),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of Iron boots.
@@ -6435,13 +4816,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_boomerang_throw',
+    )
+
+    sfx_boomerang_throw = Combobox(
         gui_text       = 'Boomerang Throw',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.BOOMERANG_THROW),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.BOOMERANG_THROW),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of the Boomerang flying in the air.
@@ -6453,13 +4834,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_hookshot_chain',
+    )
+
+    sfx_hookshot_chain = Combobox(
         gui_text       = 'Hookshot Chain',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.HOOKSHOT_CHAIN),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.HOOKSHOT_CHAIN),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of the Hookshot extending.
@@ -6470,13 +4851,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_arrow_shot',
+    )
+
+    sfx_arrow_shot = Combobox(
         gui_text       = 'Arrow Shot',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.ARROW_SHOT),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.ARROW_SHOT),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of a regular arrow shot.
@@ -6488,13 +4869,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_slingshot_shot',
+    )
+
+    sfx_slingshot_shot = Combobox(
         gui_text       = 'Slingshot Shot',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.SLINGSHOT_SHOT),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.SLINGSHOT_SHOT),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of a Slingshot shot.
@@ -6505,13 +4886,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_magic_arrow_shot',
+    )
+
+    sfx_magic_arrow_shot = Combobox(
         gui_text       = 'Magic Arrow Shot',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.MAGIC_ARROW_SHOT),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.MAGIC_ARROW_SHOT),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of a Magic arrow shot.
@@ -6523,13 +4904,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_explosion',
+    )
+
+    sfx_explosion = Combobox(
         gui_text       = 'Bomb Explosion',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.EXPLOSION),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.EXPLOSION),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of a bomb exploding.
@@ -6538,15 +4919,15 @@ setting_infos = [
             'randomize_key': 'randomize_all_sfx',
             'distribution': [
                 ('random-ear-safe', 1),
-            ]
-        }
-    ),
-    Combobox(
-        name           = 'sfx_link_adult',
+            ],
+        },
+    )
+
+    sfx_link_adult = Combobox(
         gui_text       = 'Adult Voice',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_voice_sfx_choices(1),
+        choices        = Sounds.get_voice_sfx_choices(1),
         default        = 'Default',
         gui_tooltip    = '''\
             Change Link's adult voice.
@@ -6554,14 +4935,14 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
             "dynamic": True,
-        }
-    ),
-    Combobox(
-        name           = 'sfx_link_child',
+        },
+    )
+
+    sfx_link_child = Combobox(
         gui_text       = 'Child Voice',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_voice_sfx_choices(0),
+        choices        = Sounds.get_voice_sfx_choices(0),
         default        = 'Default',
         gui_tooltip    = '''\
             Change Link's child voice.
@@ -6569,25 +4950,14 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
             "dynamic": True,
-        }
-    ),
-    Setting_Info(
-        name           = 'sfx_link_unavailable_msg',
-        type           = str,
-        gui_text       = "Link's Voice can only be customized when patching.",
-        gui_type       = "Textbox",
-        shared         = False,
-        gui_params     = {
-            "hide_when_disabled": True
         },
-        choices        = {},
-    ),
-    Combobox(
-        name           = 'sfx_navi_overworld',
+    )
+
+    sfx_navi_overworld = Combobox(
         gui_text       = 'Navi Overworld',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.NAVI_OVERWORLD),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.NAVI_OVERWORLD),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of Navi calling in the overworld.
@@ -6598,13 +4968,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_navi_enemy',
+    )
+
+    sfx_navi_enemy = Combobox(
         gui_text       = 'Navi Enemy',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.NAVI_ENEMY),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.NAVI_ENEMY),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of Navi targetting an enemy.
@@ -6615,13 +4985,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_horse_neigh',
+    )
+
+    sfx_horse_neigh = Combobox(
         gui_text       = 'Horse',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.HORSE_NEIGH),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.HORSE_NEIGH),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of Epona and other horses.
@@ -6632,13 +5002,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_cucco',
+    )
+
+    sfx_cucco = Combobox(
         gui_text       = 'Cucco',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.CUCCO),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.CUCCO),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound of Cuccos.
@@ -6649,13 +5019,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_daybreak',
+    )
+
+    sfx_daybreak = Combobox(
         gui_text       = 'Daybreak',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.DAYBREAK),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.DAYBREAK),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound when morning comes.
@@ -6666,13 +5036,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_nightfall',
+    )
+
+    sfx_nightfall = Combobox(
         gui_text       = 'Nightfall',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.NIGHTFALL),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.NIGHTFALL),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound when night falls.
@@ -6683,13 +5053,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-     Combobox(
-        name           = 'sfx_menu_cursor',
+    )
+
+    sfx_menu_cursor = Combobox(
         gui_text       = 'Menu Cursor',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.MENU_CURSOR),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.MENU_CURSOR),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound when the cursor move in the main menu.
@@ -6700,13 +5070,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_menu_select',
+    )
+
+    sfx_menu_select = Combobox(
         gui_text       = 'Menu Select',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.MENU_SELECT),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.MENU_SELECT),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound when pressing A in the main menu.
@@ -6717,13 +5087,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_low_hp',
+    )
+
+    sfx_low_hp = Combobox(
         gui_text       = 'Low HP',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.HP_LOW),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.HP_LOW),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound when being low on HP.
@@ -6734,9 +5104,9 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Checkbutton(
-        name           = 'slowdown_music_when_lowhp',
+    )
+
+    slowdown_music_when_lowhp = Checkbutton(
         gui_text       = 'Slow Down Music When Low HP',
         shared         = False,
         cosmetic       = True,
@@ -6745,13 +5115,13 @@ setting_infos = [
             Does not apply on the standard battle enemy music.
         ''',
         default        = False,
-    ),
-    Combobox(
-        name           = 'sfx_silver_rupee',
+    )
+
+    sfx_silver_rupee = Combobox(
         gui_text       = 'Silver Rupee Jingle',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.SILVER_RUPEE),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.SILVER_RUPEE),
         default        = 'default',
         gui_tooltip    = '''\
             Change the jingle when getting a silver rupee.
@@ -6762,13 +5132,13 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-    Combobox(
-        name           = 'sfx_get_small_item',
+    )
+
+    sfx_get_small_item = Combobox(
         gui_text       = 'Get Refill',
         shared         = False,
         cosmetic       = True,
-        choices        = sfx.get_setting_choices(sfx.SoundHooks.GET_SMALL_ITEM),
+        choices        = Sounds.get_setting_choices(Sounds.SoundHooks.GET_SMALL_ITEM),
         default        = 'default',
         gui_tooltip    = '''\
             Change the sound when you get a small refill (ammo or recovery heart).
@@ -6779,17 +5149,17 @@ setting_infos = [
                 ('random-ear-safe', 1),
             ]
         }
-    ),
-]
+    )
 
+    setting_infos: Dict[str, SettingInfo] = {}
+    setting_map: dict = {}
 
-si_dict = {si.name: si for si in setting_infos}
-def get_setting_info(name):
-    return si_dict[name]
+    def __init__(self) -> None:
+        self.settings_dict = {}
 
 
 def create_dependency(setting, disabling_setting, option, negative=False):
-    disabled_info = get_setting_info(setting)
+    disabled_info = SettingInfos.setting_infos[setting]
     op = operator.__ne__ if negative else operator.__eq__
     if disabled_info.dependency is None:
         disabled_info.dependency = lambda settings: op(getattr(settings, disabling_setting.name), option)
@@ -6799,7 +5169,7 @@ def create_dependency(setting, disabling_setting, option, negative=False):
 
 
 def get_settings_from_section(section_name):
-    for tab in setting_map['Tabs']:
+    for tab in SettingInfos.setting_map['Tabs']:
         for section in tab['sections']:
             if section['name'] == section_name:
                 for setting in section['settings']:
@@ -6808,15 +5178,16 @@ def get_settings_from_section(section_name):
 
 
 def get_settings_from_tab(tab_name):
-    for tab in setting_map['Tabs']:
+    for tab in SettingInfos.setting_map['Tabs']:
         if tab['name'] == tab_name:
             for section in tab['sections']:
                 for setting in section['settings']:
                     yield setting
             return
 
+
 def is_mapped(setting_name):
-    for tab in setting_map['Tabs']:
+    for tab in SettingInfos.setting_map['Tabs']:
         for section in tab['sections']:
             if setting_name in section['settings']:
                 return True
@@ -6838,22 +5209,22 @@ def build_close_match(name, value_type, source_list=None):
     elif value_type == 'stone':
         source = [x.name for x in gossipLocations.values()]
     elif value_type == 'setting':
-        source = [x.name for x in setting_infos]
+        source = SettingInfos.setting_infos.keys()
     elif value_type == 'choice':
         source = source_list
     # Ensure name and source are type string to prevent errors
     close_match = difflib.get_close_matches(str(name), map(str, source), 1)
     if len(close_match) > 0:
         return "Did you mean %r?" % (close_match[0])
-    return "" # No matches
+    return ""  # No matches
 
 
 def validate_settings(settings_dict, *, check_conflicts=True):
     for setting, choice in settings_dict.items():
         # Ensure the supplied setting name is a real setting
-        if setting not in [x.name for x in setting_infos]:
+        if setting not in SettingInfos.setting_infos:
             raise TypeError('%r is not a valid setting. %s' % (setting, build_close_match(setting, 'setting')))
-        info = get_setting_info(setting)
+        info = SettingInfos.setting_infos[setting]
         # Ensure the type of the supplied choice is correct
         if type(choice) != info.type:
             if setting != 'starting_items' or type(choice) != dict: # allow dict (plando syntax) for starting items in addition to the list syntax used by the GUI
@@ -6870,7 +5241,7 @@ def validate_settings(settings_dict, *, check_conflicts=True):
         elif info.choice_list and choice not in info.choice_list:
             raise ValueError('%r is not a valid choice for setting %r. %s' % (choice, setting, build_close_match(choice, 'choice', info.choice_list)))
         # Ensure no conflicting settings are specified
-        if check_conflicts and info.disable != None:
+        if check_conflicts and info.disable is not None:
             for option, disabling in info.disable.items():
                 negative = False
                 if isinstance(option, str) and option[0] == '!':
@@ -6886,23 +5257,26 @@ def validate_settings(settings_dict, *, check_conflicts=True):
                         for other_setting in get_settings_from_tab(tab):
                             validate_disabled_setting(settings_dict, setting, choice, other_setting)
 
+
 def validate_disabled_setting(settings_dict, setting, choice, other_setting):
     if other_setting in settings_dict:
-        if settings_dict[other_setting] != get_setting_info(other_setting).disabled_default:
+        if settings_dict[other_setting] != SettingInfos.setting_infos[other_setting].disabled_default:
             raise ValueError(f'The {other_setting!r} setting cannot be used since {setting!r} is set to {choice!r}')
+
 
 class UnmappedSettingError(Exception):
     pass
 
 
+SettingInfos.setting_infos = {n: s for n, s in SettingInfos.__dict__.items() if isinstance(s, SettingInfo)}
 with open(data_path('settings_mapping.json')) as f:
-    setting_map = json.load(f)
+    SettingInfos.setting_map = json.load(f)
 
-for info in setting_infos:
+for info in SettingInfos.setting_infos.values():
     if info.gui_text is not None and not info.gui_params.get('optional') and not is_mapped(info.name):
         raise UnmappedSettingError(f'{info.name} is defined but is not in the settings map. Add it to the settings_mapping or set the gui_text to None to suppress.')
 
-    if info.disable != None:
+    if info.disable is not None:
         for option, disabling in info.disable.items():
             negative = False
             if isinstance(option, str) and option[0] == '!':

--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -1,0 +1,1617 @@
+# Below is the list of possible glitchless tricks.
+# The order they are listed in is also the order in which
+# they appear to the user in the GUI, so a sensible order was chosen
+
+logic_tricks = {
+
+    # General tricks
+
+    'Pass Through Visible One-Way Collisions': {
+        'name'    : 'logic_visible_collisions',
+        'tags'    : ("General", "Entrance Shuffle", "Kakariko Village", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    Allows climbing through the platform to reach
+                    Impa's House Back as adult with no items and
+                    going through the Kakariko Village Gate as child
+                    when coming from the Mountain Trail side.
+                    '''},
+    'Hidden Grottos without Stone of Agony': {
+        'name'    : 'logic_grottos_without_agony',
+        'tags'    : ("General", "Entrance Shuffle", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    Allows entering hidden grottos without the
+                    Stone of Agony.
+                    '''},
+    'Fewer Tunic Requirements': {
+        'name'    : 'logic_fewer_tunic_requirements',
+        'tags'    : ("General", "Fire Temple", "Fire Temple MQ", "Water Temple", "Water Temple MQ", "Gerudo Training Ground", "Gerudo Training Ground MQ",
+                    "Ganon's Castle", "Ganon's Castle MQ", "Zora's Fountain", "Death Mountain Crater", "Master Quest", "Overworld", "Vanilla Dungeons",
+                    "Child", "Adult",),
+        'tooltip' : '''\
+                    Allows the following possible without Tunics:
+                    - Enter Fire Temple as adult.
+                    - Zora's Fountain bottom Freestandings. You
+                    might not have enough time to resurface, and
+                    you may need to make multiple trips.
+                    - Traverse the first floor of the Fire Temple,
+                    except the elevator room and Volvagia.
+                    - Go underwater in the Water Temple. (The area
+                    below the central pillar always requires Zora
+                    Tunic.)
+                    - Gerudo Training Ground Underwater Silver
+                    Rupees. You may need to make multiple trips.
+                    - Collecting some Silver Rupees in the Fire
+                    Trial. You may need to make multiple trips.
+                    - All instances also apply in Master Quest.
+                    '''},
+    'Beehives with Bombchus' : {
+        'name'    : 'logic_beehives_bombchus',
+        'tags'    : ("General", "Beehives", "Overworld", "Zora's Fountain", "Child", "Adult",),
+        'tooltip' : '''\
+                    Puts breaking beehives with bombchus into logic.
+                    Using bombs is already expected on beehives that
+                    that are low enough that a bomb throw will reach.
+                    '''},
+    'Hammer Rusted Switches Through Walls': {
+        'name'    : 'logic_rusted_switches',
+        'tags'    : ("General", "Fire Temple", "Fire Temple MQ", "Ganon's Castle MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Applies to:
+                    - Fire Temple Highest Goron Chest.
+                    - MQ Fire Temple Lizalfos Maze.
+                    - MQ Spirit Trial.
+                    '''},
+
+    # Overworld tricks
+
+    'Adult Kokiri Forest GS with Hover Boots': {
+        'name'    : 'logic_adult_kokiri_gs',
+        'tags'    : ("Kokiri Forest", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Can be obtained without Hookshot by using the Hover
+                    Boots off of one of the roots.
+                    '''},
+    'Jump onto the Lost Woods Bridge as Adult with Nothing': {
+        'name'    : 'logic_lost_woods_bridge',
+        'tags'    : ("Lost Woods", "Entrance Shuffle", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    With very precise movement it's possible for
+                    adult to jump onto the bridge without needing
+                    Longshot, Hover Boots, or Bean.
+                    '''},
+    'Backflip over Mido as Adult': {
+        'name'    : 'logic_mido_backflip',
+        'tags'    : ("Lost Woods", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    With a specific position and angle, you can
+                    backflip over Mido.
+                    '''},
+    'Lost Woods Adult GS without Bean': {
+        'name'    : 'logic_lost_woods_gs_bean',
+        'tags'    : ("Lost Woods", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    You can collect the token with a precise
+                    Hookshot use, as long as you can kill the
+                    Skulltula somehow first. It can be killed
+                    using Longshot, Bow, Bombchus or Din's Fire.
+                    '''},
+    'Hyrule Castle Storms Grotto GS with Just Boomerang': {
+        'name'    : 'logic_castle_storms_gs',
+        'tags'    : ("Hyrule Castle", "Gold Skulltulas", "Overworld", "Child",),
+        'tooltip' : '''\
+                    With precise throws, the Boomerang alone can
+                    kill the Skulltula and collect the token,
+                    without first needing to blow up the wall.
+                    '''},
+    'Man on Roof without Hookshot': {
+        'name'    : 'logic_man_on_roof',
+        'tags'    : ("Kakariko Village", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    Can be reached by side-hopping off
+                    the watchtower as either age, or by
+                    jumping onto the potion shop's roof
+                    from the ledge as adult.
+                    '''},
+    'Kakariko Tower GS with Jump Slash': {
+        'name'    : 'logic_kakariko_tower_gs',
+        'tags'    : ("Kakariko Village", "Gold Skulltulas", "Overworld", "Child",),
+        'tooltip' : '''\
+                    Climb the tower as high as you can without
+                    touching the Gold Skulltula, then let go and
+                    jump slash immediately. By jump-slashing from
+                    as low on the ladder as possible to still
+                    hit the Skulltula, this trick can be done
+                    without taking fall damage.
+                    '''},
+    'Windmill PoH as Adult with Nothing': {
+        'name'    : 'logic_windmill_poh',
+        'tags'    : ("Kakariko Village", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Can jump up to the spinning platform from
+                    below as adult.
+                    '''},
+    'Kakariko Rooftop GS with Hover Boots': {
+        'name'    : 'logic_kakariko_rooftop_gs',
+        'tags'    : ("Kakariko Village", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Take the Hover Boots from the entrance to Impa's
+                    House over to the rooftop of Skulltula House. From
+                    there, a precise Hover Boots backwalk with backflip
+                    can be used to get onto a hill above the side of
+                    the village. And then from there you can Hover onto
+                    Impa's rooftop to kill the Skulltula and backflip
+                    into the token.
+                    '''},
+    'Graveyard Freestanding PoH with Boomerang': {
+        'name'    : 'logic_graveyard_poh',
+        'tags'    : ("Graveyard", "Overworld", "Child",),
+        'tooltip' : '''\
+                    Using a precise moving setup you can obtain
+                    the Piece of Heart by having the Boomerang
+                    interact with it along the return path.
+                    '''},
+    'Second Dampe Race as Child': {
+        'name'    : 'logic_child_dampe_race_poh',
+        'tags'    : ("Graveyard", "Entrance Shuffle", "Overworld", "Child",),
+        'tooltip' : '''\
+                    It is possible to complete the second dampe
+                    race as child in under a minute, but it is
+                    a strict time limit.
+                    '''},
+    'Shadow Temple Entry with Fire Arrows': {
+        'name'    : 'logic_shadow_fire_arrow_entry',
+        'tags'    : ("Graveyard", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    It is possible to light all of the torches to
+                    open the Shadow Temple entrance with just Fire
+                    Arrows, but you must be very quick, precise,
+                    and strategic with how you take your shots.
+                    '''},
+    'Death Mountain Trail Soil GS without Destroying Boulder': {
+        'name'    : 'logic_dmt_soil_gs',
+        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Child",),
+        'tooltip' : '''\
+                    Bugs will go into the soft soil even while the boulder is
+                    still blocking the entrance.
+                    Then, using a precise moving setup you can kill the Gold
+                    Skulltula and obtain the token by having the Boomerang
+                    interact with it along the return path.
+                    '''},
+    'Death Mountain Trail Chest with Strength': {
+        'name'    : 'logic_dmt_bombable',
+        'tags'    : ("Death Mountain Trail", "Overworld", "Child",),
+        'tooltip' : '''\
+                    Child Link can blow up the wall using a nearby bomb
+                    flower. You must backwalk with the flower and then
+                    quickly throw it toward the wall.
+                    '''},
+    'Death Mountain Trail Lower Red Rock GS with Hookshot': {
+        'name'    : 'logic_trail_gs_lower_hookshot',
+        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    After killing the Skulltula, the token can be fished
+                    out of the rock without needing to destroy it, by
+                    using the Hookshot in the correct way.
+                    '''},
+    'Death Mountain Trail Lower Red Rock GS with Hover Boots': {
+        'name'    : 'logic_trail_gs_lower_hovers',
+        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    After killing the Skulltula, the token can be
+                    collected without needing to destroy the rock by
+                    backflipping down onto it with the Hover Boots.
+                    First use the Hover Boots to stand on a nearby
+                    fence, and go for the Skulltula Token from there.
+                    '''},
+    'Death Mountain Trail Lower Red Rock GS with Magic Bean': {
+        'name'    : 'logic_trail_gs_lower_bean',
+        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    After killing the Skulltula, the token can be
+                    collected without needing to destroy the rock by
+                    jumping down onto it from the bean plant,
+                    midflight, with precise timing and positioning.
+                    '''},
+    'Death Mountain Trail Climb with Hover Boots': {
+        'name'    : 'logic_dmt_climb_hovers',
+        'tags'    : ("Death Mountain Trail", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    It is possible to use the Hover Boots to bypass
+                    needing to destroy the boulders blocking the path
+                    to the top of Death Mountain.
+                    '''},
+    'Death Mountain Trail Upper Red Rock GS without Hammer': {
+        'name'    : 'logic_trail_gs_upper',
+        'tags'    : ("Death Mountain Trail", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    After killing the Skulltula, the token can be collected
+                    by backflipping into the rock at the correct angle.
+                    '''},
+    'Deliver Eye Drops with Bolero of Fire': {
+        'name'    : 'logic_biggoron_bolero',
+        'tags'    : ("Death Mountain Trail", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Playing a warp song normally causes a trade item to
+                    spoil immediately, however, it is possible use Bolero
+                    to reach Biggoron and still deliver the Eye Drops
+                    before they spoil. If you do not wear the Goron Tunic,
+                    the heat timer inside the crater will override the trade
+                    item's timer. When you exit to Death Mountain Trail you
+                    will have one second to show the Eye Drops before they
+                    expire. You can get extra time to show the Eye Drops if
+                    you warp immediately upon receiving them. If you don't
+                    have many hearts, you may have to reset the heat timer
+                    by quickly dipping in and out of Darunia's chamber or
+                    quickly equipping and unequipping the Goron Tunic.
+                    This trick does not apply if "Randomize Warp Song
+                    Destinations" is enabled, or if the settings are such
+                    that trade items do not need to be delivered within a
+                    time limit.
+                    '''},
+    'Goron City Spinning Pot PoH with Bombchu': {
+        'name'    : 'logic_goron_city_pot',
+        'tags'    : ("Goron City", "Overworld", "Child",),
+        'tooltip' : '''\
+                    A Bombchu can be used to stop the spinning
+                    pot, but it can be quite finicky to get it
+                    to work.
+                    '''},
+    'Goron City Spinning Pot PoH with Strength': {
+        'name'    : 'logic_goron_city_pot_with_strength',
+        'tags'    : ("Goron City", "Overworld", "Child",),
+        'tooltip' : '''\
+                    Allows for stopping the Goron City Spinning
+                    Pot using a bomb flower alone, requiring
+                    strength in lieu of inventory explosives.
+                    '''},
+    'Rolling Goron (Hot Rodder Goron) as Child with Strength': {
+        'name'    : 'logic_child_rolling_with_strength',
+        'tags'    : ("Goron City", "Overworld", "Child",),
+        'tooltip' : '''\
+                    Use the bombflower on the stairs or near Medigoron.
+                    Timing is tight, especially without backwalking.
+                    '''},
+    'Stop Link the Goron with Din\'s Fire': {
+        'name'    : 'logic_link_goron_dins',
+        'tags'    : ("Goron City", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    The timing is quite awkward.
+                    '''},
+    'Goron City Maze Left Chest with Hover Boots': {
+        'name'    : 'logic_goron_city_leftmost',
+        'tags'    : ("Goron City", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    A precise backwalk starting from on top of the
+                    crate and ending with a precisely-timed backflip
+                    can reach this chest without needing either
+                    the Hammer or Silver Gauntlets.
+                    '''},
+    'Goron City Grotto with Hookshot While Taking Damage': {
+        'name'    : 'logic_goron_grotto',
+        'tags'    : ("Goron City", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    It is possible to reach the Goron City Grotto by
+                    quickly using the Hookshot while in the midst of
+                    taking damage from the lava floor. This trick will
+                    not be expected on OHKO or quadruple damage.
+                    '''},
+    'Crater\'s Bean PoH with Hover Boots': {
+        'name'    : 'logic_crater_bean_poh_with_hovers',
+        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Hover from the base of the bridge
+                    near Goron City and walk up the
+                    very steep slope.
+                    '''},
+    'Death Mountain Crater Jump to Bolero': {
+        'name'    : 'logic_crater_bolero_jump',
+        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    As Adult , using a shield to drop a pot while you have
+                    the perfect speed and position, the pot can
+                    push you that little extra distance you
+                    need to jump across the gap in the bridge.
+                    '''},
+    'Death Mountain Crater Upper to Lower with Hammer': {
+        'name'    : 'logic_crater_boulder_jumpslash',
+        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    With the Hammer, you can jump slash the rock twice
+                    in the same jump in order to destroy it before you
+                    fall into the lava.
+                    '''},
+    'Death Mountain Crater Upper to Lower Boulder Skip': {
+        'name'    : 'logic_crater_boulder_skip',
+        'tags'    : ("Death Mountain Crater", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    As adult, With careful positioning, you can jump to the ledge
+                    where the boulder is, then use repeated ledge grabs
+                    to shimmy to a climbable ledge. This trick supersedes
+                    "Death Mountain Crater Upper to Lower with Hammer".
+                    '''},
+    'Zora\'s River Lower Freestanding PoH as Adult with Nothing': {
+        'name'    : 'logic_zora_river_lower',
+        'tags'    : ("Zora's River", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Adult can reach this PoH with a precise jump,
+                    no Hover Boots required.
+                    '''},
+    'Zora\'s River Upper Freestanding PoH as Adult with Nothing': {
+        'name'    : 'logic_zora_river_upper',
+        'tags'    : ("Zora's River", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Adult can reach this PoH with a precise jump,
+                    no Hover Boots required.
+                    '''},
+    'Zora\'s Domain Entry with Cucco': {
+        'name'    : 'logic_zora_with_cucco',
+        'tags'    : ("Zora's River", "Overworld", "Child",),
+        'tooltip' : '''\
+                    You can fly behind the waterfall with
+                    a Cucco as child.
+                    '''},
+    'Zora\'s Domain Entry with Hover Boots': {
+        'name'    : 'logic_zora_with_hovers',
+        'tags'    : ("Zora's River", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Can hover behind the waterfall as adult.
+                    '''},
+    'Zora\'s River Rupees with Jump Dive': {
+        'name'    : 'logic_zora_river_rupees',
+        'tags'    : ("Zora's River", "Freestandings", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    You can jump down onto them from
+                    above to skip needing Iron Boots.
+                    '''},
+    'Skip King Zora as Adult with Nothing': {
+        'name'    : 'logic_king_zora_skip',
+        'tags'    : ("Zora's Domain", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    With a precise jump as adult, it is possible to
+                    get on the fence next to King Zora from the front
+                    to access Zora's Fountain.
+                    '''},
+    'Zora\'s Domain GS with No Additional Items': {
+        'name'    : 'logic_domain_gs',
+        'tags'    : ("Zora's Domain", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    A precise jump slash can kill the Skulltula and
+                    recoil back onto the top of the frozen waterfall.
+                    To kill it, the logic normally guarantees one of
+                    Hookshot, Bow, or Magic.
+                    '''},
+    'Lake Hylia Lab Wall GS with Jump Slash': {
+        'name'    : 'logic_lab_wall_gs',
+        'tags'    : ("Lake Hylia", "Gold Skulltulas", "Overworld", "Child",),
+        'tooltip' : '''\
+                    The jump slash to actually collect the
+                    token is somewhat precise.
+                    '''},
+    'Lake Hylia Lab Dive without Gold Scale': {
+        'name'    : 'logic_lab_diving',
+        'tags'    : ("Lake Hylia", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Remove the Iron Boots in the midst of
+                    Hookshotting the underwater crate.
+                    '''},
+    'Water Temple Entry without Iron Boots using Hookshot': {
+        'name'    : 'logic_water_hookshot_entry',
+        'tags'    : ("Lake Hylia", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    When entering Water Temple using Gold Scale instead
+                    of Iron Boots, the Longshot is usually used to be
+                    able to hit the switch and open the gate. But, by
+                    standing in a particular spot, the switch can be hit
+                    with only the reach of the Hookshot.
+                    '''},
+    'Gerudo Valley Crate PoH as Adult with Hover Boots': {
+        'name'    : 'logic_valley_crate_hovers',
+        'tags'    : ("Gerudo Valley", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    From the far side of Gerudo Valley, a precise
+                    Hover Boots movement and jump-slash recoil can
+                    allow adult to reach the ledge with the crate
+                    PoH without needing Longshot. You will take
+                    fall damage.
+                    '''},
+    'Thieves\' Hideout "Kitchen" with No Additional Items': {
+        'name'    : 'logic_gerudo_kitchen',
+        'tags'    : ("Thieves' Hideout", "Gerudo's Fortress", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    Allows passing through the kitchen by avoiding being
+                    seen by the guards. The logic normally guarantees
+                    Bow or Hookshot to stun them from a distance, or
+                    Hover Boots to cross the room without needing to
+                    deal with the guards.
+                    '''},
+    'Gerudo\'s Fortress Ledge Jumps': {
+        'name'    : 'logic_gf_jump',
+        'tags'    : ("Gerudo's Fortress", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    Allows both ages to use a jump to reach the second
+                    floor of the fortress from the southern roof with
+                    the guard, and adult to jump to the top roof from
+                    there, without going through the interiors of the
+                    Thieves' Hideout.
+                    '''},
+    'Wasteland Crossing without Hover Boots or Longshot': {
+        'name'    : 'logic_wasteland_crossing',
+        'tags'    : ("Haunted Wasteland", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    You can beat the quicksand by backwalking across it
+                    in a specific way.
+                    Note that jumping to the carpet merchant as child
+                    typically requires a fairly precise jump slash.
+                    '''},
+    'Lensless Wasteland': {
+        'name'    : 'logic_lens_wasteland',
+        'tags'    : ("Lens of Truth", "Haunted Wasteland", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    By memorizing the path, you can travel through the
+                    Wasteland without using the Lens of Truth to see
+                    the Poe.
+                    The equivalent trick for going in reverse through
+                    the Wasteland is "Reverse Wasteland".
+                    '''},
+    'Reverse Wasteland': {
+        'name'    : 'logic_reverse_wasteland',
+        'tags'    : ("Haunted Wasteland", "Overworld", "Child", "Adult",),
+        'tooltip' : '''\
+                    By memorizing the path, you can travel through the
+                    Wasteland in reverse.
+                    Note that jumping to the carpet merchant as child
+                    typically requires a fairly precise jump slash.
+                    The equivalent trick for going forward through the
+                    Wasteland is "Lensless Wasteland".
+                    To cross the river of sand with no additional items,
+                    be sure to also enable "Wasteland Crossing without
+                    Hover Boots or Longshot".
+                    Unless Thieves' Hideout entrances or all overworld
+                    entrances are randomized, child Link will not be
+                    expected to do anything at Gerudo's Fortress.
+                    '''},
+    'Colossus Hill GS with Hookshot': {
+        'name'    : 'logic_colossus_gs',
+        'tags'    : ("Desert Colossus", "Gold Skulltulas", "Overworld", "Adult",),
+        'tooltip' : '''\
+                    Somewhat precise. If you kill enough Leevers
+                    you can get enough of a break to take some time
+                    to aim more carefully.
+                    '''},
+
+    # Dungeons
+
+    'Deku Tree Basement Vines GS with Jump Slash': {
+        'name'    : 'logic_deku_basement_gs',
+        'tags'    : ("Deku Tree", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    Can be defeated by doing a precise jump slash.
+                    '''},
+    'Deku Tree Basement without Slingshot': {
+        'name'    : 'logic_deku_b1_skip',
+        'tags'    : ("Deku Tree", "Deku Tree MQ", "Master Quest", "Vanilla Dungeons", "Child"),
+        'tooltip' : '''\
+                    A precise jump can be used to skip
+                    needing to use the Slingshot to go
+                    around B1 of the Deku Tree. If used
+                    with the "Closed Forest" setting, a
+                    Slingshot will not be guaranteed to
+                    exist somewhere inside the Forest.
+                    This trick applies to both Vanilla
+                    and Master Quest.
+                    '''},
+    'Deku Tree Basement Web to Gohma with Bow': {
+        'name'    : 'logic_deku_b1_webs_with_bow',
+        'tags'    : ("Deku Tree", "Entrance Shuffle", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    All spider web walls in the Deku Tree basement can be burnt
+                    as adult with just a bow by shooting through torches. This
+                    trick only applies to the circular web leading to Gohma;
+                    the two vertical webs are always in logic.
+
+                    Backflip onto the chest near the torch at the bottom of
+                    the vine wall. With precise positioning you can shoot
+                    through the torch to the right edge of the circular web.
+
+                    This allows completion of adult Deku Tree with no fire source.
+                    '''},
+    'Deku Tree MQ Compass Room GS Boulders with Just Hammer': {
+        'name'    : 'logic_deku_mq_compass_gs',
+        'tags'    : ("Deku Tree MQ", "Gold Skulltulas", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Climb to the top of the vines, then let go
+                    and jump slash immediately to destroy the
+                    boulders using the Hammer, without needing
+                    to spawn a Song of Time block.
+                    '''},
+    'Deku Tree MQ Roll Under the Spiked Log': {
+        'name'    : 'logic_deku_mq_log',
+        'tags'    : ("Deku Tree MQ", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    You can get past the spiked log by rolling
+                    to briefly shrink your hitbox. As adult,
+                    the timing is a bit more precise.
+                    '''},
+    'Dodongo\'s Cavern Scarecrow GS with Armos Statue': {
+        'name'    : 'logic_dc_scarecrow_gs',
+        'tags'    : ("Dodongo's Cavern", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    You can jump off an Armos Statue to reach the
+                    alcove with the Gold Skulltula. It takes quite
+                    a long time to pull the statue the entire way.
+                    The jump to the alcove can be a bit picky when
+                    done as child.
+                    '''},
+    'Dodongo\'s Cavern Vines GS from Below with Longshot': {
+        'name'    : 'logic_dc_vines_gs',
+        'tags'    : ("Dodongo's Cavern", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The vines upon which this Skulltula rests are one-
+                    sided collision. You can use the Longshot to get it
+                    from below, by shooting it through the vines,
+                    bypassing the need to lower the staircase.
+                    '''},
+    'Dodongo\'s Cavern Staircase with Bow': {
+        'name'    : 'logic_dc_staircase',
+        'tags'    : ("Dodongo's Cavern", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The Bow can be used to knock down the stairs
+                    with two well-timed shots.
+                    '''},
+    'Dodongo\'s Cavern Child Slingshot Skips': {
+        'name'    : 'logic_dc_slingshot_skip',
+        'tags'    : ("Dodongo's Cavern", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    With precise platforming, child can cross the
+                    platforms while the flame circles are there.
+                    When enabling this trick, it's recommended that
+                    you also enable the Adult variant: "Dodongo's
+                    Cavern Spike Trap Room Jump without Hover Boots".
+                    '''},
+    'Dodongo\'s Cavern Two Scrub Room with Strength': {
+        'name'    : 'logic_dc_scrub_room',
+        'tags'    : ("Dodongo's Cavern", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    With help from a conveniently-positioned block,
+                    Adult can quickly carry a bomb flower over to
+                    destroy the mud wall blocking the room with two
+                    Deku Scrubs.
+                    '''},
+    'Dodongo\'s Cavern Spike Trap Room Jump without Hover Boots': {
+        'name'    : 'logic_dc_jump',
+        'tags'    : ("Dodongo's Cavern", "Dodongo's Cavern MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The jump is adult Link only. Applies to both Vanilla and MQ.
+                    '''},
+    'Dodongo\'s Cavern Smash the Boss Lobby Floor': {
+        'name'    : 'logic_dc_hammer_floor',
+        'tags'    : ("Dodongo's Cavern", "Dodongo's Cavern MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The bombable floor before King Dodongo can be destroyed
+                    with Hammer if hit in the very center. This is only
+                    relevant with Shuffle Boss Entrances or if Dodongo's Cavern
+                    is MQ and either variant of "Dodongo's Cavern MQ Light the
+                    Eyes with Strength" is on.
+                    '''},
+    'Dodongo\'s Cavern MQ Early Bomb Bag Area as Child': {
+        'name'    : 'logic_dc_mq_child_bombs',
+        'tags'    : ("Dodongo's Cavern MQ", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    With a precise jump slash from above, you
+                    can reach the Bomb Bag area as only child
+                    without needing a Slingshot. You will
+                    take fall damage.
+                    '''},
+    'Dodongo\'s Cavern MQ Light the Eyes with Strength as Adult': {
+        'name'    : 'logic_dc_mq_eyes_adult',
+        'tags'    : ("Dodongo's Cavern MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    If you move very quickly, it is possible to use
+                    the bomb flower at the top of the room to light
+                    the eyes.
+                    '''},
+    'Dodongo\'s Cavern MQ Light the Eyes with Strength as Child': {
+        'name'    : 'logic_dc_mq_eyes_child',
+        'tags'    : ("Dodongo's Cavern MQ", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    If you move very quickly, it is possible to use
+                    the bomb flower at the top of the room to light
+                    the eyes. To perform this trick as child is
+                    significantly more difficult than adult. The
+                    player is also expected to complete the DC back
+                    area without explosives, including getting past
+                    the Armos wall to the switch for the boss door.
+                    '''},
+    'Jabu Underwater Alcove as Adult with Jump Dive': {
+        'name'    : 'logic_jabu_alcove_jump_dive',
+        'tags'    : ("Jabu Jabu's Belly", "Jabu Jabu's Belly MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Standing above the underwater tunnel leading to the scrub,
+                    jump down and swim through the tunnel. This allows adult to
+                    access the alcove with no Scale or Iron Boots. In vanilla Jabu,
+                    this alcove has a business scrub. In MQ Jabu, it has the compass
+                    chest and a door switch for the main floor.
+                    '''},
+    'Jabu Near Boss Room with Hover Boots': {
+        'name'    : 'logic_jabu_boss_hover',
+        'tags'    : ("Jabu Jabu's Belly", "Gold Skulltulas", "Entrance Shuffle", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A box for the blue switch can be carried over
+                    by backwalking with one while the elevator is
+                    at its peak. Alternatively, you can skip
+                    transporting a box by quickly rolling from the
+                    switch and opening the door before it closes.
+                    However, the timing for this is very tight.
+                    '''},
+    'Jabu Near Boss Ceiling Switch/GS without Boomerang or Explosives': {
+        'name'    : 'logic_jabu_near_boss_ranged',
+        'tags'    : ("Jabu Jabu's Belly", "Jabu Jabu's Belly MQ", "Gold Skulltulas", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    Vanilla Jabu: From near the entrance into the room, you can
+                    hit the switch that opens the door to the boss room using a
+                    precisely-aimed use of the Slingshot, Bow, or Longshot. As well,
+                    if you climb to the top of the vines you can stand on the right
+                    edge of the platform and shoot around the glass. From this
+                    distance, even the Hookshot can reach the switch. This trick is
+                    only relevant if "Shuffle Boss Entrances" is enabled.
+
+                    MQ Jabu: A Gold Skulltula Token can be collected with the
+                    Hookshot or Longshot using the same methods as hitting the switch
+                    in vanilla. This trick is usually only relevant if Jabu dungeon
+                    shortcuts are enabled.
+                    '''},
+    'Jabu Near Boss Ceiling Switch with Explosives': {
+        'name'    : 'logic_jabu_near_boss_explosives',
+        'tags'    : ("Jabu Jabu's Belly", "Entrance Shuffle", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    You can hit the switch that opens the door to the boss
+                    room using a precisely-aimed Bombchu. Also, using the
+                    Hover Boots, adult can throw a Bomb at the switch. This
+                    trick is only relevant if "Shuffle Boss Entrances" is
+                    enabled.
+                    '''},
+    'Jabu MQ without Lens of Truth': {
+        'name'    : 'logic_lens_jabu_mq',
+        'tags'    : ("Lens of Truth", "Jabu Jabu's Belly MQ", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Jabu MQ.
+                    '''},
+    'Jabu MQ Compass Chest with Boomerang': {
+        'name'    : 'logic_jabu_mq_rang_jump',
+        'tags'    : ("Jabu Jabu's Belly MQ", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    Boomerang can reach the cow switch to spawn the chest by
+                    targeting the cow, jumping off of the ledge where the
+                    chest spawns, and throwing the Boomerang in midair. This
+                    is only relevant with Jabu Jabu's Belly dungeon shortcuts
+                    enabled.
+                    '''},
+    'Jabu MQ Song of Time Block GS with Boomerang': {
+        'name'    : 'logic_jabu_mq_sot_gs',
+        'tags'    : ("Jabu Jabu's Belly MQ", "Gold Skulltulas", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    Allow the Boomerang to return to you through
+                    the Song of Time block to grab the token.
+                    '''},
+    'Bottom of the Well without Lens of Truth': {
+        'name'    : 'logic_lens_botw',
+        'tags'    : ("Lens of Truth", "Bottom of the Well", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Bottom of the Well.
+                    '''},
+    'Child Dead Hand without Kokiri Sword': {
+        'name'    : 'logic_child_deadhand',
+        'tags'    : ("Bottom of the Well", "Bottom of the Well MQ", "Vanilla Dungeons", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    Requires 9 sticks or 5 jump slashes.
+                    '''},
+    'Bottom of the Well Map Chest with Strength & Sticks': {
+        'name'    : 'logic_botw_basement',
+        'tags'    : ("Bottom of the Well", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    The chest in the basement can be reached with
+                    strength by doing a jump slash with a lit
+                    stick to access the bomb flowers.
+                    '''},
+    'Bottom of the Well MQ Jump Over the Pits': {
+        'name'    : 'logic_botw_mq_pits',
+        'tags'    : ("Bottom of the Well MQ", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    While the pits in Bottom of the Well don't allow you to
+                    jump just by running straight at them, you can still get
+                    over them by side-hopping or backflipping across. With
+                    explosives, this allows you to access the central areas
+                    without Zelda's Lullaby. With Zelda's Lullaby, it allows
+                    you to access the west inner room without explosives.
+                    '''},
+    'Bottom of the Well MQ Dead Hand Freestanding Key with Boomerang': {
+        'name'    : 'logic_botw_mq_dead_hand_key',
+        'tags'    : ("Bottom of the Well MQ", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    Boomerang can fish the item out of the rubble without
+                    needing explosives to blow it up.
+                    '''},
+    'Forest Temple First Room GS with Difficult-to-Use Weapons': {
+        'name'    : 'logic_forest_first_gs',
+        'tags'    : ("Forest Temple", "Entrance Shuffle", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    Allows killing this Skulltula with Sword or Sticks by
+                    jump slashing it as you let go from the vines. You can
+                    avoid taking fall damage by recoiling onto the tree.
+                    Also allows killing it as Child with a Bomb throw. It's
+                    much more difficult to use a Bomb as child due to
+                    Child Link's shorter height.
+                    '''},
+    'Forest Temple East Courtyard GS with Boomerang': {
+        'name'    : 'logic_forest_outdoor_east_gs',
+        'tags'    : ("Forest Temple", "Entrance Shuffle", "Gold Skulltulas", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    Precise Boomerang throws can allow child to
+                    kill the Skulltula and collect the token.
+                    '''},
+    'Forest Temple East Courtyard Vines with Hookshot': {
+        'name'    : 'logic_forest_vines',
+        'tags'    : ("Forest Temple", "Forest Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The vines in Forest Temple leading to where the well
+                    drain switch is in the standard form can be barely
+                    reached with just the Hookshot. Applies to MQ also.
+                    '''},
+    'Forest Temple NE Outdoors Ledge with Hover Boots': {
+        'name'    : 'logic_forest_outdoors_ledge',
+        'tags'    : ("Forest Temple", "Forest Temple MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    With precise Hover Boots movement you can fall down
+                    to this ledge from upper balconies. If done precisely
+                    enough, it is not necessary to take fall damage.
+                    In MQ, this skips a Longshot requirement.
+                    In Vanilla, this can skip a Hookshot requirement in
+                    entrance randomizer.
+                    '''},
+    'Forest Temple East Courtyard Door Frame with Hover Boots': {
+        'name'    : 'logic_forest_door_frame',
+        'tags'    : ("Forest Temple", "Forest Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A precise Hover Boots movement from the upper
+                    balconies in this courtyard can be used to get on
+                    top of the door frame. Applies to both Vanilla and
+                    Master Quest. In Vanilla, from on top the door
+                    frame you can summon Pierre, allowing you to access
+                    the falling ceiling room early. In Master Quest,
+                    this allows you to obtain the GS on the door frame
+                    as adult without Hookshot or Song of Time.
+                    '''},
+    'Forest Temple Outside Backdoor with Jump Slash': {
+        'name'    : 'logic_forest_outside_backdoor',
+        'tags'    : ("Forest Temple", "Forest Temple MQ", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    A jump slash recoil can be used to reach the
+                    ledge in the block puzzle room that leads to
+                    the west courtyard. This skips a potential
+                    Hover Boots requirement in vanilla, and it
+                    can sometimes apply in MQ as well. This trick
+                    can be performed as both ages.
+                    '''},
+    'Swim Through Forest Temple MQ Well with Hookshot': {
+        'name'    : 'logic_forest_well_swim',
+        'tags'    : ("Forest Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Shoot the vines in the well as low and as far to
+                    the right as possible, and then immediately swim
+                    under the ceiling to the right. This can only be
+                    required if Forest Temple is in its Master Quest
+                    form.
+                    '''},
+    'Skip Forest Temple MQ Block Puzzle with Bombchu': {
+        'name'    : 'logic_forest_mq_block_puzzle',
+        'tags'    : ("Forest Temple MQ", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    Send the Bombchu straight up the center of the
+                    wall directly to the left upon entering the room.
+                    '''},
+    'Forest Temple MQ Twisted Hallway Switch with Jump Slash': {
+        'name'    : 'logic_forest_mq_hallway_switch_jumpslash',
+        'tags'    : ("Forest Temple MQ", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    The switch to twist the hallway can be hit with
+                    a jump slash through the glass block. To get in
+                    front of the switch, either use the Hover Boots
+                    or hit the shortcut switch at the top of the
+                    room and jump from the glass blocks that spawn.
+                    Sticks can be used as child, but the Kokiri
+                    Sword is too short to reach through the glass.
+                    '''},
+    #'Forest Temple MQ Twisted Hallway Switch with Hookshot': {
+    #    'name'    : 'logic_forest_mq_hallway_switch_hookshot',
+    #    'tags'    : ("Forest Temple MQ", "Master Quest", "Adult",),
+    #    'tooltip' : '''\
+    #                There's a very small gap between the glass block
+    #                and the wall. Through that gap you can hookshot
+    #                the target on the ceiling.
+    #                '''},
+    'Forest Temple MQ Twisted Hallway Switch with Boomerang': {
+        'name'    : 'logic_forest_mq_hallway_switch_boomerang',
+        'tags'    : ("Forest Temple MQ", "Entrance Shuffle", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    The Boomerang can return to Link through walls,
+                    allowing child to hit the hallway switch. This
+                    can be used to allow adult to pass through later,
+                    or in conjuction with "Forest Temple Outside
+                    Backdoor with Jump Slash".
+                    '''},
+    'Fire Temple Boss Door without Hover Boots or Pillar': {
+        'name'    : 'logic_fire_boss_door_jump',
+        'tags'    : ("Fire Temple", "Fire Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The Fire Temple Boss Door can be reached as adult with a precise
+                    jump. You must be touching the side wall of the room so
+                    that Link will grab the ledge from farther away than
+                    is normally possible.
+                    '''},
+    'Fire Temple Song of Time Room GS without Song of Time': {
+        'name'    : 'logic_fire_song_of_time',
+        'tags'    : ("Fire Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A precise jump can be used to reach this room.
+                    '''},
+    'Fire Temple Climb without Strength': {
+        'name'    : 'logic_fire_strength',
+        'tags'    : ("Fire Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A precise jump can be used to skip
+                    pushing the block.
+                    '''},
+    'Fire Temple East Tower without Scarecrow\'s Song': {
+        'name'    : 'logic_fire_scarecrow',
+        'tags'    : ("Fire Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Also known as "Pixelshot".
+                    The Longshot can reach the target on the elevator
+                    itself, allowing you to skip needing to spawn the
+                    scarecrow.
+                    '''},
+    'Fire Temple Flame Wall Maze Skip': {
+        'name'    : 'logic_fire_flame_maze',
+        'tags'    : ("Fire Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of
+                    a flame wall before it can rise up to block you.
+                    To do it without taking damage is more precise.
+                    Allows you to progress without needing either a
+                    Small Key or Hover Boots.
+                    '''},
+    'Fire Temple MQ Chest Near Boss without Breaking Crate': {
+        'name'    : 'logic_fire_mq_near_boss',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    The hitbox for the torch extends a bit outside of the crate.
+                    Shoot a flaming arrow at the side of the crate to light the
+                    torch without needing to get over there and break the crate.
+                    '''},
+    'Fire Temple MQ Big Lava Room Blocked Door without Hookshot': {
+        'name'    : 'logic_fire_mq_blocked_chest',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    There is a gap between the hitboxes of the flame
+                    wall in the big lava room. If you know where this
+                    gap is located, you can jump through it and skip
+                    needing to use the Hookshot. To do this without
+                    taking damage is more precise.
+                    '''},
+    'Fire Temple MQ Boss Key Chest without Bow': {
+        'name'    : 'logic_fire_mq_bk_chest',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    It is possible to light both of the timed torches
+                    to unbar the door to the boss key chest's room
+                    with just Din's Fire if you move very quickly
+                    between the two torches. It is also possible to
+                    unbar the door with just Din's by abusing an
+                    oversight in the way the game counts how many
+                    torches have been lit.
+                    '''},
+    'Fire Temple MQ Climb without Fire Source': {
+        'name'    : 'logic_fire_mq_climb',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    You can use the Hover Boots to hover around to
+                    the climbable wall, skipping the need to use a
+                    fire source and spawn a Hookshot target.
+                    '''},
+    'Fire Temple MQ Lizalfos Maze Side Room without Box': {
+        'name'    : 'logic_fire_mq_maze_side_room',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    You can walk from the blue switch to the door and
+                    quickly open the door before the bars reclose. This
+                    skips needing to reach the upper sections of the
+                    maze to get a box to place on the switch.
+                    '''},
+    'Fire Temple MQ Lower to Upper Lizalfos Maze with Hover Boots': {
+        'name'    : 'logic_fire_mq_maze_hovers',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Use the Hover Boots off of a crate to
+                    climb to the upper maze without needing
+                    to spawn and use the Hookshot targets.
+                    '''},
+    'Fire Temple MQ Lower to Upper Lizalfos Maze with Precise Jump': {
+        'name'    : 'logic_fire_mq_maze_jump',
+        'tags'    : ("Fire Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    A precise jump off of a crate can be used to
+                    climb to the upper maze without needing to spawn
+                    and use the Hookshot targets. This trick
+                    supersedes both "Fire Temple MQ Lower to Upper
+                    Lizalfos Maze with Hover Boots" and "Fire Temple
+                    MQ Lizalfos Maze Side Room without Box".
+                    '''},
+    'Fire Temple MQ Above Flame Wall Maze GS from Below with Longshot': {
+        'name'    : 'logic_fire_mq_above_maze_gs',
+        'tags'    : ("Fire Temple MQ", "Gold Skulltulas", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    The floor of the room that contains this Skulltula
+                    is only solid from above. From the maze below, the
+                    Longshot can be shot through the ceiling to obtain
+                    the token with two fewer small keys than normal.
+                    '''},
+    'Fire Temple MQ Flame Wall Maze Skip': {
+        'name'    : 'logic_fire_mq_flame_maze',
+        'tags'    : ("Fire Temple MQ", "Gold Skulltulas", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of
+                    a flame wall before it can rise up to block you.
+                    To do it without taking damage is more precise.
+                    Allows you to reach the side room GS without needing
+                    Song of Time or Hover Boots. If either of "Fire Temple
+                    MQ Lower to Upper Lizalfos Maze with Hover Boots" or
+                    "with Precise Jump" are enabled, this also allows you
+                    to progress deeper into the dungeon without Hookshot.
+                    '''},
+    'Water Temple Torch Longshot': {
+        'name'    : 'logic_water_temple_torch_longshot',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Stand on the eastern side of the central pillar and longshot
+                    the torches on the bottom level. Swim through the corridor
+                    and float up to the top level. This allows access to this
+                    area and lower water levels without Iron Boots.
+                    The majority of the tricks that allow you to skip Iron Boots
+                    in the Water Temple are not going to be relevant unless this
+                    trick is first enabled.
+                    '''},
+    'Water Temple Cracked Wall with Hover Boots': {
+        'name'    : 'logic_water_cracked_wall_hovers',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    With a midair side-hop while wearing the Hover
+                    Boots, you can reach the cracked wall without
+                    needing to raise the water up to the middle level.
+                    '''},
+    'Water Temple Cracked Wall with No Additional Items': {
+        'name'    : 'logic_water_cracked_wall_nothing',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A precise jump slash (among other methods) will
+                    get you to the cracked wall without needing the
+                    Hover Boots or to raise the water to the middle
+                    level. This trick supersedes "Water Temple
+                    Cracked Wall with Hover Boots".
+                    '''},
+    'Water Temple Boss Key Region with Hover Boots': {
+        'name'    : 'logic_water_boss_key_region',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    With precise Hover Boots movement it is possible
+                    to reach the boss key chest's region without
+                    needing the Longshot. It is not necessary to take
+                    damage from the spikes. The Gold Skulltula Token
+                    in the following room can also be obtained with
+                    just the Hover Boots.
+                    '''},
+    'Water Temple North Basement Ledge with Precise Jump': {
+        'name'    : 'logic_water_north_basement_ledge_jump',
+        'tags'    : ("Water Temple", "Water Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    In the northern basement there's a ledge from where, in
+                    vanilla Water Temple, boulders roll out into the room.
+                    Normally to jump directly to this ledge logically
+                    requires the Hover Boots, but with precise jump, it can
+                    be done without them. This trick applies to both
+                    Vanilla and Master Quest.
+                    '''},
+    'Water Temple Boss Key Jump Dive': {
+        'name'    : 'logic_water_bk_jump_dive',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Stand on the very edge of the raised corridor leading from the
+                    push block room to the rolling boulder corridor. Face the
+                    gold skulltula on the waterfall and jump over the boulder
+                    corridor floor into the pool of water, swimming right once
+                    underwater. This allows access to the boss key room without
+                    Iron boots.
+                    '''},
+    'Water Temple Central Pillar GS with Farore\'s Wind': {
+        'name'    : 'logic_water_central_gs_fw',
+        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    If you set Farore's Wind inside the central pillar
+                    and then return to that warp point after raising
+                    the water to the highest level, you can obtain this
+                    Skulltula Token with Hookshot or Boomerang.
+                    '''},
+    'Water Temple Central Pillar GS with Iron Boots': {
+        'name'    : 'logic_water_central_gs_irons',
+        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    After opening the middle water level door into the
+                    central pillar, the door will stay unbarred so long
+                    as you do not leave the room -- even if you were to
+                    raise the water up to the highest level. With the
+                    Iron Boots to go through the door after the water has
+                    been raised, you can obtain the Skulltula Token with
+                    the Hookshot.
+                    '''},
+    'Water Temple Central Bow Target without Longshot or Hover Boots': {
+        'name'    : 'logic_water_central_bow',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    A very precise Bow shot can hit the eye
+                    switch from the floor above. Then, you
+                    can jump down into the hallway and make
+                    through it before the gate closes.
+                    It can also be done as child, using the
+                    Slingshot instead of the Bow.
+                    '''},
+    'Water Temple Falling Platform Room GS with Hookshot': {
+        'name'    : 'logic_water_falling_platform_gs_hookshot',
+        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    If you stand on the very edge of the platform, this
+                    Gold Skulltula can be obtained with only the Hookshot.
+                    '''},
+    'Water Temple Falling Platform Room GS with Boomerang': {
+        'name'    : 'logic_water_falling_platform_gs_boomerang',
+        'tags'    : ("Water Temple", "Gold Skulltulas", "Entrance Shuffle", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    If you stand on the very edge of the platform, this
+                    Gold Skulltula can be obtained with only the Boomerang.
+                    '''},
+    'Water Temple River GS without Iron Boots': {
+        'name'    : 'logic_water_river_gs',
+        'tags'    : ("Water Temple", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Standing on the exposed ground toward the end of
+                    the river, a precise Longshot use can obtain the
+                    token. The Longshot cannot normally reach far
+                    enough to kill the Skulltula, however. You'll
+                    first have to find some other way of killing it.
+                    '''},
+    'Water Temple Dragon Statue Jump Dive': {
+        'name'    : 'logic_water_dragon_jump_dive',
+        'tags'    : ("Water Temple", "Water Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    If you come into the dragon statue room from the
+                    serpent river, you can jump down from above and get
+                    into the tunnel without needing either Iron Boots
+                    or a Scale. This trick applies to both Vanilla and
+                    Master Quest. In Vanilla, you must shoot the switch
+                    from above with the Bow, and then quickly get
+                    through the tunnel before the gate closes.
+                    '''},
+    'Water Temple Dragon Statue Switch from Above the Water as Adult': {
+        'name'    : 'logic_water_dragon_adult',
+        'tags'    : ("Water Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Normally you need both Hookshot and Iron Boots to hit the
+                    switch and swim through the tunnel to get to the chest. But
+                    by hitting the switch from dry land, using one of Bombchus,
+                    Hookshot, or Bow, it is possible to skip one or both of
+                    those requirements. After the gate has been opened, besides
+                    just using the Iron Boots, a well-timed dive with at least
+                    the Silver Scale could be used to swim through the tunnel. If
+                    coming from the serpent river, a jump dive can also be used
+                    to get into the tunnel.
+                    '''},
+    'Water Temple Dragon Statue Switch from Above the Water as Child': {
+        'name'    : 'logic_water_dragon_child',
+        'tags'    : ("Water Temple", "Entrance Shuffle", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    It is possible for child to hit the switch from dry land
+                    using one of Bombchus, Slingshot or Boomerang. Then, to
+                    get to the chest, child can dive through the tunnel using
+                    at least the Silver Scale. The timing and positioning of
+                    this dive needs to be perfect to actually make it under the
+                    gate, and it all needs to be done very quickly to be able to
+                    get through before the gate closes. Be sure to enable "Water
+                    Temple Dragon Statue Switch from Above the Water as Adult"
+                    for adult's variant of this trick.
+                    '''},
+    'Water Temple MQ Central Pillar with Fire Arrows': {
+        'name'    : 'logic_water_mq_central_pillar',
+        'tags'    : ("Water Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Slanted torches have misleading hitboxes. Whenever
+                    you see a slanted torch jutting out of the wall,
+                    you can expect most or all of its hitbox is actually
+                    on the other side that wall. This can make slanted
+                    torches very finicky to light when using arrows. The
+                    torches in the central pillar of MQ Water Temple are
+                    a particularly egregious example. Logic normally
+                    expects Din's Fire and Song of Time.
+                    '''},
+    'Water Temple MQ North Basement GS without Small Key': {
+        'name'    : 'logic_water_mq_locked_gs',
+        'tags'    : ("Water Temple MQ", "Gold Skulltulas", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    There is an invisible Hookshot target that can be used
+                    to get over the gate that blocks you from going to this
+                    Skulltula early, skipping a small key as well as
+                    needing Hovers or Scarecrow to reach the locked door.
+                    '''},
+    'Shadow Temple Stationary Objects without Lens of Truth': {
+        'name'    : 'logic_lens_shadow',
+        'tags'    : ("Lens of Truth", "Shadow Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Shadow Temple for most areas in the dungeon
+                    except for crossing the moving platform in the huge
+                    pit room and for fighting Bongo Bongo.
+                    '''},
+    'Shadow Temple Invisible Moving Platform without Lens of Truth': {
+        'name'    : 'logic_lens_shadow_platform',
+        'tags'    : ("Lens of Truth", "Shadow Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Shadow Temple to cross the invisible moving
+                    platform in the huge pit room in either direction.
+                    '''},
+    'Shadow Temple Bongo Bongo without Lens of Truth': {
+        'name'    : 'logic_lens_bongo',
+        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Entrance Shuffle", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    Bongo Bongo can be defeated without the use of
+                    Lens of Truth, as the hands give a pretty good
+                    idea of where the eye is.
+                    '''},
+    'Shadow Temple Stone Umbrella Skip': {
+        'name'    : 'logic_shadow_umbrella',
+        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A very precise Hover Boots movement
+                    from off of the lower chest can get you
+                    on top of the crushing spikes without
+                    needing to pull the block. Applies to
+                    both Vanilla and Master Quest.
+                    '''},
+    'Shadow Temple Falling Spikes GS with Hover Boots': {
+        'name'    : 'logic_shadow_umbrella_gs',
+        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Gold Skulltulas", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    After killing the Skulltula, a very precise Hover Boots
+                    movement from off of the lower chest can get you on top
+                    of the crushing spikes without needing to pull the block.
+                    From there, another very precise Hover Boots movement can
+                    be used to obtain the token without needing the Hookshot.
+                    Applies to both Vanilla and Master Quest. For obtaining
+                    the chests in this room with just Hover Boots, be sure to
+                    enable "Shadow Temple Stone Umbrella Skip".
+                    '''},
+    'Shadow Temple Freestanding Key with Bombchu': {
+        'name'    : 'logic_shadow_freestanding_key',
+        'tags'    : ("Shadow Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Release the Bombchu with good timing so that
+                    it explodes near the bottom of the pot.
+                    '''},
+    'Shadow Temple River Statue with Bombchu': {
+        'name'    : 'logic_shadow_statue',
+        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    By sending a Bombchu around the edge of the
+                    gorge, you can knock down the statue without
+                    needing a Bow.
+                    Applies in both vanilla and MQ Shadow.
+                    '''},
+    'Shadow Temple Bongo Bongo without projectiles': {
+        'name'    : 'logic_shadow_bongo',
+        'tags'    : ("Shadow Temple", "Shadow Temple MQ", "Entrance Shuffle", "Vanilla Dungeons", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    Using precise sword slashes, Bongo Bongo can be
+                    defeated without using projectiles. This is
+                    only relevant in conjunction with Shadow Temple
+                    dungeon shortcuts or shuffled boss entrances.
+                    '''},
+    'Shadow Temple MQ Stationary Objects without Lens of Truth': {
+        'name'    : 'logic_lens_shadow_mq',
+        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Shadow Temple MQ for most areas in the dungeon.
+                    See "Shadow Temple MQ Invisible Moving Platform
+                    without Lens of Truth", "Shadow Temple MQ Invisible
+                    Blades Silver Rupees without Lens of Truth",
+                    "Shadow Temple MQ 2nd Dead Hand without Lens of Truth",
+                    and "Shadow Temple Bongo Bongo without Lens of Truth"
+                    for exceptions.
+                    '''},
+    'Shadow Temple MQ Invisible Blades Silver Rupees without Lens of Truth': {
+        'name'    : 'logic_lens_shadow_mq_invisible_blades',
+        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Silver Rupees", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirement for the Lens of Truth or
+                    Nayru's Love in Shadow Temple MQ for the Invisible
+                    Blades room silver rupee collection.
+                    '''},
+    'Shadow Temple MQ Invisible Moving Platform without Lens of Truth': {
+        'name'    : 'logic_lens_shadow_mq_platform',
+        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Shadow Temple MQ to cross the invisible moving
+                    platform in the huge pit room in either direction.
+                    '''},
+    'Shadow Temple MQ 2nd Dead Hand without Lens of Truth': {
+        'name'    : 'logic_lens_shadow_mq_dead_hand',
+        'tags'    : ("Lens of Truth", "Shadow Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Dead Hand spawns in a random spot within the room.
+                    Having Lens removes the hassle of having to comb
+                    the room looking for his spawn location.
+                    '''},
+    'Shadow Temple MQ Truth Spinner Gap with Longshot': {
+        'name'    : 'logic_shadow_mq_gap',
+        'tags'    : ("Shadow Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    You can Longshot a torch and jump-slash recoil onto
+                    the tongue. It works best if you Longshot the right
+                    torch from the left side of the room.
+                    '''},
+    'Shadow Temple MQ Invisible Blades without Song of Time': {
+        'name'    : 'logic_shadow_mq_invisible_blades',
+        'tags'    : ("Shadow Temple MQ", "Master Quest", "Silver Rupees", "Freestandings", "Adult",),
+        'tooltip' : '''\
+                    The Like Like can be used to boost you into the
+                    silver rupee or recovery hearts that normally
+                    require Song of Time. This cannot be performed
+                    on OHKO since the Like Like does not boost you
+                    high enough if you die.
+                    '''},
+    'Shadow Temple MQ Lower Huge Pit without Fire Source': {
+        'name'    : 'logic_shadow_mq_huge_pit',
+        'tags'    : ("Shadow Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Normally a frozen eye switch spawns some platforms
+                    that you can use to climb down, but there's actually
+                    a small piece of ground that you can stand on that
+                    you can just jump down to.
+                    '''},
+    'Shadow Temple MQ Windy Walkway Reverse without Hover Boots': {
+        'name'    : 'logic_shadow_mq_windy_walkway',
+        'tags'    : ("Shadow Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    With shadow dungeon shortcuts enabled, it is possible
+                    to jump from the alcove in the windy hallway to the
+                    middle platform. There are two methods: wait out the fan
+                    opposite the door and hold forward, or jump to the right
+                    to be pushed by the fan there towards the platform ledge.
+                    Note that jumps of this distance are inconsistent, but
+                    still possible.
+                    '''},
+    'Spirit Temple without Lens of Truth': {
+        'name'    : 'logic_lens_spirit',
+        'tags'    : ("Lens of Truth", "Spirit Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Spirit Temple.
+                    '''},
+    'Spirit Temple Child Side Bridge with Bombchu': {
+        'name'    : 'logic_spirit_child_bombchu',
+        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    A carefully-timed Bombchu can hit the switch.
+                    '''},
+    'Spirit Temple Collect Metal Fence GS Through the Fence': {
+        'name'    : 'logic_spirit_fence_gs',
+        'tags'    : ("Spirit Temple", "Silver Rupees", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    After killing the Skulltula through the fence, the token
+                    can be collected from the wrong side of the fence by
+                    moving against the fence in a certain way. Also, the
+                    Skulltula can be defeated using the Kokiri Sword, by
+                    jump slashing into it after letting go from the fence.
+                    This trick is only relevant if Silver Rupees are shuffled.
+                    '''},
+    'Spirit Temple Main Room GS with Boomerang': {
+        'name'    : 'logic_spirit_lobby_gs',
+        'tags'    : ("Spirit Temple", "Gold Skulltulas", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    Standing on the highest part of the arm of the statue, a
+                    precise Boomerang throw can kill and obtain this Gold
+                    Skulltula. You must throw the Boomerang slightly off to
+                    the side so that it curves into the Skulltula, as aiming
+                    directly at it will clank off of the wall in front.
+                    '''},
+    'Spirit Temple Lower Adult Switch with Bombs': {
+        'name'    : 'logic_spirit_lower_adult_switch',
+        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A bomb can be used to hit the switch on the ceiling,
+                    but it must be thrown from a particular distance
+                    away and with precise timing.
+                    '''},
+    'Spirit Temple Main Room Jump from Hands to Upper Ledges': {
+        'name'    : 'logic_spirit_lobby_jump',
+        'tags'    : ("Spirit Temple", "Spirit Temple MQ", "Gold Skulltulas", "Pots", "Master Quest", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    A precise jump to obtain the following as adult
+                    without needing one of Hover Boots, or Hookshot
+                    (in vanilla) or Song of Time (in MQ):
+                    - Spirit Temple Statue Room Northeast Chest
+                    - Spirit Temple GS Lobby
+                    - Spirit Temple MQ Central Chamber Top Left Pot (Left)
+                    - Spirit Temple MQ Central Chamber Top Left Pot (Right)
+                    '''},
+    'Spirit Temple Main Room Hookshot to Boss Platform': {
+        'name'    : 'logic_spirit_platform_hookshot',
+        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Precise hookshot aiming at the platform chains can be
+                    used to reach the boss platform from the middle landings.
+                    Using a jump slash immediately after reaching a chain
+                    makes aiming more lenient. Relevant only when Spirit
+                    Temple boss shortcuts are on.
+                    '''},
+    'Spirit Temple Map Chest with Bow': {
+        'name'    : 'logic_spirit_map_chest',
+        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    To get a line of sight from the upper torch to
+                    the map chest torches, you must pull an Armos
+                    statue all the way up the stairs.
+                    '''},
+    'Spirit Temple Sun Block Room Chest with Bow': {
+        'name'    : 'logic_spirit_sun_chest_bow',
+        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Using the blocks in the room as platforms you can
+                    get lines of sight to all three torches. The timer
+                    on the torches is quite short so you must move
+                    quickly in order to light all three.
+                    '''},
+    'Spirit Temple Sun Block Room Chest with Sticks without Silver Rupees': {
+        'name'    : 'logic_spirit_sun_chest_no_rupees',
+        'tags'    : ("Spirit Temple", "Silver Rupees", "Vanilla Dungeons", "Child",),
+        'tooltip' : '''\
+                    With lightning fast movement, the chest can
+                    be spawned using a lit stick brought in from
+                    the main room. This trick is only relevant
+                    if Silver Rupees are shuffled.
+                    '''},
+    'Spirit Temple Shifting Wall with No Additional Items': {
+        'name'    : 'logic_spirit_wall',
+        'tags'    : ("Spirit Temple", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    Logic normally guarantees a way of dealing with both
+                    the Beamos and the Walltula before climbing the wall.
+                    '''},
+    'Spirit Temple MQ without Lens of Truth': {
+        'name'    : 'logic_lens_spirit_mq',
+        'tags'    : ("Lens of Truth", "Spirit Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Spirit Temple MQ.
+                    '''},
+    'Spirit Temple MQ Sun Block Room as Child without Song of Time': {
+        'name'    : 'logic_spirit_mq_sun_block_sot',
+        'tags'    : ("Spirit Temple MQ", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    While adult can easily jump directly to the switch that
+                    unbars the door to the sun block room, child Link cannot
+                    make the jump without spawning a Song of Time block to
+                    jump from. You can skip this by throwing the crate down
+                    onto the switch from above, which does unbar the door,
+                    however the crate immediately breaks, so you must move
+                    quickly to get through the door before it closes back up.
+                    '''},
+    'Spirit Temple MQ Sun Block Room GS with Boomerang': {
+        'name'    : 'logic_spirit_mq_sun_block_gs',
+        'tags'    : ("Spirit Temple MQ", "Gold Skulltulas", "Master Quest", "Child",),
+        'tooltip' : '''\
+                    Throw the Boomerang in such a way that it
+                    curves through the side of the glass block
+                    to hit the Gold Skulltula.
+                    '''},
+    'Spirit Temple MQ Lower Adult without Fire Arrows': {
+        'name'    : 'logic_spirit_mq_lower_adult',
+        'tags'    : ("Spirit Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    By standing in a precise position it is possible to
+                    light two of the torches with a single use of Din\'s
+                    Fire. This saves enough time to be able to light all
+                    three torches with only Din\'s.
+                    '''},
+    'Spirit Temple MQ Frozen Eye Switch without Fire': {
+        'name'    : 'logic_spirit_mq_frozen_eye',
+        'tags'    : ("Spirit Temple MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    You can melt the ice by shooting an arrow through a
+                    torch. The only way to find a line of sight for this
+                    shot is to first spawn a Song of Time block, and then
+                    stand on the very edge of it.
+                    '''},
+    'Ice Cavern Block Room GS with Hover Boots': {
+        'name'    : 'logic_ice_block_gs',
+        'tags'    : ("Ice Cavern", "Gold Skulltulas", "Vanilla Dungeons", "Adult",),
+        'tooltip' : '''\
+                    The Hover Boots can be used to get in front of the
+                    Skulltula to kill it with a jump slash. Then, the
+                    Hover Boots can again be used to obtain the Token,
+                    all without Hookshot or Boomerang.
+                    '''},
+    'Ice Cavern MQ Red Ice GS without Song of Time': {
+        'name'    : 'logic_ice_mq_red_ice_gs',
+        'tags'    : ("Ice Cavern MQ", "Gold Skulltulas", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    If you side-hop into the perfect position, you
+                    can briefly stand on the platform with the red
+                    ice just long enough to dump some blue fire.
+                    '''},
+    'Ice Cavern MQ Scarecrow GS with No Additional Items': {
+        'name'    : 'logic_ice_mq_scarecrow',
+        'tags'    : ("Ice Cavern MQ", "Gold Skulltulas", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    As adult a precise jump can be used to reach this alcove.
+                    '''},
+    'Gerudo Training Ground without Lens of Truth': {
+        'name'    : 'logic_lens_gtg',
+        'tags'    : ("Lens of Truth", "Gerudo Training Ground", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Gerudo Training Ground.
+                    '''},
+    'Gerudo Training Ground Highest Underwater Rupee with Gold Scale': {
+        'name'    : 'logic_gtg_underwater_highest',
+        'tags'    : ("Gerudo Training Ground", "Vanilla Dungeons", "Silver Rupees", "Child", "Adult",),
+        'tooltip' : '''\
+                    The camera is a menance while attempting to do this,
+                    though, as least as Adult, you will be automatically
+                    pulled by the current into the rupee. This trick is
+                    only relevant if Silver Rupees are shuffled.
+                    '''},
+    'Gerudo Training Ground Left Side Ceiling Silver Rupee without Hookshot': {
+        'name'    : 'logic_gtg_without_hookshot',
+        'tags'    : ("Gerudo Training Ground", "Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    The Silver Rupee on the ceiling can be reached by being pulled
+                    up into it by the Wallmaster. If Silver Rupees are not shuffled,
+                    you can save this rupee for last to unbar the door to the next
+                    room. In MQ, this trick is a bit more difficult since the
+                    Wallmaster will not track you to directly beneath the rupee, so
+                    you must inch forward after it begins its attempt to grab you.
+                    This trick is relevant if Silver Rupees are shuffled, or if GTG
+                    is in its MQ form, or if "Gerudo Training Ground Boulder Room
+                    Flame Wall Skip" is also enabled. This trick supersedes "Gerudo
+                    Training Ground MQ Left Side Ceiling Silver Rupee with Hookshot".
+                    '''},
+    'Gerudo Training Ground Boulder Room Flame Wall Skip': {
+        'name'    : 'logic_gtg_flame_wall',
+        'tags'    : ("Gerudo Training Ground", "Vanilla Dungeons", "Silver Rupees", "Child", "Adult",),
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of a flame wall
+                    before it can rise up to block you. To do so without taking damage
+                    is more precise. This trick is only relevant if Silver Rupees are
+                    shuffled, or if "Gerudo Training Ground Left Side Ceiling Silver
+                    Rupee without Hookshot" is also enabled.
+                    '''},
+    'Reach Gerudo Training Ground Fake Wall Ledge with Hover Boots': {
+        'name'    : 'logic_gtg_fake_wall',
+        'tags'    : ("Gerudo Training Ground", "Gerudo Training Ground MQ", "Master Quest", "Vanilla Dungeons", "Silver Rupees", "Adult",),
+        'tooltip' : '''\
+                    A precise Hover Boots use from the top of the chest can allow you
+                    to grab the ledge without needing the usual requirements. In Master
+                    Quest, this always skips a Song of Time requirement. In Vanilla,
+                    this can skip a Hookshot requirement, but it is only relevant if
+                    Silver Rupees are shuffled, or if "Gerudo Training Ground Left Side
+                    Ceiling Silver Rupee without Hookshot" is enabled.
+                    '''},
+    'Gerudo Training Ground MQ without Lens of Truth': {
+        'name'    : 'logic_lens_gtg_mq',
+        'tags'    : ("Lens of Truth", "Gerudo Training Ground MQ", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Gerudo Training Ground MQ.
+                    '''},
+    'Gerudo Training Ground MQ Left Side Ceiling Silver Rupee with Hookshot': {
+        'name'    : 'logic_gtg_mq_with_hookshot',
+        'tags'    : ("Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    The highest Silver Rupee can be obtained by
+                    hookshotting the target and then immediately jump
+                    slashing toward the rupee.
+                    '''},
+    'Gerudo Training Ground MQ Eye Statue Room Switch with Jump Slash': {
+        'name'    : 'logic_gtg_mq_eye_statue_jumpslash',
+        'tags'    : ("Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    The switch that unbars the door to the Ice Arrows chest
+                    can be hit with a precise jump slash. This trick is
+                    only relevant if Silver Rupees are shuffled, or if
+                    "Gerudo Training Ground Left Side Ceiling Silver Rupee
+                    without Hookshot" is also enabled.
+                    '''},
+    'Gerudo Training Ground MQ Central Maze Right to Dinolfos Room with Hookshot': {
+        'name'    : 'logic_gtg_mq_maze_right',
+        'tags'    : ("Gerudo Training Ground MQ", "Silver Rupees", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    You can stand next to the flame circle to the right of
+                    the entrance into the lava room from central maze right.
+                    From there, Hookshot can reach the torch to access the
+                    Dinolfos room without Bow. This trick is only relevant
+                    if Silver Rupees are shuffled or if one of the two tricks
+                    to collect the ceiling Silver Rupee without Longshot
+                    is enabled.
+                    '''},
+    'Ganon\'s Castle without Lens of Truth': {
+        'name'    : 'logic_lens_castle',
+        'tags'    : ("Lens of Truth", "Ganon's Castle", "Vanilla Dungeons", "Child", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Ganon's Castle.
+                    '''},
+    'Fire Trial Torch Slug Silver Rupee as Child': {
+        'name'    : 'logic_fire_trial_slug_rupee',
+        'tags'    : ("Ganon's Castle", "Entrance Shuffle", "Vanilla Dungeons", "Silver Rupees", "Child"),
+        'tooltip' : '''\
+                    To jump to the platform with the Torch Slug as child requires
+                    that the sinking platform be almost as high as possible. This
+                    trick is only relevant if Silver Rupees and the Ganon's Castle
+                    entrance are both shuffled, and the Fewer Tunic Requirements
+                    trick is also enabled.
+                    '''},
+    'Spirit Trial Ceiling Silver Rupee without Hookshot': {
+        'name'    : 'logic_spirit_trial_hookshot',
+        'tags'    : ("Ganon's Castle", "Vanilla Dungeons", "Silver Rupees", "Child", "Adult",),
+        'tooltip' : '''\
+                    The highest rupee can be obtained as either age by performing
+                    a precise jump and a well-timed jumpslash off of an Armos.
+                    '''},
+    'Ganon\'s Castle MQ without Lens of Truth': {
+        'name'    : 'logic_lens_castle_mq',
+        'tags'    : ("Lens of Truth", "Ganon's Castle MQ", "Master Quest", "Child", "Adult",),
+        'tooltip' : '''\
+                    Removes the requirements for the Lens of Truth
+                    in Ganon's Castle MQ.
+                    '''},
+    'Fire Trial MQ with Hookshot': {
+        'name'    : 'logic_fire_trial_mq',
+        'tags'    : ("Ganon's Castle MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    It's possible to hook the target at the end of
+                    fire trial with just Hookshot, but it requires
+                    precise aim and perfect positioning. The main
+                    difficulty comes from getting on the very corner
+                    of the obelisk without falling into the lava.
+                    '''},
+    'Shadow Trial MQ Torch with Bow': {
+        'name'    : 'logic_shadow_trial_mq',
+        'tags'    : ("Ganon's Castle MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    You can light the torch in this room without a fire
+                    source by shooting an arrow through the lit torch
+                    at the beginning of the room. Because the room is
+                    so dark and the unlit torch is so far away, it can
+                    be difficult to aim the shot correctly.
+                    '''},
+    'Light Trial MQ without Hookshot': {
+        'name'    : 'logic_light_trial_mq',
+        'tags'    : ("Ganon's Castle MQ", "Master Quest", "Adult",),
+        'tooltip' : '''\
+                    If you move quickly you can sneak past the edge of
+                    a flame wall before it can rise up to block you.
+                    In this case to do it without taking damage is
+                    especially precise.
+                    '''},
+}

--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -1,8 +1,11 @@
+from typing import Dict, Tuple, Union
+
+
 # Below is the list of possible glitchless tricks.
 # The order they are listed in is also the order in which
 # they appear to the user in the GUI, so a sensible order was chosen
 
-logic_tricks: dict = {
+logic_tricks: Dict[str, Dict[str, Union[str, Tuple[str, ...]]]] = {
 
     # General tricks
 

--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -2,7 +2,7 @@
 # The order they are listed in is also the order in which
 # they appear to the user in the GUI, so a sensible order was chosen
 
-logic_tricks = {
+logic_tricks: dict = {
 
     # General tricks
 

--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -1,11 +1,11 @@
-from typing import Dict, Tuple, Union
+from __future__ import annotations
 
 
 # Below is the list of possible glitchless tricks.
 # The order they are listed in is also the order in which
 # they appear to the user in the GUI, so a sensible order was chosen
 
-logic_tricks: Dict[str, Dict[str, Union[str, Tuple[str, ...]]]] = {
+logic_tricks: dict[str, dict[str, str | tuple[str, ...]]] = {
 
     # General tricks
 

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 import copy
 import json
 import sys
-from typing import Dict, List, Any, Optional
+from typing import Any, Optional
 
 from Hints import hint_dist_files
 from SettingsList import SettingInfos, get_settings_from_section, get_settings_from_tab
 from Utils import data_path
 
 
-tab_keys: List[str] = ['text', 'app_type', 'footer']
-section_keys: List[str] = ['text', 'app_type', 'is_colors', 'is_sfx', 'col_span', 'row_span', 'subheader']
-setting_keys: List[str] = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function', 'option_remove', 'dynamic']
-types_with_options: List[str] = ['Checkbutton', 'Radiobutton', 'Combobox', 'SearchBox', 'MultipleSelect']
+tab_keys: list[str] = ['text', 'app_type', 'footer']
+section_keys: list[str] = ['text', 'app_type', 'is_colors', 'is_sfx', 'col_span', 'row_span', 'subheader']
+setting_keys: list[str] = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_types', 'no_line_break', 'function', 'option_remove', 'dynamic']
+types_with_options: list[str] = ['Checkbutton', 'Radiobutton', 'Combobox', 'SearchBox', 'MultipleSelect']
 
 
 def remove_trailing_lines(text: str) -> str:
@@ -34,7 +35,7 @@ def deep_update(source: dict, new_dict: dict) -> dict:
     return source
 
 
-def add_disable_option_to_json(disable_option: Dict[str, Any], option_json: Dict[str, Any]) -> None:
+def add_disable_option_to_json(disable_option: dict[str, Any], option_json: dict[str, Any]) -> None:
     if disable_option.get('settings') is not None:
         if 'controls_visibility_setting' not in option_json:
             option_json['controls_visibility_setting'] = ','.join(disable_option['settings'])
@@ -52,7 +53,7 @@ def add_disable_option_to_json(disable_option: Dict[str, Any], option_json: Dict
             option_json['controls_visibility_tab'] += ',' + ','.join(disable_option['tabs'])
 
 
-def get_setting_json(setting: str, web_version: bool, as_array: bool = False) -> Optional[Dict[str, Any]]:
+def get_setting_json(setting: str, web_version: bool, as_array: bool = False) -> Optional[dict[str, Any]]:
     try:
         setting_info = SettingInfos.setting_infos[setting]
     except KeyError:
@@ -64,7 +65,7 @@ def get_setting_json(setting: str, web_version: bool, as_array: bool = False) ->
     if setting_info.gui_text is None:
         return None
 
-    setting_json: Dict[str, Any] = {
+    setting_json: dict[str, Any] = {
         'options':       [],
         'default':       setting_info.default,
         'text':          setting_info.gui_text,
@@ -180,7 +181,7 @@ def get_setting_json(setting: str, web_version: bool, as_array: bool = False) ->
     return setting_json
 
 
-def get_section_json(section: Dict[str, Any], web_version: bool, as_array: bool = False) -> Dict[str, Any]:
+def get_section_json(section: dict[str, Any], web_version: bool, as_array: bool = False) -> dict[str, Any]:
     if as_array:
         section_json = {
             'name'     : section['name'],
@@ -205,7 +206,7 @@ def get_section_json(section: Dict[str, Any], web_version: bool, as_array: bool 
     return section_json
 
 
-def get_tab_json(tab: Dict[str, Any], web_version: bool, as_array: bool = False) -> Dict[str, Any]:
+def get_tab_json(tab: dict[str, Any], web_version: bool, as_array: bool = False) -> dict[str, Any]:
     if as_array:
         tab_json = {
             'name'     : tab['name'],

--- a/SettingsToJson.py
+++ b/SettingsToJson.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from Hints import HintDistFiles
-from SettingsList import setting_infos, setting_map, get_setting_info, get_settings_from_section, get_settings_from_tab
+from SettingsList import SettingInfos, get_settings_from_section, get_settings_from_tab
 from Utils import data_path
 import sys
 import json
@@ -13,7 +13,7 @@ setting_keys = ['hide_when_disabled', 'min', 'max', 'size', 'max_length', 'file_
 types_with_options = ['Checkbutton', 'Radiobutton', 'Combobox', 'SearchBox', 'MultipleSelect']
 
 
-def RemoveTrailingLines(text):
+def remove_trailing_lines(text):
     while text.endswith('<br>'):
         text = text[:-4]
     while text.startswith('<br>'):
@@ -32,27 +32,27 @@ def deep_update(source, new_dict):
     return source
 
 
-def add_disable_option_to_json(disable_option, optionJson):
-    if disable_option.get('settings') != None:
-        if 'controls_visibility_setting' not in optionJson:
-            optionJson['controls_visibility_setting'] = ','.join(disable_option['settings'])
+def add_disable_option_to_json(disable_option, option_json):
+    if disable_option.get('settings') is not None:
+        if 'controls_visibility_setting' not in option_json:
+            option_json['controls_visibility_setting'] = ','.join(disable_option['settings'])
         else:
-            optionJson['controls_visibility_setting'] += ',' + ','.join(disable_option['settings'])
-    if disable_option.get('sections') != None:
-        if 'controls_visibility_section' not in optionJson:
-            optionJson['controls_visibility_section'] = ','.join(disable_option['sections'])
+            option_json['controls_visibility_setting'] += ',' + ','.join(disable_option['settings'])
+    if disable_option.get('sections') is not None:
+        if 'controls_visibility_section' not in option_json:
+            option_json['controls_visibility_section'] = ','.join(disable_option['sections'])
         else:
-            optionJson['controls_visibility_section'] += ',' + ','.join(disable_option['sections'])
-    if disable_option.get('tabs') != None:
-        if 'controls_visibility_tab' not in optionJson:
-            optionJson['controls_visibility_tab'] = ','.join(disable_option['tabs'])
+            option_json['controls_visibility_section'] += ',' + ','.join(disable_option['sections'])
+    if disable_option.get('tabs') is not None:
+        if 'controls_visibility_tab' not in option_json:
+            option_json['controls_visibility_tab'] = ','.join(disable_option['tabs'])
         else:
-            optionJson['controls_visibility_tab'] += ',' + ','.join(disable_option['tabs'])
+            option_json['controls_visibility_tab'] += ',' + ','.join(disable_option['tabs'])
 
 
-def GetSettingJson(setting, web_version, as_array=False):
+def get_setting_json(setting, web_version, as_array=False):
     try:
-        setting_info = get_setting_info(setting)
+        setting_info = SettingInfos.setting_infos[setting]
     except KeyError:
         if as_array:
             return {'name': setting}
@@ -62,22 +62,22 @@ def GetSettingJson(setting, web_version, as_array=False):
     if setting_info.gui_text is None:
         return None
 
-    settingJson = {
+    setting_json = {
         'options':       [],
         'default':       setting_info.default,
         'text':          setting_info.gui_text,
-        'tooltip':       RemoveTrailingLines('<br>'.join(line.strip() for line in setting_info.gui_tooltip.split('\n'))),
+        'tooltip': remove_trailing_lines('<br>'.join(line.strip() for line in setting_info.gui_tooltip.split('\n'))),
         'type':          setting_info.gui_type,
         'shared':        setting_info.shared,
     }
 
     if as_array:
-        settingJson['name'] = setting_info.name
+        setting_json['name'] = setting_info.name
     else:
-        settingJson['current_value'] = setting_info.default
+        setting_json['current_value'] = setting_info.default
 
     setting_disable = {}
-    if setting_info.disable != None:
+    if setting_info.disable is not None:
         setting_disable = copy.deepcopy(setting_info.disable)
 
     version_specific_keys = []
@@ -100,142 +100,142 @@ def GetSettingJson(setting, web_version, as_array=False):
                 continue
 
         if key in setting_keys and (key not in version_specific_keys or version_specific):
-            settingJson[key] = value
+            setting_json[key] = value
         if key == 'disable':
             for option,types in value.items():
                 for s in types.get('settings', []):
-                    if get_setting_info(s).shared:
+                    if SettingInfos.setting_infos[s].shared:
                         raise ValueError(f'Cannot disable setting {s}. Disabling "shared" settings in the gui_params is forbidden. Use the non gui_param version of disable instead.')
                 for section in types.get('sections', []):
                     for s in get_settings_from_section(section):
-                        if get_setting_info(s).shared:
+                        if SettingInfos.setting_infos[s].shared:
                             raise ValueError(f'Cannot disable setting {s} in {section}. Disabling "shared" settings in the gui_params is forbidden. Use the non gui_param version of disable instead.')
                 for tab in types.get('tabs', []):
                     for s in get_settings_from_tab(tab):
-                        if get_setting_info(s).shared:
+                        if SettingInfos.setting_infos[s].shared:
                             raise ValueError(f'Cannot disable setting {s} in {tab}. Disabling "shared" settings in the gui_params is forbidden. Use the non gui_param version of disable instead.')
             deep_update(setting_disable, value)
 
-
-    if settingJson['type'] in types_with_options:
+    if setting_json['type'] in types_with_options:
         if as_array:
-            settingJson['options'] = []
+            setting_json['options'] = []
         else:
-            settingJson['options'] = {}
+            setting_json['options'] = {}
 
         tags_list = []
 
         for option_name in setting_info.choice_list:
-            if option_name in settingJson.get('option_remove', []):
+            if option_name in setting_json.get('option_remove', []):
                 continue
 
             if as_array:
-                optionJson = {
+                option_json = {
                     'name':     option_name,
                     'text':     setting_info.choices[option_name],
                 }
             else:
-                optionJson = {
+                option_json = {
                     'text':     setting_info.choices[option_name],
                 }
 
             if option_name in setting_disable:
-                add_disable_option_to_json(setting_disable[option_name], optionJson)
+                add_disable_option_to_json(setting_disable[option_name], option_json)
 
             option_tooltip = setting_info.gui_params.get('choice_tooltip', {}).get(option_name, None)
-            if option_tooltip != None:
-                optionJson['tooltip'] = RemoveTrailingLines('<br>'.join(line.strip() for line in option_tooltip.split('\n')))
+            if option_tooltip is not None:
+                option_json['tooltip'] = remove_trailing_lines(
+                    '<br>'.join(line.strip() for line in option_tooltip.split('\n')))
 
             option_filter = setting_info.gui_params.get('filterdata', {}).get(option_name, None)
-            if option_filter != None:
-                optionJson['tags'] = option_filter
+            if option_filter is not None:
+                option_json['tags'] = option_filter
                 for tag in option_filter:
                     if tag not in tags_list:
                         tags_list.append(tag)
 
             if as_array:
-                settingJson['options'].append(optionJson)
+                setting_json['options'].append(option_json)
             else:
-                settingJson['options'][option_name] = optionJson
+                setting_json['options'][option_name] = option_json
 
         # For disables with '!', add disable settings to all options other than the one marked.
         for option_name in setting_disable:
             if isinstance(option_name, str) and option_name[0] == '!':
                 if as_array:
-                    for option in settingJson['options']:
+                    for option in setting_json['options']:
                         if option['name'] != option_name[1:]:
                             add_disable_option_to_json(setting_disable[option_name], option)
                 else:
-                    for name, option in settingJson['options'].items():
+                    for name, option in setting_json['options'].items():
                         if name != option_name[1:]:
                             add_disable_option_to_json(setting_disable[option_name], option)
 
 
         if tags_list:
             tags_list.sort()
-            settingJson['tags'] = ['(all)'] + tags_list
-            settingJson['filter_by_tag'] = True
+            setting_json['tags'] = ['(all)'] + tags_list
+            setting_json['filter_by_tag'] = True
 
-    return settingJson
+    return setting_json
 
 
-def GetSectionJson(section, web_version, as_array=False):
+def get_section_json(section, web_version, as_array=False):
     if as_array:
-        sectionJson = {
+        section_json = {
             'name'     : section['name'],
             'settings' : []
         }
     else:
-        sectionJson = {
+        section_json = {
             'settings' : {}
         }
 
     for key, value in section.items():
         if key in section_keys:
-            sectionJson[key] = value
+            section_json[key] = value
 
     for setting in section['settings']:
-        settingJson = GetSettingJson(setting, web_version, as_array)
+        setting_json = get_setting_json(setting, web_version, as_array)
         if as_array:
-            sectionJson['settings'].append(settingJson)
+            section_json['settings'].append(setting_json)
         else:
-            sectionJson['settings'][setting] = settingJson
+            section_json['settings'][setting] = setting_json
 
-    return sectionJson
+    return section_json
 
 
-def GetTabJson(tab, web_version, as_array=False):
+def get_tab_json(tab, web_version, as_array=False):
     if as_array:
-        tabJson = {
+        tab_json = {
             'name'     : tab['name'],
             'sections' : []
         }
     else:
-        tabJson = {
+        tab_json = {
             'sections' : {}
         }
 
     for key, value in tab.items():
         if key in tab_keys:
-            tabJson[key] = value
+            tab_json[key] = value
 
     for section in tab['sections']:
-        sectionJson = GetSectionJson(section, web_version, as_array)
+        section_json = get_section_json(section, web_version, as_array)
         if section.get('exclude_from_web', False) and web_version:
             continue
         elif section.get('exclude_from_electron', False) and not web_version:
             continue
 
         if as_array:
-            tabJson['sections'].append(sectionJson)
+            tab_json['sections'].append(section_json)
         else:
-            tabJson['sections'][section['name']] = sectionJson
+            tab_json['sections'][section['name']] = section_json
 
-    return tabJson
+    return tab_json
 
 
-def CreateJSON(path, web_version=False):
-    settingOutputJson = {
+def create_settings_list_json(path, web_version=False):
+    output_json = {
         'settingsObj'   : {},
         'settingsArray' : [],
         'cosmeticsObj'  : {},
@@ -243,20 +243,20 @@ def CreateJSON(path, web_version=False):
         'distroArray'   : [],
     }
 
-    for tab in setting_map['Tabs']:
+    for tab in SettingInfos.setting_map['Tabs']:
         if tab.get('exclude_from_web', False) and web_version:
             continue
         elif tab.get('exclude_from_electron', False) and not web_version:
             continue
 
-        tabJsonObj = GetTabJson(tab, web_version, as_array=False)
-        tabJsonArr = GetTabJson(tab, web_version, as_array=True)
+        tab_json_object = get_tab_json(tab, web_version, as_array=False)
+        tab_json_array = get_tab_json(tab, web_version, as_array=True)
 
-        settingOutputJson['settingsObj'][tab['name']] = tabJsonObj
-        settingOutputJson['settingsArray'].append(tabJsonArr)
+        output_json['settingsObj'][tab['name']] = tab_json_object
+        output_json['settingsArray'].append(tab_json_array)
         if tab.get('is_cosmetics', False):
-            settingOutputJson['cosmeticsObj'][tab['name']] = tabJsonObj
-            settingOutputJson['cosmeticsArray'].append(tabJsonArr)
+            output_json['cosmeticsObj'][tab['name']] = tab_json_object
+            output_json['cosmeticsArray'].append(tab_json_array)
 
     for d in HintDistFiles():
         with open(d, 'r') as dist_file:
@@ -265,21 +265,21 @@ def CreateJSON(path, web_version=False):
            'goal' in dist['distribution'] and
            (dist['distribution']['goal']['fixed'] != 0 or
                 dist['distribution']['goal']['weight'] != 0)):
-            settingOutputJson['distroArray'].append(dist['name'])
+            output_json['distroArray'].append(dist['name'])
 
     with open(path, 'w') as f:
-        json.dump(settingOutputJson, f)
+        json.dump(output_json, f)
 
 
-def GetSettingDetails(setting_key, web_version):
-    settingJsonObj = GetSettingJson(setting_key, web_version, as_array=False)
-    settingJsonArr = GetSettingJson(setting_key, web_version, as_array=True)
+def get_setting_details(setting_key, web_version):
+    setting_json_object = get_setting_json(setting_key, web_version, as_array=False)
+    setting_json_array = get_setting_json(setting_key, web_version, as_array=True)
 
-    settingOutput = { "object": settingJsonObj, "array": settingJsonArr }
-    print(json.dumps(settingOutput))
+    setting_output = {"object": setting_json_object, "array": setting_json_array}
+    print(json.dumps(setting_output))
 
 
-def settingToJsonMain():
+def main():
     args = sys.argv[1:]
     web_version = '--web' in args
 
@@ -287,10 +287,10 @@ def settingToJsonMain():
         arg_index = args.index('--setting') + 1
         if len(args) < arg_index:
             raise Exception("Usage: SettingsToJson.py --setting <setting_key>")
-        return GetSettingDetails(args[arg_index], web_version)
+        return get_setting_details(args[arg_index], web_version)
 
-    CreateJSON(data_path('generated/settings_list.json'), web_version)
+    create_settings_list_json(data_path('generated/settings_list.json'), web_version)
 
 
 if __name__ == '__main__':
-    settingToJsonMain()
+    main()

--- a/Sounds.py
+++ b/Sounds.py
@@ -24,18 +24,12 @@
 # hook would contain a bunch of addresses, whether they share the same default
 # value or not.
 
+from __future__ import annotations
 import os
-import sys
+from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List
 
 from Utils import data_path
-
-# Python 3.6 support. We can drop the conditional usage of namedtuple if we decide to no longer support Python 3.6.
-if sys.version_info >= (3, 7):
-    from dataclasses import dataclass
-else:
-    from collections import namedtuple
 
 
 class Tags(Enum):
@@ -56,15 +50,12 @@ class Tags(Enum):
                         # I'm now thinking it has to do with a limit of concurrent sounds)
 
 
-if sys.version_info >= (3, 7):
-    @dataclass(frozen=True)
-    class Sound:
-        id: int
-        keyword: str
-        label: str
-        tags: List[Tags]
-else:
-    Sound = namedtuple('Sound', 'id    keyword                  label                        tags')
+@dataclass(frozen=True)
+class Sound:
+    id: int
+    keyword: str
+    label: str
+    tags: list[Tags]
 
 
 class Sounds(Enum):
@@ -171,17 +162,6 @@ class Sounds(Enum):
     ZELDA_ADULT_GASP   = Sound(0x6879, 'adult-zelda-gasp',      'Zelda Gasp (Adult)',        [Tags.NAVI, Tags.HPLOW])
 
 
-if sys.version_info >= (3, 7):
-    @dataclass(frozen=True)
-    class SoundHook:
-        name: str
-        pool: List[Sounds]
-        locations: List[int]
-        sfx_flag: bool
-else:
-    SoundHook = namedtuple('SoundHook', 'name pool locations sfx_flag')
-
-
 # Sound pools
 standard    = [s for s in Sounds if Tags.LOOPED not in s.value.tags]
 looping     = [s for s in Sounds if Tags.LOOPED in s.value.tags]
@@ -193,6 +173,14 @@ nightfall   = [s for s in Sounds if Tags.NIGHTFALL in s.value.tags]
 menu_select = [s for s in Sounds if Tags.MENUSELECT in s.value.tags]
 menu_cursor = [s for s in Sounds if Tags.MENUMOVE in s.value.tags]
 horse_neigh = [s for s in Sounds if Tags.HORSE in s.value.tags]
+
+
+@dataclass(frozen=True)
+class SoundHook:
+    name: str
+    pool: list[Sounds]
+    locations: list[int]
+    sfx_flag: bool
 
 
 class SoundHooks(Enum):
@@ -236,11 +224,11 @@ class SoundHooks(Enum):
 #   SWORD_SLASH     = SoundHook('Sword Slash',      standard,         [0xAC2942])
 
 
-def get_patch_dict() -> Dict[str, int]:
+def get_patch_dict() -> dict[str, int]:
     return {s.value.keyword: s.value.id for s in Sounds}
 
 
-def get_hook_pool(sound_hook: SoundHooks, earsafeonly: bool = False) -> List[Sounds]:
+def get_hook_pool(sound_hook: SoundHooks, earsafeonly: bool = False) -> list[Sounds]:
     if earsafeonly:
         list = [s for s in sound_hook.value.pool if Tags.PAINFUL not in s.value.tags]
         return list
@@ -248,7 +236,7 @@ def get_hook_pool(sound_hook: SoundHooks, earsafeonly: bool = False) -> List[Sou
         return sound_hook.value.pool
 
 
-def get_setting_choices(sound_hook: SoundHooks) -> Dict[str, str]:
+def get_setting_choices(sound_hook: SoundHooks) -> dict[str, str]:
     pool = sound_hook.value.pool
     choices = {s.value.keyword: s.value.label for s in sorted(pool, key=lambda s: s.value.label)}
     result = {
@@ -262,7 +250,7 @@ def get_setting_choices(sound_hook: SoundHooks) -> Dict[str, str]:
     return result
 
 
-def get_voice_sfx_choices(age: int, include_random: bool = True) -> List[str]:
+def get_voice_sfx_choices(age: int, include_random: bool = True) -> list[str]:
     # Dynamically populate the SettingsList entry for the voice effects
     # Voice packs should be a folder of .bin files in the Voices/{age} directory
     names = ['Default', 'Silent']

--- a/Sounds.py
+++ b/Sounds.py
@@ -24,9 +24,11 @@
 # hook would contain a bunch of addresses, whether they share the same default
 # value or not.
 
-from enum import Enum
 import os
 import sys
+from enum import Enum
+from typing import Dict, List
+
 from Utils import data_path
 
 # Python 3.6 support. We can drop the conditional usage of namedtuple if we decide to no longer support Python 3.6.
@@ -61,7 +63,7 @@ if dataclass_supported:
         id: int
         keyword: str
         label: str
-        tags: list
+        tags: List[Tags]
 else:
     Sound = namedtuple('Sound', 'id    keyword                  label                        tags')
 
@@ -174,8 +176,8 @@ if dataclass_supported:
     @dataclass(frozen=True)
     class SoundHook:
         name: str
-        pool: list
-        locations: list
+        pool: List[Sounds]
+        locations: List[int]
         sfx_flag: bool
 else:
     SoundHook = namedtuple('SoundHook', 'name pool locations sfx_flag')
@@ -235,33 +237,33 @@ class SoundHooks(Enum):
 #   SWORD_SLASH     = SoundHook('Sword Slash',      standard,         [0xAC2942])
 
 
-def get_patch_dict():
+def get_patch_dict() -> Dict[str, int]:
     return {s.value.keyword: s.value.id for s in Sounds}
 
 
-def get_hook_pool(sound_hook, earsafeonly = "FALSE"):
-    if earsafeonly == "TRUE":
+def get_hook_pool(sound_hook: SoundHooks, earsafeonly: bool = False) -> List[Sounds]:
+    if earsafeonly:
         list = [s for s in sound_hook.value.pool if Tags.PAINFUL not in s.value.tags]
         return list
     else:
         return sound_hook.value.pool
 
 
-def get_setting_choices(sound_hook):
-    pool     = sound_hook.value.pool
-    choices  = {s.value.keyword: s.value.label for s in sorted(pool, key=lambda s: s.value.label)}
-    result   = {
+def get_setting_choices(sound_hook: SoundHooks) -> Dict[str, str]:
+    pool = sound_hook.value.pool
+    choices = {s.value.keyword: s.value.label for s in sorted(pool, key=lambda s: s.value.label)}
+    result = {
         'default':           'Default',
         'completely-random': 'Completely Random',
         'random-ear-safe':   'Random Ear-Safe',
         'random-choice':     'Random Choice',
         'none':              'None',
         **choices,
-        }
+    }
     return result
 
 
-def get_voice_sfx_choices(age, include_random=True):
+def get_voice_sfx_choices(age: int, include_random: bool = True) -> List[str]:
     # Dynamically populate the SettingsList entry for the voice effects
     # Voice packs should be a folder of .bin files in the Voices/{age} directory
     names = ['Default', 'Silent']

--- a/Sounds.py
+++ b/Sounds.py
@@ -32,8 +32,7 @@ from typing import Dict, List
 from Utils import data_path
 
 # Python 3.6 support. We can drop the conditional usage of namedtuple if we decide to no longer support Python 3.6.
-dataclass_supported = sys.version_info >= (3, 7)
-if dataclass_supported:
+if sys.version_info >= (3, 7):
     from dataclasses import dataclass
 else:
     from collections import namedtuple
@@ -57,7 +56,7 @@ class Tags(Enum):
                         # I'm now thinking it has to do with a limit of concurrent sounds)
 
 
-if dataclass_supported:
+if sys.version_info >= (3, 7):
     @dataclass(frozen=True)
     class Sound:
         id: int
@@ -172,7 +171,7 @@ class Sounds(Enum):
     ZELDA_ADULT_GASP   = Sound(0x6879, 'adult-zelda-gasp',      'Zelda Gasp (Adult)',        [Tags.NAVI, Tags.HPLOW])
 
 
-if dataclass_supported:
+if sys.version_info >= (3, 7):
     @dataclass(frozen=True)
     class SoundHook:
         name: str

--- a/Sounds.py
+++ b/Sounds.py
@@ -30,7 +30,7 @@ import sys
 from Utils import data_path
 
 # Python 3.6 support. We can drop the conditional usage of namedtuple if we decide to no longer support Python 3.6.
-dataclass_supported = sys.version_info[0] >= 3 and sys.version_info[1] >= 7
+dataclass_supported = sys.version_info >= (3, 7)
 if dataclass_supported:
     from dataclasses import dataclass
 else:

--- a/Spoiler.py
+++ b/Spoiler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from collections import OrderedDict
 import logging
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from Item import Item
 from LocationList import location_sort_order
@@ -118,8 +118,8 @@ class Spoiler:
             self.entrances[world.id] = spoiler_entrances
 
     def copy_worlds(self) -> list[World]:
-        worlds = [world.copy() for world in self.worlds]
-        Item.fix_worlds_after_copy(worlds)
+        copy_dict: dict[int, Any] = {}
+        worlds = [world.copy(copy_dict=copy_dict) for world in self.worlds]
         return worlds
 
     def find_misc_hint_items(self) -> None:
@@ -137,11 +137,10 @@ class Spoiler:
 
     def create_playthrough(self) -> None:
         logger = logging.getLogger('')
-        worlds = self.worlds
-        if worlds[0].check_beatable_only and not Search([world.state for world in worlds]).can_beat_game():
+        if self.worlds[0].check_beatable_only and not Search([world.state for world in self.worlds]).can_beat_game():
             raise RuntimeError('Game unbeatable after placing all items.')
+
         # create a copy as we will modify it
-        old_worlds = worlds
         worlds = self.copy_worlds()
 
         # if we only check for beatable, we can do this sanity check first before writing down spheres

--- a/Spoiler.py
+++ b/Spoiler.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
 from collections import OrderedDict
 import logging
 import random
-from typing import TYPE_CHECKING, List, Dict
+from typing import TYPE_CHECKING
 
 from Item import Item
 from LocationList import location_sort_order
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
     from Settings import Settings
     from World import World
 
-HASH_ICONS: List[str] = [
+HASH_ICONS: list[str] = [
     'Deku Stick',
     'Deku Nut',
     'Bow',
@@ -52,20 +53,20 @@ HASH_ICONS: List[str] = [
 
 
 class Spoiler:
-    def __init__(self, worlds: "List[World]") -> None:
-        self.worlds: "List[World]" = worlds
-        self.settings: "Settings" = worlds[0].settings
-        self.playthrough: "Dict[str, List[Location]]" = {}
-        self.entrance_playthrough: "Dict[str, List[Entrance]]" = {}
-        self.full_playthrough: Dict[str, int] = {}
+    def __init__(self, worlds: list[World]) -> None:
+        self.worlds: list[World] = worlds
+        self.settings: Settings = worlds[0].settings
+        self.playthrough: dict[str, list[Location]] = {}
+        self.entrance_playthrough: dict[str, list[Entrance]] = {}
+        self.full_playthrough: dict[str, int] = {}
         self.max_sphere: int = 0
-        self.locations: "Dict[int, Dict[str, Item]]" = {}
-        self.entrances: "Dict[int, List[Entrance]]" = {}
-        self.required_locations: "Dict[int, List[Location]]" = {}
-        self.goal_locations: "Dict[int, Dict[str, Dict[str, Dict[int, List[Location]]]]]" = {}
-        self.goal_categories: "Dict[int, Dict[str, GoalCategory]]" = {}
-        self.hints: "Dict[int, Dict[int, GossipText]]" = {world.id: {} for world in worlds}
-        self.file_hash: List[int] = []
+        self.locations: dict[int, dict[str, Item]] = {}
+        self.entrances: dict[int, list[Entrance]] = {}
+        self.required_locations: dict[int, list[Location]] = {}
+        self.goal_locations: dict[int, dict[str, dict[str, dict[int, list[Location]]]]] = {}
+        self.goal_categories: dict[int, dict[str, GoalCategory]] = {}
+        self.hints: dict[int, dict[int, GossipText]] = {world.id: {} for world in worlds}
+        self.file_hash: list[int] = []
 
     def build_file_hash(self) -> None:
         dist_file_hash = self.settings.distribution.file_hash
@@ -116,7 +117,7 @@ class Spoiler:
             spoiler_entrances.sort(key=lambda entrance: entrance_sort_order.get(entrance.type, -1))
             self.entrances[world.id] = spoiler_entrances
 
-    def copy_worlds(self) -> "List[World]":
+    def copy_worlds(self) -> list[World]:
         worlds = [world.copy() for world in self.worlds]
         Item.fix_worlds_after_copy(worlds)
         return worlds

--- a/Spoiler.py
+++ b/Spoiler.py
@@ -1,9 +1,21 @@
 from collections import OrderedDict
+import logging
 import random
+from typing import TYPE_CHECKING, List, Dict
 
+from Item import Item
 from LocationList import location_sort_order
+from Search import Search, RewindableSearch
 
-HASH_ICONS = [
+if TYPE_CHECKING:
+    from Entrance import Entrance
+    from Goals import GoalCategory
+    from Hints import GossipText
+    from Location import Location
+    from Settings import Settings
+    from World import World
+
+HASH_ICONS: List[str] = [
     'Deku Stick',
     'Deku Nut',
     'Bow',
@@ -38,32 +50,29 @@ HASH_ICONS = [
     'Big Magic',
 ]
 
-class Spoiler(object):
 
-    def __init__(self, worlds):
-        self.worlds = worlds
-        self.settings = worlds[0].settings
-        self.playthrough = {}
-        self.entrance_playthrough = {}
-        self.full_playthrough = {}
-        self.max_sphere = 0
-        self.locations = {}
-        self.entrances = []
-        self.metadata = {}
-        self.required_locations = {}
-        self.goal_locations = {}
-        self.goal_categories = {}
-        self.hints = {world.id: {} for world in worlds}
-        self.file_hash = []
+class Spoiler:
+    def __init__(self, worlds: "List[World]") -> None:
+        self.worlds: "List[World]" = worlds
+        self.settings: "Settings" = worlds[0].settings
+        self.playthrough: "Dict[str, List[Location]]" = {}
+        self.entrance_playthrough: "Dict[str, List[Entrance]]" = {}
+        self.full_playthrough: Dict[str, int] = {}
+        self.max_sphere: int = 0
+        self.locations: "Dict[int, Dict[str, Item]]" = {}
+        self.entrances: "Dict[int, List[Entrance]]" = {}
+        self.required_locations: "Dict[int, List[Location]]" = {}
+        self.goal_locations: "Dict[int, Dict[str, Dict[str, Dict[int, List[Location]]]]]" = {}
+        self.goal_categories: "Dict[int, Dict[str, GoalCategory]]" = {}
+        self.hints: "Dict[int, Dict[int, GossipText]]" = {world.id: {} for world in worlds}
+        self.file_hash: List[int] = []
 
-
-    def build_file_hash(self):
+    def build_file_hash(self) -> None:
         dist_file_hash = self.settings.distribution.file_hash
         for i in range(5):
-            self.file_hash.append(random.randint(0,31) if dist_file_hash[i] is None else HASH_ICONS.index(dist_file_hash[i]))
+            self.file_hash.append(random.randint(0, 31) if dist_file_hash[i] is None else HASH_ICONS.index(dist_file_hash[i]))
 
-
-    def parse_data(self):
+    def parse_data(self) -> None:
         for (sphere_nr, sphere) in self.playthrough.items():
             sorted_sphere = [location for location in sphere]
             sort_order = {"Song": 0, "Boss": -1}
@@ -106,3 +115,172 @@ class Spoiler(object):
             spoiler_entrances.sort(key=lambda entrance: entrance.name)
             spoiler_entrances.sort(key=lambda entrance: entrance_sort_order.get(entrance.type, -1))
             self.entrances[world.id] = spoiler_entrances
+
+    def copy_worlds(self) -> "List[World]":
+        worlds = [world.copy() for world in self.worlds]
+        Item.fix_worlds_after_copy(worlds)
+        return worlds
+
+    def find_misc_hint_items(self) -> None:
+        search = Search([world.state for world in self.worlds])
+        all_locations = [location for world in self.worlds for location in world.get_filled_locations()]
+        for location in search.iter_reachable_locations(all_locations[:]):
+            search.collect(location.item)
+            # include locations that are reachable but not part of the spoiler log playthrough in misc. item hints
+            location.maybe_set_misc_item_hints()
+            all_locations.remove(location)
+        for location in all_locations:
+            # finally, collect unreachable locations for misc. item hints
+            location.maybe_set_misc_item_hints()
+
+    def create_playthrough(self) -> None:
+        logger = logging.getLogger('')
+        worlds = self.worlds
+        if worlds[0].check_beatable_only and not Search([world.state for world in worlds]).can_beat_game():
+            raise RuntimeError('Game unbeatable after placing all items.')
+        # create a copy as we will modify it
+        old_worlds = worlds
+        worlds = self.copy_worlds()
+
+        # if we only check for beatable, we can do this sanity check first before writing down spheres
+        if worlds[0].check_beatable_only and not Search([world.state for world in worlds]).can_beat_game():
+            raise RuntimeError('Uncopied world beatable but copied world is not.')
+
+        search = RewindableSearch([world.state for world in worlds])
+        logger.debug('Initial search: %s', search.state_list[0].get_prog_items())
+        # Get all item locations in the worlds
+        item_locations = search.progression_locations()
+        # Omit certain items from the playthrough
+        internal_locations = {location for location in item_locations if location.internal}
+        # Generate a list of spheres by iterating over reachable locations without collecting as we go.
+        # Collecting every item in one sphere means that every item
+        # in the next sphere is collectable. Will contain every reachable item this way.
+        logger.debug('Building up collection spheres.')
+        collection_spheres = []
+        entrance_spheres = []
+        remaining_entrances = set(entrance for world in worlds for entrance in world.get_shuffled_entrances())
+
+        search.checkpoint()
+        search.collect_pseudo_starting_items()
+        logger.debug('With pseudo starting items: %s', search.state_list[0].get_prog_items())
+
+        while True:
+            search.checkpoint()
+            # Not collecting while the generator runs means we only get one sphere at a time
+            # Otherwise, an item we collect could influence later item collection in the same sphere
+            collected = list(search.iter_reachable_locations(item_locations))
+            if not collected:
+                break
+            random.shuffle(collected)
+            # Gather the new entrances before collecting items.
+            collection_spheres.append(collected)
+            accessed_entrances = set(filter(search.spot_access, remaining_entrances))
+            entrance_spheres.append(list(accessed_entrances))
+            remaining_entrances -= accessed_entrances
+            for location in collected:
+                # Collect the item for the state world it is for
+                search.state_list[location.item.world.id].collect(location.item)
+                location.maybe_set_misc_item_hints()
+        logger.info('Collected %d spheres', len(collection_spheres))
+        self.full_playthrough = dict((location.name, i + 1) for i, sphere in enumerate(collection_spheres) for location in sphere)
+        self.max_sphere = len(collection_spheres)
+
+        # Reduce each sphere in reverse order, by checking if the game is beatable
+        # when we remove the item. We do this to make sure that progressive items
+        # like bow and slingshot appear as early as possible rather than as late as possible.
+        required_locations = []
+        for sphere in reversed(collection_spheres):
+            random.shuffle(sphere)
+            for location in sphere:
+                # we remove the item at location and check if the game is still beatable in case the item could be required
+                old_item = location.item
+
+                # Uncollect the item and location.
+                search.state_list[old_item.world.id].remove(old_item)
+                search.unvisit(location)
+
+                # Generic events might show up or not, as usual, but since we don't
+                # show them in the final output, might as well skip over them. We'll
+                # still need them in the final pass, so make sure to include them.
+                if location.internal:
+                    required_locations.append(location)
+                    continue
+
+                location.item = None
+
+                # An item can only be required if it isn't already obtained or if it's progressive
+                if search.state_list[old_item.world.id].item_count(old_item.solver_id) < old_item.world.max_progressions[old_item.name]:
+                    # Test whether the game is still beatable from here.
+                    logger.debug('Checking if %s is required to beat the game.', old_item.name)
+                    if not search.can_beat_game():
+                        # still required, so reset the item
+                        location.item = old_item
+                        required_locations.append(location)
+
+        # Reduce each entrance sphere in reverse order, by checking if the game is beatable when we disconnect the entrance.
+        required_entrances = []
+        for sphere in reversed(entrance_spheres):
+            random.shuffle(sphere)
+            for entrance in sphere:
+                # we disconnect the entrance and check if the game is still beatable
+                old_connected_region = entrance.disconnect()
+
+                # we use a new search to ensure the disconnected entrance is no longer used
+                sub_search = Search([world.state for world in worlds])
+
+                # Test whether the game is still beatable from here.
+                logger.debug('Checking if reaching %s, through %s, is required to beat the game.', old_connected_region.name, entrance.name)
+                if not sub_search.can_beat_game():
+                    # still required, so reconnect the entrance
+                    entrance.connect(old_connected_region)
+                    required_entrances.append(entrance)
+
+        # Regenerate the spheres as we might not reach places the same way anymore.
+        search.reset() # search state has no items, okay to reuse sphere 0 cache
+        collection_spheres = [list(
+            filter(lambda loc: loc.item.advancement and loc.item.world.max_progressions[loc.item.name] > 0,
+                   search.iter_pseudo_starting_locations()))]
+        entrance_spheres = []
+        remaining_entrances = set(required_entrances)
+        collected = set()
+        while True:
+            # Not collecting while the generator runs means we only get one sphere at a time
+            # Otherwise, an item we collect could influence later item collection in the same sphere
+            collected.update(search.iter_reachable_locations(required_locations))
+            if not collected:
+                break
+            internal = collected & internal_locations
+            if internal:
+                # collect only the internal events but don't record them in a sphere
+                for location in internal:
+                    search.state_list[location.item.world.id].collect(location.item)
+                # Remaining locations need to be saved to be collected later
+                collected -= internal
+                continue
+            # Gather the new entrances before collecting items.
+            collection_spheres.append(list(collected))
+            accessed_entrances = set(filter(search.spot_access, remaining_entrances))
+            entrance_spheres.append(accessed_entrances)
+            remaining_entrances -= accessed_entrances
+            for location in collected:
+                # Collect the item for the state world it is for
+                search.state_list[location.item.world.id].collect(location.item)
+            collected.clear()
+        logger.info('Collected %d final spheres', len(collection_spheres))
+
+        if not search.can_beat_game(False):
+            logger.error('Playthrough could not beat the game!')
+            # Add temporary debugging info or breakpoint here if this happens
+
+        # Then we can finally output our playthrough
+        self.playthrough = OrderedDict((str(i), {location: location.item for location in sphere}) for i, sphere in enumerate(collection_spheres))
+        # Copy our misc. hint items, since we set them in the world copy
+        for w, sw in zip(worlds, self.worlds):
+            # But the actual location saved here may be in a different world
+            for item_name, item_location in w.hinted_dungeon_reward_locations.items():
+                sw.hinted_dungeon_reward_locations[item_name] = self.worlds[item_location.world.id].get_location(item_location.name)
+            for hint_type, item_location in w.misc_hint_item_locations.items():
+                sw.misc_hint_item_locations[hint_type] = self.worlds[item_location.world.id].get_location(item_location.name)
+
+        if worlds[0].entrance_shuffle:
+            self.entrance_playthrough = OrderedDict((str(i + 1), list(sphere)) for i, sphere in enumerate(entrance_spheres))

--- a/StartingItems.py
+++ b/StartingItems.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
 from collections import namedtuple
 from itertools import chain
-from typing import Dict, List, Tuple, Optional
+from typing import Optional
 
 Entry = namedtuple("Entry", ['setting_name', 'item_name', 'available', 'gui_text', 'special', 'ammo', 'i'])
 
 
 def _entry(setting_name: str, item_name: Optional[str] = None, available: int = 1, gui_text: Optional[str] = None,
-           special: bool = False, ammo: Optional[Dict[str, Tuple[int, ...]]] = None) -> List[Tuple[str, Entry]]:
+           special: bool = False, ammo: Optional[dict[str, tuple[int, ...]]] = None) -> list[tuple[str, Entry]]:
     if item_name is None:
         item_name = setting_name.capitalize()
     if gui_text is None:
@@ -22,7 +23,7 @@ def _entry(setting_name: str, item_name: Optional[str] = None, available: int = 
 
 
 # Ammo items must be declared in ItemList.py.
-inventory: Dict[str, Entry] = dict(chain(
+inventory: dict[str, Entry] = dict(chain(
     _entry('deku_stick', 'Deku Stick Capacity', available=2, ammo={'Deku Sticks': (20, 30)}),
     _entry('deku_nut', 'Deku Nut Capacity', available=2, ammo={'Deku Nuts': (30, 40)}),
     _entry('bombs', 'Bomb Bag', available=3, ammo={'Bombs': (20, 30, 40)}),
@@ -67,7 +68,7 @@ inventory: Dict[str, Entry] = dict(chain(
     _entry("mask_of_truth","Mask of Truth", gui_text="Mask of Truth"),
 ))
 
-songs: Dict[str, Entry] = dict(chain(
+songs: dict[str, Entry] = dict(chain(
     _entry('lullaby', 'Zeldas Lullaby', gui_text="Zelda's Lullaby"),
     _entry('eponas_song', 'Eponas Song', gui_text="Epona's Song"),
     _entry('sarias_song', 'Sarias Song', gui_text="Saria's Song"),
@@ -82,7 +83,7 @@ songs: Dict[str, Entry] = dict(chain(
     _entry('prelude', 'Prelude of Light'),
 ))
 
-equipment: Dict[str, Entry] = dict(chain(
+equipment: dict[str, Entry] = dict(chain(
     _entry('kokiri_sword', 'Kokiri Sword'),
     _entry('giants_knife', 'Giants Knife'),
     _entry('biggoron_sword', 'Biggoron Sword'),
@@ -101,4 +102,4 @@ equipment: Dict[str, Entry] = dict(chain(
     _entry('defense', 'Double Defense'),
 ))
 
-everything: Dict[str, Entry] = {**equipment, **inventory, **songs}
+everything: dict[str, Entry] = {**equipment, **inventory, **songs}

--- a/StartingItems.py
+++ b/StartingItems.py
@@ -3,6 +3,8 @@ from itertools import chain
 
 
 _Entry = namedtuple("_Entry", ['settingname', 'itemname', 'available', 'guitext', 'special', 'ammo', 'i'])
+
+
 def _entry(settingname, itemname=None, available=1, guitext=None, special=False, ammo=None):
     if itemname is None:
         itemname = settingname.capitalize()
@@ -13,9 +15,10 @@ def _entry(settingname, itemname=None, available=1, guitext=None, special=False,
         if i == 0:
             name = settingname
         else:
-            name = "{}{}".format(settingname, i+1)
+            name = f"{settingname}{i+1}"
         result.append((name, _Entry(name, itemname, available, guitext, special, ammo, i)))
     return result
+
 
 # Ammo items must be declared in ItemList.py.
 inventory = dict(chain(
@@ -27,13 +30,13 @@ inventory = dict(chain(
     _entry('dins_fire', 'Dins Fire', guitext="Din's Fire"),
     _entry('slingshot', available=3, ammo={'Deku Seeds': (30, 40, 50)}),
     _entry('ocarina', available=2),
-    _entry('bombchus', ammo={'Bombchus': (20,)}), # start with additional bombchus
+    _entry('bombchus', ammo={'Bombchus': (20,)}),  # start with additional bombchus
     _entry('hookshot', 'Progressive Hookshot', available=2),
     _entry('ice_arrow', 'Ice Arrows'),
     _entry('farores_wind', 'Farores Wind', guitext="Farore's Wind"),
     _entry('boomerang'),
     _entry('lens', 'Lens of Truth'),
-    _entry('beans', 'Magic Bean', ammo={'Magic Bean': (10,)}), # start with additional beans
+    _entry('beans', 'Magic Bean', ammo={'Magic Bean': (10,)}),  # start with additional beans
     _entry('megaton_hammer', 'Megaton Hammer', guitext = 'Megaton Hammer'),
     _entry('light_arrow', 'Light Arrows'),
     _entry('nayrus_love', 'Nayrus Love', guitext="Nayru's Love"),

--- a/StartingItems.py
+++ b/StartingItems.py
@@ -1,76 +1,77 @@
 from collections import namedtuple
 from itertools import chain
+from typing import Dict, List, Tuple, Optional
+
+Entry = namedtuple("Entry", ['setting_name', 'item_name', 'available', 'gui_text', 'special', 'ammo', 'i'])
 
 
-_Entry = namedtuple("_Entry", ['settingname', 'itemname', 'available', 'guitext', 'special', 'ammo', 'i'])
-
-
-def _entry(settingname, itemname=None, available=1, guitext=None, special=False, ammo=None):
-    if itemname is None:
-        itemname = settingname.capitalize()
-    if guitext is None:
-        guitext = itemname
+def _entry(setting_name: str, item_name: Optional[str] = None, available: int = 1, gui_text: Optional[str] = None,
+           special: bool = False, ammo: Optional[Dict[str, Tuple[int, ...]]] = None) -> List[Tuple[str, Entry]]:
+    if item_name is None:
+        item_name = setting_name.capitalize()
+    if gui_text is None:
+        gui_text = item_name
     result = []
     for i in range(available):
         if i == 0:
-            name = settingname
+            name = setting_name
         else:
-            name = f"{settingname}{i+1}"
-        result.append((name, _Entry(name, itemname, available, guitext, special, ammo, i)))
+            name = f"{setting_name}{i + 1}"
+        result.append((name, Entry(name, item_name, available, gui_text, special, ammo, i)))
     return result
 
 
 # Ammo items must be declared in ItemList.py.
-inventory = dict(chain(
+inventory: Dict[str, Entry] = dict(chain(
     _entry('deku_stick', 'Deku Stick Capacity', available=2, ammo={'Deku Sticks': (20, 30)}),
     _entry('deku_nut', 'Deku Nut Capacity', available=2, ammo={'Deku Nuts': (30, 40)}),
     _entry('bombs', 'Bomb Bag', available=3, ammo={'Bombs': (20, 30, 40)}),
     _entry('bow', available=3, ammo={'Arrows': (30, 40, 50)}),
     _entry('fire_arrow', 'Fire Arrows'),
-    _entry('dins_fire', 'Dins Fire', guitext="Din's Fire"),
+    _entry('dins_fire', 'Dins Fire', gui_text="Din's Fire"),
     _entry('slingshot', available=3, ammo={'Deku Seeds': (30, 40, 50)}),
     _entry('ocarina', available=2),
     _entry('bombchus', ammo={'Bombchus': (20,)}),  # start with additional bombchus
     _entry('hookshot', 'Progressive Hookshot', available=2),
     _entry('ice_arrow', 'Ice Arrows'),
-    _entry('farores_wind', 'Farores Wind', guitext="Farore's Wind"),
+    _entry('farores_wind', 'Farores Wind', gui_text="Farore's Wind"),
     _entry('boomerang'),
     _entry('lens', 'Lens of Truth'),
     _entry('beans', 'Magic Bean', ammo={'Magic Bean': (10,)}),  # start with additional beans
-    _entry('megaton_hammer', 'Megaton Hammer', guitext = 'Megaton Hammer'),
+    _entry('megaton_hammer', 'Megaton Hammer', gui_text='Megaton Hammer'),
     _entry('light_arrow', 'Light Arrows'),
-    _entry('nayrus_love', 'Nayrus Love', guitext="Nayru's Love"),
+    _entry('nayrus_love', 'Nayrus Love', gui_text="Nayru's Love"),
     _entry('bottle', available=3, special=True),
-    _entry('letter', 'Rutos Letter', guitext="Ruto's Letter", special=True),
-    _entry("pocket_egg",   "Pocket Egg", guitext="Pocket Egg"),
-    _entry("pocket_cucco", "Pocket Cucco", guitext="Pocket Cucco"),
-    _entry("cojiro",       "Cojiro", guitext="Cojiro"),
-    _entry("odd_mushroom", "Odd Mushroom", guitext="Odd Mushroom"),
-    _entry("odd_potion",   "Odd Potion", guitext="Odd Potion"),
-    _entry("poachers_saw", "Poachers Saw", guitext="Poacher's Saw"),
-    _entry("broken_sword", "Broken Sword", guitext="Broken Sword"),
-    _entry("prescription", "Prescription", guitext="Prescription"),
-    _entry("eyeball_frog", "Eyeball Frog", guitext="Eyeball Frog"),
-    _entry("eyedrops",     "Eyedrops", guitext="Eyedrops"),
-    _entry("claim_check",  "Claim Check", guitext="Claim Check"),
-    _entry("weird_egg",    "Weird Egg", guitext="Weird Egg"),
-    _entry("chicken",      "Chicken", guitext="Chicken"),
-    _entry("zeldas_letter","Zeldas Letter", guitext="Zelda's Letter"),
-    _entry("keaton_mask",  "Keaton Mask", guitext="Keaton Mask"),
-    _entry("skull_mask",   "Skull Mask", guitext="Skull Mask"),
-    _entry("spooky_mask",  "Spooky Mask", guitext="Spooky Mask"),
-    _entry("bunny_hood",   "Bunny Hood", guitext="Bunny Hood"),
-    _entry("goron_mask",   "Goron Mask", guitext="Goron Mask"),
-    _entry("zora_mask",    "Zora Mask", guitext="Zora Mask"),
-    _entry("gerudo_mask",  "Gerudo Mask", guitext="Gerudo Mask"),
-    _entry("mask_of_truth","Mask of Truth", guitext="Mask of Truth"),
+    _entry('letter', 'Rutos Letter', gui_text="Ruto's Letter", special=True),
+    _entry("pocket_egg",   "Pocket Egg", gui_text="Pocket Egg"),
+    _entry("pocket_cucco", "Pocket Cucco", gui_text="Pocket Cucco"),
+    _entry("cojiro",       "Cojiro", gui_text="Cojiro"),
+    _entry("odd_mushroom", "Odd Mushroom", gui_text="Odd Mushroom"),
+    _entry("odd_potion",   "Odd Potion", gui_text="Odd Potion"),
+    _entry("poachers_saw", "Poachers Saw", gui_text="Poacher's Saw"),
+    _entry("broken_sword", "Broken Sword", gui_text="Broken Sword"),
+    _entry("prescription", "Prescription", gui_text="Prescription"),
+    _entry("eyeball_frog", "Eyeball Frog", gui_text="Eyeball Frog"),
+    _entry("eyedrops",     "Eyedrops", gui_text="Eyedrops"),
+    _entry("claim_check",  "Claim Check", gui_text="Claim Check"),
+    _entry("weird_egg",    "Weird Egg", gui_text="Weird Egg"),
+    _entry("chicken",      "Chicken", gui_text="Chicken"),
+    _entry("zeldas_letter","Zeldas Letter", gui_text="Zelda's Letter"),
+    _entry("keaton_mask",  "Keaton Mask", gui_text="Keaton Mask"),
+    _entry("skull_mask",   "Skull Mask", gui_text="Skull Mask"),
+    _entry("spooky_mask",  "Spooky Mask", gui_text="Spooky Mask"),
+    _entry("bunny_hood",   "Bunny Hood", gui_text="Bunny Hood"),
+    _entry("goron_mask",   "Goron Mask", gui_text="Goron Mask"),
+    _entry("zora_mask",    "Zora Mask", gui_text="Zora Mask"),
+    _entry("gerudo_mask",  "Gerudo Mask", gui_text="Gerudo Mask"),
+    _entry("mask_of_truth","Mask of Truth", gui_text="Mask of Truth"),
 ))
 
-songs = dict(chain(
-    _entry('lullaby', 'Zeldas Lullaby', guitext="Zelda's Lullaby"),
-    _entry('eponas_song', 'Eponas Song', guitext="Epona's Song"),
-    _entry('sarias_song', 'Sarias Song', guitext="Saria's Song"),
-    _entry('suns_song', 'Suns Song', guitext="Sun's Song"),
+songs: Dict[str, Entry] = dict(chain(
+    _entry('lullaby', 'Zeldas Lullaby', gui_text="Zelda's Lullaby"),
+    _entry('eponas_song', 'Eponas Song', gui_text="Epona's Song"),
+    _entry('sarias_song', 'Sarias Song', gui_text="Saria's Song"),
+    _entry('suns_song', 'Suns Song', gui_text="Sun's Song"),
     _entry('song_of_time', 'Song of Time'),
     _entry('song_of_storms', 'Song of Storms'),
     _entry('minuet', 'Minuet of Forest'),
@@ -81,7 +82,7 @@ songs = dict(chain(
     _entry('prelude', 'Prelude of Light'),
 ))
 
-equipment = dict(chain(
+equipment: Dict[str, Entry] = dict(chain(
     _entry('kokiri_sword', 'Kokiri Sword'),
     _entry('giants_knife', 'Giants Knife'),
     _entry('biggoron_sword', 'Biggoron Sword'),
@@ -93,11 +94,11 @@ equipment = dict(chain(
     _entry('iron_boots', 'Iron Boots'),
     _entry('hover_boots', 'Hover Boots'),
     _entry('magic', 'Magic Meter', available=2),
-    _entry('strength', 'Progressive Strength Upgrade', guitext='Progressive Strength', available=3),
+    _entry('strength', 'Progressive Strength Upgrade', available=3, gui_text='Progressive Strength'),
     _entry('scale', 'Progressive Scale', available=2),
     _entry('wallet', 'Progressive Wallet', available=3),
     _entry('stone_of_agony', 'Stone of Agony'),
     _entry('defense', 'Double Defense'),
 ))
 
-everything = dict(chain(equipment.items(), inventory.items(), songs.items()))
+everything: Dict[str, Entry] = {**equipment, **inventory, **songs}

--- a/State.py
+++ b/State.py
@@ -1,25 +1,27 @@
-from collections import Counter
-import copy
-import logging
+from typing import TYPE_CHECKING, Dict, List, Iterable, Optional, Union, Any
 
-from Item import ItemInfo
+from Item import Item, ItemInfo
 from RulesCommon import escape_name
 
-Triforce_Piece = ItemInfo.solver_ids['Triforce_Piece']
-Triforce = ItemInfo.solver_ids['Triforce']
-Rutos_Letter = ItemInfo.solver_ids['Rutos_Letter']
-Piece_of_Heart = ItemInfo.solver_ids['Piece_of_Heart']
+if TYPE_CHECKING:
+    from Goals import GoalCategory, Goal
+    from Location import Location
+    from Search import Search
+    from World import World
 
-class State(object):
-
-    def __init__(self, parent):
-        self.solv_items = [0] * len(ItemInfo.solver_ids)
-        self.world = parent
-        self.search = None
-        self._won = self.won_triforce_hunt if self.world.settings.triforce_hunt else self.won_normal
+Triforce_Piece: int = ItemInfo.solver_ids['Triforce_Piece']
+Triforce: int = ItemInfo.solver_ids['Triforce']
+Rutos_Letter: int = ItemInfo.solver_ids['Rutos_Letter']
+Piece_of_Heart: int = ItemInfo.solver_ids['Piece_of_Heart']
 
 
-    def copy(self, new_world=None):
+class State:
+    def __init__(self, parent: "World") -> None:
+        self.solv_items: List[int] = [0] * len(ItemInfo.solver_ids)
+        self.world: "World" = parent
+        self.search: "Optional[Search]" = None
+
+    def copy(self, new_world: "Optional[World]" = None) -> 'State':
         if not new_world:
             new_world = self.world
         new_state = State(new_world)
@@ -27,106 +29,89 @@ class State(object):
             new_state.solv_items[i] = val
         return new_state
 
-
-    def item_name(self, location):
+    def item_name(self, location: "Union[str, Location]") -> Optional[str]:
         location = self.world.get_location(location)
         if location.item is None:
             return None
         return location.item.name
 
+    def won(self) -> bool:
+        return self.won_triforce_hunt() if self.world.settings.triforce_hunt else self.won_normal()
 
-    def won(self):
-        return self._won()
-
-
-    def won_triforce_hunt(self):
+    def won_triforce_hunt(self) -> bool:
         return self.has(Triforce_Piece, self.world.settings.triforce_goal_per_world)
 
-
-    def won_normal(self):
+    def won_normal(self) -> bool:
         return self.has(Triforce)
 
-
-    def has(self, item, count=1):
+    def has(self, item: int, count: int = 1) -> bool:
         return self.solv_items[item] >= count
 
-
-    def has_any_of(self, items):
+    def has_any_of(self, items: Iterable[int]) -> bool:
         for i in items:
-            if self.solv_items[i]: return True
+            if self.solv_items[i]:
+                return True
         return False
 
-
-    def has_all_of(self, items):
+    def has_all_of(self, items: Iterable[int]) -> bool:
         for i in items:
-            if not self.solv_items[i]: return False
+            if not self.solv_items[i]:
+                return False
         return True
 
-
-    def count_of(self, items):
+    def count_of(self, items: Iterable[int]) -> int:
         s = 0
         for i in items:
             s += self.solv_items[i]
         return s
 
-
-    def item_count(self, item):
+    def item_count(self, item: int) -> int:
         return self.solv_items[item]
 
-
-    def item_name_count(self, name):
+    def item_name_count(self, name: str) -> int:
         return self.solv_items[ItemInfo.solver_ids[escape_name(name)]]
 
-
-    def has_bottle(self, **kwargs):
+    def has_bottle(self, **kwargs) -> bool:
         # Extra Ruto's Letter are automatically emptied
         return self.has_any_of(ItemInfo.bottle_ids) or self.has(Rutos_Letter, 2)
 
-
-    def has_hearts(self, count):
+    def has_hearts(self, count: int) -> bool:
         # Warning: This is limited by World.max_progressions so it currently only works if hearts are required for LACS, bridge, or Ganon bk
         return self.heart_count() >= count
 
-
-    def heart_count(self):
+    def heart_count(self) -> int:
         # Warning: This is limited by World.max_progressions so it currently only works if hearts are required for LACS, bridge, or Ganon bk
         return (
             self.item_count(Piece_of_Heart) // 4 # aliases ensure Heart Container and Piece of Heart (Treasure Chest Game) are included in this
             + 3 # starting hearts
         )
 
-    def has_medallions(self, count):
+    def has_medallions(self, count: int) -> bool:
         return self.count_of(ItemInfo.medallion_ids) >= count
 
-
-    def has_stones(self, count):
+    def has_stones(self, count: int) -> bool:
         return self.count_of(ItemInfo.stone_ids) >= count
 
-
-    def has_dungeon_rewards(self, count):
+    def has_dungeon_rewards(self, count: int) -> bool:
         return (self.count_of(ItemInfo.medallion_ids) + self.count_of(ItemInfo.stone_ids)) >= count
 
-
     # TODO: Store the item's solver id in the goal
-    def has_item_goal(self, item_goal):
+    def has_item_goal(self, item_goal: Dict[str, Any]) -> bool:
         return self.solv_items[ItemInfo.solver_ids[escape_name(item_goal['name'])]] >= item_goal['minimum']
 
-
-    def has_full_item_goal(self, category, goal, item_goal):
+    def has_full_item_goal(self, category: "GoalCategory", goal: "Goal", item_goal: Dict[str, Any]) -> bool:
         local_goal = self.world.goal_categories[category.name].get_goal(goal.name)
         per_world_max_quantity = local_goal.get_item(item_goal['name'])['quantity']
         return self.solv_items[ItemInfo.solver_ids[escape_name(item_goal['name'])]] >= per_world_max_quantity
 
-
-    def has_all_item_goals(self):
+    def has_all_item_goals(self) -> bool:
         for category in self.world.goal_categories.values():
             for goal in category.goals:
                 if not all(map(lambda i: self.has_full_item_goal(category, goal, i), goal.items)):
                     return False
         return True
 
-
-    def had_night_start(self):
+    def had_night_start(self) -> bool:
         stod = self.world.settings.starting_tod
         # These are all not between 6:30 and 18:00
         if (stod == 'sunset' or         # 18
@@ -137,9 +122,8 @@ class State(object):
         else:
             return False
 
-
     # Used for fall damage and other situations where damage is unavoidable
-    def can_live_dmg(self, hearts):
+    def can_live_dmg(self, hearts: int) -> bool:
         mult = self.world.settings.damage_multiplier
         if hearts*4 >= 3:
             return mult != 'ohko' and mult != 'quadruple'
@@ -148,15 +132,13 @@ class State(object):
         else:
             return True
 
-
     # Use the guarantee_hint rule defined in json.
-    def guarantee_hint(self):
+    def guarantee_hint(self) -> bool:
         return self.world.parser.parse_rule('guarantee_hint')(self)
-
 
     # Be careful using this function. It will not collect any
     # items that may be locked behind the item, only the item itself.
-    def collect(self, item):
+    def collect(self, item: Item) -> None:
         if 'Small Key Ring' in item.name and self.world.settings.keyring_give_bk:
             dungeon_name = item.name[:-1].split(' (', 1)[1]
             if dungeon_name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
@@ -167,10 +149,9 @@ class State(object):
         if item.advancement:
             self.solv_items[item.solver_id] += 1
 
-
     # Be careful using this function. It will not uncollect any
     # items that may be locked behind the item, only the item itself.
-    def remove(self, item):
+    def remove(self, item: Item) -> None:
         if 'Small Key Ring' in item.name and self.world.settings.keyring_give_bk:
             dungeon_name = item.name[:-1].split(' (', 1)[1]
             if dungeon_name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
@@ -183,20 +164,16 @@ class State(object):
         if self.solv_items[item.solver_id] > 0:
             self.solv_items[item.solver_id] -= 1
 
-
-    def region_has_shortcuts(self, region_name):
+    def region_has_shortcuts(self, region_name: str) -> bool:
         return self.world.region_has_shortcuts(region_name)
 
-
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         return self.__dict__.copy()
 
-
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         self.__dict__.update(state)
 
-
-    def get_prog_items(self):
+    def get_prog_items(self) -> Dict[str, int]:
         return {
             **{item.name: self.solv_items[item.solver_id]
                 for item in ItemInfo.items.values()
@@ -205,4 +182,3 @@ class State(object):
                 for event in self.world.event_items
                 if self.solv_items[ItemInfo.solver_ids[event]]}
         }
-

--- a/State.py
+++ b/State.py
@@ -24,8 +24,7 @@ class State:
         self.search: Optional[Search] = None
 
     def copy(self, new_world: Optional[World] = None) -> State:
-        if not new_world:
-            new_world = self.world
+        new_world = new_world if new_world else self.world
         new_state = State(new_world)
         for i, val in enumerate(self.solv_items):
             new_state.solv_items[i] = val

--- a/State.py
+++ b/State.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Dict, List, Iterable, Optional, Union, Any
+from __future__ import annotations
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Optional, Any
 
 from Item import Item, ItemInfo
 from RulesCommon import escape_name
@@ -16,12 +18,12 @@ Piece_of_Heart: int = ItemInfo.solver_ids['Piece_of_Heart']
 
 
 class State:
-    def __init__(self, parent: "World") -> None:
-        self.solv_items: List[int] = [0] * len(ItemInfo.solver_ids)
-        self.world: "World" = parent
-        self.search: "Optional[Search]" = None
+    def __init__(self, parent: World) -> None:
+        self.solv_items: list[int] = [0] * len(ItemInfo.solver_ids)
+        self.world: World = parent
+        self.search: Optional[Search] = None
 
-    def copy(self, new_world: "Optional[World]" = None) -> 'State':
+    def copy(self, new_world: Optional[World] = None) -> State:
         if not new_world:
             new_world = self.world
         new_state = State(new_world)
@@ -29,7 +31,7 @@ class State:
             new_state.solv_items[i] = val
         return new_state
 
-    def item_name(self, location: "Union[str, Location]") -> Optional[str]:
+    def item_name(self, location: str | Location) -> Optional[str]:
         location = self.world.get_location(location)
         if location.item is None:
             return None
@@ -96,10 +98,10 @@ class State:
         return (self.count_of(ItemInfo.medallion_ids) + self.count_of(ItemInfo.stone_ids)) >= count
 
     # TODO: Store the item's solver id in the goal
-    def has_item_goal(self, item_goal: Dict[str, Any]) -> bool:
+    def has_item_goal(self, item_goal: dict[str, Any]) -> bool:
         return self.solv_items[ItemInfo.solver_ids[escape_name(item_goal['name'])]] >= item_goal['minimum']
 
-    def has_full_item_goal(self, category: "GoalCategory", goal: "Goal", item_goal: Dict[str, Any]) -> bool:
+    def has_full_item_goal(self, category: GoalCategory, goal: Goal, item_goal: dict[str, Any]) -> bool:
         local_goal = self.world.goal_categories[category.name].get_goal(goal.name)
         per_world_max_quantity = local_goal.get_item(item_goal['name'])['quantity']
         return self.solv_items[ItemInfo.solver_ids[escape_name(item_goal['name'])]] >= per_world_max_quantity
@@ -170,13 +172,13 @@ class State:
     def region_has_shortcuts(self, region_name: str) -> bool:
         return self.world.region_has_shortcuts(region_name)
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         return self.__dict__.copy()
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
 
-    def get_prog_items(self) -> Dict[str, int]:
+    def get_prog_items(self) -> dict[str, int]:
         return {
             **{item.name: self.solv_items[item.solver_id]
                 for item in ItemInfo.items.values()

--- a/State.py
+++ b/State.py
@@ -139,25 +139,28 @@ class State:
     # Be careful using this function. It will not collect any
     # items that may be locked behind the item, only the item itself.
     def collect(self, item: Item) -> None:
+        if item.solver_id is None:
+            raise Exception(f"Item '{item.name}' lacks a `solver_id` and can not be used in `State.collect()`.")
         if 'Small Key Ring' in item.name and self.world.settings.keyring_give_bk:
             dungeon_name = item.name[:-1].split(' (', 1)[1]
             if dungeon_name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
                 bk = f'Boss Key ({dungeon_name})'
                 self.solv_items[ItemInfo.solver_ids[escape_name(bk)]] = 1
-        if item.alias:
+        if item.alias and item.alias_id is not None:
             self.solv_items[item.alias_id] += item.alias[1]
-        if item.advancement:
-            self.solv_items[item.solver_id] += 1
+        self.solv_items[item.solver_id] += 1
 
     # Be careful using this function. It will not uncollect any
     # items that may be locked behind the item, only the item itself.
     def remove(self, item: Item) -> None:
+        if item.solver_id is None:
+            raise Exception(f"Item '{item.name}' lacks a `solver_id` and can not be used in `State.remove()`.")
         if 'Small Key Ring' in item.name and self.world.settings.keyring_give_bk:
             dungeon_name = item.name[:-1].split(' (', 1)[1]
             if dungeon_name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
                 bk = f'Boss Key ({dungeon_name})'
                 self.solv_items[ItemInfo.solver_ids[escape_name(bk)]] = 0
-        if item.alias and self.solv_items[item.alias_id] > 0:
+        if item.alias and item.alias_id is not None and self.solv_items[item.alias_id] > 0:
             self.solv_items[item.alias_id] -= item.alias[1]
             if self.solv_items[item.alias_id] < 0:
                 self.solv_items[item.alias_id] = 0
@@ -177,7 +180,7 @@ class State:
         return {
             **{item.name: self.solv_items[item.solver_id]
                 for item in ItemInfo.items.values()
-                if item.junk is None and self.solv_items[item.solver_id]},
+                if item.solver_id is not None},
             **{event: self.solv_items[ItemInfo.solver_ids[event]]
                 for event in self.world.event_items
                 if self.solv_items[ItemInfo.solver_ids[event]]}

--- a/TextBox.py
+++ b/TextBox.py
@@ -1,36 +1,44 @@
-import Messages
 import re
+from typing import TYPE_CHECKING, Dict, List, Pattern, Match
+
+import Messages
+
+if TYPE_CHECKING:
+    from Messages import TextCode
 
 # Least common multiple of all possible character widths. A line wrap must occur when the combined widths of all of the
 # characters on a line reach this value.
-NORMAL_LINE_WIDTH = 1801800
+NORMAL_LINE_WIDTH: int = 1801800
 
 # Attempting to display more lines in a single text box will cause additional lines to bleed past the bottom of the box.
-LINES_PER_BOX = 4
+LINES_PER_BOX: int = 4
 
 # Attempting to display more characters in a single text box will cause buffer overflows. First, visual artifacts will
 # appear in lower areas of the text box. Eventually, the text box will become uncloseable.
-MAX_CHARACTERS_PER_BOX = 200
+MAX_CHARACTERS_PER_BOX: int = 200
 
-CONTROL_CHARS = {
+CONTROL_CHARS: Dict[str, List[str]] = {
     'LINE_BREAK':   ['&', '\x01'],
     'BOX_BREAK':    ['^', '\x04'],
     'NAME':         ['@', '\x0F'],
     'COLOR':        ['#', '\x05\x00'],
 }
-TEXT_END = '\x02'
+TEXT_END: str = '\x02'
 
 
-def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, replace_control_chars=True):
+hex_string_regex: Pattern = re.compile(r"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", flags=re.IGNORECASE)
+
+
+def line_wrap(text: str, strip_existing_lines: bool = False, strip_existing_boxes: bool = False, replace_control_chars: bool = True):
     # Replace stand-in characters with their actual control code.
     if replace_control_chars:
-        def replace_bytes(matchobj):
-            return ''.join(chr(x) for x in bytes.fromhex(matchobj[1]))
+        def replace_bytes(match: Match) -> str:
+            return ''.join(chr(x) for x in bytes.fromhex(match[1]))
 
         for char in CONTROL_CHARS.values():
             text = text.replace(char[0], char[1])
 
-        text = re.sub(r"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", replace_bytes, text, flags=re.IGNORECASE)
+        text = hex_string_regex.sub(replace_bytes, text)
 
     # Parse the text into a list of control codes.
     text_codes = Messages.parse_control_codes(text)
@@ -57,7 +65,7 @@ def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, repl
                     text_codes.pop(index)
                     continue
                 # Replace this text code with a space.
-                text_codes[index] = Messages.Text_Code(0x20, 0)
+                text_codes[index] = Messages.TextCode(0x20, 0)
             index += 1
 
     # Split the text codes by current box breaks.
@@ -94,7 +102,7 @@ def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, repl
                 if index > 1:
                     words.append(box_codes[0:index-1])
                 if text_code.code in [0x01, 0x04]:
-                    # If we have ran into a line or box break, add it as a "word" as well.
+                    # If we have run into a line or box break, add it as a "word" as well.
                     words.append([box_codes[index-1]])
                 box_codes = box_codes[index:]
                 index = 0
@@ -138,7 +146,7 @@ def line_wrap(text, strip_existing_lines=False, strip_existing_boxes=False, repl
     return '\x04'.join(['\x01'.join([' '.join([''.join([code.get_string() for code in word]) for word in line]) for line in box]) for box in processed_boxes])
 
 
-def calculate_width(words):
+def calculate_width(words: "List[List[TextCode]]"):
     words_width = 0
     for word in words:
         index = 0
@@ -154,7 +162,7 @@ def calculate_width(words):
     return words_width + spaces_width
 
 
-def get_character_width(character):
+def get_character_width(character: str) -> int:
     try:
         return character_table[character]
     except KeyError:
@@ -168,7 +176,7 @@ def get_character_width(character):
             return character_table[' ']
 
 
-control_code_width = {
+control_code_width: Dict[str, str] = {
     '\x0F': '00000000',
     '\x16': '00\'00"',
     '\x17': '00\'00"',
@@ -186,7 +194,7 @@ control_code_width = {
 # at worst. This ensures that we will never bleed text out of the text box while line wrapping.
 # Larger numbers in the denominator mean more of that character fits on a line; conversely, larger values in this table
 # mean the character is wider and can't fit as many on one line.
-character_table = {
+character_table: Dict[str, int] = {
     '\x0F': 655200,
     '\x16': 292215,
     '\x17': 292215,
@@ -195,88 +203,89 @@ character_table = {
     '\x1D': 85800,
     '\x1E': 300300,
     '\x1F': 265980,
-    'a':  51480, # LINE_WIDTH /  35
-    'b':  51480, # LINE_WIDTH /  35
-    'c':  51480, # LINE_WIDTH /  35
-    'd':  51480, # LINE_WIDTH /  35
-    'e':  51480, # LINE_WIDTH /  35
-    'f':  34650, # LINE_WIDTH /  52
-    'g':  51480, # LINE_WIDTH /  35
-    'h':  51480, # LINE_WIDTH /  35
-    'i':  25740, # LINE_WIDTH /  70
-    'j':  34650, # LINE_WIDTH /  52
-    'k':  51480, # LINE_WIDTH /  35
-    'l':  25740, # LINE_WIDTH /  70
-    'm':  81900, # LINE_WIDTH /  22
-    'n':  51480, # LINE_WIDTH /  35
-    'o':  51480, # LINE_WIDTH /  35
-    'p':  51480, # LINE_WIDTH /  35
-    'q':  51480, # LINE_WIDTH /  35
-    'r':  42900, # LINE_WIDTH /  42
-    's':  51480, # LINE_WIDTH /  35
-    't':  42900, # LINE_WIDTH /  42
-    'u':  51480, # LINE_WIDTH /  35
-    'v':  51480, # LINE_WIDTH /  35
-    'w':  81900, # LINE_WIDTH /  22
-    'x':  51480, # LINE_WIDTH /  35
-    'y':  51480, # LINE_WIDTH /  35
-    'z':  51480, # LINE_WIDTH /  35
-    'A':  81900, # LINE_WIDTH /  22
-    'B':  51480, # LINE_WIDTH /  35
-    'C':  72072, # LINE_WIDTH /  25
-    'D':  72072, # LINE_WIDTH /  25
-    'E':  51480, # LINE_WIDTH /  35
-    'F':  51480, # LINE_WIDTH /  35
-    'G':  81900, # LINE_WIDTH /  22
-    'H':  60060, # LINE_WIDTH /  30
-    'I':  25740, # LINE_WIDTH /  70
-    'J':  51480, # LINE_WIDTH /  35
-    'K':  60060, # LINE_WIDTH /  30
-    'L':  51480, # LINE_WIDTH /  35
-    'M':  81900, # LINE_WIDTH /  22
-    'N':  72072, # LINE_WIDTH /  25
-    'O':  81900, # LINE_WIDTH /  22
-    'P':  51480, # LINE_WIDTH /  35
-    'Q':  81900, # LINE_WIDTH /  22
-    'R':  60060, # LINE_WIDTH /  30
-    'S':  60060, # LINE_WIDTH /  30
-    'T':  51480, # LINE_WIDTH /  35
-    'U':  60060, # LINE_WIDTH /  30
-    'V':  72072, # LINE_WIDTH /  25
-    'W': 100100, # LINE_WIDTH /  18
-    'X':  72072, # LINE_WIDTH /  25
-    'Y':  60060, # LINE_WIDTH /  30
-    'Z':  60060, # LINE_WIDTH /  30
-    ' ':  51480, # LINE_WIDTH /  35
-    '1':  25740, # LINE_WIDTH /  70
-    '2':  51480, # LINE_WIDTH /  35
-    '3':  51480, # LINE_WIDTH /  35
-    '4':  60060, # LINE_WIDTH /  30
-    '5':  51480, # LINE_WIDTH /  35
-    '6':  51480, # LINE_WIDTH /  35
-    '7':  51480, # LINE_WIDTH /  35
-    '8':  51480, # LINE_WIDTH /  35
-    '9':  51480, # LINE_WIDTH /  35
-    '0':  60060, # LINE_WIDTH /  30
-    '!':  51480, # LINE_WIDTH /  35
-    '?':  72072, # LINE_WIDTH /  25
-    '\'': 17325, # LINE_WIDTH / 104
-    '"':  34650, # LINE_WIDTH /  52
-    '.':  25740, # LINE_WIDTH /  70
-    ',':  25740, # LINE_WIDTH /  70
-    '/':  51480, # LINE_WIDTH /  35
-    '-':  34650, # LINE_WIDTH /  52
-    '_':  51480, # LINE_WIDTH /  35
-    '(':  42900, # LINE_WIDTH /  42
-    ')':  42900, # LINE_WIDTH /  42
-    '$':  51480  # LINE_WIDTH /  35
+    'a':  51480,  # LINE_WIDTH /  35
+    'b':  51480,  # LINE_WIDTH /  35
+    'c':  51480,  # LINE_WIDTH /  35
+    'd':  51480,  # LINE_WIDTH /  35
+    'e':  51480,  # LINE_WIDTH /  35
+    'f':  34650,  # LINE_WIDTH /  52
+    'g':  51480,  # LINE_WIDTH /  35
+    'h':  51480,  # LINE_WIDTH /  35
+    'i':  25740,  # LINE_WIDTH /  70
+    'j':  34650,  # LINE_WIDTH /  52
+    'k':  51480,  # LINE_WIDTH /  35
+    'l':  25740,  # LINE_WIDTH /  70
+    'm':  81900,  # LINE_WIDTH /  22
+    'n':  51480,  # LINE_WIDTH /  35
+    'o':  51480,  # LINE_WIDTH /  35
+    'p':  51480,  # LINE_WIDTH /  35
+    'q':  51480,  # LINE_WIDTH /  35
+    'r':  42900,  # LINE_WIDTH /  42
+    's':  51480,  # LINE_WIDTH /  35
+    't':  42900,  # LINE_WIDTH /  42
+    'u':  51480,  # LINE_WIDTH /  35
+    'v':  51480,  # LINE_WIDTH /  35
+    'w':  81900,  # LINE_WIDTH /  22
+    'x':  51480,  # LINE_WIDTH /  35
+    'y':  51480,  # LINE_WIDTH /  35
+    'z':  51480,  # LINE_WIDTH /  35
+    'A':  81900,  # LINE_WIDTH /  22
+    'B':  51480,  # LINE_WIDTH /  35
+    'C':  72072,  # LINE_WIDTH /  25
+    'D':  72072,  # LINE_WIDTH /  25
+    'E':  51480,  # LINE_WIDTH /  35
+    'F':  51480,  # LINE_WIDTH /  35
+    'G':  81900,  # LINE_WIDTH /  22
+    'H':  60060,  # LINE_WIDTH /  30
+    'I':  25740,  # LINE_WIDTH /  70
+    'J':  51480,  # LINE_WIDTH /  35
+    'K':  60060,  # LINE_WIDTH /  30
+    'L':  51480,  # LINE_WIDTH /  35
+    'M':  81900,  # LINE_WIDTH /  22
+    'N':  72072,  # LINE_WIDTH /  25
+    'O':  81900,  # LINE_WIDTH /  22
+    'P':  51480,  # LINE_WIDTH /  35
+    'Q':  81900,  # LINE_WIDTH /  22
+    'R':  60060,  # LINE_WIDTH /  30
+    'S':  60060,  # LINE_WIDTH /  30
+    'T':  51480,  # LINE_WIDTH /  35
+    'U':  60060,  # LINE_WIDTH /  30
+    'V':  72072,  # LINE_WIDTH /  25
+    'W': 100100,  # LINE_WIDTH /  18
+    'X':  72072,  # LINE_WIDTH /  25
+    'Y':  60060,  # LINE_WIDTH /  30
+    'Z':  60060,  # LINE_WIDTH /  30
+    ' ':  51480,  # LINE_WIDTH /  35
+    '1':  25740,  # LINE_WIDTH /  70
+    '2':  51480,  # LINE_WIDTH /  35
+    '3':  51480,  # LINE_WIDTH /  35
+    '4':  60060,  # LINE_WIDTH /  30
+    '5':  51480,  # LINE_WIDTH /  35
+    '6':  51480,  # LINE_WIDTH /  35
+    '7':  51480,  # LINE_WIDTH /  35
+    '8':  51480,  # LINE_WIDTH /  35
+    '9':  51480,  # LINE_WIDTH /  35
+    '0':  60060,  # LINE_WIDTH /  30
+    '!':  51480,  # LINE_WIDTH /  35
+    '?':  72072,  # LINE_WIDTH /  25
+    '\'': 17325,  # LINE_WIDTH / 104
+    '"':  34650,  # LINE_WIDTH /  52
+    '.':  25740,  # LINE_WIDTH /  70
+    ',':  25740,  # LINE_WIDTH /  70
+    '/':  51480,  # LINE_WIDTH /  35
+    '-':  34650,  # LINE_WIDTH /  52
+    '_':  51480,  # LINE_WIDTH /  35
+    '(':  42900,  # LINE_WIDTH /  42
+    ')':  42900,  # LINE_WIDTH /  42
+    '$':  51480,  # LINE_WIDTH /  35
 }
+
 
 # To run tests, enter the following into a python3 REPL:
 # >>> import Messages
 # >>> from TextBox import line_wrap_tests
 # >>> line_wrap_tests()
-def line_wrap_tests():
+def line_wrap_tests() -> None:
     test_wrap_simple_line()
     test_honor_forced_line_wraps()
     test_honor_box_breaks()
@@ -287,7 +296,7 @@ def line_wrap_tests():
     test_support_long_words()
 
 
-def test_wrap_simple_line():
+def test_wrap_simple_line() -> None:
     words = 'Hello World! Hello World! Hello World!'
     expected = 'Hello World! Hello World! Hello\x01World!'
     result = line_wrap(words)
@@ -298,7 +307,7 @@ def test_wrap_simple_line():
         print('"Wrap Simple Line" test passed!')
 
 
-def test_honor_forced_line_wraps():
+def test_honor_forced_line_wraps() -> None:
     words = 'Hello World! Hello World!&Hello World! Hello World! Hello World!'
     expected = 'Hello World! Hello World!\x01Hello World! Hello World! Hello\x01World!'
     result = line_wrap(words)
@@ -309,7 +318,7 @@ def test_honor_forced_line_wraps():
         print('"Honor Forced Line Wraps" test passed!')
 
 
-def test_honor_box_breaks():
+def test_honor_box_breaks() -> None:
     words = 'Hello World! Hello World!^Hello World! Hello World! Hello World!'
     expected = 'Hello World! Hello World!\x04Hello World! Hello World! Hello\x01World!'
     result = line_wrap(words)
@@ -320,7 +329,7 @@ def test_honor_box_breaks():
         print('"Honor Box Breaks" test passed!')
 
 
-def test_honor_control_characters():
+def test_honor_control_characters() -> None:
     words = 'Hello World! #Hello# World! Hello World!'
     expected = 'Hello World! \x05\x00Hello\x05\x00 World! Hello\x01World!'
     result = line_wrap(words)
@@ -331,7 +340,7 @@ def test_honor_control_characters():
         print('"Honor Control Characters" test passed!')
 
 
-def test_honor_player_name():
+def test_honor_player_name() -> None:
     words = 'Hello @! Hello World! Hello World!'
     expected = 'Hello \x0F! Hello World!\x01Hello World!'
     result = line_wrap(words)
@@ -342,7 +351,7 @@ def test_honor_player_name():
         print('"Honor Player Name" test passed!')
 
 
-def test_maintain_multiple_forced_breaks():
+def test_maintain_multiple_forced_breaks() -> None:
     words = 'Hello World!&&&Hello World!'
     expected = 'Hello World!\x01\x01\x01Hello World!'
     result = line_wrap(words)
@@ -353,7 +362,7 @@ def test_maintain_multiple_forced_breaks():
         print('"Maintain Multiple Forced Breaks" test passed!')
 
 
-def test_trim_whitespace():
+def test_trim_whitespace() -> None:
     words = 'Hello World! & Hello World!'
     expected = 'Hello World!\x01Hello World!'
     result = line_wrap(words)
@@ -364,7 +373,7 @@ def test_trim_whitespace():
         print('"Trim Whitespace" test passed!')
 
 
-def test_support_long_words():
+def test_support_long_words() -> None:
     words = 'Hello World! WWWWWWWWWWWWWWWWWWWW Hello World!'
     expected = 'Hello World!\x01WWWWWWWWWWWWWWWWWWWW\x01Hello World!'
     result = line_wrap(words)

--- a/TextBox.py
+++ b/TextBox.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 import re
-from typing import TYPE_CHECKING, Dict, List, Pattern, Match
+from typing import TYPE_CHECKING
 
 import Messages
 
@@ -17,7 +18,7 @@ LINES_PER_BOX: int = 4
 # appear in lower areas of the text box. Eventually, the text box will become uncloseable.
 MAX_CHARACTERS_PER_BOX: int = 200
 
-CONTROL_CHARS: Dict[str, List[str]] = {
+CONTROL_CHARS: dict[str, list[str]] = {
     'LINE_BREAK':   ['&', '\x01'],
     'BOX_BREAK':    ['^', '\x04'],
     'NAME':         ['@', '\x0F'],
@@ -26,13 +27,13 @@ CONTROL_CHARS: Dict[str, List[str]] = {
 TEXT_END: str = '\x02'
 
 
-hex_string_regex: Pattern = re.compile(r"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", flags=re.IGNORECASE)
+hex_string_regex: re.Pattern = re.compile(r"\$\{((?:[0-9a-f][0-9a-f] ?)+)}", flags=re.IGNORECASE)
 
 
 def line_wrap(text: str, strip_existing_lines: bool = False, strip_existing_boxes: bool = False, replace_control_chars: bool = True):
     # Replace stand-in characters with their actual control code.
     if replace_control_chars:
-        def replace_bytes(match: Match) -> str:
+        def replace_bytes(match: re.Match) -> str:
             return ''.join(chr(x) for x in bytes.fromhex(match[1]))
 
         for char in CONTROL_CHARS.values():
@@ -146,7 +147,7 @@ def line_wrap(text: str, strip_existing_lines: bool = False, strip_existing_boxe
     return '\x04'.join(['\x01'.join([' '.join([''.join([code.get_string() for code in word]) for word in line]) for line in box]) for box in processed_boxes])
 
 
-def calculate_width(words: "List[List[TextCode]]"):
+def calculate_width(words: list[list[TextCode]]):
     words_width = 0
     for word in words:
         index = 0
@@ -176,7 +177,7 @@ def get_character_width(character: str) -> int:
             return character_table[' ']
 
 
-control_code_width: Dict[str, str] = {
+control_code_width: dict[str, str] = {
     '\x0F': '00000000',
     '\x16': '00\'00"',
     '\x17': '00\'00"',
@@ -194,7 +195,7 @@ control_code_width: Dict[str, str] = {
 # at worst. This ensures that we will never bleed text out of the text box while line wrapping.
 # Larger numbers in the denominator mean more of that character fits on a line; conversely, larger values in this table
 # mean the character is wider and can't fit as many on one line.
-character_table: Dict[str, int] = {
+character_table: dict[str, int] = {
     '\x0F': 655200,
     '\x16': 292215,
     '\x17': 292215,

--- a/Unittest.py
+++ b/Unittest.py
@@ -363,7 +363,7 @@ class TestPlandomizer(unittest.TestCase):
             distribution_file, spoiler = generate_with_plandomizer(filename)
             pool_set = {i for i, c in spoiler['item_pool'].items()}
             self.assertEqual(
-                set(['Rupees (5)']),
+                {'Rupees (5)'},
                 pool_set - ludicrous_set,
                 'Ludicrous pool missing forced location junk items')
 
@@ -838,7 +838,7 @@ class TestValidSpoilers(unittest.TestCase):
                 except Exception as e:
                     # output the settings file in case of any failure
                     with open(settings_file, 'w') as f:
-                        d = {k: settings.__dict__[k] for k in out_keys}
+                        d = {k: settings.settings_dict[k] for k in out_keys}
                         json.dump(d, f, indent=0)
                     logging.getLogger('').exception(f'Failed to generate with these settings:\n{settings.get_settings_display()}\n')
                     raise

--- a/Unittest.py
+++ b/Unittest.py
@@ -2,6 +2,7 @@
 # With python3.10, you can instead run pytest Unittest.py
 # See `python -m unittest -h` or `pytest -h` for more options.
 
+from __future__ import annotations
 import json
 import logging
 import os
@@ -10,7 +11,7 @@ import re
 import sys
 import unittest
 from collections import Counter, defaultdict
-from typing import Dict, Tuple, Optional, Union, Any, overload
+from typing import Optional, Any, overload
 
 from EntranceShuffle import EntranceShuffleError
 from Fill import ShuffleError
@@ -60,7 +61,7 @@ ludicrous_junk = set(remove_junk_ludicrous_items)
 ludicrous_set = set(ludicrous_items_base) | set(ludicrous_items_extended) | ludicrous_junk | set(trade_items) | set(bottles) | set(ludicrous_exclusions) | {'Bottle with Big Poe'} | shop_items
 
 
-def make_settings_for_test(settings_dict: Dict[str, Any], seed: Optional[str] = None, outfilename: str = '', strict: bool = True) -> Settings:
+def make_settings_for_test(settings_dict: dict[str, Any], seed: Optional[str] = None, outfilename: str = '', strict: bool = True) -> Settings:
     # Some consistent settings for testability
     settings_dict.update({
         'create_patch_file': False,
@@ -76,7 +77,7 @@ def make_settings_for_test(settings_dict: Dict[str, Any], seed: Optional[str] = 
     return Settings(settings_dict, strict=strict)
 
 
-def load_settings(settings_file: Union[Dict[str, Any], str], seed: Optional[str] = None, filename: Optional[str] = None) -> Settings:
+def load_settings(settings_file: dict[str, Any] | str, seed: Optional[str] = None, filename: Optional[str] = None) -> Settings:
     if isinstance(settings_file, dict):  # Check if settings_file is a distribution file settings dict
         if filename is None:
             raise RuntimeError("Running test with in memory file but did not supply a filename for output file.")
@@ -99,14 +100,16 @@ def load_spoiler(json_file: str) -> Any:
 
 
 @overload
-def generate_with_plandomizer(filename: str, live_copy: LiteralFalse = False, max_attempts: int = 10) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def generate_with_plandomizer(filename: str, live_copy: LiteralFalse = False, max_attempts: int = 10) -> tuple[dict[str, Any], dict[str, Any]]:
     pass
+
 
 @overload
-def generate_with_plandomizer(filename: str, live_copy: LiteralTrue, max_attempts: int = 10) -> Tuple[Dict[str, Any], Spoiler]:
+def generate_with_plandomizer(filename: str, live_copy: LiteralTrue, max_attempts: int = 10) -> tuple[dict[str, Any], Spoiler]:
     pass
 
-def generate_with_plandomizer(filename: str, live_copy: bool = False, max_attempts: int = 10) -> Tuple[Dict[str, Any], Union[Spoiler, Dict[str, Any]]]:
+
+def generate_with_plandomizer(filename: str, live_copy: bool = False, max_attempts: int = 10) -> tuple[dict[str, Any], Spoiler | dict[str, Any]]:
     distribution_file = load_spoiler(os.path.join(test_dir, 'plando', filename + '.json'))
     try:
         settings = load_settings(distribution_file['settings'], seed='TESTTESTTEST', filename=filename)
@@ -129,7 +132,7 @@ def generate_with_plandomizer(filename: str, live_copy: bool = False, max_attemp
     return distribution_file, spoiler
 
 
-def get_actual_pool(spoiler: Dict[str, Any]) -> Dict[str, int]:
+def get_actual_pool(spoiler: dict[str, Any]) -> dict[str, int]:
     """Retrieves the actual item pool based on items placed in the spoiler log.
 
     :param spoiler: Spoiler log output from generator

--- a/Unittest.py
+++ b/Unittest.py
@@ -8,10 +8,9 @@ import logging
 import os
 import random
 import re
-import sys
 import unittest
 from collections import Counter, defaultdict
-from typing import Optional, Any, overload
+from typing import Literal, Optional, Any, overload
 
 from EntranceShuffle import EntranceShuffleError
 from Fill import ShuffleError
@@ -23,13 +22,6 @@ from Main import main, resolve_settings, build_world_graphs
 from Messages import Message
 from Settings import Settings, get_preset_files
 from Spoiler import Spoiler
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-    LiteralTrue = Literal[True]
-    LiteralFalse = Literal[False]
-else:
-    LiteralTrue = LiteralFalse = bool
 
 test_dir = os.path.join(os.path.dirname(__file__), 'tests')
 output_dir = os.path.join(test_dir, 'Output')
@@ -100,12 +92,12 @@ def load_spoiler(json_file: str) -> Any:
 
 
 @overload
-def generate_with_plandomizer(filename: str, live_copy: LiteralFalse = False, max_attempts: int = 10) -> tuple[dict[str, Any], dict[str, Any]]:
+def generate_with_plandomizer(filename: str, live_copy: Literal[False] = False, max_attempts: int = 10) -> tuple[dict[str, Any], dict[str, Any]]:
     pass
 
 
 @overload
-def generate_with_plandomizer(filename: str, live_copy: LiteralTrue, max_attempts: int = 10) -> tuple[dict[str, Any], Spoiler]:
+def generate_with_plandomizer(filename: str, live_copy: Literal[True], max_attempts: int = 10) -> tuple[dict[str, Any], Spoiler]:
     pass
 
 

--- a/Unittest.py
+++ b/Unittest.py
@@ -2,24 +2,25 @@
 # With python3.10, you can instead run pytest Unittest.py
 # See `python -m unittest -h` or `pytest -h` for more options.
 
-from collections import Counter, defaultdict
 import json
 import logging
 import os
 import random
 import re
 import unittest
+from collections import Counter, defaultdict
+from typing import Dict, Tuple, Optional, Union, Any
 
 from EntranceShuffle import EntranceShuffleError
 from Fill import ShuffleError
-from Hints import HintArea
-from Hints import HintArea, buildMiscItemHints
+from Hints import HintArea, build_misc_item_hints
 from Item import ItemInfo
 from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions
 from LocationList import location_is_viewable
 from Main import main, resolve_settings, build_world_graphs
 from Messages import Message
 from Settings import Settings, get_preset_files
+from Spoiler import Spoiler
 
 test_dir = os.path.join(os.path.dirname(__file__), 'tests')
 output_dir = os.path.join(test_dir, 'Output')
@@ -48,10 +49,10 @@ bottles = {name for name, item in ItemInfo.items.items() if item.special.get('bo
 junk = set(remove_junk_items)
 shop_items = {i for i, nfo in ItemInfo.items.items() if nfo.type == 'Shop'}
 ludicrous_junk = set(remove_junk_ludicrous_items)
-ludicrous_set = set(ludicrous_items_base) | set(ludicrous_items_extended) | ludicrous_junk | set(trade_items) | set(bottles) | set(ludicrous_exclusions) | set(['Bottle with Big Poe']) | shop_items
+ludicrous_set = set(ludicrous_items_base) | set(ludicrous_items_extended) | ludicrous_junk | set(trade_items) | set(bottles) | set(ludicrous_exclusions) | {'Bottle with Big Poe'} | shop_items
 
 
-def make_settings_for_test(settings_dict, seed=None, outfilename=None, strict=True):
+def make_settings_for_test(settings_dict: Dict[str, Any], seed: Optional[str] = None, outfilename: str = None, strict: bool = True) -> Settings:
     # Some consistent settings for testability
     settings_dict.update({
         'create_patch_file': False,
@@ -67,7 +68,7 @@ def make_settings_for_test(settings_dict, seed=None, outfilename=None, strict=Tr
     return Settings(settings_dict, strict=strict)
 
 
-def load_settings(settings_file, seed=None, filename=None):
+def load_settings(settings_file: Union[Dict[str, Any], str], seed: Optional[str] = None, filename: Optional[str] = None) -> Settings:
     if isinstance(settings_file, dict):  # Check if settings_file is a distribution file settings dict
         try:
             j = settings_file
@@ -85,12 +86,12 @@ def load_settings(settings_file, seed=None, filename=None):
     return make_settings_for_test(j, seed=seed, outfilename=filename)
 
 
-def load_spoiler(json_file):
+def load_spoiler(json_file: str) -> Any:
     with open(json_file) as f:
         return json.load(f)
 
 
-def generate_with_plandomizer(filename, live_copy=False, max_attempts=10):
+def generate_with_plandomizer(filename: str, live_copy: bool = False, max_attempts: int = 10) -> Tuple[Dict[str, Any], Union[Spoiler, Dict[str, Any]]]:
     distribution_file = load_spoiler(os.path.join(test_dir, 'plando', filename + '.json'))
     try:
         settings = load_settings(distribution_file['settings'], seed='TESTTESTTEST', filename=filename)
@@ -109,11 +110,11 @@ def generate_with_plandomizer(filename, live_copy=False, max_attempts=10):
         })
     spoiler = main(settings, max_attempts=max_attempts)
     if not live_copy:
-        spoiler = load_spoiler('%s_Spoiler.json' % settings.output_file)
+        spoiler = load_spoiler(f'{settings.output_file}_Spoiler.json')
     return distribution_file, spoiler
 
 
-def get_actual_pool(spoiler):
+def get_actual_pool(spoiler: Dict[str, Any]) -> Dict[str, int]:
     """Retrieves the actual item pool based on items placed in the spoiler log.
 
     :param spoiler: Spoiler log output from generator
@@ -617,7 +618,7 @@ class TestHints(unittest.TestCase):
         self.assertEqual(area, "#Ganondorf's Chamber#")
         # Build a test message with the same ID as the ganondorf hint (0x70CC)
         messages = [Message("Test", 0, 0x70CC, 0,0,0)]
-        buildMiscItemHints(spoiler.worlds[0], messages)
+        build_misc_item_hints(spoiler.worlds[0], messages)
         for message in messages:
             if(message.id == 0x70CC): # Ganondorf hint message
                 self.assertTrue("thosepotsoverthere" in message.text.replace('\n', '').replace(' ', ''))

--- a/Utils.py
+++ b/Utils.py
@@ -12,14 +12,6 @@ from urllib.error import URLError, HTTPError
 from version import __version__, base_version, supplementary_version, branch_url
 
 
-# For easy import of TypeAlias that won't break older versions of Python.
-if sys.version_info >= (3, 10):
-    # noinspection PyUnresolvedReferences
-    from typing import TypeAlias
-else:
-    TypeAlias = str
-
-
 def is_bundled() -> bool:
     return getattr(sys, 'frozen', False)
 
@@ -85,16 +77,6 @@ def open_file(filename: str) -> None:
     else:
         open_command = 'open' if sys.platform == 'darwin' else 'xdg-open'
         subprocess.call([open_command, filename])
-
-
-def close_console() -> None:
-    if sys.platform == 'win32':
-        # windows
-        import win32gui, win32con
-        try:
-            win32gui.ShowWindow(win32gui.GetForegroundWindow(), win32con.SW_HIDE)
-        except Exception:
-            pass
 
 
 def get_version_bytes(a: str, b: int = 0x00, c: int = 0x00) -> List[int]:
@@ -234,8 +216,14 @@ def run_process(logger: logging.Logger, args: Sequence[str], stdin: Optional[Any
 
 
 # https://stackoverflow.com/a/23146126
-def find_last(source_list: Sequence[Any], sought_element: Any) -> Optional[int]:
+def try_find_last(source_list: Sequence[Any], sought_element: Any) -> Optional[int]:
     for reverse_index, element in enumerate(reversed(source_list)):
         if element == sought_element:
             return len(source_list) - 1 - reverse_index
     return None
+
+def find_last(source_list: Sequence[Any], sought_element: Any) -> int:
+    last = try_find_last(source_list, sought_element)
+    if last is None:
+        raise Exception(f"Element {sought_element} not found in sequence {source_list}.")
+    return last

--- a/Utils.py
+++ b/Utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import json
 import logging
@@ -6,7 +7,8 @@ import re
 import subprocess
 import sys
 import urllib.request
-from typing import Dict, List, Sequence, Optional, AnyStr, Any
+from collections.abc import Sequence
+from typing import AnyStr, Optional, Any
 from urllib.error import URLError, HTTPError
 
 from version import __version__, base_version, supplementary_version, branch_url
@@ -79,7 +81,7 @@ def open_file(filename: str) -> None:
         subprocess.call([open_command, filename])
 
 
-def get_version_bytes(a: str, b: int = 0x00, c: int = 0x00) -> List[int]:
+def get_version_bytes(a: str, b: int = 0x00, c: int = 0x00) -> list[int]:
     version_bytes = [0x00, 0x00, 0x00, b, c]
 
     if not a:
@@ -163,7 +165,7 @@ def check_version(checked_version: str) -> None:
 # variants) call work with or without Pyinstaller, ``--noconsole`` or
 # not, on Windows and Linux. Typical use::
 #   subprocess.call(['program_to_run', 'arg_1'], **subprocess_args())
-def subprocess_args(include_stdout: bool = True) -> Dict[str, Any]:
+def subprocess_args(include_stdout: bool = True) -> dict[str, Any]:
     # The following is true only on Windows.
     if hasattr(subprocess, 'STARTUPINFO'):
         # On Windows, subprocess calls will pop up a command window by default
@@ -221,6 +223,7 @@ def try_find_last(source_list: Sequence[Any], sought_element: Any) -> Optional[i
         if element == sought_element:
             return len(source_list) - 1 - reverse_index
     return None
+
 
 def find_last(source_list: Sequence[Any], sought_element: Any) -> int:
     last = try_find_last(source_list, sought_element)

--- a/Utils.py
+++ b/Utils.py
@@ -201,7 +201,7 @@ def subprocess_args(include_stdout=True):
     return ret
 
 
-def run_process(window, logger, args, stdin=None):
+def run_process(logger, args, stdin=None):
     process = subprocess.Popen(args, bufsize=1, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
     filecount = None
     if stdin is not None:
@@ -215,7 +215,6 @@ def run_process(window, logger, args, stdin=None):
                     files = int(line[:find_index].strip())
                     if filecount is None:
                         filecount = files
-                    window.update_progress(65 + 30*(1 - files/filecount))
                 logger.info(line.decode('utf-8').strip('\n'))
             else:
                 break

--- a/World.py
+++ b/World.py
@@ -15,7 +15,7 @@ from LocationList import business_scrubs, location_groups
 from Plandomizer import InvalidFileException
 from Region import Region, TimeOfDay
 from RuleParser import Rule_AST_Transformer
-from SettingsList import get_setting_info, get_settings_from_section
+from SettingsList import SettingInfos, get_settings_from_section
 from State import State
 from Utils import read_logic_file
 
@@ -381,11 +381,11 @@ class World(object):
     def resolve_random_settings(self):
         # evaluate settings (important for logic, nice for spoiler)
         self.randomized_list = []
-        dist_keys = []
+        dist_keys = set()
         if '_settings' in self.distribution.distribution.src_dict:
             dist_keys = self.distribution.distribution.src_dict['_settings'].keys()
         if self.settings.randomize_settings:
-            setting_info = get_setting_info('randomize_settings')
+            setting_info = SettingInfos.setting_infos['randomize_settings']
             self.randomized_list.extend(setting_info.disable[True]['settings'])
             for section in setting_info.disable[True]['sections']:
                 self.randomized_list.extend(get_settings_from_section(section))
@@ -415,7 +415,7 @@ class World(object):
         if (self.settings.starting_tod == 'random'
             and ('starting_tod' not in dist_keys
              or self.distribution.distribution.src_dict['_settings']['starting_tod'] == 'random')):
-            setting_info = get_setting_info('starting_tod')
+            setting_info = SettingInfos.setting_infos['starting_tod']
             choices = [ch for ch in setting_info.choices if ch not in ['default', 'random']]
             self.settings.starting_tod = random.choice(choices)
             self.randomized_list.append('starting_tod')
@@ -1244,7 +1244,7 @@ class World(object):
             self.settings.shuffle_scrubs == 'off' and not self.settings.shuffle_grotto_entrances):
             # nayru's love may be required to prevent forced damage
             exclude_item_list.append('Nayrus Love')
-        if self.settings.logic_grottos_without_agony and self.settings.hints != 'agony':
+        if 'logic_grottos_without_agony' in self.settings.allowed_tricks and self.settings.hints != 'agony':
             # Stone of Agony skippable if not used for hints or grottos
             exclude_item_list.append('Stone of Agony')
         if not self.shuffle_special_interior_entrances and not self.settings.shuffle_overworld_entrances and not self.settings.warp_songs:
@@ -1263,7 +1263,7 @@ class World(object):
         if not self.settings.blue_fire_arrows:
             # Ice Arrows can only be required when the Blue Fire Arrows setting is enabled
             exclude_item_list.append('Ice Arrows')
-        if self.settings.logic_lens_botw or self.settings.shuffle_pots in ('off', 'overworld'):
+        if 'logic_lens_botw' in self.settings.allowed_tricks or self.settings.shuffle_pots in ('off', 'overworld'):
             # These silver rupees unlock a door to an area that's also reachable with lens
             exclude_item_list.append('Silver Rupee (Bottom of the Well Basement)')
             exclude_item_list.append('Silver Rupee Pouch (Bottom of the Well Basement)')
@@ -1271,7 +1271,7 @@ class World(object):
             # These silver rupees only unlock the map chest
             exclude_item_list.append('Silver Rupee (Shadow Temple Scythe Shortcut)')
             exclude_item_list.append('Silver Rupee Pouch (Shadow Temple Scythe Shortcut)')
-        if self.settings.logic_spirit_sun_chest_no_rupees and not self.settings.logic_spirit_sun_chest_bow:
+        if 'logic_spirit_sun_chest_no_rupees' in self.settings.allowed_tricks and 'logic_spirit_sun_chest_bow' not in self.settings.allowed_tricks:
             # With this trickset, these silver rupees are logically irrelevant
             exclude_item_list.append('Silver Rupee (Spirit Temple Sun Block)')
             exclude_item_list.append('Silver Rupee Pouch (Spirit Temple Sun Block)')

--- a/World.py
+++ b/World.py
@@ -19,9 +19,9 @@ from SettingsList import get_setting_info, get_settings_from_section
 from State import State
 from Utils import read_logic_file
 
-class World(object):
 
-    def __init__(self, id, settings, resolveRandomizedSettings=True):
+class World(object):
+    def __init__(self, id, settings, resolve_randomized_settings=True):
         self.id = id
         self.dungeons = []
         self.regions = []
@@ -147,7 +147,7 @@ class World(object):
             'Ganons Castle': False
         }
 
-        if resolveRandomizedSettings:
+        if resolve_randomized_settings:
             self.resolve_random_settings()
 
         if len(settings.hint_dist_user) == 0:

--- a/World.py
+++ b/World.py
@@ -35,7 +35,7 @@ class World:
         self._region_cache: Dict[str, Region] = {}
         self._location_cache: Dict[str, Location] = {}
         self.shop_prices: Dict[str, int] = {}
-        self.scrub_prices: Dict[str, int] = {}
+        self.scrub_prices: Dict[int, int] = {}
         self.maximum_wallets: int = 0
         self.hinted_dungeon_reward_locations: Dict[str, Location] = {}
         self.misc_hint_item_locations: Dict[str, Location] = {}
@@ -63,7 +63,7 @@ class World:
         self.shuffle_special_dungeon_entrances: bool = settings.shuffle_dungeon_entrances == 'all'
         self.shuffle_dungeon_entrances: bool = settings.shuffle_dungeon_entrances in ['simple', 'all']
 
-        self.entrance_shuffle: bool = (
+        self.entrance_shuffle: bool = bool(
             self.shuffle_interior_entrances or settings.shuffle_grotto_entrances or self.shuffle_dungeon_entrances
             or settings.shuffle_overworld_entrances or settings.shuffle_gerudo_valley_river_exit or settings.owl_drops or settings.warp_songs
             or settings.spawn_positions or (settings.shuffle_bosses != 'off')
@@ -71,7 +71,7 @@ class World:
 
         self.mixed_pools_bosses = False # this setting is still in active development at https://github.com/Roman971/OoT-Randomizer
 
-        self.ensure_tod_access: bool = self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.spawn_positions
+        self.ensure_tod_access: bool = bool(self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.spawn_positions)
         self.disable_trade_revert: bool = self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.adult_trade_shuffle
         self.skip_child_zelda: bool = 'Zeldas Letter' not in settings.shuffle_child_trade and \
                                       'Zeldas Letter' in self.distribution.starting_items
@@ -128,7 +128,7 @@ class World:
             def __missing__(self, dungeon_name: str) -> EmptyDungeonInfo:
                 return self.EmptyDungeonInfo(None)
 
-        self.empty_dungeons: EmptyDungeons[str, EmptyDungeons.EmptyDungeonInfo] = EmptyDungeons()
+        self.empty_dungeons: Dict[str, EmptyDungeons.EmptyDungeonInfo] = EmptyDungeons()
 
         # dungeon forms will be decided later
         self.dungeon_mq: Dict[str, bool] = {

--- a/World.py
+++ b/World.py
@@ -1040,36 +1040,39 @@ class World:
             return self._region_cache[region_name]
         except KeyError:
             for region in self.regions:
-                if region.name == region_name:
-                    self._region_cache[region_name] = region
-                    return region
-            raise KeyError('No such region %s' % region_name)
+                self._region_cache[region.name] = region
+            region = self._region_cache.get(region_name, None)
+            if region is not None:
+                return region
+        raise KeyError('No such region %s' % region_name)
 
-    def get_entrance(self, entrance: str | Entrance) -> Entrance:
-        if isinstance(entrance, Entrance):
-            return entrance
+    def get_entrance(self, entrance_name: str | Entrance) -> Entrance:
+        if isinstance(entrance_name, Entrance):
+            return entrance_name
         try:
-            return self._entrance_cache[entrance]
+            return self._entrance_cache[entrance_name]
         except KeyError:
             for region in self.regions:
-                for exit in region.exits:
-                    if exit.name == entrance:
-                        self._entrance_cache[entrance] = exit
-                        return exit
-            raise KeyError('No such entrance %s' % entrance)
+                for entrance in region.exits:
+                    self._entrance_cache[entrance.name] = entrance
+            entrance = self._entrance_cache.get(entrance_name, None)
+            if entrance is not None:
+                return entrance
+        raise KeyError('No such entrance %s' % entrance_name)
 
-    def get_location(self, location: str | Location) -> Location:
-        if isinstance(location, Location):
-            return location
+    def get_location(self, location_name: str | Location) -> Location:
+        if isinstance(location_name, Location):
+            return location_name
         try:
-            return self._location_cache[location]
+            return self._location_cache[location_name]
         except KeyError:
             for region in self.regions:
-                for r_location in region.locations:
-                    if r_location.name == location:
-                        self._location_cache[location] = r_location
-                        return r_location
-        raise KeyError('No such location %s' % location)
+                for location in region.locations:
+                    self._location_cache[location.name] = location
+            location = self._location_cache.get(location_name, None)
+            if location is not None:
+                return location
+        raise KeyError('No such location %s' % location_name)
 
     def get_items(self) -> list[Item]:
         return [loc.item for loc in self.get_filled_locations()] + self.itempool

--- a/crc.py
+++ b/crc.py
@@ -4,24 +4,16 @@ from ntype import uint32, BigStream
 
 
 def calculate_crc(data: BigStream) -> bytearray:
-    t1: int
-    t2: int
-    t3: int
-    t4: int
-    t5: int
-    t6: int
     t1 = t2 = t3 = t4 = t5 = t6 = 0xDF26F436
 
-    u32: int = 0xFFFFFFFF
+    u32 = 0xFFFFFFFF
 
-    m1: bytearray = data.read_bytes(0x1000, 0x100000)
+    m1 = data.read_bytes(0x1000, 0x100000)
     words = map(uint32.value, zip(m1[0::4], m1[1::4], m1[2::4], m1[3::4]))
 
-    m2: bytearray = data.read_bytes(0x750, 0x100)
+    m2 = data.read_bytes(0x750, 0x100)
     words2 = map(uint32.value, zip(m2[0::4], m2[1::4], m2[2::4], m2[3::4]))
 
-    d: int
-    d2: int
     for d, d2 in zip(words, itertools.cycle(words2)):
         # keep t2 and t6 in u32 for comparisons; others can wait to be truncated
         if ((t6 + d) & u32) < t6:

--- a/crc.py
+++ b/crc.py
@@ -1,4 +1,5 @@
 import itertools
+
 from ntype import uint32, BigStream
 
 

--- a/crc.py
+++ b/crc.py
@@ -1,17 +1,26 @@
 import itertools
-from ntype import BigStream, uint32
+from ntype import uint32, BigStream
 
-def calculate_crc(self):
 
+def calculate_crc(data: BigStream) -> bytearray:
+    t1: int
+    t2: int
+    t3: int
+    t4: int
+    t5: int
+    t6: int
     t1 = t2 = t3 = t4 = t5 = t6 = 0xDF26F436
-    u32 = 0xFFFFFFFF
 
-    m1 = self.read_bytes(0x1000, 0x100000)
+    u32: int = 0xFFFFFFFF
+
+    m1: bytearray = data.read_bytes(0x1000, 0x100000)
     words = map(uint32.value, zip(m1[0::4], m1[1::4], m1[2::4], m1[3::4]))
 
-    m2 = self.read_bytes(0x750, 0x100)
+    m2: bytearray = data.read_bytes(0x750, 0x100)
     words2 = map(uint32.value, zip(m2[0::4], m2[1::4], m2[2::4], m2[3::4]))
 
+    d: int
+    d2: int
     for d, d2 in zip(words, itertools.cycle(words2)):
         # keep t2 and t6 in u32 for comparisons; others can wait to be truncated
         if ((t6 + d) & u32) < t6:

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -65,7 +65,7 @@
         ],
         "allowed_tricks": [],
         "starting_equipment": [],
-        "starting_items": [
+        "starting_inventory": [
             "zeldas_letter"
         ],
         "starting_songs": [],
@@ -202,7 +202,7 @@
         "starting_equipment": [
             "deku_shield"
         ],
-        "starting_items": [
+        "starting_inventory": [
             "ocarina",
             "zeldas_letter"
         ],
@@ -338,7 +338,7 @@
             "logic_lens_spirit"
         ],
         "starting_equipment": [],
-        "starting_items": [],
+        "starting_inventory": [],
         "starting_songs": [],
         "start_with_consumables": false,
         "start_with_rupees": false,
@@ -470,7 +470,7 @@
             "logic_lens_spirit"
         ],
         "starting_equipment": [],
-        "starting_items": [],
+        "starting_inventory": [],
         "starting_songs": [],
         "start_with_consumables": false,
         "start_with_rupees": false,
@@ -607,7 +607,7 @@
         "starting_equipment": [
             "deku_shield"
         ],
-        "starting_items": [
+        "starting_inventory": [
             "ocarina",
             "lens",
             "zeldas_letter"
@@ -761,7 +761,7 @@
             "logic_dc_scarecrow_gs"
         ],
         "starting_equipment": [],
-        "starting_items": [
+        "starting_inventory": [
             "ocarina",
             "farores_wind",
             "lens",
@@ -1067,7 +1067,7 @@
             "logic_light_trial_mq"
         ],
         "starting_equipment": [],
-        "starting_items": [],
+        "starting_inventory": [],
         "starting_songs": [],
         "start_with_consumables": false,
         "start_with_rupees": false,
@@ -1194,7 +1194,7 @@
             "logic_lens_spirit"
         ],
         "starting_equipment": [],
-        "starting_items": [],
+        "starting_inventory": [],
         "starting_songs": [],
         "start_with_consumables": false,
         "start_with_rupees": false,
@@ -1355,7 +1355,7 @@
         "starting_equipment": [
             "deku_shield"
         ],
-        "starting_items": [
+        "starting_inventory": [
             "ocarina",
             "lens",
             "farores_wind",
@@ -1491,7 +1491,7 @@
             "logic_lens_spirit"
         ],
         "starting_equipment": [],
-        "starting_items": [
+        "starting_inventory": [
             "ocarina",
             "zeldas_letter"
         ],

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -289,7 +289,7 @@
           "col_span": 2,
           "row_span": [3,3,3],
           "settings": [
-            "starting_items"
+            "starting_inventory"
           ]
         },
         {

--- a/ntype.py
+++ b/ntype.py
@@ -1,54 +1,69 @@
-# Written by mzxrules
-
+# Originally written by mzxrules
+from typing import Sequence, Optional
 import struct
 
 
 class uint16:
     _struct = struct.Struct('>H')
-    def write(buffer, address, value):
+
+    @staticmethod
+    def write(buffer: bytearray, address: int, value: int) -> None:
         struct.pack_into('>H', buffer, address, value)
 
-    def read(buffer, address=0):
+    @staticmethod
+    def read(buffer: bytearray, address: int = 0) -> int:
         return uint16._struct.unpack_from(buffer, address)[0]
 
-    def bytes(value):
-        value = value & 0xFFFF
-        return [(value >> 8) & 0xFF, value & 0xFF]
+    @staticmethod
+    def bytes(value: int) -> bytearray:
+        value: int = value & 0xFFFF
+        return bytearray([(value >> 8) & 0xFF, value & 0xFF])
 
-    def value(values):
-        return (values[0] << 8) | values[1]
+    @staticmethod
+    def value(values: Sequence[int]) -> int:
+        return ((values[0] & 0xFF) << 8) | (values[1] & 0xFF)
 
 
 class uint32:
     _struct = struct.Struct('>I')
-    def write(buffer, address, value):
+
+    @staticmethod
+    def write(buffer: bytearray, address: int, value: int) -> None:
         struct.pack_into('>I', buffer, address, value)
 
-    def read(buffer, address=0):
+    @staticmethod
+    def read(buffer: bytearray, address: int = 0) -> int:
         return uint32._struct.unpack_from(buffer, address)[0]
 
-    def bytes(value):
-        value = value & 0xFFFFFFFF
-        return [(value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF]
+    @staticmethod
+    def bytes(value: int) -> bytearray:
+        value: int = value & 0xFFFFFFFF
+        return bytearray([(value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
 
-    def value(values):
-        return (values[0] << 24) | (values[1] << 16) | (values[2] << 8) | values[3]
+    @staticmethod
+    def value(values: Sequence[int]) -> int:
+        return ((values[0] & 0xFF) << 24) | ((values[1] & 0xFF) << 16) | ((values[2] & 0xFF) << 8) | (values[3] & 0xFF)
 
 
 class int32:
     _struct = struct.Struct('>i')
-    def write(buffer, address, value):
+
+    @staticmethod
+    def write(buffer: bytearray, address: int, value: int) -> None:
         struct.pack_into('>i', buffer, address, value)
 
-    def read(buffer, address=0):
+    @staticmethod
+    def read(buffer: bytearray, address: int = 0) -> int:
         return int32._struct.unpack_from(buffer, address)[0]
 
-    def bytes(value):
-        value = value & 0xFFFFFFFF
-        return [(value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF]
+    @staticmethod
+    def bytes(value: int) -> bytearray:
+        value: int = value & 0xFFFFFFFF
+        return bytearray([(value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
 
-    def value(values):
-        value = (values[0] << 24) | (values[1] << 16) | (values[2] << 8) | values[3]
+    @staticmethod
+    def value(values: Sequence[int]) -> int:
+        value: int = ((values[0] & 0xFF) << 24) | ((values[1] & 0xFF) << 16) | ((values[2] & 0xFF) << 8) | (values[3] & 0xFF)
         if value >= 0x80000000:
             value ^= 0xFFFFFFFF
             value += 1
@@ -56,175 +71,164 @@ class int32:
 
 
 class uint24:
-    def write(buffer, address, value):
-        byte_arr = bytes(value)
+    @staticmethod
+    def write(buffer: bytearray, address: int, value: int) -> None:
+        byte_arr: bytes = bytes(value)
         buffer[address:address + 3] = byte_arr[0:3]
 
-    def read(buffer, address=0):
+    @staticmethod
+    def read(buffer: bytearray, address: int = 0) -> int:
         return (buffer[address+0] << 16) | (buffer[address+1] << 8) | buffer[address+2]
 
-    def bytes(value):
-        value = value & 0xFFFFFF
-        return [(value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF]
+    @staticmethod
+    def bytes(value: int) -> bytearray:
+        value: int = value & 0xFFFFFF
+        return bytearray([(value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
 
-    def value(values):
-        return (values[0] << 16) | (values[1] << 8) | values[2]
-
-
-class BigStream(object):
-
-    def __init__(self, buffer:bytearray):
-        self.last_address = 0
-        self.buffer = buffer
+    @staticmethod
+    def value(values: Sequence[int]) -> int:
+        return ((values[0] & 0xFF) << 16) | ((values[1] & 0xFF) << 8) | (values[2] & 0xFF)
 
 
-    def seek_address(self, address=None, delta=None):
-        if delta is None:
+class BigStream:
+    def __init__(self, buffer: bytearray) -> None:
+        self.last_address: int = 0
+        self.buffer: bytearray = buffer
+
+    def seek_address(self, address: Optional[int] = None, delta: Optional[int] = None) -> None:
+        if address is not None:
             self.last_address = address
-        else:
+        if delta is not None:
             self.last_address += delta
 
-
-    def eof(self):
+    def eof(self) -> bool:
         return self.last_address >= len(self.buffer)
 
-
-    def read_byte(self, address=None):
-        if address == None:
+    def read_byte(self, address: Optional[int] = None) -> int:
+        if address is None:
             address = self.last_address
         self.last_address = address + 1
         return self.buffer[address]
 
-
-    def read_bytes(self, address=None, length=1):
-        if address == None:
+    def read_bytes(self, address: Optional[int] = None, length: int = 1) -> bytearray:
+        if address is None:
             address = self.last_address
         self.last_address = address + length
-        return self.buffer[address : address + length]
+        return self.buffer[address: address + length]
 
-
-    def read_int16(self, address=None):
-        if address == None:
+    def read_int16(self, address: Optional[int] = None) -> int:
+        if address is None:
             address = self.last_address
         return uint16.value(self.read_bytes(address, 2))
 
-
-    def read_int24(self, address=None):
-        if address == None:
+    def read_int24(self, address: Optional[int] = None) -> int:
+        if address is None:
             address = self.last_address
         return uint24.value(self.read_bytes(address, 3))
 
-
-    def read_int32(self, address=None):
-        if address == None:
+    def read_int32(self, address: Optional[int] = None) -> int:
+        if address is None:
             address = self.last_address
         return uint32.value(self.read_bytes(address, 4))
 
-
-    def write_byte(self, address, value):
-        if address == None:
+    def write_byte(self, address: Optional[int], value: int) -> None:
+        if address is None:
             address = self.last_address
         self.buffer[address] = value
         self.last_address = address + 1
 
-
-    def write_sbyte(self, address, value):
-        if address == None:
+    def write_sbyte(self, address: Optional[int], value: int) -> None:
+        if address is None:
             address = self.last_address
         self.write_bytes(address, struct.pack('b', value))
 
-
-    def write_int16(self, address, value):
-        if address == None:
+    def write_int16(self, address: Optional[int], value: int) -> None:
+        if address is None:
             address = self.last_address
         self.write_bytes(address, uint16.bytes(value))
 
-
-    def write_int24(self, address, value):
-        if address == None:
+    def write_int24(self, address: Optional[int], value: int) -> None:
+        if address is None:
             address = self.last_address
         self.write_bytes(address, uint24.bytes(value))
 
-
-    def write_int32(self, address, value):
-        if address == None:
+    def write_int32(self, address: Optional[int], value: int) -> None:
+        if address is None:
             address = self.last_address
         self.write_bytes(address, uint32.bytes(value))
 
-
-    def write_f32(self, address, value:float):
-        if address == None:
+    def write_f32(self, address: Optional[int], value: float) -> None:
+        if address is None:
             address = self.last_address
         self.write_bytes(address, struct.pack('>f', value))
 
+    def write_bytes(self, address: Optional[int], values: Sequence[int]) -> None:
+        if address is None:
+            address = self.last_address
+        self.last_address = address + len(values)
+        self.buffer[address:address + len(values)] = values
 
-    def write_bytes(self, startaddress, values):
-        if startaddress == None:
-            startaddress = self.last_address
-        self.last_address = startaddress + len(values)
-        self.buffer[startaddress:startaddress + len(values)] = values
+    def write_int16s(self, address: Optional[int], values: Sequence[int]) -> None:
+        if address is None:
+            address = self.last_address
 
-
-    def write_int16s(self, startaddress, values):
-        if startaddress == None:
-            startaddress = self.last_address
+        i: int
+        value: int
         for i, value in enumerate(values):
-            self.write_int16(startaddress + (i * 2), value)
+            self.write_int16(address + (i * 2), value)
 
+    def write_int24s(self, address: Optional[int], values: Sequence[int]) -> None:
+        if address is None:
+            address = self.last_address
 
-    def write_int24s(self, startaddress, values):
-        if startaddress == None:
-            startaddress = self.last_address
+        i: int
+        value: int
         for i, value in enumerate(values):
-            self.write_int24(startaddress + (i * 3), value)
+            self.write_int24(address + (i * 3), value)
 
+    def write_int32s(self, address: Optional[int], values: Sequence[int]) -> None:
+        if address is None:
+            address = self.last_address
 
-    def write_int32s(self, startaddress, values):
-        if startaddress == None:
-            startaddress = self.last_address
+        i: int
+        value: int
         for i, value in enumerate(values):
-            self.write_int32(startaddress + (i * 4), value)
+            self.write_int32(address + (i * 4), value)
 
-
-    def append_byte(self, value):
+    def append_byte(self, value: int) -> None:
         self.buffer.append(value)
 
-
-    def append_sbyte(self, value):
+    def append_sbyte(self, value: int) -> None:
         self.append_bytes(struct.pack('b', value))
 
-
-    def append_int16(self, value):
+    def append_int16(self, value: int) -> None:
         self.append_bytes(uint16.bytes(value))
 
-
-    def append_int24(self, value):
+    def append_int24(self, value: int) -> None:
         self.append_bytes(uint24.bytes(value))
 
-
-    def append_int32(self, value):
+    def append_int32(self, value: int) -> None:
         self.append_bytes(uint32.bytes(value))
 
-
-    def append_f32(self, value:float):
+    def append_f32(self, value: float) -> None:
         self.append_bytes(struct.pack('>f', value))
 
-
-    def append_bytes(self, values):
+    def append_bytes(self, values: Sequence[int]) -> None:
+        value: int
         for value in values:
             self.append_byte(value)
 
-
-    def append_int16s(self, values):
+    def append_int16s(self, values: Sequence[int]) -> None:
+        value: int
         for value in values:
             self.append_int16(value)
 
-
-    def append_int24s(self, values):
+    def append_int24s(self, values: Sequence[int]) -> None:
+        value: int
         for value in values:
             self.append_int24(value)
 
-
-    def append_int32s(self, values):
+    def append_int32s(self, values: Sequence[int]) -> None:
+        value: int
         for value in values:
             self.append_int32(value)

--- a/ntype.py
+++ b/ntype.py
@@ -16,7 +16,7 @@ class uint16:
 
     @staticmethod
     def bytes(value: int) -> bytearray:
-        value: int = value & 0xFFFF
+        value = value & 0xFFFF
         return bytearray([(value >> 8) & 0xFF, value & 0xFF])
 
     @staticmethod
@@ -37,7 +37,7 @@ class uint32:
 
     @staticmethod
     def bytes(value: int) -> bytearray:
-        value: int = value & 0xFFFFFFFF
+        value = value & 0xFFFFFFFF
         return bytearray([(value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
 
     @staticmethod
@@ -58,7 +58,7 @@ class int32:
 
     @staticmethod
     def bytes(value: int) -> bytearray:
-        value: int = value & 0xFFFFFFFF
+        value = value & 0xFFFFFFFF
         return bytearray([(value >> 24) & 0xFF, (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
 
     @staticmethod
@@ -82,7 +82,7 @@ class uint24:
 
     @staticmethod
     def bytes(value: int) -> bytearray:
-        value: int = value & 0xFFFFFF
+        value = value & 0xFFFFFF
         return bytearray([(value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
 
     @staticmethod

--- a/ntype.py
+++ b/ntype.py
@@ -1,5 +1,7 @@
 # Originally written by mzxrules
-from typing import Sequence, Optional
+from __future__ import annotations
+from collections.abc import Sequence
+from typing import Optional
 import struct
 
 

--- a/ntype.py
+++ b/ntype.py
@@ -10,9 +10,9 @@ class uint16:
     def write(buffer: bytearray, address: int, value: int) -> None:
         struct.pack_into('>H', buffer, address, value)
 
-    @staticmethod
-    def read(buffer: bytearray, address: int = 0) -> int:
-        return uint16._struct.unpack_from(buffer, address)[0]
+    @classmethod
+    def read(cls, buffer: bytearray, address: int = 0) -> int:
+        return cls._struct.unpack_from(buffer, address)[0]
 
     @staticmethod
     def bytes(value: int) -> bytearray:
@@ -31,9 +31,9 @@ class uint32:
     def write(buffer: bytearray, address: int, value: int) -> None:
         struct.pack_into('>I', buffer, address, value)
 
-    @staticmethod
-    def read(buffer: bytearray, address: int = 0) -> int:
-        return uint32._struct.unpack_from(buffer, address)[0]
+    @classmethod
+    def read(cls, buffer: bytearray, address: int = 0) -> int:
+        return cls._struct.unpack_from(buffer, address)[0]
 
     @staticmethod
     def bytes(value: int) -> bytearray:
@@ -52,9 +52,9 @@ class int32:
     def write(buffer: bytearray, address: int, value: int) -> None:
         struct.pack_into('>i', buffer, address, value)
 
-    @staticmethod
-    def read(buffer: bytearray, address: int = 0) -> int:
-        return int32._struct.unpack_from(buffer, address)[0]
+    @classmethod
+    def read(cls, buffer: bytearray, address: int = 0) -> int:
+        return cls._struct.unpack_from(buffer, address)[0]
 
     @staticmethod
     def bytes(value: int) -> bytearray:

--- a/tests/plando/empty-dungeons-all-plentiful.json
+++ b/tests/plando/empty-dungeons-all-plentiful.json
@@ -18,7 +18,7 @@
           "Shadow Temple",
           "Spirit Temple"
         ],
-        "starting_items": [
+        "starting_inventory": [
           "zeldas_letter"
         ]
     }

--- a/tests/plando/empty-dungeons-all-songs-dungeon.json
+++ b/tests/plando/empty-dungeons-all-songs-dungeon.json
@@ -18,7 +18,7 @@
           "Shadow Temple",
           "Spirit Temple"
         ],
-        "starting_items": [
+        "starting_inventory": [
           "zeldas_letter"
         ]
     }

--- a/tests/plando/empty-dungeons-half-plentiful.json
+++ b/tests/plando/empty-dungeons-half-plentiful.json
@@ -9,7 +9,7 @@
         "shuffle_song_items":                      "song",
         "empty_dungeons_mode":                     "count",
         "empty_dungeons_count":                    4,
-        "starting_items": [
+        "starting_inventory": [
           "zeldas_letter"
         ]
     }

--- a/tests/plando/empty-dungeons-half-songs-dungeon.json
+++ b/tests/plando/empty-dungeons-half-songs-dungeon.json
@@ -9,7 +9,7 @@
         "shuffle_song_items":                      "dungeon",
         "empty_dungeons_mode":                     "count",
         "empty_dungeons_count":                    4,
-        "starting_items": [
+        "starting_inventory": [
           "zeldas_letter"
         ]
     }

--- a/tests/plando/plando-ctmc-test-reverse.json
+++ b/tests/plando/plando-ctmc-test-reverse.json
@@ -27,7 +27,7 @@
       "stone_of_agony",
       "defense"
     ],
-    "starting_items":                          [
+    "starting_inventory":                      [
       "ocarina",
       "deku_stick",
       "deku_stick2",

--- a/tests/plando/plando-ctmc-test.json
+++ b/tests/plando/plando-ctmc-test.json
@@ -27,7 +27,7 @@
       "stone_of_agony",
       "defense"
     ],
-    "starting_items":                          [
+    "starting_inventory":                      [
       "ocarina",
       "deku_stick",
       "deku_stick2",

--- a/tests/plando/plando-er-colossus-spawn-validity.json
+++ b/tests/plando/plando-er-colossus-spawn-validity.json
@@ -8,7 +8,7 @@
       "child",
       "adult"
     ],
-    "starting_items":                          [
+    "starting_inventory":                      [
       "ocarina"
     ],
     "starting_age":                            "adult"

--- a/tests/plando/plando-fix-broken-drops-good.json
+++ b/tests/plando/plando-fix-broken-drops-good.json
@@ -8,7 +8,7 @@
     "shuffle_song_items": "any",
     "starting_age": "child",
     "starting_equipment": ["kokiri_sword"],
-    "starting_items": [
+    "starting_inventory": [
       "bombs",
       "deku_nut",
       "deku_stick",

--- a/tests/plando/plando-goals-multiworld-crisscross-entrance-locks.json
+++ b/tests/plando/plando-goals-multiworld-crisscross-entrance-locks.json
@@ -97,7 +97,7 @@
     "starting_equipment":                      [
       "deku_shield"
     ],
-    "starting_items":                          [
+    "starting_inventory":                      [
       "ocarina",
       "zeldas_letter"
     ],

--- a/tests/plando/plando-ludicrous-ice-traps.json
+++ b/tests/plando/plando-ludicrous-ice-traps.json
@@ -29,7 +29,7 @@
     "shuffle_tcgkeys":                         "keysanity",
     "shuffle_bosskeys":                        "keysanity",
     "disabled_locations":                      [],
-    "starting_items":                          [],
+    "starting_inventory":                      [],
     "ice_trap_appearance":                     "junk_only",
     "junk_ice_traps":                          "onslaught"
   }

--- a/tests/plando/plando-ludicrous-max-locations.json
+++ b/tests/plando/plando-ludicrous-max-locations.json
@@ -33,7 +33,7 @@
     "shuffle_tcgkeys":                         "keysanity",
     "shuffle_bosskeys":                        "keysanity",
     "disabled_locations":                      [],
-    "starting_items":                          [],
+    "starting_inventory":                      [],
     "ice_trap_appearance":                     "junk_only",
     "junk_ice_traps":                          "normal"
   }

--- a/tests/plando/plando-ludicrous-skip-child-zelda.json
+++ b/tests/plando/plando-ludicrous-skip-child-zelda.json
@@ -2,7 +2,7 @@
   "settings": {
     "item_pool_value": "ludicrous",
     "shuffle_child_trade": [],
-    "starting_items": [
+    "starting_inventory": [
       "zeldas_letter"
     ]
   }

--- a/tests/plando/plando-ludicrous-starting-bottles.json
+++ b/tests/plando/plando-ludicrous-starting-bottles.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "item_pool_value": "ludicrous",
-    "starting_items": [
+    "starting_inventory": [
       "bottle",
       "bottle2",
       "bottle3",

--- a/tests/plando/skip-zelda.json
+++ b/tests/plando/skip-zelda.json
@@ -8,7 +8,7 @@
         "HC GS Storms Grotto",
         "HC GS Tree"
     ],
-    "starting_items": [
+    "starting_inventory": [
       "zeldas_letter"
     ]
 },

--- a/texture_util.py
+++ b/texture_util.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python3
+from typing import List, Tuple
 
 from Rom import Rom
-from Utils import *
+
 
 # Read a ci4 texture from rom and convert to rgba16
 # rom - Rom
 # address - address of the ci4 texture in Rom
 # length - size of the texture in PIXELS
 # palette - 4-bit color palette to use (max of 16 colors)
-def ci4_to_rgba16(rom: Rom, address, length, palette):
-    newPixels = []
+def ci4_to_rgba16(rom: Rom, address: int, length: int, palette: List[int]) -> List[int]:
+    new_pixels = []
     texture = rom.read_bytes(address, length // 2)
     for byte in texture:
-        newPixels.append(palette[(byte & 0xF0) >> 4])
-        newPixels.append(palette[byte & 0x0F])
-    return newPixels
+        new_pixels.append(palette[(byte & 0xF0) >> 4])
+        new_pixels.append(palette[byte & 0x0F])
+    return new_pixels
+
 
 # Convert an rgba16 texture to ci8
 # rgba16_texture - texture to convert
 # returns - tuple (ci8_texture, palette)
-def rgba16_to_ci8(rgba16_texture):
+def rgba16_to_ci8(rgba16_texture: List[int]) -> Tuple[List[int], List[int]]:
     ci8_texture = []
-    palette = get_colors_from_rgba16(rgba16_texture) # Get all of the colors in the texture
-    if len(palette) > 0x100: # Make sure there are <= 256 colors. Could probably do some fancy stuff to convert, but nah.
+    palette = get_colors_from_rgba16(rgba16_texture)  # Get all the colors in the texture
+    if len(palette) > 0x100:  # Make sure there are <= 256 colors. Could probably do some fancy stuff to convert, but nah.
         raise(Exception("RGB Texture exceeds maximum of 256 colors"))
-    if len(palette) < 0x100: #Pad the palette with 0x0001 #Pad the palette with 0001s to take up the full 256 colors
+    if len(palette) < 0x100:  # Pad the palette with 0x0001 #Pad the palette with 0001s to take up the full 256 colors
         for i in range(0, 0x100 - len(palette)):
             palette.append(0x0001)
 
@@ -32,28 +34,31 @@ def rgba16_to_ci8(rgba16_texture):
     for pixel in rgba16_texture:
         if pixel in palette:
             ci8_texture.append(palette.index(pixel))
-    return (ci8_texture, palette)
+    return ci8_texture, palette
+
 
 # Load a palette (essentially just an rgba16 texture) from rom
-def load_palette(rom: Rom, address, length):
+def load_palette(rom: Rom, address: int, length: int) -> List[int]:
     palette = []
     for i in range(0, length):
         palette.append(rom.read_int16(address + 2 * i))
     return palette
 
+
 # Get a list of unique colors (palette) from an rgba16 texture
-def get_colors_from_rgba16(rgba16_texture):
+def get_colors_from_rgba16(rgba16_texture: List[int]) -> List[int]:
     colors = []
     for pixel in rgba16_texture:
         if pixel not in colors:
             colors.append(pixel)
     return colors
 
+
 # Apply a patch to a rgba16 texture. The patch texture is exclusive or'd with the original to produce the result
 # rgba16_texture - Original texture
 # rgba16_patch - Patch texture. If this parameter is not supplied, this function will simply return the original texture.
 # returns - new texture = texture xor patch
-def apply_rgba16_patch(rgba16_texture, rgba16_patch):
+def apply_rgba16_patch(rgba16_texture: List[int], rgba16_patch: List[int]) -> List[int]:
     if rgba16_patch is not None and (len(rgba16_texture) != len(rgba16_patch)):
         raise(Exception("OG Texture and Patch not the same length!"))
 
@@ -66,46 +71,51 @@ def apply_rgba16_patch(rgba16_texture, rgba16_patch):
         new_texture.append(rgba16_texture[i] ^ rgba16_patch[i])
     return new_texture
 
+
 # Save a rgba16 texture to a file
-def save_rgba16_texture(rgba16_texture, fileStr):
-    file = open(fileStr, 'wb')
+def save_rgba16_texture(rgba16_texture: List[int], filename: str) -> None:
+    file = open(filename, 'wb')
     bytes = bytearray()
     for pixel in rgba16_texture:
         bytes.extend(pixel.to_bytes(2, 'big'))
     file.write(bytes)
     file.close()
 
+
 # Save a ci8 texture to a file
-def save_ci8_texture(ci8_texture, fileStr):
-    file = open(fileStr, 'wb')
+def save_ci8_texture(ci8_texture: List[int], filename: str) -> None:
+    file = open(filename, 'wb')
     bytes = bytearray()
     for pixel in ci8_texture:
         bytes.extend(pixel.to_bytes(1, 'big'))
     file.write(bytes)
     file.close()
 
+
 # Read an rgba16 texture from ROM
 # rom - Rom object to load the texture from
 # base_texture_address - Address of the rbga16 texture in ROM
 # size - Size of the texture in PIXELS
 # returns - list of ints representing each 16-bit pixel
-def load_rgba16_texture_from_rom(rom: Rom, base_texture_address, size):
+def load_rgba16_texture_from_rom(rom: Rom, base_texture_address: int, size: int) -> List[int]:
     texture = []
     for i in range(0, size):
         texture.append(int.from_bytes(rom.read_bytes(base_texture_address + 2 * i, 2), 'big'))
     return texture
 
+
 # Load an rgba16 texture from a binary file.
-# fileStr - path to the file
+# filename - path to the file
 # size - number of 16-bit pixels in the texture.
-def load_rgba16_texture(fileStr, size):
+def load_rgba16_texture(filename: str, size: int) -> List[int]:
     texture = []
-    file = open(fileStr, 'rb')
+    file = open(filename, 'rb')
     for i in range(0, size):
         texture.append(int.from_bytes(file.read(2), 'big'))
 
     file.close()
-    return(texture)
+    return texture
+
 
 # Create an new rgba16 texture byte array from a rgba16 binary file. Use this if you want to create complete new textures using no copyrighted content (or for testing).
 # rom - Unused set to None
@@ -114,12 +124,13 @@ def load_rgba16_texture(fileStr, size):
 # size - Size of the texture in PIXELS
 # patchfile - File containing the texture to load
 # returns - bytearray containing the new texture
-def rgba16_from_file(rom: Rom, base_texture_address, base_palette_address, size, patchfile):
+def rgba16_from_file(rom: Rom, base_texture_address: int, base_palette_address: int, size: int, patchfile: str) -> bytearray:
     new_texture = load_rgba16_texture(patchfile, size)
     bytes = bytearray()
     for pixel in new_texture:
         bytes.extend(int.to_bytes(pixel, 2, 'big'))
     return bytes
+
 
 # Create a new rgba16 texture from a original rgba16 texture and a rgba16 patch file
 # rom - Rom object to load the original texture from
@@ -128,7 +139,7 @@ def rgba16_from_file(rom: Rom, base_texture_address, base_palette_address, size,
 # size - Size of the texture in PIXELS
 # patchfile - file path of a rgba16 binary texture to patch
 # returns - bytearray of the new texture
-def rgba16_patch(rom: Rom, base_texture_address, base_palette_address, size, patchfile):
+def rgba16_patch(rom: Rom, base_texture_address: int, base_palette_address: int, size: int, patchfile: str) -> bytearray:
     base_texture_rgba16 = load_rgba16_texture_from_rom(rom, base_texture_address, size)
     patch_rgba16 = None
     if patchfile:
@@ -139,6 +150,7 @@ def rgba16_patch(rom: Rom, base_texture_address, base_palette_address, size, pat
         bytes.extend(int.to_bytes(pixel, 2, 'big'))
     return bytes
 
+
 # Create a new ci8 texture from a ci4 texture/palette and a rgba16 patch file
 # rom - Rom object to load the original textures from
 # base_texture_address - Address of the original ci4 texture in ROM
@@ -146,7 +158,7 @@ def rgba16_patch(rom: Rom, base_texture_address, base_palette_address, size, pat
 # size - Size of the texture in PIXELS
 # patchfile - file path of a rgba16 binary texture to patch
 # returns - bytearray of the new texture
-def ci4_rgba16patch_to_ci8(rom, base_texture_address, base_palette_address, size, patchfile):
+def ci4_rgba16patch_to_ci8(rom: Rom, base_texture_address: int, base_palette_address: int, size: int, patchfile: str) -> bytearray:
     palette = load_palette(rom, base_palette_address, 16) # load the original palette from rom
     base_texture_rgba16 = ci4_to_rgba16(rom, base_texture_address, size, palette) # load the original texture from rom and convert to ci8
     patch_rgba16 = None
@@ -162,8 +174,9 @@ def ci4_rgba16patch_to_ci8(rom, base_texture_address, base_palette_address, size
         bytes.extend(int.to_bytes(pixel, 1, 'big'))
     return bytes
 
+
 # Function to create rgba16 texture patches for crates
-def build_crate_ci8_patches():
+def build_crate_ci8_patches() -> None:
     # load crate textures from rom
     object_kibako2_addr = 0x018B6000
     SIZE_CI4_32X128 = 4096
@@ -181,7 +194,7 @@ def build_crate_ci8_patches():
     save_rgba16_texture(gold_patch, 'crate_heart_rgba16_patch.bin')
 
 # Function to create rgba16 texture patches for pots.
-def build_pot_patches():
+def build_pot_patches() -> None:
     # load pot textures from rom
     object_tsubo_side_addr = 0x01738000
     SIZE_32X64 = 2048
@@ -205,7 +218,8 @@ def build_pot_patches():
     save_rgba16_texture(skull_patch, 'pot_skull_rgba16_patch.bin')
     save_rgba16_texture(bosskey_patch, 'pot_bosskey_rgba16_patch.bin')
 
-def build_smallcrate_patches():
+
+def build_smallcrate_patches() -> None:
     # load small crate texture from rom
     object_kibako_texture_addr = 0xF7ECA0
 

--- a/texture_util.py
+++ b/texture_util.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import List, Tuple
+from __future__ import annotations
 
 from Rom import Rom
 
@@ -9,7 +9,7 @@ from Rom import Rom
 # address - address of the ci4 texture in Rom
 # length - size of the texture in PIXELS
 # palette - 4-bit color palette to use (max of 16 colors)
-def ci4_to_rgba16(rom: Rom, address: int, length: int, palette: List[int]) -> List[int]:
+def ci4_to_rgba16(rom: Rom, address: int, length: int, palette: list[int]) -> list[int]:
     new_pixels = []
     texture = rom.read_bytes(address, length // 2)
     for byte in texture:
@@ -21,7 +21,7 @@ def ci4_to_rgba16(rom: Rom, address: int, length: int, palette: List[int]) -> Li
 # Convert an rgba16 texture to ci8
 # rgba16_texture - texture to convert
 # returns - tuple (ci8_texture, palette)
-def rgba16_to_ci8(rgba16_texture: List[int]) -> Tuple[List[int], List[int]]:
+def rgba16_to_ci8(rgba16_texture: list[int]) -> tuple[list[int], list[int]]:
     ci8_texture = []
     palette = get_colors_from_rgba16(rgba16_texture)  # Get all the colors in the texture
     if len(palette) > 0x100:  # Make sure there are <= 256 colors. Could probably do some fancy stuff to convert, but nah.
@@ -38,7 +38,7 @@ def rgba16_to_ci8(rgba16_texture: List[int]) -> Tuple[List[int], List[int]]:
 
 
 # Load a palette (essentially just an rgba16 texture) from rom
-def load_palette(rom: Rom, address: int, length: int) -> List[int]:
+def load_palette(rom: Rom, address: int, length: int) -> list[int]:
     palette = []
     for i in range(0, length):
         palette.append(rom.read_int16(address + 2 * i))
@@ -46,7 +46,7 @@ def load_palette(rom: Rom, address: int, length: int) -> List[int]:
 
 
 # Get a list of unique colors (palette) from an rgba16 texture
-def get_colors_from_rgba16(rgba16_texture: List[int]) -> List[int]:
+def get_colors_from_rgba16(rgba16_texture: list[int]) -> list[int]:
     colors = []
     for pixel in rgba16_texture:
         if pixel not in colors:
@@ -58,7 +58,7 @@ def get_colors_from_rgba16(rgba16_texture: List[int]) -> List[int]:
 # rgba16_texture - Original texture
 # rgba16_patch - Patch texture. If this parameter is not supplied, this function will simply return the original texture.
 # returns - new texture = texture xor patch
-def apply_rgba16_patch(rgba16_texture: List[int], rgba16_patch: List[int]) -> List[int]:
+def apply_rgba16_patch(rgba16_texture: list[int], rgba16_patch: list[int]) -> list[int]:
     if rgba16_patch is not None and (len(rgba16_texture) != len(rgba16_patch)):
         raise(Exception("OG Texture and Patch not the same length!"))
 
@@ -73,7 +73,7 @@ def apply_rgba16_patch(rgba16_texture: List[int], rgba16_patch: List[int]) -> Li
 
 
 # Save a rgba16 texture to a file
-def save_rgba16_texture(rgba16_texture: List[int], filename: str) -> None:
+def save_rgba16_texture(rgba16_texture: list[int], filename: str) -> None:
     file = open(filename, 'wb')
     bytes = bytearray()
     for pixel in rgba16_texture:
@@ -83,7 +83,7 @@ def save_rgba16_texture(rgba16_texture: List[int], filename: str) -> None:
 
 
 # Save a ci8 texture to a file
-def save_ci8_texture(ci8_texture: List[int], filename: str) -> None:
+def save_ci8_texture(ci8_texture: list[int], filename: str) -> None:
     file = open(filename, 'wb')
     bytes = bytearray()
     for pixel in ci8_texture:
@@ -97,7 +97,7 @@ def save_ci8_texture(ci8_texture: List[int], filename: str) -> None:
 # base_texture_address - Address of the rbga16 texture in ROM
 # size - Size of the texture in PIXELS
 # returns - list of ints representing each 16-bit pixel
-def load_rgba16_texture_from_rom(rom: Rom, base_texture_address: int, size: int) -> List[int]:
+def load_rgba16_texture_from_rom(rom: Rom, base_texture_address: int, size: int) -> list[int]:
     texture = []
     for i in range(0, size):
         texture.append(int.from_bytes(rom.read_bytes(base_texture_address + 2 * i, 2), 'big'))
@@ -107,7 +107,7 @@ def load_rgba16_texture_from_rom(rom: Rom, base_texture_address: int, size: int)
 # Load an rgba16 texture from a binary file.
 # filename - path to the file
 # size - number of 16-bit pixels in the texture.
-def load_rgba16_texture(filename: str, size: int) -> List[int]:
+def load_rgba16_texture(filename: str, size: int) -> list[int]:
     texture = []
     file = open(filename, 'rb')
     for i in range(0, size):


### PR DESCRIPTION
Drops support for Python 3.6/3.7 and adds type hints to all class/instance attributes and function definitions to make it easier to know what variables contain while working on the code.

These are likely far from perfect as I learned while working through all of them, but at the very least nothing should be broken.

Comparing the spoiler outputs from running tests on Dev and this branch yields a few differences:

- When `hint_dist_user` is modified by `World`, those changes no longer modify it in the original settings that get output to the spoiler log as setting values are now deep copied. This seems like better behavior in general, though it does make me question why `hint_dist_user` is modified in `World` to begin with.
- The spoilers from the preset tests have slightly different ordering to the starting items. Whatever.
- Playthroughs in some of the tests with entrance rando appear to be slightly different for reasons I don't feel like debugging right now. The actual seed is the same, though I'll probably look into it at some point.
- A few tests had their plandos updated, as I renamed the GUI's `starting_items` setting to `starting_inventory` so that we don't have to try to accept two completely different formats into the same setting name. Those obviously have completely different output, as the plando file is part of the seed.