### PR TITLE
Fix White Bubble/Dins Fire crash

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -2310,6 +2310,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         torch_count = world.settings.fae_torch_count
         rom.write_byte(0xCA61E3, torch_count)
 
+    # Fix crash when hitting white bubbles enemies with Dins Fire
+    rom.write_byte(0xCB4397, 0x00)
+
     # actually write the save table to rom
     world.distribution.give_items(world, save_context)
     if world.settings.starting_age == 'adult':


### PR DESCRIPTION
Vanilla crash which happens if you use Dins Fire on the White Bubble enemy (which is only found in the Topmost room of Spirit Temple).

The cause of the crash is well documented in decomp : https://github.com/zeldaret/oot/blob/master/src/overlays/actors/ovl_En_Bb/z_en_bb.c#L1162

This change sets the fireIceTimer variable at 0x00 to avoid the crash in EnBb_Draw. The only purpose of this variable is to draw some fire effect on the Bubble if it's touched by a Fire attack.

Fixes #1354