### PR TITLE
Integrate Owls saying where they fly to in the Warp Songs Misc. Hint

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -1118,10 +1118,14 @@ def update_warp_song_text(messages, world):
         0x0891: 'Nocturne of Shadow Warp -> Graveyard Warp Pad Region',
         0x0892: 'Prelude of Light Warp -> Temple of Time',
     }
+    owl_messages = {
+        0x3063: 'DMT Owl Flight -> Kak Impas Rooftop',
+        0x4004: 'LH Owl Flight -> Hyrule Field',
+    }
 
     if world.settings.logic_rules != "glitched": # Entrances not set on glitched logic so following code will error
         for id, entr in msg_list.items():
-            if 'warp_songs' in world.settings.misc_hints or not world.settings.warp_songs:
+            if 'warp_songs_and_owls' in world.settings.misc_hints or not world.settings.warp_songs:
                 destination = world.get_entrance(entr).connected_region
                 destination_name = HintArea.at(destination)
                 color = COLOR_MAP[destination_name.color]
@@ -1132,4 +1136,19 @@ def update_warp_song_text(messages, world):
                 color = COLOR_MAP['White']
 
             new_msg = f"\x08\x05{color}Warp {destination_name}?\x05\40\x09\x01\x01\x1b\x05\x42OK\x01No\x05\40"
+            update_message_by_id(messages, id, new_msg)
+
+    if world.settings.owl_drops:
+        for id, entr in owl_messages.items():
+            if 'warp_songs_and_owls' in world.settings.misc_hints:
+                destination = world.get_entrance(entr).connected_region
+                destination_name = HintArea.at(destination)
+                color = COLOR_MAP[destination_name.color]
+                if destination_name.preposition(True) is not None:
+                    destination_name = f'to {destination_name}'
+            else:
+                destination_name = 'to a mysterious place'
+                color = COLOR_MAP['White']
+
+            new_msg = f"Hold on to my talons! I'll fly you\x01\x08\x05{color}{destination_name}\x05\40\x09!"
             update_message_by_id(messages, id, new_msg)

--- a/Patches.py
+++ b/Patches.py
@@ -1198,6 +1198,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     save_context.write_bits(0x00D4 + 0x5B * 0x1C + 0x04 + 0x3, 0x80) # Lost Woods switch flag (Owl)
     save_context.write_bits(0x00D4 + 0x5C * 0x1C + 0x04 + 0x0, 0x80) # Desert Colossus switch flag (Owl)
     save_context.write_bits(0x00D4 + 0x5F * 0x1C + 0x04 + 0x3, 0x20) # Hyrule Castle switch flag (Owl)
+    save_context.write_bits(0x0F2B, 0x20) # Spoke to Lake Hylia Owl once
 
     save_context.write_bits(0x0ED4, 0x10) # "Met Deku Tree"
     save_context.write_bits(0x0ED5, 0x20) # "Deku Tree Opened Mouth"

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4824,7 +4824,7 @@ setting_infos = [
             'altar':       'Temple of Time Altar',
             'dampe_diary': "Dampé's Diary (Hookshot)",
             'ganondorf':   'Ganondorf (Light Arrows)',
-            'warp_songs':  'Warp Songs',
+            'warp_songs_and_owls':  'Warp Songs and Owls',
             '10_skulltulas':  'House of Skulltula: 10',
             '20_skulltulas':  'House of Skulltula: 20',
             '30_skulltulas':  'House of Skulltula: 30',
@@ -4862,6 +4862,8 @@ setting_infos = [
             Playing a warp song will tell you where
             it leads. (If warp song destinations
             are vanilla, this is always enabled.)
+            The two Owls at Lake Hylia and Death Mountain
+            that move you around will tell you where they go.
 
             Talking to a cursed House of Skulltula
             resident will tell you the reward they will
@@ -4878,7 +4880,7 @@ setting_infos = [
             Mask of Truth's shelf slot is always visible.
         ''',
         shared         = True,
-        default        = ['altar', 'ganondorf', 'warp_songs'],
+        default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],
     ),
     Combobox(
         name           = 'text_shuffle',

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -96,7 +96,7 @@
             "altar",
             "dampe_diary",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
@@ -232,7 +232,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
@@ -368,7 +368,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs",
+            "warp_songs_and_owls",
             "40_skulltulas",
             "50_skulltulas"
         ],
@@ -499,7 +499,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
@@ -640,7 +640,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
@@ -793,7 +793,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
@@ -1207,7 +1207,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
@@ -1373,7 +1373,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs",
+            "warp_songs_and_owls",
             "30_skulltulas",
             "40_skulltulas",
             "50_skulltulas"
@@ -1503,7 +1503,7 @@
         "misc_hints": [
             "altar",
             "ganondorf",
-            "warp_songs"
+            "warp_songs_and_owls"
         ],
         "text_shuffle": "none",
         "damage_multiplier": "normal",


### PR DESCRIPTION
The hint has been renamed accordingly in Warp Songs and Owls.

![UI](https://user-images.githubusercontent.com/65768236/230156915-2dfa7c58-8daa-480a-84ca-2fe83ac064a1.png)

This will replace the two Owls textboxes that warp you to another place by a customized text saying where they go, only if Randomize Owl Drops is on.

![owl_dmt](https://user-images.githubusercontent.com/65768236/230157221-d8dda508-10a4-4a77-8395-c8f11079f09e.png)

![owl_lake](https://user-images.githubusercontent.com/65768236/230157236-80cb6c29-59e4-4767-91c6-3f6c2f114afa.png)

In order to change only one textbox for the Lake Owl, i set the permanent flag that tags if you already talked to that owl once. 
It has the bonus effect of replacing 5 consecutives textboxes by a single one, even when owls drops are not shuffled.
At the detriment of removing again some textboxes, sorry to all the full text shuffle players :sweat_smile: