### PR TITLE
Add trade path with beans into logic

### DIFF
--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -82,7 +82,7 @@
     # Biggoron's trade path
     # ER with certain settings disables timers and prevents items from reverting on save warp.
     # Otherwise, to get to Biggoron requires: a trick, clearing boulders on DMT, or Darunia's Chamber
-    "guarantee_trade_path": "disable_trade_revert or can_blast_or_smash or 'Stop GC Rolling Goron as Adult' or (logic_dmt_climb_hovers and can_use(Hover_Boots)) or (logic_biggoron_bolero and not warp_songs and can_play(Bolero_of_Fire) and at('DMC Central Local', can_use(Hookshot) or can_use(Hover_Boots) or can_plant_bean))",
+    "guarantee_trade_path": "disable_trade_revert or plant_beans or can_blast_or_smash or 'Stop GC Rolling Goron as Adult' or (logic_dmt_climb_hovers and can_use(Hover_Boots)) or (logic_biggoron_bolero and not warp_songs and can_play(Bolero_of_Fire) and at('DMC Central Local', can_use(Hookshot) or can_use(Hover_Boots) or can_plant_bean))",
     "guarantee_hint": "(hints == 'mask' and Mask_of_Truth) or (hints == 'agony' and Stone_of_Agony) or (hints != 'mask' and hints != 'agony')",
     "has_fire_source": "can_use(Dins_Fire) or can_use(Fire_Arrows)",
     "has_fire_source_with_torch": "has_fire_source or (is_child and Sticks)",


### PR DESCRIPTION
The `guarantee_trade_path` logic helper checks to make sure you can reach Biggoron without the eyedrops expiring. Doing so by riding the bean was previously not logically relevant because it required explosives or strength to blow up the DC entrance, both of which can also be used to stop Link the Goron. With #1511, this is no longer the case, so this PR puts the trade path into logic with pre-planted beans.

Thanks to @r0bd0g for pointing out that this was missing.