### PR TITLE
Fix Grog spawn in Lost Woods with trade quest fully unshuffled

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1335,7 +1335,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
 
     # Mark unreachable trade-ins as traded. Only applicable with trade quest shuffle off,
     # and only practically affects the Blue Potion purchase from Granny's Potion Shop.
-    if not world.settings.adult_trade_shuffle:
+    if not world.settings.adult_trade_shuffle and len(world.settings.adult_trade_start) > 0:
         def calculate_traded_flags(world):
             traded_flags = 0
             reverting_item_map = {


### PR DESCRIPTION
Fixes #2018. Extends #1911 fixes to adult trade shuffle fully disabled with Pocket Egg placed at Anju as Adult.

I could use help making sure the following didn't regress with this fix:
* Skull Kid in LW only spawns if Grog or Fado aren't there
* Grog and Fado spawn only when the player has their trade item and hasn't turned it in, trade shuffle on/off
* Granny's Potion Shop item purchase still works, trade shuffle on/off plus expensive merchants on/off
* Shuffled adult trade item but not full trade shuffle sets appropriate flags for the above three bullets
* Above bullet with starting trade item before, at, and after each of the trading actors' items