### PR TITLE
Custom ice traps

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -937,7 +937,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
             pool.remove(junk_item)
             pool.append(pending_item)
 
-    if world.settings.junk_ice_traps in ['custom_count', 'custom_percent']:
+    if world.settings.junk_ice_traps in ('custom_count', 'custom_percent'):
         junk_pool[:] = [('Ice Trap', 1)]
         # Get a list of all "junk" type items
         junk = [item for item, weight in junk_pool_base] + ['Rupee (1)', 'Recovery Heart', 'Bombs (20)', 'Arrows (30)']

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -404,7 +404,7 @@ def get_pool_count(pool: list[str], item_list: list[str]) -> int:
 def replace_x_items(items: list[str], replace_list: list[str], x: int) -> None:
     random.shuffle(items)
     count = 0
-    for i,val in enumerate(items):
+    for i, val in enumerate(items):
         if val in replace_list:
             if count < x:
                 items[i] = get_junk_item()[0]

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -899,7 +899,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
     else:
         placed_items['Gift from Sages'] = ItemFactory(IGNORE_LOCATION, world)
 
-    if world.settings.junk_ice_traps in ['off', 'custom_count', 'custom_percent']:
+    if world.settings.junk_ice_traps in ('off', 'custom_count', 'custom_percent'):
         replace_max_item(pool, 'Ice Trap', 0)
     elif world.settings.junk_ice_traps == 'onslaught':
         for item in [item for item, weight in junk_pool_base] + ['Recovery Heart', 'Bombs (20)', 'Arrows (30)']:

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -396,7 +396,7 @@ def get_junk_item(count: int = 1, pool: Optional[list[str]] = None, plando_pool:
 
 def get_pool_count(pool: list[str], item_list: list[str]) -> int:
     count = 0
-    for i, val in enumerate(pool):
+    for val in pool:
         if val in item_list:
             count += 1
     return count

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -394,7 +394,6 @@ def get_junk_item(count: int = 1, pool: Optional[list[str]] = None, plando_pool:
     return return_pool
 
 
-
 def get_pool_count(pool: list[str], item_list: list[str]) -> int:
     count = 0
     for i, val in enumerate(pool):

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -394,6 +394,25 @@ def get_junk_item(count: int = 1, pool: Optional[list[str]] = None, plando_pool:
     return return_pool
 
 
+
+def get_pool_count(pool: list[str], item_list: list[str]) -> int:
+    count = 0
+    for i, val in enumerate(pool):
+        if val in item_list:
+            count += 1
+    return count
+
+def replace_x_items(items: list[str], replace_list: list[str], x: int) -> None:
+    random.shuffle(items)
+    count = 0
+    for i,val in enumerate(items):
+        if val in replace_list:
+            if count < x:
+                items[i] = get_junk_item()[0]
+                count += 1
+            else:
+                return
+
 def replace_max_item(items: list[str], item: str, max_count: int) -> None:
     count = 0
     for i, val in enumerate(items):
@@ -881,7 +900,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
     else:
         placed_items['Gift from Sages'] = ItemFactory(IGNORE_LOCATION, world)
 
-    if world.settings.junk_ice_traps == 'off':
+    if world.settings.junk_ice_traps in ['off', 'custom_count', 'custom_percent']:
         replace_max_item(pool, 'Ice Trap', 0)
     elif world.settings.junk_ice_traps == 'onslaught':
         for item in [item for item, weight in junk_pool_base] + ['Recovery Heart', 'Bombs (20)', 'Arrows (30)']:
@@ -891,6 +910,14 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         replace_max_item(pool, item, maximum)
 
     world.distribution.alter_pool(world, pool)
+
+    if world.settings.junk_ice_traps in ['custom_count', 'custom_percent']:
+        junk_pool[:] = [('Ice Trap', 1)]
+        # Get a list of all "junk" type items
+        junk = [item for item, weight in junk_pool_base] + ['Rupee (1)', 'Recovery Heart', 'Bombs (20)', 'Arrows (30)']
+        junk_count = get_pool_count(pool, junk) 
+        num_to_replace = int((world.settings.custom_ice_trap_percent / 100.0) * junk_count) if world.settings.junk_ice_traps == 'custom_percent' else world.settings.custom_ice_trap_count
+        replace_x_items(pool, junk, num_to_replace)
 
     # Make sure our pending_junk_pool is empty. If not, remove some random junk here.
     if pending_junk_pool:

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -911,14 +911,6 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
 
     world.distribution.alter_pool(world, pool)
 
-    if world.settings.junk_ice_traps in ['custom_count', 'custom_percent']:
-        junk_pool[:] = [('Ice Trap', 1)]
-        # Get a list of all "junk" type items
-        junk = [item for item, weight in junk_pool_base] + ['Rupee (1)', 'Recovery Heart', 'Bombs (20)', 'Arrows (30)']
-        junk_count = get_pool_count(pool, junk)
-        num_to_replace = int((world.settings.custom_ice_trap_percent / 100.0) * junk_count) if world.settings.junk_ice_traps == 'custom_percent' else world.settings.custom_ice_trap_count
-        replace_x_items(pool, junk, num_to_replace)
-
     # Make sure our pending_junk_pool is empty. If not, remove some random junk here.
     if pending_junk_pool:
         for item in set(pending_junk_pool):
@@ -945,6 +937,14 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
             junk_candidates.remove(junk_item)
             pool.remove(junk_item)
             pool.append(pending_item)
+
+    if world.settings.junk_ice_traps in ['custom_count', 'custom_percent']:
+        junk_pool[:] = [('Ice Trap', 1)]
+        # Get a list of all "junk" type items
+        junk = [item for item, weight in junk_pool_base] + ['Rupee (1)', 'Recovery Heart', 'Bombs (20)', 'Arrows (30)']
+        junk_count = get_pool_count(pool, junk)
+        num_to_replace = int((world.settings.custom_ice_trap_percent / 100.0) * junk_count) if world.settings.junk_ice_traps == 'custom_percent' else world.settings.custom_ice_trap_count
+        replace_x_items(pool, junk, num_to_replace)
 
     if world.settings.item_pool_value == 'ludicrous':
         # Replace all junk items with major items

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -915,7 +915,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         junk_pool[:] = [('Ice Trap', 1)]
         # Get a list of all "junk" type items
         junk = [item for item, weight in junk_pool_base] + ['Rupee (1)', 'Recovery Heart', 'Bombs (20)', 'Arrows (30)']
-        junk_count = get_pool_count(pool, junk) 
+        junk_count = get_pool_count(pool, junk)
         num_to_replace = int((world.settings.custom_ice_trap_percent / 100.0) * junk_count) if world.settings.junk_ice_traps == 'custom_percent' else world.settings.custom_ice_trap_count
         replace_x_items(pool, junk, num_to_replace)
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3630,7 +3630,7 @@ class SettingInfos:
             replaced by Ice Traps, even those in the
             base pool.
 
-            'Custom (count)' : Allows specifying a specific number of
+            'Custom (count)': Allows specifying a specific number of
             "Junk items" to be converted to Ice Traps in the pool.
 
             'Custom (%)' : Allows specifiying a percentage of

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3633,7 +3633,7 @@ class SettingInfos:
             'Custom (count)': Allows specifying a specific number of
             "Junk items" to be converted to Ice Traps in the pool.
 
-            'Custom (%)' : Allows specifiying a percentage of
+            'Custom (%)': Allows specifiying a percentage of
             "Junk" items to be converted to Ice Traps in the pool
         ''',
         shared         = True,

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3675,6 +3675,7 @@ class SettingInfos:
         shared         = True,
         gui_params     = {
             "hide_when_disabled": True,
+            "size": "medium"
         },
     )
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3630,7 +3630,7 @@ class SettingInfos:
             replaced by Ice Traps, even those in the
             base pool.
 
-            'Custom (count)' : Allows specifying a specific number of 
+            'Custom (count)' : Allows specifying a specific number of
             "Junk items" to be converted to Ice Traps in the pool.
 
             'Custom (%)' : Allows specifiying a percentage of

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3606,11 +3606,13 @@ class SettingInfos:
         gui_text       = 'Ice Traps',
         default        = 'normal',
         choices        = {
-            'off':       'No Ice Traps',
-            'normal':    'Normal Ice Traps',
-            'on':        'Extra Ice Traps',
-            'mayhem':    'Ice Trap Mayhem',
-            'onslaught': 'Ice Trap Onslaught',
+            'off':              'No Ice Traps',
+            'normal':           'Normal Ice Traps',
+            'on':               'Extra Ice Traps',
+            'mayhem':           'Ice Trap Mayhem',
+            'onslaught':        'Ice Trap Onslaught',
+            'custom_count':     'Custom (count)',
+            'custom_percent':   'Custom (%)',
         },
         gui_tooltip    = '''\
             'Off': All Ice Traps are removed.
@@ -3627,8 +3629,53 @@ class SettingInfos:
             'Ice Trap Onslaught': All junk items will be
             replaced by Ice Traps, even those in the
             base pool.
+
+            'Custom (count)' : Allows specifying a specific number of 
+            "Junk items" to be converted to Ice Traps in the pool.
+
+            'Custom (%)' : Allows specifiying a percentage of
+            "Junk" items to be converted to Ice Traps in the pool
         ''',
         shared         = True,
+        disable        = {
+            'off' : {'settings': ['custom_ice_trap_percent', 'custom_ice_trap_count']},
+            'normal' : {'settings': ['custom_ice_trap_percent', 'custom_ice_trap_count']},
+            'on' : {'settings': ['custom_ice_trap_percent', 'custom_ice_trap_count']},
+            'mayhem' : {'settings': ['custom_ice_trap_percent', 'custom_ice_trap_count']},
+            'onslaught' : {'settings': ['custom_ice_trap_percent', 'custom_ice_trap_count']},
+            'custom_percent' : {'settings': ['custom_ice_trap_count']},
+            'custom_count' : {'settings': ['custom_ice_trap_percent']}
+        }
+    )
+
+    custom_ice_trap_percent = Scale(
+        gui_text       = 'Custom Ice Trap Percent',
+        default        = 50,
+        minimum        = 0,
+        maximum        = 100,
+        gui_tooltip    = '''\
+            Percentage of junk items that will be replaced
+            with Ice Traps when using 'Custom' Ice Traps setting.
+        ''',
+        shared         = True,
+        gui_params     = {
+            "hide_when_disabled": True,
+        },
+    )
+
+    custom_ice_trap_count = Scale(
+        gui_text       = 'Custom Ice Trap Count',
+        default        = 100,
+        minimum        = 0,
+        maximum        = 2000,
+        gui_tooltip    = '''\
+            Number of junk items that will be replaced
+            with Ice Traps when using 'Custom' Ice Traps setting.
+        ''',
+        shared         = True,
+        gui_params     = {
+            "hide_when_disabled": True,
+        },
     )
 
     ice_trap_appearance = Combobox(

--- a/Unittest.py
+++ b/Unittest.py
@@ -232,6 +232,9 @@ class TestPlandomizer(unittest.TestCase):
             "plando-new-placed-ice-traps",
             "plando-placed-and-added-ice-traps",
             "non-standard-visible-ice-traps",
+            "custom-ice-traps-percent-triforce-hunt",
+            "custom-ice-traps-count",
+            "custom-ice-traps-percent"
         ]
         for filename in filenames:
             with self.subTest(filename):
@@ -257,6 +260,19 @@ class TestPlandomizer(unittest.TestCase):
                     with self.subTest("ice trap models in non-standard visible locations"):
                         for location in distribution_file['locations']:
                             self.assertIn('model', spoiler['locations'][location])
+                if filename == "custom-ice-traps-count":
+                    self.assertEqual(spoiler['item_pool']['Ice Trap'], 50)
+                if filename in  ["custom-ice-traps-percent", "custom-ice-traps-percent-triforce-hunt"]:
+                    # Count up all the junk that is left
+                    from ItemPool import junk_pool_base
+                    junk = [item for item, weight in junk_pool_base] + ['Rupee (1)', 'Recovery Heart', 'Bombs (20)', 'Arrows (30)']
+                    junk_count = 0
+                    for item in spoiler['item_pool'].keys():
+                        if item in junk:
+                            junk_count += spoiler['item_pool'][item]
+                    ice_trap_count = spoiler['item_pool']['Ice Trap']
+                    # Check that 75% of the junk is ice traps, per the plando
+                    self.assertEqual(int((junk_count + ice_trap_count) * .75), ice_trap_count)
 
     def test_should_not_throw_exception(self):
         filenames = [

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -377,6 +377,8 @@
           "settings": [
             "item_pool_value",
             "junk_ice_traps",
+            "custom_ice_trap_percent",
+            "custom_ice_trap_count",
             "ice_trap_appearance"
           ]
         }

--- a/tests/plando/custom-ice-traps-count.json
+++ b/tests/plando/custom-ice-traps-count.json
@@ -1,0 +1,6 @@
+{
+    "settings": {
+        "junk_ice_traps": "custom_count",
+        "custom_ice_trap_count": 50
+    }
+}

--- a/tests/plando/custom-ice-traps-percent-triforce-hunt.json
+++ b/tests/plando/custom-ice-traps-percent-triforce-hunt.json
@@ -1,0 +1,10 @@
+{
+    "settings": {
+        "triforce_hunt": true,
+        "shuffle_pots": "all",
+        "triforce_count_per_world": 100,
+        "triforce_goal_per_world": 50,
+        "junk_ice_traps": "custom_percent",
+        "custom_ice_trap_percent": 75
+    }
+}

--- a/tests/plando/custom-ice-traps-percent.json
+++ b/tests/plando/custom-ice-traps-percent.json
@@ -1,0 +1,6 @@
+{
+    "settings": {
+        "junk_ice_traps": "custom_percent",
+        "custom_ice_trap_percent": 75
+    }
+}


### PR DESCRIPTION
Adds setting to select a custom amount of ice traps. When pots/crates/etc. are enabled, there is a pretty big jump between Ice Trap "Mayhem" and "Onslaught" because all of the junk items from pots don't get included under Mayhem. This setting allows more fine-grained control over how many ice traps are in the seed.

Two additional items are available under the "Ice Traps" drop down:
- Custom (count):  Specify an exact amount of "Junk" items to be converted to Ice Traps
- Custom (%): Specify a percentage of the "Junk" items to be converted to Ice Traps.

In both of these cases, "Junk" items includes base pool junk.