### PR TITLE
Restrict Gerudo Valley River Exit ER from linking to interiors

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -544,8 +544,8 @@ def shuffle_random_entrances(worlds):
         for pool_type, entrance_pool in one_way_entrance_pools.items():
             # One way entrances are extra entrances that will be connected to entrance positions from a selection of entrance pools
             if pool_type == 'OverworldOneWay':
-                valid_target_types = ('Spawn', 'WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
-                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
+                valid_target_types = ('WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Extra')
+                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Prelude of Light Warp -> Temple of Time'])
             elif pool_type == 'OwlDrop':
                 valid_target_types = ('WarpSong', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Prelude of Light Warp -> Temple of Time'])


### PR DESCRIPTION
The `OverworldOneWay` entrance pool, which currently only contains the Gerudo Valley to Lake Hylia entrance, has the following valid target pools:
* Spawn
* WarpSong
* OwlDrop
* OverworldOneWay
* Overworld
* Interior
* SpecialInterior
* Extra

While this is consistent with the WarpSong and Spawn one way entrance pools, it does not mesh well in my opinion with all of these targets while mixed pools is not available. The GV river entrance is ostensibly an overworld entrance and should target other overworld entrances. There is precedence for this with the OwlDrop oneway pool including only targets reachable from the air, excluding interiors, spawn points, and the Prelude warp pad inside the Temple of Time. A waterfall exit like the GV river exit can be thought of in the same way.

This PR changes the target pool for OverworldOneWay to match the OwlDrop targets. If preferred, a more literal interpretation could also exclude the WarpSong and OwlDrop targets as well as the Eyedrops extra entrance as they are not as close to region edges. The ZR waterfall Extra entrance should remain a target given its similarity.