### PR TITLE
Set flags with skip child zelda off and Zelda's Letter as a starting item

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1329,6 +1329,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         save_context.write_bits(0x0EDD, 0x01) # "Obtained Zelda's Letter"
         save_context.write_bits(0x0EDE, 0x02) # "Learned Zelda's Lullaby"
         save_context.write_bits(0x00D4 + 0x5F * 0x1C + 0x04 + 0x3, 0x10) # "Moved crates to access the courtyard"
+    if world.skip_child_zelda or "Zeldas Letter" in world.distribution.starting_items.keys():
         if world.settings.open_kakariko != 'closed':
             save_context.write_bits(0x0F07, 0x40) # "Spoke to Gate Guard About Mask Shop"
         if world.settings.complete_mask_quest:


### PR DESCRIPTION
Relevant for the Kakariko Gate set to Zelda's Letter Opens Gate. If the letter is a starting item, the flags in the item get callback were not set. The game would still prevent the player from presenting the letter to the guard to open the gate and the mask shop manually, permanently locking child out of the Kak -> DMT entrance and all of the mask trading sequence.