### PR TITLE
Fix Adult Trade Starting Item with Shuffle All Adult Trade off.

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1113,7 +1113,7 @@ class WorldDistribution(object):
             items[child_trade_items[effective_child_trade_item_index]] = effective_child_trade_item
         if effective_adult_trade_item_index >= 0:
             items[trade_items[effective_adult_trade_item_index]] = effective_adult_trade_item
-            world.adult_trade_starting_inventory = effective_adult_trade_item
+            world.adult_trade_starting_inventory = trade_items[effective_adult_trade_item_index]
 
         self.effective_starting_items = items
 


### PR DESCRIPTION
`world.adult_trade_starting_inventory` was being set to a StarterRecord instead of the name of the item, resulting in all of the adult trade item traded flags being set when starting with any adult trade item.