### PR TITLE
Remove enabling Ocarina in Bombchu Bowling

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -864,7 +864,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     # Allow Ocarina in some places
     rom.write_byte(0xB6D346, 0x11) # Granny's Potion Shop
-    rom.write_byte(0xB6D33A, 0x51) # Bombchu Bowling
     rom.write_byte(0xB6D30A, 0x51) # Archery
 
     # Remove disruptive text from Gerudo Training Ground and early Shadow Temple (vanilla)


### PR DESCRIPTION
Fixes https://github.com/OoTRandomizer/OoT-Randomizer/issues/1938 by putting back the restriction on Ocarina lifted in https://github.com/OoTRandomizer/OoT-Randomizer/pull/1845
It's a VC/Dolphin specific crash, and i can't see either how to fix it or what exactly causes it. Probably some camera data issue due to how the viewpoint moves in Bowling.
It's not a huge change anyway so removing it does not make a big difference.