### PR TITLE
Fix search Time of Day feedback to the Root region

### DIFF
--- a/Search.py
+++ b/Search.py
@@ -135,7 +135,7 @@ class Search:
                     # If it found a new tod, make sure we try other entrances again.
                     # Probably would take too long and not be worth it if we only grabbed the exits
                     # for the given world...
-                    if exit.connected_region.provides_time and not regions[exit.world.get_region('Root')] & exit.connected_region.provides_time:
+                    if exit.connected_region.provides_time and ~regions[exit.world.get_region('Root')] & exit.connected_region.provides_time:
                         exit_queue.extend(failed)
                         failed = []
                         regions[exit.world.get_region('Root')] |= exit.connected_region.provides_time


### PR DESCRIPTION
Accessible times of day are supposed to be passed back to the Root region when searching the world graph encounters a new time of day. This time of day is then spread from Root to every region accessible from Root the next time an exit or location with time of day requirements in its access rules is tested for accessibility. Entrance shuffle has a test in world validation to ensure both ages have itemless access to regions providing all times of day. This validation step works as expected.

However, there is a problem in the search algorithm condition to spread time of day back to Root if the first region providing time does not provide all times of day. For example, if adult encounters Ganons Castle Grounds before an area where time passes, Root will be updated to provide TimeOfDay.DAMPE (2). Subsequently finding an area where time passes (TimeOfDay.ALL or 3) will always fail to pass this time of day back to Root because the bit math will always be truthy, which is then negated by the conditional. Since there are no areas providing exclusively TimeOfDay.DAY, Root will never have day access in search until Sun Song and Ocarina are found. A practical example can be found in this spoiler: [OoT_604B0_8WZHPMGQLG_Spoiler.txt](https://github.com/OoTRandomizer/OoT-Randomizer/files/12065852/OoT_604B0_8WZHPMGQLG_Spoiler.txt). Adult spawns in Kakariko at night, and logic will not collect Kak Anju as Adult until sphere 5 instead of sphere 0, as Sun Song and Ocarina are not available until Sphere 5. Sphere numbers used here are from the full playthrough before reduction for the spoiler log.

This PR fixes the issue by using the same bit math as seen in `_expand_tod_regions`. As stated before, this does not affect seed completion as the entrance shuffle check uses an independent process to ensure itemless access to all times of day from Root. This will affect item placement, relaxing restrictions in edge cases like the attached spoiler.