### PR TITLE
Make House of Skulltula residents come down instantly if a Misc skulltula hint is on

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1754,6 +1754,12 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     if 'mask_shop' in world.settings.misc_hints:
         rom.write_int32(rom.sym('CFG_MASK_SHOP_HINT'), 1)
 
+    # Make the cursed skulltula people come down instantly when entering if skull hints are on.
+    # Change  lui     $at, 0x4320 to  lui     $at, 0x44C8
+    if ('10_skulltulas' in world.settings.misc_hints or '20_skulltulas' in world.settings.misc_hints or '30_skulltulas' in world.settings.misc_hints or
+     '40_skulltulas' in world.settings.misc_hints or '50_skulltulas' in world.settings.misc_hints):
+        rom.write_int16(0xEA185A, 0x44C8)
+
     # Patch freestanding items
     if world.settings.shuffle_freestanding_items:
     # Get freestanding item locations


### PR DESCRIPTION
Talking to all 5 of residents is a bit annoying since you have to wait for all of them to come down, which they only do if you come close enough.
This patch make their "detect Link" radius x10 so they come down as soon as you enter the house.
Applied only if one or more corresponding Misc. hint is on, which as a bonus, serve as a decent way to instantly tell ingame if you have those hints on.

https://user-images.githubusercontent.com/65768236/221781184-f6d9d515-2945-4de9-8249-43620bbc0a20.mp4

