### PR TITLE
Add “Vanilla Locations” option for “Shuffle Songs” setting

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -799,8 +799,11 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
                     if vanilla_items_processed[location.vanilla_item]:
                         item = get_junk_item()[0]
                         shuffle_item = True
+            # Song
+            elif location.type == 'Song':
+                shuffle_item = world.settings.shuffle_song_items != 'vanilla'
             # Any other item in a dungeon.
-            elif location.type in ["Chest", "NPC", "Song", "Collectable", "Cutscene", "BossHeart"]:
+            elif location.type in ["Chest", "NPC", "Collectable", "Cutscene", "BossHeart"]:
                 shuffle_item = True
 
             # Handle dungeon item.
@@ -814,8 +817,12 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
                 elif shuffle_item is None:
                     dungeon_collection.append(ItemFactory(item, world))
 
+        # Songs
+        elif location.type == 'Song':
+            shuffle_item = world.settings.shuffle_song_items != 'vanilla'
+
         # The rest of the overworld items.
-        elif location.type in ["Chest", "NPC", "Song", "Collectable", "Cutscene", "BossHeart"]:
+        elif location.type in ["Chest", "NPC", "Collectable", "Cutscene", "BossHeart"]:
             shuffle_item = True
 
         # Now, handle the item as necessary.

--- a/Patches.py
+++ b/Patches.py
@@ -355,7 +355,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     rom.write_bytes(0x1FC0CF8, block_code)
 
     # songs as items flag
-    songs_as_items = world.settings.shuffle_song_items != 'song' or \
+    songs_as_items = world.settings.shuffle_song_items not in ('vanilla', 'song') or \
                      world.distribution.song_as_items or \
                      any(name in song_list and record.count for name, record in world.settings.starting_items.items()) or \
                      world.settings.shuffle_individual_ocarina_notes

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -889,14 +889,14 @@ class WorldDistribution:
             if record.item in item_groups['DungeonReward']:
                 raise RuntimeError('Cannot place dungeon reward %s in world %d in location %s.' % (record.item, self.id + 1, location_name))
 
-            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items == 'song' and not any(name in song_list and r.count for name, r in world.settings.starting_items.items()):
+            if record.item == '#Junk' and location.type == 'Song' and world.settings.shuffle_song_items in ('vanilla', 'song') and not any(name in song_list and r.count for name, r in world.settings.starting_items.items()):
                 record.item = '#JunkSong'
 
             ignore_pools = None
             is_invert = self.pattern_matcher(record.item)('!')
-            if is_invert and location.type != 'Song' and world.settings.shuffle_song_items == 'song':
+            if is_invert and location.type != 'Song' and world.settings.shuffle_song_items in ('vanilla', 'song'):
                 ignore_pools = [2]
-            if is_invert and location.type == 'Song' and world.settings.shuffle_song_items == 'song':
+            if is_invert and location.type == 'Song' and world.settings.shuffle_song_items in ('vanilla', 'song'):
                 ignore_pools = [i for i in range(len(item_pools)) if i != 2]
             # location.price will be None for Shop Buy items
             if location.type == 'Shop' and location.price is None:
@@ -1096,7 +1096,7 @@ class WorldDistribution:
             skipped_locations_from_dungeons = []
             if True: #TODO dungeon rewards not shuffled
                 skipped_locations_from_dungeons += location_groups['Boss']
-            if world.settings.shuffle_song_items == 'song':
+            if world.settings.shuffle_song_items in ('vanilla', 'song'):
                 skipped_locations_from_dungeons += location_groups['Song']
             elif world.settings.shuffle_song_items == 'dungeon':
                 skipped_locations_from_dungeons += location_groups['BossHeart']

--- a/Rules.py
+++ b/Rules.py
@@ -25,7 +25,7 @@ def set_rules(world: World) -> None:
     is_child = world.parser.parse_rule('is_child')
 
     for location in world.get_locations():
-        if world.settings.shuffle_song_items == 'song':
+        if world.settings.shuffle_song_items in ('vanilla', 'song'):
             if location.type == 'Song':
                 # allow junk items, but songs must still have matching world
                 add_item_rule(location, lambda location, item:

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2351,7 +2351,7 @@ class SettingInfos:
 
             'Vanilla Locations': Songs will remain unshuffled.
 
-            'Song Locations': Song will only appear at locations that
+            'Song Locations': Songs will only appear at locations that
             normally teach songs. In Multiworld, songs will only
             appear in their own world.
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2341,12 +2341,15 @@ class SettingInfos:
         gui_text       = 'Shuffle Songs',
         default        = 'song',
         choices        = {
+            'vanilla': 'Vanilla Locations',
             'song':    'Song Locations',
             'dungeon': 'Dungeon Rewards',
             'any':     'Anywhere',
             },
         gui_tooltip    = '''\
             This restricts where song items can appear.
+
+            'Vanilla Locations': Songs will remain unshuffled.
 
             'Song Locations': Song will only appear at locations that
             normally teach songs. In Multiworld, songs will only
@@ -2370,7 +2373,8 @@ class SettingInfos:
         gui_params     = {
             'randomize_key': 'randomize_settings',
             'distribution':  [
-                ('song',    2),
+                ('vanilla', 1),
+                ('song',    1),
                 ('dungeon', 1),
                 ('any',     1),
             ],

--- a/World.py
+++ b/World.py
@@ -59,6 +59,8 @@ class World:
         self.keysanity: bool = settings.shuffle_smallkeys in ['keysanity', 'remove', 'any_dungeon', 'overworld', 'regional']
         self.shuffle_silver_rupees = settings.shuffle_silver_rupees != 'vanilla'
         self.check_beatable_only: bool = settings.reachable_locations != 'all'
+        if settings.starting_age == 'adult' and settings.shuffle_song_items == 'vanilla' and settings.reachable_locations == 'all' and not settings.open_door_of_time:
+            raise ValueError("Cannot combine songs on vanilla locations, adult start, all locations reachable, and closed Door of Time since access to the Song of Time would be locked behind itself.")
 
         self.shuffle_special_interior_entrances: bool = settings.shuffle_interior_entrances == 'all'
         self.shuffle_interior_entrances: bool = settings.shuffle_interior_entrances in ['simple', 'all']
@@ -429,7 +431,7 @@ class World:
         if (self.settings.starting_age == 'random'
             and ('starting_age' not in dist_keys
              or self.distribution.distribution.src_dict['_settings']['starting_age'] == 'random')):
-            if self.settings.open_forest == 'closed':
+            if self.settings.open_forest == 'closed' or (self.settings.shuffle_song_items == 'vanilla' and self.settings.reachable_locations == 'all' and not self.settings.open_door_of_time):
                 # adult is not compatible
                 self.settings.starting_age = 'child'
             else:


### PR DESCRIPTION
This new option is fairly straightforward. It behaves like songs on songs except songs are not even shuffled among each other. The usual considerations for unshuffled items such as being considered “already hinted” are taken care of by the item pool code.

This PR is part of my work on a “Shuffle Items” setting, which can be turned off to make _all_ item locations vanilla, e.g. if you only want to shuffle entrances.