### PR TITLE
Fix Mask of Truth logic for child trade shuffle

### DIFF
--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -537,7 +537,16 @@
         "region_name": "Market Mask Shop",
         "events": {
             "Mask Shop Open": "at('HC Garden Locations', is_child) and 'Kakariko Village Gate Open'",
-            "Mask of Truth Access": "'Mask Shop Open' and (complete_mask_quest or (Bunny_Hood and at('Hyrule Field', is_child and has_all_stones)))"
+            "Mask of Truth Access": "
+                'Mask Shop Open' and
+                (complete_mask_quest or
+                    (
+                    Keaton_Mask and at('Kakariko Village', is_child) and
+                    Skull_Mask and at('Lost Woods', is_child and can_play(Sarias_Song)) and
+                    Spooky_Mask and at('Graveyard', is_child and at_day) and
+                    Bunny_Hood and at('Hyrule Field', is_child and has_all_stones)
+                    )
+                )"
         },
         "locations": {
             # Gerudo Mask

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1303,7 +1303,16 @@
             # This is relevant with open mask shop for adult-only access to shuffled items
             # with interior entrance randomizer.
             "Mask Shop Open": "Zeldas_Letter and (at('Kakariko Village', is_child) or open_kakariko == 'open')",
-            "Mask of Truth Access": "'Mask Shop Open' and (complete_mask_quest or (Bunny_Hood and at('Hyrule Field', is_child and has_all_stones)))"
+            "Mask of Truth Access": "
+                'Mask Shop Open' and
+                (complete_mask_quest or
+                    (
+                    Keaton_Mask and at('Kakariko Village', is_child) and
+                    Skull_Mask and at('Lost Woods', is_child and can_play(Sarias_Song)) and
+                    Spooky_Mask and at('Graveyard', is_child and at_day) and
+                    Bunny_Hood and at('Hyrule Field', is_child and has_all_stones)
+                    )
+                )"
         },
         "locations": {
             # Gerudo Mask


### PR DESCRIPTION
The Mask Shop was changed to give right side mask slot access after trading in all masks instead of just Bunny Hood to stay in the spirit of the trade quest. The logic was still checking for just the Bunny Hood trade.