### PR TITLE
Fix Biggoron being an always hint when Adult Trade Shuffle is on

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -219,7 +219,7 @@ conditional_always: dict[str, Callable[[World], bool]] = {
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
     'HF Ocarina of Time Item':      lambda world: stones_required_by_settings(world) < 2,
     'Sheik in Kakariko':            lambda world: medallions_required_by_settings(world) < 5,
-    'DMT Biggoron':                 lambda world: 'Claim Check' not in world.settings.adult_trade_start or len(world.settings.adult_trade_start) != 1,
+    'DMT Biggoron':                 lambda world: ('Claim Check' not in world.settings.adult_trade_start or len(world.settings.adult_trade_start) != 1) and not world.settings.adult_trade_shuffle,
     'Kak 30 Gold Skulltula Reward': lambda world: tokens_required_by_settings(world) < 30 and '30_skulltulas' not in world.settings.misc_hints,
     'Kak 40 Gold Skulltula Reward': lambda world: tokens_required_by_settings(world) < 40 and '40_skulltulas' not in world.settings.misc_hints,
     'Kak 50 Gold Skulltula Reward': lambda world: tokens_required_by_settings(world) < 50 and '50_skulltulas' not in world.settings.misc_hints,


### PR DESCRIPTION
Fixes #2024 that i opened yesterday.

Biggoron will now only be a sometimes hint if Adult Trade Shuffle is on.

Generated 20 seeds without adult trade shuffle : all seeds have a Biggoron hint.
Generated 20 seeds with adult trade shuffle : some seed have a Biggoron hint, but not all. There were some seeds where Biggoron had a required item, and it was the target of a WOTH hint. There was also one seed where Biggoron had a required item but was not hinted in any way.