### PR TITLE
fix chu bags logic

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1358,7 +1358,7 @@
         "locations": {
             "Market Bombchu Bowling First Prize": "has_explosives",
             "Market Bombchu Bowling Second Prize": "has_explosives",
-            "Market Bombchu Bowling Bombchus": "has_explosives",
+            "Market Bombchu Bowling Bombchus": "found_bombchus",
             "Market Bombchu Bowling Bomb": "has_explosives"
         },
         "exits": {


### PR DESCRIPTION
I didn't test this at all. But it's a serious issue with a quick fix so I figured I'd try to get the ball rolling on having it fixed sooner than later.

If it ever becomes possible to shuffle this location (which I think was proposed at one point, and probably from where this bug originates), then it would need to change back to has_explosives if the setting is on to shuffle the check. (I don't think a setting to shuffle that currently exists, right?)