### PR TITLE
Fix Voices SFX section not showing on patch page and None option crash

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -757,7 +757,7 @@ def patch_sfx(rom, settings, log, symbols):
             elif selection == 'completely-random':
                 selection = random.choice(sfx.standard).value.keyword
             sound_id  = sound_dict[selection]
-            if hook.value.sfx_flag:
+            if hook.value.sfx_flag and sound_id > 0x799:
                 sound_id -= 0x800
             for loc in hook.value.locations:
                 rom.write_int16(loc, sound_id)

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -538,8 +538,8 @@
           ]
         },
         {
-          "name": "linksfx_section_patcher",
-          "text": "Link",
+          "name": "voicesfx_section_patcher",
+          "text": "Voices",
           "exclude_from_electron": true,
           "app_type": ["patcher"],
           "is_sfx": true,
@@ -547,7 +547,11 @@
           "row_span": [5,5,5],
           "settings": [
             "sfx_link_adult",
-            "sfx_link_child"
+            "sfx_link_child",
+            "sfx_navi_overworld",
+            "sfx_navi_enemy",
+            "sfx_horse_neigh",
+            "sfx_cucco"
           ]
         },
         {


### PR DESCRIPTION
I didn't update the patcher specific section for Voices SFX in settings_mappings, so it used the old one which only had Link's voices options, when on patch page.
Also fixes the crash when selecting None for options that uses the SFX_FLAG to not repeat every frame (hook, hovers, boomerang and chus).