### PR TITLE
Fix logic for LH GS Lab Crate

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -490,7 +490,7 @@
             "LH Lab Dive Red Rupee 3": "(Progressive_Scale, 2) or can_use(Iron_Boots)",
             "LH GS Lab Crate": "
                 Iron_Boots and can_use(Hookshot) and
-                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_interior_entrances == 'off'))"
+                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and not shuffle_interior_entrances))"
         },
         "exits": {
             "Lake Hylia": "True"


### PR DESCRIPTION
`shuffle_interior_entrances` is defined here:

https://github.com/TestRunnerSRL/OoT-Randomizer/blob/25a14b85b5612f52112512ae4bcbbac43f52ef1e/World.py#L56

This definition overrides the setting, because attributes on `World` are checked before settings:

https://github.com/TestRunnerSRL/OoT-Randomizer/blob/25a14b85b5612f52112512ae4bcbbac43f52ef1e/RuleParser.py#L85-L89

So the access expression needs to check it as a Boolean, not as a string.