### PR TITLE
Add trick into logic to enhance dungeon ER

### DIFF
--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -317,6 +317,7 @@
             "logic_child_deadhand",
             "logic_man_on_roof",
             "logic_dc_jump",
+            "logic_dc_scarecrow_gs",
             "logic_rusted_switches",
             "logic_windmill_poh",
             "logic_crater_bean_poh_with_hovers",


### PR DESCRIPTION
This PR adds "logic_dc_scarecrow_gs" into the Weekly Preset to allow the possibility of DC entrance being linked to Jabu.

(Sorry this wasn't included in the first PR)