### PR TITLE
Fixes for Item.unshuffled_dungeon_item

### DIFF
--- a/Item.py
+++ b/Item.py
@@ -146,10 +146,11 @@ class Item(object):
 
     @property
     def unshuffled_dungeon_item(self):
-        return ((self.type == 'SmallKey' and self.world.settings.shuffle_smallkeys in ['remove','vanilla','dungeon']) or
-                (self.type == 'FortressSmallKey' and self.world.settings.shuffle_fortresskeys in ['vanilla']) or
-                (self.bosskey and self.world.settings.shuffle_bosskeys in ['remove','vanilla','dungeon']) or
-                ((self.map or self.compass) and (self.world.settings.shuffle_mapcompass in ['remove','startwith','vanilla','dungeon'])))
+        return ((self.type == 'SmallKey' and self.world.settings.shuffle_smallkeys in ('remove', 'vanilla', 'dungeon')) or
+                (self.type == 'HideoutSmallKey' and self.world.settings.shuffle_hideoutkeys == 'vanilla') or
+                (self.type == 'BossKey' and self.world.settings.shuffle_bosskeys in ('remove', 'vanilla', 'dungeon')) or
+                (self.type == 'GanonBossKey' and self.world.settings.shuffle_ganon_bosskey in ('remove', 'vanilla', 'dungeon')) or
+                ((self.map or self.compass) and (self.world.settings.shuffle_mapcompass in ('remove', 'startwith', 'vanilla', 'dungeon'))))
 
     @property
     def majoritem(self):


### PR DESCRIPTION
The property `Item.unshuffled_dungeon_item` is used for pre-completed dungeons (they can be placed in pre-completed dungeons) and for hints (hints won't include the name of their dungeon). This PR fixes 2 bugs in this property:

1. Hideout keys checked for an item type that was renamed in #1280 and were thus always considered shuffled.
2. Ganon's boss key was checking for the setting for regular boss keys.