### PR TITLE
Apply bias towards middle values to Tycoon Wallet shop prices

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3955,7 +3955,8 @@ setting_infos = [
 
             'X Wallet': Shop prices for shopsanity items will range
             between 0 and the specified wallet's maximum capacity,
-            in multiples of 5.
+            in multiples of 5, except for Tycoon Wallet who will have
+            a bias towards values slightly below the middle of the range.
 
             'Affordable': Shop prices for shopsanity items will be
             fixed to 10 rupees.

--- a/World.py
+++ b/World.py
@@ -644,7 +644,7 @@ class World(object):
                         elif self.settings.shopsanity_prices == 'random_giant':
                             self.shop_prices[location.name] = random.randrange(0,501,5)
                         elif self.settings.shopsanity_prices == 'random_tycoon':
-                            self.shop_prices[location.name] = random.randrange(0,1000,5)
+                            self.shop_prices[location.name] = int(random.betavariate(1.5, 2) * 200) * 5
                         elif self.settings.shopsanity_prices == 'affordable':
                             self.shop_prices[location.name] = 10
 


### PR DESCRIPTION
All shopsanity prices option except 'Random' currently uses a fully uniform distribution between min and max prices.
When using the Tycoon Wallet option, this means half of the prices will be greater than 500, which can be extremely hard and boring to farm rupees for.
Which to be fair, is kinda what you're signing for when using the option, but a bias towards middle values could help this setting being a bit less tedious.

This change applies the same distribution used for the 'Random' option, which is a Beta distribution with alpha = 1.5 and beta = 2.0.

For reference, here is the corresponding chart to this distribution : 
![image](https://user-images.githubusercontent.com/65768236/220640290-820d870d-bab0-4ff0-86cb-1d13e029345b.png)
