### PR TITLE
Fix goal hint nondeterminism introduced by #2021

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -629,7 +629,7 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
 
         # Collect set of unhinted locations for the category. Reduces the bias
         # from locations in multiple goals for the category.
-        location_reverse_map = defaultdict(set)
+        location_reverse_map = defaultdict(list)
         for goal in goals:
             if zero_weights or goal.weight > 0:
                 goal_locations = list(filter(lambda location:
@@ -641,7 +641,7 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
                     goal.required_locations))
                 for location in goal_locations:
                     for world_id in location[3]:
-                        location_reverse_map[location[0]].add((goal, world_id))
+                        location_reverse_map[location[0]].append((goal, world_id))
 
         if not location_reverse_map:
             del world.goal_categories[goal_category.name]
@@ -651,8 +651,8 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
             else:
                 goals = goal_category.goals
 
-    location, goal_set = random.choice(list(location_reverse_map.items()))
-    goal, world_id = random.choice(list(goal_set))
+    location, goal_list = random.choice(list(location_reverse_map.items()))
+    goal, world_id = random.choice(goal_list)
     checked.add(location.name)
 
     # Make sure this wasn't the last hintable location for other goals.


### PR DESCRIPTION
I used a set. *Really* shouldn't have done that. The internal ordering of the set isn't the same across generations, so the seeded random pull doesn't result in the same goal+world tuple every time.

The result is that the same location gets hinted, but if the location is required for multiple goal+worlds, it's inconsistent which is selected.