### PR TITLE
Remove wallet requirement from Buy Arrows (50)

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -140,7 +140,7 @@ def set_shop_rules(world: World):
     for location in world.get_filled_locations():
         if location.item.type == 'Shop':
             # Add wallet requirements
-            if location.item.name in ['Buy Arrows (50)', 'Buy Fish', 'Buy Goron Tunic', 'Buy Bombchu (20)', 'Buy Bombs (30)']:
+            if location.item.name in ['Buy Fish', 'Buy Goron Tunic', 'Buy Bombchu (20)', 'Buy Bombs (30)']:
                 location.add_rule(wallet)
             elif location.item.name in ['Buy Zora Tunic', 'Buy Blue Fire']:
                 location.add_rule(wallet2)


### PR DESCRIPTION
Extremely minor change that has no practical impact as ammo refills are not accounted for currently. 50 arrows cost 90 rupees, which is technically possible with the default wallet.

![image](https://github.com/OoTRandomizer/OoT-Randomizer/assets/19615534/8ed2853e-5910-4dc7-990c-1793a81b8f9f)
