### PR TITLE
New Timesaver setting : Ruto Already at F1

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1241,8 +1241,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     save_context.write_bits(0x0F09, 0x10)  # "Met Child Malon at Castle or Market"
     save_context.write_bits(0x0F09, 0x20)  # "Child Malon Said Epona Was Scared of You"
 
-    save_context.write_bits(0x0F21, 0x04)  # "Ruto in JJ (M3) Talk First Time"
-    save_context.write_bits(0x0F21, 0x02)  # "Ruto in JJ (M2) Meet Ruto"
+    save_context.write_bits(0x0F21, 0x04) # "Ruto in JJ (M3) Talk First Time"
+    save_context.write_bits(0x0F21, 0x02) # "Ruto in JJ (M2) Meet Ruto"
+    if world.settings.ruto_already_f1_jabu and not world.dungeon_mq['Jabu Jabus Belly']:
+        save_context.write_bits(0x0F21, 0x80) # Ruto in JJ, Spawns on F1 instead of B1
 
     save_context.write_bits(0x0EE2, 0x01)  # "Began Ganondorf Battle"
     save_context.write_bits(0x0EE3, 0x80)  # "Began Bongo Bongo Battle"

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3133,6 +3133,17 @@ class SettingInfos:
         },
     )
 
+    ruto_already_f1_jabu = Checkbutton(
+        gui_text       = 'Ruto Already at F1',
+        gui_tooltip    = '''\
+            Ruto in Jabu Jabu's Belly will already be at the top floor.
+            Only applied in the original version of the dungeon, since
+            in Master Quest you don't need to bring Ruto up.
+        ''',
+        default        = False,
+        shared         = True,
+    )
+
     ocarina_songs = Combobox(
         gui_text       = 'Randomize Ocarina Song Notes',
         default        = 'off',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -339,7 +339,8 @@
             "big_poe_count_random",
             "big_poe_count",
             "easier_fire_arrow_entry",
-            "fae_torch_count"
+            "fae_torch_count",
+            "ruto_already_f1_jabu"
           ]
         },
         {


### PR DESCRIPTION
Idea from Ryuukane, so blame him if it's bad.
![ruto_f1](https://user-images.githubusercontent.com/65768236/235604574-e169f230-1b90-4a67-9a0f-e142a6cff4c8.png)
This setting sets the flag for Ruto to be already in the upper floor in Jabu Jabu. Only applied of course in the vanilla version of the dungeon, since in MQ you don't need to bring Ruto up.

Since it removes gameplay, this is better as a toggle and not some default behaviour in my opinion.
Makes the scrub and B1 skull pretty bad to check, but it's around a minute timesave if you ignore these 2 checks.

I think this setting would be interesting in "usual" tournament settings or in Triforce Blitz for example.