### PR TITLE
Add unit test for duplicate message ID checks

### DIFF
--- a/CI.py
+++ b/CI.py
@@ -12,6 +12,7 @@ import argparse
 import Unittest as Tests
 from SettingsList import logic_tricks, validate_settings
 from Utils import data_path
+from Messages import ITEM_MESSAGES, KEYSANITY_MESSAGES, MISC_MESSAGES
 
 
 def error(msg, can_fix):
@@ -79,6 +80,22 @@ def check_hell_mode_tricks(fix_errors=False):
             print(file=file)
 
 
+# Check the message tables to ensure no duplicate entries exist.
+# This is not a perfect check because it doesn't account for everything that gets manually done in Patches.py
+# For that, we perform additional checking at patch time
+def check_message_duplicates():
+    def check_for_duplicates(new_item_messages):
+        for i in range(0, len(new_item_messages)):
+            for j in range(i, len(new_item_messages)):
+                if i != j:
+                    message_id1, message1 = new_item_messages[i]
+                    message_id2, message2 = new_item_messages[j]
+                    if message_id1 == message_id2:
+                        error("Duplicate MessageID found: " + hex(message_id1) + ", " + message1 + ", " + message2, False)
+
+    messages = ITEM_MESSAGES + KEYSANITY_MESSAGES + MISC_MESSAGES
+    check_for_duplicates(messages)
+
 def check_code_style(fix_errors=False):
     # Check for code style errors
     repo_dir = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -143,6 +160,7 @@ def run_ci_checks():
         check_hell_mode_tricks(args.fix)
         check_code_style(args.fix)
         check_presets_formatting(args.fix)
+        check_message_duplicates()
 
     exit_ci(args.fix)
 

--- a/Messages.py
+++ b/Messages.py
@@ -490,30 +490,30 @@ COLOR_MAP = {
     'Black':      '\x47',
 }
 
-MISC_MESSAGES = {
-    0x507B: (bytearray(
+MISC_MESSAGES = [
+    (0x507B, (bytearray(
             b"\x08I tell you, I saw him!\x04" \
             b"\x08I saw the ghostly figure of Damp\x96\x01" \
             b"the gravekeeper sinking into\x01" \
             b"his grave. It looked like he was\x01" \
             b"holding some kind of \x05\x41treasure\x05\x40!\x02"
-            ), None),
-    0x0422: ("They say that once \x05\x41Morpha's Curse\x05\x40\x01is lifted, striking \x05\x42this stone\x05\x40 can\x01shift the tides of \x05\x44Lake Hylia\x05\x40.\x02", 0x23),
-    0x401C: ("Please find my dear \05\x41Princess Ruto\x05\x40\x01immediately... Zora!\x12\x68\x7A", 0x23),
-    0x9100: ("I am out of goods now.\x01Sorry!\x04The mark that will lead you to\x01the Spirit Temple is the \x05\x41flag on\x01the left \x05\x40outside the shop.\x01Be seeing you!\x02", 0x00),
-    0x0451: ("\x12\x68\x7AMweep\x07\x04\x52", 0x23),
-    0x0452: ("\x12\x68\x7AMweep\x07\x04\x53", 0x23),
-    0x0453: ("\x12\x68\x7AMweep\x07\x04\x54", 0x23),
-    0x0454: ("\x12\x68\x7AMweep\x07\x04\x55", 0x23),
-    0x0455: ("\x12\x68\x7AMweep\x07\x04\x56", 0x23),
-    0x0456: ("\x12\x68\x7AMweep\x07\x04\x57", 0x23),
-    0x0457: ("\x12\x68\x7AMweep\x07\x04\x58", 0x23),
-    0x0458: ("\x12\x68\x7AMweep\x07\x04\x59", 0x23),
-    0x0459: ("\x12\x68\x7AMweep\x07\x04\x5A", 0x23),
-    0x045A: ("\x12\x68\x7AMweep\x07\x04\x5B", 0x23),
-    0x045B: ("\x12\x68\x7AMweep", 0x23),
-    0x6013: ("Hey, newcomer!\x04Want me to throw you in jail?\x01\x01\x1B\x05\x42No\x01Yes\x05\x40", 0x00),
-}
+            ), None)),
+    (0x0422, ("They say that once \x05\x41Morpha's Curse\x05\x40\x01is lifted, striking \x05\x42this stone\x05\x40 can\x01shift the tides of \x05\x44Lake Hylia\x05\x40.\x02", 0x23)),
+    (0x401C, ("Please find my dear \05\x41Princess Ruto\x05\x40\x01immediately... Zora!\x12\x68\x7A", 0x23)),
+    (0x9100, ("I am out of goods now.\x01Sorry!\x04The mark that will lead you to\x01the Spirit Temple is the \x05\x41flag on\x01the left \x05\x40outside the shop.\x01Be seeing you!\x02", 0x00)),
+    (0x0451, ("\x12\x68\x7AMweep\x07\x04\x52", 0x23)),
+    (0x0452, ("\x12\x68\x7AMweep\x07\x04\x53", 0x23)),
+    (0x0453, ("\x12\x68\x7AMweep\x07\x04\x54", 0x23)),
+    (0x0454, ("\x12\x68\x7AMweep\x07\x04\x55", 0x23)),
+    (0x0455, ("\x12\x68\x7AMweep\x07\x04\x56", 0x23)),
+    (0x0456, ("\x12\x68\x7AMweep\x07\x04\x57", 0x23)),
+    (0x0457, ("\x12\x68\x7AMweep\x07\x04\x58", 0x23)),
+    (0x0458, ("\x12\x68\x7AMweep\x07\x04\x59", 0x23)),
+    (0x0459, ("\x12\x68\x7AMweep\x07\x04\x5A", 0x23)),
+    (0x045A, ("\x12\x68\x7AMweep\x07\x04\x5B", 0x23)),
+    (0x045B, ("\x12\x68\x7AMweep", 0x23)),
+    (0x6013, ("Hey, newcomer!\x04Want me to throw you in jail?\x01\x01\x1B\x05\x42No\x01Yes\x05\x40", 0x00)),
+]
 
 
 # convert byte array to an integer
@@ -1066,25 +1066,28 @@ def make_player_message(text):
 # make sure to call this AFTER move_shop_item_messages()
 def update_item_messages(messages, world):
     new_item_messages = ITEM_MESSAGES + KEYSANITY_MESSAGES
-    check_message_dupes(new_item_messages)
     for id, text in new_item_messages:
         if world.settings.world_count > 1:
             update_message_by_id(messages, id, make_player_message(text), 0x23)
         else:
             update_message_by_id(messages, id, text, 0x23)
 
-    for id, (text, opt) in MISC_MESSAGES.items():
+    for id, (text, opt) in MISC_MESSAGES:
         update_message_by_id(messages, id, text, opt)
 
 # Check the message table to ensure no duplicate entries exist.
-def check_message_dupes(new_item_messages):
+def _check_message_duplicates(new_item_messages):
     for i in range(0, len(new_item_messages)):
-        for j in range(1, len(new_item_messages)):
+        for j in range(i, len(new_item_messages)):
             if i != j:
                 message_id1, message1 = new_item_messages[i]
                 message_id2, message2 = new_item_messages[j]
                 if message_id1 == message_id2:
                     raise Exception("Duplicate MessageID found: " + hex(message_id1) + ", " + message1 + ", " + message2)
+
+def check_message_duplicates():
+    messages = ITEM_MESSAGES + KEYSANITY_MESSAGES + MISC_MESSAGES
+    _check_message_duplicates(messages)
 
 # run all keysanity related patching to add messages for dungeon specific items
 def add_item_messages(messages, shop_items, world):

--- a/Patches.py
+++ b/Patches.py
@@ -14,7 +14,7 @@ from HintList import getHint
 from Hints import GossipText, HintArea, writeGossipStoneHints, buildAltarHints, \
         buildGanonText, buildMiscItemHints, buildMiscLocationHints, getSimpleHintNoPrefix, getItemGenericName
 from Utils import data_path
-from Messages import read_messages, update_message_by_id, read_shop_items, update_warp_song_text, \
+from Messages import read_messages, update_message_by_id, check_message_duplicates, read_shop_items, update_warp_song_text, \
         write_shop_items, remove_unused_messages, make_player_message, \
         add_item_messages, repack_messages, shuffle_messages, \
         get_message_by_id, Text_Code
@@ -2265,6 +2265,9 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     }
     symbol = rom.sym('POTCRATE_TEXTURES_MATCH_CONTENTS')
     rom.write_byte(symbol, ptmc_options[world.settings.correct_potcrate_appearances])
+
+    # Check for duplicated message IDs
+    check_message_duplicates()
 
     # give dungeon items the correct messages
     add_item_messages(messages, shop_items, world)

--- a/Patches.py
+++ b/Patches.py
@@ -14,10 +14,10 @@ from HintList import getHint
 from Hints import GossipText, HintArea, writeGossipStoneHints, buildAltarHints, \
         buildGanonText, buildMiscItemHints, buildMiscLocationHints, getSimpleHintNoPrefix, getItemGenericName
 from Utils import data_path
-from Messages import read_messages, update_message_by_id, check_message_duplicates, read_shop_items, update_warp_song_text, \
+from Messages import read_messages, update_message_by_id, read_shop_items, update_warp_song_text, \
         write_shop_items, remove_unused_messages, make_player_message, \
         add_item_messages, repack_messages, shuffle_messages, \
-        get_message_by_id, Text_Code
+        get_message_by_id, Text_Code, new_messages
 from OcarinaSongs import replace_songs
 from MQ import patch_files, File, update_dmadata, insert_space, add_relocations
 from SaveContext import SaveContext, Scenes, FlagType
@@ -1644,6 +1644,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
 
     # Load Message and Shop Data
     messages = read_messages(rom)
+    new_messages.clear()
     remove_unused_messages(messages)
     shop_items = read_shop_items(rom, shop_item_file.start + 0x1DEC)
 
@@ -2162,7 +2163,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
             location = world.get_location("Market Treasure Chest Game Salesman")
             item_text = getHint(getItemGenericName(location.item), True).text
             update_message_by_id(messages, 0x6D, "I seem to have misplaced my\x01keys, but I have a fun item to\x01sell instead.\x04How about \x05\x4110 Rupees\x05\x40 for\x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't Buy\x05\x40\x02")
-        update_message_by_id(messages, 0x908B, "That's OK!\x01More fun for me.\x0B\x02", 0x00)
+        update_message_by_id(messages, 0x908B, "That's OK!\x01More fun for me.\x0B\x02", 0x00, True)
         update_message_by_id(messages, 0x6E, "Wait, that room was off limits!\x02")
         update_message_by_id(messages, 0x704C, "I hope you like it!\x02")
 
@@ -2265,9 +2266,6 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     }
     symbol = rom.sym('POTCRATE_TEXTURES_MATCH_CONTENTS')
     rom.write_byte(symbol, ptmc_options[world.settings.correct_potcrate_appearances])
-
-    # Check for duplicated message IDs
-    check_message_duplicates()
 
     # give dungeon items the correct messages
     add_item_messages(messages, shop_items, world)

--- a/Patches.py
+++ b/Patches.py
@@ -2305,7 +2305,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
                     map_message = "\x13\x76\x08You found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x01It\'s %s!\x09" % (dungeon_name, "masterful" if world.dungeon_mq[dungeon] else "ordinary")
 
                 if world.settings.mq_dungeons_mode == 'random' or world.settings.mq_dungeons_count != 0 and world.settings.mq_dungeons_count != 12:
-                    update_message_by_id(messages, map_id, map_message)
+                    update_message_by_id(messages, map_id, map_message, allow_duplicates=True)
             else:
                 dungeon_name, boss_name, compass_id, map_id = dungeon_list[dungeon]
                 if world.settings.world_count > 1:
@@ -2320,13 +2320,13 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
                     boss_location = next(filter(lambda loc: loc.type == 'Boss', world.get_entrance(f'{dungeon} Before Boss -> {boss_name} Boss Room').connected_region.locations))
                     dungeon_reward = reward_list[boss_location.item.name]
                     compass_message = "\x13\x75\x08You found the \x05\x41Compass\x05\x40\x01for %s\x05\x40!\x01It holds the %s!\x09" % (dungeon_name, dungeon_reward)
-                update_message_by_id(messages, compass_id, compass_message)
+                update_message_by_id(messages, compass_id, compass_message, allow_duplicates=True)
                 if world.settings.mq_dungeons_mode == 'random' or world.settings.mq_dungeons_count != 0 and world.settings.mq_dungeons_count != 12:
                     if world.settings.world_count > 1:
                         map_message = "\x13\x76\x08\x05\x42\x0F\x05\x40 found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x09" % (dungeon_name)
                     else:
                         map_message = "\x13\x76\x08You found the \x05\x41Dungeon Map\x05\x40\x01for %s\x05\x40!\x01It\'s %s!\x09" % (dungeon_name, "masterful" if world.dungeon_mq[dungeon] else "ordinary")
-                    update_message_by_id(messages, map_id, map_message)
+                    update_message_by_id(messages, map_id, map_message, allow_duplicates=True)
 
     # Set hints on the altar inside ToT
     rom.write_int16(0xE2ADB2, 0x707A)
@@ -2394,7 +2394,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
         bfa_message = "\x08\x13\x0CYou got the \x05\x43Blue Fire Arrow\x05\x40!\x01This is a cool arrow you can\x01use on red ice."
         if world.settings.world_count > 1:
             bfa_message = make_player_message(bfa_message)
-        update_message_by_id(messages, 0x0071, bfa_message, 0x23)
+        update_message_by_id(messages, 0x0071, bfa_message, 0x23, allow_duplicates=True)
 
         with open(data_path('blue_fire_arrow_item_name_eng.ia4'), 'rb') as stream:
             bfa_name_bytes = stream.read()

--- a/Unittest.py
+++ b/Unittest.py
@@ -18,7 +18,7 @@ from Item import ItemInfo
 from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions
 from LocationList import location_is_viewable
 from Main import main, resolve_settings, build_world_graphs
-from Messages import Message, check_message_duplicates
+from Messages import Message
 from Settings import Settings, get_preset_files
 
 test_dir = os.path.join(os.path.dirname(__file__), 'tests')
@@ -627,10 +627,6 @@ class TestHints(unittest.TestCase):
         _, spoiler = generate_with_plandomizer("plando-blue-fire-arrows-hints")
         woth = list(spoiler[':woth_locations'].values())
         self.assertIn('Blue Fire Arrows', woth)
-
-class TestMessages(unittest.TestCase):
-    def test_messages_for_duplicates(self):
-        check_message_duplicates()
 
 class TestEntranceRandomizer(unittest.TestCase):
     def test_spawn_point_invalid_areas(self):

--- a/Unittest.py
+++ b/Unittest.py
@@ -18,7 +18,7 @@ from Item import ItemInfo
 from ItemPool import remove_junk_items, remove_junk_ludicrous_items, ludicrous_items_base, ludicrous_items_extended, trade_items, ludicrous_exclusions
 from LocationList import location_is_viewable
 from Main import main, resolve_settings, build_world_graphs
-from Messages import Message
+from Messages import Message, check_message_duplicates
 from Settings import Settings, get_preset_files
 
 test_dir = os.path.join(os.path.dirname(__file__), 'tests')
@@ -628,6 +628,9 @@ class TestHints(unittest.TestCase):
         woth = list(spoiler[':woth_locations'].values())
         self.assertIn('Blue Fire Arrows', woth)
 
+class TestMessages(unittest.TestCase):
+    def test_messages_for_duplicates(self):
+        check_message_duplicates()
 
 class TestEntranceRandomizer(unittest.TestCase):
     def test_spawn_point_invalid_areas(self):
@@ -651,7 +654,6 @@ class TestEntranceRandomizer(unittest.TestCase):
             # If the test succeeds, this confirms Serenade and Prelude can be foolish.
             with self.assertRaises(EntranceShuffleError):
                 build_world_graphs(settings)
-
 
 class TestValidSpoilers(unittest.TestCase):
 


### PR DESCRIPTION
Because we keep running into this problem.

Adds a runtime check that is capable of detecting duplicate messages being updated/added. Generation will throw an exception if a duplicate is detected:

![Screenshot 2023-05-20 130331](https://github.com/OoTRandomizer/OoT-Randomizer/assets/5086838/c314a9cd-ba9e-4374-af5b-2788f5c6120c)

Also adds a more basic CI check that just checks the static tables.