### PR TITLE
Restrict spawn ER targets from selecting locked-in regions

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -559,7 +559,7 @@ def shuffle_random_entrances(worlds: list[World]) -> None:
                     target.set_rule(lambda state, age=None, **kwargs: age == 'child')
             elif pool_type == 'Spawn':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
-                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Volvagia Boss Room -> DMC Central Local', 'Queen Gohma Boss Room -> KF Outside Deku Tree'])
+                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Volvagia Boss Room -> DMC Central Local', 'Bolero of Fire Warp -> DMC Central Local', 'Queen Gohma Boss Room -> KF Outside Deku Tree'])
             elif pool_type == 'WarpSong':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -559,6 +559,7 @@ def shuffle_random_entrances(worlds: list[World]) -> None:
                     target.set_rule(lambda state, age=None, **kwargs: age == 'child')
             elif pool_type == 'Spawn':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
+                # Restrict spawn entrances from linking to regions with no or extremely specific glitchless itemless escapes.
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Volvagia Boss Room -> DMC Central Local', 'Bolero of Fire Warp -> DMC Central Local', 'Queen Gohma Boss Room -> KF Outside Deku Tree'])
             elif pool_type == 'WarpSong':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')

--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -559,7 +559,7 @@ def shuffle_random_entrances(worlds: list[World]) -> None:
                     target.set_rule(lambda state, age=None, **kwargs: age == 'child')
             elif pool_type == 'Spawn':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
-                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
+                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Volvagia Boss Room -> DMC Central Local', 'Queen Gohma Boss Room -> KF Outside Deku Tree'])
             elif pool_type == 'WarpSong':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)


### PR DESCRIPTION
The `test_presets` unit test was failing when attempting to generate the hell mode preset with seed `TESTTESTTEST`. Other seeds can successfully generate. Playing around with the changes from the mixed pools bosses prep PR, it appears tied to introducing blue warps as targets for all one way entrances. That said, it is difficult to tell if this is the root cause or successful generation with `TESTTESTTEST` is an artifact of changing the shuffle progression.

This PR introduces restrictions on valid spawn targets to reduce the probability of impossible world layouts:
* ___Volvagia -> Crater___ is impossible to escape itemless as either age for most settings combinations. It could be possible with alternate age spawn elsewhere, dungeon ER, vanilla Spirit Temple placed at Fire Temple entrance, and either pots or freestanding items shuffled to give enough keys/items to reach the exits to Colossus. Since this is too specific, I believe the entrance should be removed from the spawn pool.
* ___Bolero Warp -> Crater___ is on this list for the same reason as Volvagia -> Crater.
* ___Queen Gohma -> Outside Deku Tree___ is impossible itemless as child with closed Deku Tree or closed Forest on. Without mixed pools, child does not have renewable Deku Shield access even if a Kokiri Sword is placed inside the Deku Tree entrance. This could be made conditional, but that feels too complicated.

An alternative could be to remove blue warps as valid targets until blue warp shuffle is PR'd, though I see no reason to do so.