### PR TITLE
Fix generation of bad goal hints in multiworld

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -618,7 +618,7 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
     # Collect unhinted locations for the category across all category goals.
     # If all locations for all goals in the category are hinted, try remaining goal categories
     # If all locations for all goal categories are hinted, return no hint.
-    while not category_locations:
+    while not location_reverse_map:
         # Filter hinted goals until every goal in the category has been hinted.
         weights = []
         zero_weights = True
@@ -629,23 +629,21 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
 
         # Collect set of unhinted locations for the category. Reduces the bias
         # from locations in multiple goals for the category.
-        category_locations = []
-        location_reverse_map = defaultdict(list)
+        location_reverse_map = defaultdict(set)
         for goal in goals:
             if zero_weights or goal.weight > 0:
                 goal_locations = list(filter(lambda location:
-                    location not in category_locations
-                    and location[0].name not in checked
+                    location[0].name not in checked
                     and location[0].name not in world.hint_exclusions
                     and location[0].name not in world.hint_type_overrides['goal']
                     and location[0].item.name not in world.item_hint_type_overrides['goal']
                     and location[0].item.name not in unHintableWothItems,
                     goal.required_locations))
                 for location in goal_locations:
-                    location_reverse_map[location[0]].append(goal)
-                category_locations.extend(goal_locations)
+                    for world_id in location[3]:
+                        location_reverse_map[location[0]].add((goal, world_id))
 
-        if not category_locations:
+        if not location_reverse_map:
             del world.goal_categories[goal_category.name]
             goal_category = get_goal_category(spoiler, world, world.goal_categories)
             if not goal_category:
@@ -653,12 +651,9 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
             else:
                 goals = goal_category.goals
 
-    location_tuple = random.choice(category_locations)
-    location = location_tuple[0]
-    world_ids = location_tuple[3]
-    world_id = random.choice(world_ids)
+    location, goal_set = random.choice(list(location_reverse_map.items()))
+    goal, world_id = random.choice(list(goal_set))
     checked.add(location.name)
-    goal = random.choice(location_reverse_map[location])
 
     # Make sure this wasn't the last hintable location for other goals.
     # If so, set weights to zero. This is important for one-hint-per-goal.


### PR DESCRIPTION
Fixes an issue in the goal hint system. In multiworld seeds, this can result in hints for the wrong world's goal. The fix also happens to address some minor biasing.

In the example I debugged, a Ruto's Letter in World 0 was considered required for 3 goals: W1 Fire Medallion, W0 Shadow Medallion, and W1 Spirit Medallion. Due to the bug, it generated a hint for the invalid combination W0 Spirit Medallion. Since Spirit Medallion was a starting item in W0, the hint text was "path to Link's pocket". That's an obviously broken hint, but in other circumstances the fact that the hint is incorrect can be non-obvious.

The bug is in the relationship between category_locations and location_reverse_map in get_goal_hint. category_locations is populated with multiple goals' required_locations tuples, which describe the set of worlds in which the location is required for a goal. location_reverse_map is populated with the set of goals a location is required for. To generate a hint, we draw a location + world from category_locations, and then a goal for the location from location_reverse_map. The problem is that we're drawing the world and the goal independently, and can end up with invalid combinations of world + goal.

The fix I went with eliminates category_locations. The required_locations tuple data in category_locations isn't a great fit here because its world list can only be interpreted in the context of a specific goal; pulling the tuples of multiple goals into a list loses that context.
Instead, I enhanced location_reverse_map to map locations to a set of goal+world tuples. We draw a location first and then the goal+world. Let me know if that's not ideal in terms of random distribution (e.g. if I should nest world *under* goals to give uniform chance of selecting a given goal, regardless of how many worlds it shows up in). My intuition is that if a location is required for 5 different worlds' Shadow Medallions, and 1 world's Kokiri Emerald, then it's fine for the location to be more likely to be hinted as path of one of the Shadows; but if that's not the preferred/precedented approach then it's easy to change.

When debugging the issue, I also noticed that category_locations introduces some interesting bias. "location not in category_locations" is used to filter out duplicate entries to prevent bias towared multi-required locations being hinted more often. However, these entries are required_locations tuples, which contain a per-goal world list in addition to the location itself. That leads to some odd behavior:
* If 2 goals have non-identical required_locations tuples for the same location (i.e. because of different world lists), then the location is double-counted in category_locations, creating bias toward selecting that location.
* On the other hand, if 2 goals have identical required_locations tuples, then the second one gets filtered out. That's good from the perspective of avoiding bias toward multi-required locations, but it also means that the second goal doesn't get put into location_reverse_map. This creates subtle bias toward hinting goals that are earlier in the category's goal ordering (e.g. hinting Stones over Medallions). This would affect single-world seeds as well.

In the Ruto's Letter example I debugged, when the first goal hint was generated the RL could only be hinted as path of W1 Fire Medallion or W0 Shadow Medallion, even though it was also required for W1 Spirit Medallion. The RL was double-counted in category_locations, making it more likely to be drawn. And the potential for hinting W1 Spirit Medallion was completely suppressed because the Fire and Spirit goals had identical required_locations tuples (i.e. "RL is required for this goal in W1"). We eventually generated a *different* path of Fire, which lowered the Fire goal's weight to 0; this removed the suppression, allowing the W1 Spirit hint to be considered and ultimately incorrectly used to hint the RL as path of W0 Spirit.

Please do let me know if I've made any mistakes in terms of style/best-practice, as well as functionality. Python isn't my native language.