### PR TITLE
Mask Shop Logic Fix

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1402,7 +1402,7 @@
         "scene": "Market Mask Shop",
         "exits": {
             "Market": "True",
-            "Market Mask Shop Storefront": "'Kakariko Village Gate Open'"
+            "Market Mask Shop Storefront": "Zeldas_Letter and 'Kakariko Village Gate Open'"
         }
     },
     {


### PR DESCRIPTION
Untested quick fix.

I forgot that you still needed the Letter to use the mask shop even when the gate is open. In vanilla, it's showing the letter to the guard that opens the shop. You can get the gate open early by going adult (it's the going adult cutscenes that shares a flag or something?; in rando we set those flags to skip the cutscenes, which is why the gate was automatically opened in early versions), but you still have to show the letter. We fixed the bug where the gate was automatically opened by the adult cutscenes being viewed. Then we added a setting to add back having the gate automatically opened from the start (and then later the open on zelda setting on top of that). At some point we changed it so that the gate being open means the mask shop is also open, but you still needed zelda's letter because otherwise you could get locked out of malon/talon. Now with trade quest shuffle, I'm not entirely sure that's still desired behaviour anymore? If you can just select an earlier trade item, it doesn't seem like it should be necessary? Perhaps there's a change that could be made there I dunno.

So somewhere in there I got confused and I just kind of forgot about the still needing the letter thing. The check for it wasn't intentionally removed, I just forgot it was supposed to be there and so it got lost in the rewrite. In my defense the behaviour has changed a lot.