### PR TITLE
Multiworld docs improvements

### DIFF
--- a/Notes/coop-ctx.md
+++ b/Notes/coop-ctx.md
@@ -7,7 +7,7 @@ The starting address of the auto-tracker context is listed at address `0x8040_00
 |Offset|Name|Min version|Size|Description|
 |--:|---|--:|--:|---|
 |`0x04`|`PLAYER_ID`|1|`0x0001`|The world number of this world, 1-indexed.|
-|`0x05`|`PLAYER_NAME_ID`|1|`0x0001`|The world number of the player whose item is being picked up, used as an index into `PLAYER_NAME_ID` to render that player's name in the text box. `0` if no item is being picked up. This should usually not be read or modified by the multiworld plugin; use `OUTGOING_PLAYER` instead.|
+|`0x05`|`PLAYER_NAME_ID`|1|`0x0001`|The world number of the player whose item is being picked up, used as an index into `PLAYER_NAMES` to render that player's name in the text box. `0` if no item is being picked up. This should usually not be read or modified by the multiworld plugin; use `OUTGOING_PLAYER` instead.|
 |`0x06`|`INCOMING_ITEM`|1|`0x0002`|The ID (as in `Item.index`) of the next item to receive from the network, or `0` if there is none.|
 |`0x08`|`OUTGOING_KEY`|1|`0x0004`|A unique ID (see `get_override_entry` in Patches.py for details) for the source location of the outgoing item, or `0` if no item is being sent. The multiworld plugin should set this to `0` after handling an outgoing item.|
 |`0x0c`|`OUTGOING_ITEM`|1|`0x0002`|The ID (as in `Item.index`) of the outgoing item, or `0` if no item is being sent. The multiworld plugin should set this to `0` after handling an outgoing item.|
@@ -19,7 +19,7 @@ The starting address of the auto-tracker context is listed at address `0x8040_00
 |Offset|Name|Min version|Size|Description|
 |--:|---|--:|--:|---|
 |`0x0004`|`PLAYER_ID`|1|`0x0001`|The world number of this world, 1-indexed.|
-|`0x0005`|`PLAYER_NAME_ID`|1|`0x0001`|The world number of the player whose item is being picked up, used as an index into `PLAYER_NAME_ID` to render that player's name in the text box. `0` if no item is being picked up. This should usually not be read or modified by the multiworld plugin; use `OUTGOING_PLAYER` instead.|
+|`0x0005`|`PLAYER_NAME_ID`|1|`0x0001`|The world number of the player whose item is being picked up, used as an index into `PLAYER_NAMES` to render that player's name in the text box. `0` if no item is being picked up. This should usually not be read or modified by the multiworld plugin; use `OUTGOING_PLAYER` instead.|
 |`0x0006`|`INCOMING_PLAYER`|2|`0x0002`|The world number from which the `INCOMING_ITEM` came, or `0` if there is no incoming item.|
 |`0x0008`|`INCOMING_ITEM`|2|`0x0002`|The ID (as in `Item.index`) of the next item to receive from the network, or `0` if there is none.|
 |`0x000a`|`MW_SEND_OWN_ITEMS`|3|`0x0001`|The multiworld plugin can set this to `1` to make the game set `OUTGOING_KEY`, `OUTGOING_ITEM`, and `OUTGOING_PLAYER` even when finding an item for its own world. Defaults to `0`, meaning these fields are only set for Triforce pieces (which affect all worlds) and other players' items.|

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -62,7 +62,7 @@
         {
           "name": "multiworld_section",
           "text": "Multi-World Generation",
-          "subheader": "Play interconnected seeds with multiple players. Each player receives one of the worlds, which can contain items for other players. See <a href='https://wiki.ootrandomizer.com/index.php?title=Multiworld' target='_blank'>the wiki article on multiworld</a> for details.<br>You will need a plugin like <a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>bizhawk-co-op</a> or <a href='https://midos.house/mw' target='_blank'>Mido's House Multiworld</a> to connect the worlds together. You can also use <a href='https://github.com/authorblues/bizhawk-shuffler-2' target='_blank'>Bizhawk Shuffler 2</a> to play all of the worlds on the same emulator and randomly swap between them.<br>Increasing Player Count will drastically increase the generation time.",
+          "subheader": "Play interconnected seeds with multiple players. Each player receives one of the worlds, which can contain items for other players. See <a href='https://wiki.ootrandomizer.com/index.php?title=Multiworld' target='_blank'>the wiki article on multiworld</a> for details.<br>You will need a plugin like <a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>bizhawk-co-op</a> or <a href='https://midos.house/mw' target='_blank'>Mido's House Multiworld</a> to connect the worlds together.<br>Increasing Player Count will drastically increase the generation time.",
           "row_span": [1,1,1],
           "settings": [
             "world_count",
@@ -107,7 +107,7 @@
         {
           "name": "multiworld_section",
           "text": "Multi-World Generation",
-          "subheader": "Play interconnected seeds with multiple players. Each player receives one of the worlds, which can contain items for other players. See <a href='https://wiki.ootrandomizer.com/index.php?title=Multiworld' target='_blank'>the wiki article on multiworld</a> for details.<br>You will need a plugin like <a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>bizhawk-co-op</a> or <a href='https://midos.house/mw' target='_blank'>Mido's House Multiworld</a> to connect the worlds together. You can also use <a href='https://github.com/authorblues/bizhawk-shuffler-2' target='_blank'>Bizhawk Shuffler 2</a> to play all of the worlds on the same emulator and randomly swap between them.",
+          "subheader": "Play interconnected seeds with multiple players. Each player receives one of the worlds, which can contain items for other players. See <a href='https://wiki.ootrandomizer.com/index.php?title=Multiworld' target='_blank'>the wiki article on multiworld</a> for details.<br>You will need a plugin like <a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>bizhawk-co-op</a> or <a href='https://midos.house/mw' target='_blank'>Mido's House Multiworld</a> to connect the worlds together.",
           "row_span": [1,1,1],
           "settings": [
             "player_num"

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -62,7 +62,7 @@
         {
           "name": "multiworld_section",
           "text": "Multi-World Generation",
-          "subheader": "This is used for co-op generations. Increasing Player Count will drastically increase the generation time.<br>For more information, see:<br><a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>https://github.com/TestRunnerSRL/bizhawk-co-op</a>",
+          "subheader": "Play interconnected seeds with multiple players. Each player receives one of the worlds, which can contain items for other players. See <a href='https://wiki.ootrandomizer.com/index.php?title=Multiworld' target='_blank'>the wiki article on multiworld</a> for details.<br>You will need a plugin like <a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>bizhawk-co-op</a> or <a href='https://midos.house/mw' target='_blank'>Mido's House Multiworld</a> to connect the worlds together. You can also use <a href='https://github.com/authorblues/bizhawk-shuffler-2' target='_blank'>Bizhawk Shuffler 2</a> to play all of the worlds on the same emulator and randomly swap between them.<br>Increasing Player Count will drastically increase the generation time.",
           "row_span": [1,1,1],
           "settings": [
             "world_count",
@@ -107,7 +107,7 @@
         {
           "name": "multiworld_section",
           "text": "Multi-World Generation",
-          "subheader": "This is used for co-op generations.<br>For more information, see:<br><a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>https://github.com/TestRunnerSRL/bizhawk-co-op</a>",
+          "subheader": "Play interconnected seeds with multiple players. Each player receives one of the worlds, which can contain items for other players. See <a href='https://wiki.ootrandomizer.com/index.php?title=Multiworld' target='_blank'>the wiki article on multiworld</a> for details.<br>You will need a plugin like <a href='https://github.com/TestRunnerSRL/bizhawk-co-op' target='_blank'>bizhawk-co-op</a> or <a href='https://midos.house/mw' target='_blank'>Mido's House Multiworld</a> to connect the worlds together. You can also use <a href='https://github.com/authorblues/bizhawk-shuffler-2' target='_blank'>Bizhawk Shuffler 2</a> to play all of the worlds on the same emulator and randomly swap between them.",
           "row_span": [1,1,1],
           "settings": [
             "player_num"


### PR DESCRIPTION
* Improves the subheader of the multiworld settings section, giving a better explanation of what multiworld does and adding links to [the wiki article on multiworld](https://wiki.ootrandomizer.com/index.php?title=Multiworld) as well as [Mido's House Multiworld](https://midos.house/mw) and [Bizhawk Shuffler 2](https://github.com/authorblues/bizhawk-shuffler-2).
* Fixes a typo in the description of the `PLAYER_NAME_ID` field in the co-op context docs.