### PR TITLE
Fix chu bags logic again (+bonus market crate logic fix)

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -952,7 +952,9 @@
         "hint": "HAUNTED_WASTELAND",
         "locations": {
             "Wasteland Chest": "has_fire_source",
-            "Wasteland Bombchu Salesman": "Progressive_Wallet and can_jumpslash",
+            "Wasteland Bombchu Salesman": "
+                Progressive_Wallet and can_jumpslash and
+                (shuffle_expensive_merchants or has_bombchus)",
             "Wasteland Near GS Pot 1": "True",
             "Wasteland Near GS Pot 2": "True",
             "Wasteland Near GS Pot 3": "True",
@@ -1050,10 +1052,18 @@
         "scene": "Market",
         "hint": "MARKET",
         "locations": {
-            "Market Night Red Rupee Crate": "is_child and at_night and (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))",
-            "Market Night Green Rupee Crate 1": "is_child and at_night and (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))",
-            "Market Night Green Rupee Crate 2": "is_child and at_night and (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))",
-            "Market Night Green Rupee Crate 3": "is_child and at_night (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))"
+            "Market Night Red Rupee Crate": "
+                is_child and at_night and
+                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))",
+            "Market Night Green Rupee Crate 1": "
+                is_child and at_night and
+                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))",
+            "Market Night Green Rupee Crate 2": "
+                is_child and at_night and
+                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))",
+            "Market Night Green Rupee Crate 3": "
+                is_child and at_night and
+                (deadly_bonks != 'ohko' or Fairy or (can_use(Nayrus_Love) and shuffle_overworld_entrances == 'off'))"
         },
         "exits": {
             "Market Entrance": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -954,7 +954,7 @@
             "Wasteland Chest": "has_fire_source",
             "Wasteland Bombchu Salesman": "
                 Progressive_Wallet and can_jumpslash and
-                (shuffle_expensive_merchants or has_bombchus)",
+                (shuffle_expensive_merchants or not free_bombchu_drops or has_bombchus)",
             "Wasteland Near GS Pot 1": "True",
             "Wasteland Near GS Pot 2": "True",
             "Wasteland Near GS Pot 3": "True",


### PR DESCRIPTION
I'm not sure what the intention is for the logic on carpet guy. I assume we still view buying bombchus from him as too arduous of a repeatable source? But I have no idea if opinions might have changed on that.

I needed to make some change now that you can no longer buy from him without having bombchus, if chu bags are on and he's not shuffled. I guess the vanilla chus are never logically relevant, if they can't be used as a repeatable source, so I only need to check whether expensive merchants are on. I checked for has_bombchus as an alternative just so that the location wouldn't be forever unreachable in those settings, in case that's somehow problematic. If chu bags are off, you don't need bombchus to reach the check, but still it should be logically locked by bombchus if we don't want carpet guy to be a source of refills. (And again I have no idea if he's supposed to be a logical source of refills or not. The logic on this check has changed a lot, from completely out of logic, to potentially first bombchu source, to who knows what, to eventually broken now, and then to whatever results from fixing the broken.)

Make sure you find out what the intention is for this carpet guy as potential logical source of chu refills before merging this.

Bonus logic fix since I had the file open. One of the market crates was missing an "and" and so... the check for bonko was instead being passed as a parameter into at_night or something??? Really weird lol.

Both of these fixes are wholly untested, just did them quickly on web.

(I don't think shuffle_expensive_merchants has been used in the logic before. That setting was renamed not all that long ago... I dunno if it gets renamed again now you have to remember to come in here and change it.)