### PR TITLE
Fix misc hint for Expensive Merchants when the item name is longer than one line

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -2133,7 +2133,11 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         else:
             location = world.get_location("ZR Magic Bean Salesman")
             item_text = get_hint(get_item_generic_name(location.item), True).text
-            update_message_by_id(messages, 0x405E, "\x1AChomp chomp chomp...We have...\x01\x05\x41" + item_text + "\x05\x40! \x01Do you want it...huh? Huh?\x04\x05\x41\x0860 Rupees\x05\x40 and it's yours!\x01Keyahahah!\x01\x1B\x05\x42Yes\x01No\x05\x40\x02")
+            wrapped_item_text = line_wrap(item_text, False, False, False)
+            if wrapped_item_text != item_text:
+                update_message_by_id(messages, 0x405E, "\x1AChomp chomp chomp...We have...\x01\x05\x41" + wrapped_item_text + "\x05\x40!\x04\x05\x41\x0860 Rupees\x05\x40 and it's yours!\x01Keyahahah!\x01\x1B\x05\x42Yes\x01No\x05\x40\x02")
+            else:
+                update_message_by_id(messages, 0x405E, "\x1AChomp chomp chomp...We have...\x01\x05\x41" + item_text + "\x05\x40! \x01Do you want it...huh? Huh?\x04\x05\x41\x0860 Rupees\x05\x40 and it's yours!\x01Keyahahah!\x01\x1B\x05\x42Yes\x01No\x05\x40\x02")
         update_message_by_id(messages, 0x4069, "You don't have enough money.\x01I can't sell it to you.\x01Chomp chomp...\x02")
         update_message_by_id(messages, 0x406C, "We hope you like it!\x01Chomp chomp chomp.\x02")
         # Change first magic bean to cost 60 (is used as the price for the one time item when beans are shuffled)
@@ -2147,7 +2151,11 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         else:
             location = world.get_location("Wasteland Bombchu Salesman")
             item_text = get_hint(get_item_generic_name(location.item), True).text
-            update_message_by_id(messages, 0x6077, "\x06\x41Well Come!\x04I am selling stuff, strange and \x01rare, from all over the world to \x01everybody. Today's special is...\x01\x05\x41"+ item_text + "\x05\x40! \x01\x04How about \x05\x41200 Rupees\x05\x40?\x01\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
+            wrapped_item_text = line_wrap(item_text, False, False, False)
+            if wrapped_item_text != item_text:
+                update_message_by_id(messages, 0x6077, "\x06\x41Well Come!\x04I am selling stuff, strange and \x01rare. Today's special is...\x01\x05\x41"+ wrapped_item_text + "\x05\x40!\x04How about \x05\x41200 Rupees\x05\x40?\x01\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
+            else:
+                update_message_by_id(messages, 0x6077, "\x06\x41Well Come!\x04I am selling stuff, strange and \x01rare, from all over the world to \x01everybody. Today's special is...\x01\x05\x41"+ wrapped_item_text + "\x05\x40! \x01\x04How about \x05\x41200 Rupees\x05\x40?\x01\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
         update_message_by_id(messages, 0x6078, "Thank you very much!\x04The mark that will lead you to\x01the Spirit Temple is the \x05\x41flag on\x01the left \x05\x40outside the shop.\x01Be seeing you!\x02")
 
         rom.write_byte(rom.sym('SHUFFLE_MEDIGORON'), 0x01)
@@ -2159,7 +2167,11 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         else:
             location = world.get_location("GC Medigoron")
             item_text = get_hint(get_item_generic_name(location.item), True).text
-            update_message_by_id(messages, 0x304F, "For 200 Rupees, how about buying \x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
+            wrapped_item_text = line_wrap(item_text, False, False, False)
+            if wrapped_item_text != item_text:
+                update_message_by_id(messages, 0x304F, "For 200 Rupees, how about buying...\x04\x05\x41" + wrapped_item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
+            else:
+                update_message_by_id(messages, 0x304F, "For 200 Rupees, how about buying \x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
 
         rom.write_byte(rom.sym('SHUFFLE_GRANNYS_POTION_SHOP'), 0x01)
         if 'unique_merchants' not in world.settings.misc_hints:
@@ -2167,7 +2179,11 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         else:
             location = world.get_location("Kak Granny Buy Blue Potion")
             item_text = get_hint(get_item_generic_name(location.item), True).text
-            update_message_by_id(messages, 0x500C, "How about \x05\x41100 Rupees\x05\x40 for\x01\x05\x41"+ item_text +"\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
+            wrapped_item_text = line_wrap(item_text, False, False, False)
+            if wrapped_item_text != item_text:
+                update_message_by_id(messages, 0x500C, "How about \x05\x41100 Rupees\x05\x40 for...\x04\x05\x41"+ wrapped_item_text +"\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
+            else:
+                update_message_by_id(messages, 0x500C, "How about \x05\x41100 Rupees\x05\x40 for\x01\x05\x41"+ item_text +"\x05\x40?\x01\x1B\x05\x42Buy\x01Don't buy\x05\x40\x02")
 
     new_message = "All right. You don't have to play\x01if you don't want to.\x0B\x02"
     update_message_by_id(messages, 0x908B, new_message, 0x00)
@@ -2182,7 +2198,11 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         else:
             location = world.get_location("Market Treasure Chest Game Salesman")
             item_text = get_hint(get_item_generic_name(location.item), True).text
-            update_message_by_id(messages, 0x6D, "I seem to have misplaced my\x01keys, but I have a fun item to\x01sell instead.\x04How about \x05\x4110 Rupees\x05\x40 for\x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't Buy\x05\x40\x02")
+            wrapped_item_text = line_wrap(item_text, False, False, False)
+            if wrapped_item_text != item_text:
+                update_message_by_id(messages, 0x6D, "I seem to have misplaced my\x01keys, but I have a fun item to\x01sell instead.\x01How about \x05\x4110 Rupees\x05\x40 for...\x04\x05\x41" + wrapped_item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't Buy\x05\x40\x02")
+            else:
+                update_message_by_id(messages, 0x6D, "I seem to have misplaced my\x01keys, but I have a fun item to\x01sell instead.\x04How about \x05\x4110 Rupees\x05\x40 for\x01\x05\x41" + item_text + "\x05\x40?\x01\x1B\x05\x42Buy\x01Don't Buy\x05\x40\x02")
         update_message_by_id(messages, 0x908B, "That's OK!\x01More fun for me.\x0B\x02", 0x00)
         update_message_by_id(messages, 0x6E, "Wait, that room was off limits!\x02")
         update_message_by_id(messages, 0x704C, "I hope you like it!\x02")


### PR DESCRIPTION
The formatting expected only one line of text for the item name, but some of them (notably Silver Rupee Pouches) can be longer than that.
This PR checks if the item name will be longer than one line by using the line_wrap function in Textbox, and re-arranges the hint textbox if it's the case.

Here are the new resulting textboxes (compare with https://github.com/OoTRandomizer/OoT-Randomizer/pull/1930 for the original ones).
ZR Magic Bean Salesman : 
![hintbean](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/158389d8-6eb9-46e2-8996-a11a4b58a39f)
Wasteland Bombchu Salesman : 
![hintcarpet](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/0afef3b8-8fb9-49e2-85e4-fb77e8e0f559)
GC Medigoron (now two textboxes instead of one) : 
![hintmedigoron1](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/eb9ca39a-d01f-405d-af9f-047e3332e01a)
![hintmedigoron2](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/41c8392f-b9dd-4b31-b867-e2a7d39bec9a)
Kak Granny Buy Blue Potion (now two textboxes instead of one) :  
![hintgranny1](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/309e81d0-c23b-4425-96df-1e9c86bf0bb6)
![hintgranny2](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/e4afa3fe-4849-4ac3-89c1-5365e304d8a7)
Market Treasure Chest Game Salesman : 
![hintcmg1](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/5cee687e-1a2a-472b-96eb-f7e1158bbcec)
![hintcmg2](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/488ddd96-1323-45aa-8f79-e63b473e503d)
