### PR TITLE
Make items required for Ganon hintable with more wincons

### DIFF
--- a/Unittest.py
+++ b/Unittest.py
@@ -606,7 +606,7 @@ class TestHints(unittest.TestCase):
                     # We need at least one hint per goal, but it doesn't matter if there are duplicates
                     # of a goal hint or more than one hint for the goal.
                     for hint in spoiler['gossip_stones'].values():
-                        if goals[g].lower() in hint['text'].replace('#','').lower():
+                        if goals[g].lower() in hint['text'].replace('#','').lower() or goals[g].lower() == "path of the hero":
                             found_goals.append(goals[g])
                             break
                 self.assertEqual(found_goals, goals)

--- a/World.py
+++ b/World.py
@@ -327,12 +327,13 @@ class World:
         # over again after the first round through the categories.
         if len(self.goal_categories) > 0:
             self.one_hint_per_goal = True
+            minor_goal_categories = ('door_of_time', 'ganon')
             goal_list1 = []
             for category in self.goal_categories.values():
-                if category.name != 'door_of_time':
+                if category.name not in minor_goal_categories:
                     goal_list1 = [goal.name for goal in category.goals]
             for category in self.goal_categories.values():
-                if goal_list1 != [goal.name for goal in category.goals] and category.name != 'door_of_time':
+                if goal_list1 != [goal.name for goal in category.goals] and category.name not in minor_goal_categories:
                     self.one_hint_per_goal = False
 
         # initialize category check for first rounds of goal hints

--- a/World.py
+++ b/World.py
@@ -797,6 +797,7 @@ class World:
         gbk = GoalCategory('ganon_bosskey', 20)
         trials = GoalCategory('trials', 30, minimum_goals=1)
         th = GoalCategory('triforce_hunt', 30, goal_count=round(self.settings.triforce_goal_per_world / 10), minimum_goals=1)
+        ganon = GoalCategory('ganon', 40, goal_count=1)
         trial_goal = Goal(self, 'the Tower', 'path to #the Tower#', 'White', items=[], create_empty=True)
 
         if self.settings.triforce_hunt and self.settings.triforce_goal_per_world > 0:
@@ -817,10 +818,9 @@ class World:
         # Ganon's Boss Key can be Stones, Medallions, Dungeons, Skulls, LACS or
         # one of the keysanity variants.
         # Trials is one goal that is only on if at least one trial is on in the world.
-        # If there are no win conditions beyond Kill Ganon (open bridge, GBK removed,
-        # no trials), a fallback "path of the hero" clone of WOTH is created. Path
-        # wording is used to distinguish the hint type even though the hintable location
-        # set is identical to WOTH.
+        # If there are no trials, a "path of the hero" clone of WOTH is created, which
+        # is deprioritized compared to other goals. Path wording is used to distinguish
+        # the hint type even though the hintable location set is identical to WOTH.
         if not self.settings.triforce_hunt:
             if self.settings.starting_age == 'child':
                 dot_items = [{'name': 'Temple of Time Access', 'quantity': 1, 'minimum': 1, 'hintable': True}]
@@ -1040,12 +1040,12 @@ class World:
                 trials.add_goal(trial_goal)
                 self.goal_categories[trials.name] = trials
 
-            if (self.shuffle_special_dungeon_entrances or self.settings.bridge == 'open') and (self.settings.shuffle_ganon_bosskey == 'remove' or self.settings.shuffle_ganon_bosskey == 'vanilla') and self.settings.trials == 0:
-                g = GoalCategory('ganon', 30, goal_count=1)
-                # Equivalent to WOTH, but added in case WOTH hints are disabled in favor of goal hints
-                g.add_goal(Goal(self, 'the hero', 'path of #the hero#', 'White', items=[{'name': 'Triforce', 'quantity': 1, 'minimum': 1, 'hintable': True}]))
-                g.minimum_goals = 1
-                self.goal_categories[g.name] = g
+            # In glitched logic or if trials are off, it's possible that some items required to beat the game
+            # (such as bow, magic, light arrows, or anything required to reach Ganon's Castle)
+            # don't appear on any other paths, so a goal specifically for beating the game is added.
+            ganon.add_goal(Goal(self, 'the hero', 'path of #the hero#', 'White', items=[{'name': 'Triforce', 'quantity': 1, 'minimum': 1, 'hintable': True}]))
+            ganon.minimum_goals = 1
+            self.goal_categories[ganon.name] = ganon
 
     def get_region(self, region_name: str | Region) -> Region:
         if isinstance(region_name, Region):

--- a/tests/plando/one-hint-per-goal-stones.json
+++ b/tests/plando/one-hint-per-goal-stones.json
@@ -36,7 +36,7 @@
                 "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 2},
                 "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},
                 "woth":       {"order":  3, "weight": 0.0, "fixed":   0, "copies": 2},
-                "goal":       {"order":  4, "weight": 0.0, "fixed":   3, "copies": 2},
+                "goal":       {"order":  4, "weight": 0.0, "fixed":   4, "copies": 2},
                 "barren":     {"order":  5, "weight": 0.0, "fixed":   0, "copies": 2},
                 "entrance":   {"order":  6, "weight": 0.0, "fixed":   0, "copies": 2},
                 "sometimes":  {"order":  7, "weight": 0.0, "fixed":  99, "copies": 2},


### PR DESCRIPTION
Ever since goal hints were added in #1361, there has been a “path of the hero” goal representing defeating Ganon. However, this goal was only used when no other goals existed. (After #1529, it could now coexist with “path of time”.) With this system, it was possible for required items, such as a bow, magic, or the light arrows (if the misc. hint was off) to be completely unhintable simply because they weren't required for the bridge or Ganon boss key conditions.

This PR allows the “path of the hero” goal to appear even when there are conditions for the rainbow bridge and/or Ganon boss key, or even trials (which is relevant for glitched logic). It comes after all other built-in goals in the priority list so items that are required for other goals are still only hinted as part of those.