### PR TITLE
Prevent hinting heart pieces/containers directly as woth/path

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -42,7 +42,7 @@ defaultHintDists = [
     'weekly.json',
 ]
 
-unHintableWothItems = ['Triforce Piece', 'Gold Skulltula Token']
+unHintableWothItems = ['Triforce Piece', 'Gold Skulltula Token', 'Piece of Heart', 'Piece of Heart (Treasure Chest Game)', 'Heart Container']
 
 class RegionRestriction(Enum):
     NONE = 0,


### PR DESCRIPTION
This PR adds heart pieces and containers to the list of items that can't be hinted directly by Way of the Hero or Goal hints, which makes them consistent with gold skulltula tokens. I believe this was an oversight due to #1402 being opened before #1517 but merged after.