### PR TITLE
Don't disable shuffle_bosskeys when keyrings give boss keys

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3073,9 +3073,6 @@ setting_infos = [
         gui_params     = {
             "hide_when_disabled": True,
         },
-        disable={
-            True: {'settings' : ['shuffle_bosskeys']},
-        },
     ),
     Combobox(
         name           = 'shuffle_mapcompass',


### PR DESCRIPTION
The `keyring_give_bk` setting only affects dungeons which have keyrings, but it also forces the other boss keys to be shuffled in their own dungeon. This PR removes this limitation. In the future, an enable relation (#1827) could be used to hide the boss key shuffle setting if keyrings give boss keys and are enabled for all dungeons.