### PR TITLE
Fix possible softlock with Key Rings give Boss Keys

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1109,6 +1109,15 @@ class WorldDistribution:
                     self.skipped_locations.append(loc)
                 if loc.item is not None and world.id == loc.item.world.id:
                     add_starting_item_with_ammo(items, loc.item.name)
+            # With small keysy, key rings, and key rings give boss key, but boss keysy
+            # is not on, boss keys are still required in the game to open boss doors.
+            # The boss key is also shuffled in the world, but may not be reachable as
+            # logic assumes the boss key was already obtained with the free keysy keyring.
+            for dungeon in world.dungeons:
+                if (dungeon.name in world.settings.key_rings and dungeon.name != 'Ganons Castle'
+                    and dungeon.shuffle_smallkeys == 'remove' and dungeon.shuffle_bosskeys != 'remove'
+                    and world.settings.keyring_give_bk and len(dungeon.boss_key) > 0):
+                    items[dungeon.boss_key[0].name] = StarterRecord(1)
 
         effective_adult_trade_item_index = -1
         effective_child_trade_item_index = -1


### PR DESCRIPTION
if Key Rings give Boss Keys is on, Key Rings are enabled for a dungeon, small keys are removed from the world, and boss keys are shuffled anywhere, logic assumes the player starts with boss keys for dungeons with key rings. Boss keys are still shuffled in the item pool, and you do not start with any boss keys in the rom.

Using [OoT_36F6D_XLY3J1WCQ5_Spoiler.txt](https://github.com/OoTRandomizer/OoT-Randomizer/files/12065235/OoT_36F6D_XLY3J1WCQ5_Spoiler.txt) as a plando, if you step through search, it'll pick up the King Dodongo boss room chest in sphere 2 behind the locked Fire Temple boss door, with the shuffled Fire BK locked away in Child Fishing with no way to go child.

This PR gives the player boss keys as starting items for any dungeon with keyrings enabled with the above settings combination. The exception is if boss keys are also removed, in which case having boss keys in-game is irrelevant.