### PR TITLE
Fix SFX tab not working on website

### DIFF
--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -477,7 +477,7 @@
       "name": "sfx_tab",
       "text": "SFX",
       "app_type": ["generator", "patcher"],
-      "is_sfx": true,
+      "is_cosmetics": true,
       "sections": [
         {
           "name": "sfx_main_section",


### PR DESCRIPTION
Unwanted change in #1890 that i forgot to remove, and is very probably why the SFX overrides are not working on 7.1.60 on website.