### PR TITLE
Redefine important_check hints for consistency with barren

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -639,25 +639,28 @@ def get_barren_hint(spoiler, world, checked, allChecked):
         world.get_barren_hint_prev = RegionRestriction.NONE
 
     checked_areas = get_checked_areas(world, checked)
-    areas = list(filter(lambda area:
-        area not in checked_areas
+    areas = [
+        area
+        for area, area_info in world.important_locations.items()
+        if area_info['important_locations'] == 0
+        and area not in checked_areas
         and area not in world.hint_type_overrides['barren']
-        and not (world.barren_dungeon >= world.hint_dist_user['dungeons_barren_limit'] and world.empty_areas[area]['dungeon'])
+        and not (world.barren_dungeon >= world.hint_dist_user['dungeons_barren_limit'] and area_info['dungeon'])
         and any(
             location.name not in allChecked
             and location.name not in world.hint_exclusions
             and location.name not in hintExclusions(world)
             and HintArea.at(location) == area
             for location in world.get_locations()
-        ),
-        world.empty_areas))
+        )
+    ]
 
     if not areas:
         return None
 
     # Randomly choose between overworld or dungeon
-    dungeon_areas = list(filter(lambda area: world.empty_areas[area]['dungeon'], areas))
-    overworld_areas = list(filter(lambda area: not world.empty_areas[area]['dungeon'], areas))
+    dungeon_areas = list(filter(lambda area: world.important_locations[area]['dungeon'], areas))
+    overworld_areas = list(filter(lambda area: not world.important_locations[area]['dungeon'], areas))
     if not dungeon_areas:
         # no dungeons left, default to overworld
         world.get_barren_hint_prev = RegionRestriction.OVERWORLD
@@ -682,10 +685,10 @@ def get_barren_hint(spoiler, world, checked, allChecked):
     if not areas:
         return None
 
-    area_weights = [world.empty_areas[area]['weight'] for area in areas]
+    area_weights = [world.important_locations[area]['weight'] for area in areas]
 
     area = random_choices(areas, weights=area_weights)[0]
-    if world.empty_areas[area]['dungeon']:
+    if world.important_locations[area]['dungeon']:
         world.barren_dungeon += 1
 
     checked.add(area)

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1307,7 +1307,7 @@ class Distribution(object):
                                 world_dist.goal_locations[cat_name][goal_text] = {loc.name: LocationRecord.from_item(loc.item).to_json() for loc in locations}
                             else:
                                 world_dist.goal_locations[cat_name][goal_text]['from World ' + str(location_world + 1)] = {loc.name: LocationRecord.from_item(loc.item).to_json() for loc in locations}
-            world_dist.barren_regions = list(map(str, world.empty_areas))
+            world_dist.barren_regions = [str(area) for area, area_info in world.important_locations.items() if area_info['important_locations'] == 0]
             world_dist.gossip_stones = {}
             for loc in spoiler.hints[world.id]:
                 hint = GossipRecord(spoiler.hints[world.id][loc].to_json())


### PR DESCRIPTION
Proposing as an alternative to #1868.

The function for `important_check` hints, originally introduced in #1668, currently defines a long list of special cases for which items to count as important. We already have something like that in the function that checks whether an area is barren. So I repurposed that code to also count the number of locations that prevent the area from being barren, which becomes the number of important checks. I think this not only cleans up the codebase but also makes this new hint type easier to explain.

As a consequence, Triforce pieces are no longer excluded from the count. I don't see how this “sorta defeats the purpose of triforce hunt”. If necessary, excluding them again would be a simple change, but I feel like in that case, areas with only Triforce pieces should also count as barren.

This also makes important_check hints use the normal mechanism for “already hinted” areas, making them mutually exclusive with barren hints for the same area.

I also changed the color-coding of the number itself in the hint text to something that makes more sense in relation to other hint types: 0 is pink (like barren hints), and 4 or more is light blue (like woth hints).