### PR TITLE
King Zora conditionnal dual hint

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -250,10 +250,12 @@ conditional_sometimes: dict[str, Callable[[World], bool]] = {
     'HC Great Fairy Reward':                    lambda world: world.settings.shuffle_interior_entrances == 'off',
     'OGC Great Fairy Reward':                   lambda world: world.settings.shuffle_interior_entrances == 'off',
     'ZR Frogs in the Rain':                     lambda world: not world.settings.shuffle_frog_song_rupees,
+    'ZD King Zora Thawed':                      lambda world: not world.settings.adult_trade_shuffle,
 
     # Conditional dual hints
     'GV Pieces of Heart Ledges':                lambda world: not world.settings.shuffle_cows and world.settings.tokensanity not in ['overworld', 'all'],
     'LH Adult Bean Destination Checks':         lambda world: world.settings.shuffle_interior_entrances == 'off',
+    'King Zora Items':                          lambda world: world.settings.adult_trade_shuffle,
 
     'Fire Temple Lower Loop':                   lambda world: world.settings.tokensanity not in ['dungeons', 'all'],
     'Water Temple River Loop Chests':           lambda world: world.settings.tokensanity not in ['dungeons', 'all'],
@@ -620,6 +622,7 @@ hintTable: dict[str, tuple[list[str] | str, Optional[str], str | list[str]]] = {
     'Graveyard Royal Family Tomb Contents':                        ("inside the #Royal Family Tomb#, you will find...^", None, 'dual'),
     'DMC Child Upper Checks':                                      ("in the #crater, a spider in a crate and a single scrub# guard...^", None, 'dual'),
     'Haunted Wasteland Checks':                                    ("deep in the #wasteland a spider and a chest# hold...^", None, 'dual'),
+    'King Zora Items':                                             ("#unfreezing King Zora and giving him Prescription# rewards both...^", None, 'dual'),
 
     'Deku Tree MQ Basement GS':                                    ("in the back of the #basement of the Great Deku Tree# two spiders hold...^", None, 'dual'),
     'Dodongos Cavern Upper Business Scrubs':                       ("deep in #Dodongo's Cavern a pair of scrubs# sell...^", None, 'dual'),
@@ -1726,6 +1729,7 @@ multiTable: dict[str, list[str]] = {
     'Graveyard Royal Family Tomb Contents':                     ['Graveyard Royal Familys Tomb Chest', 'Song from Royal Familys Tomb'],
     'DMC Child Upper Checks':                                   ['DMC GS Crate', 'DMC Deku Scrub'],
     'Haunted Wasteland Checks':                                 ['Wasteland Chest', 'Wasteland GS'],
+    'King Zora Items':                                          ['ZD King Zora Thawed', 'ZD Trade Prescription'],
 
     'Deku Tree MQ Basement GS':                                 ['Deku Tree MQ GS Basement Graves Room','Deku Tree MQ GS Basement Back Room'],
     'Dodongos Cavern Upper Business Scrubs':                    ['Dodongos Cavern Deku Scrub Near Bomb Bag Left', 'Dodongos Cavern Deku Scrub Near Bomb Bag Right'],

--- a/HintList.py
+++ b/HintList.py
@@ -250,12 +250,12 @@ conditional_sometimes: dict[str, Callable[[World], bool]] = {
     'HC Great Fairy Reward':                    lambda world: world.settings.shuffle_interior_entrances == 'off',
     'OGC Great Fairy Reward':                   lambda world: world.settings.shuffle_interior_entrances == 'off',
     'ZR Frogs in the Rain':                     lambda world: not world.settings.shuffle_frog_song_rupees,
-    'ZD King Zora Thawed':                      lambda world: not world.settings.adult_trade_shuffle,
+    'ZD King Zora Thawed':                      lambda world: not world.settings.adult_trade_shuffle or 'Eyeball Frog' not in world.settings.adult_trade_start,
 
     # Conditional dual hints
     'GV Pieces of Heart Ledges':                lambda world: not world.settings.shuffle_cows and world.settings.tokensanity not in ['overworld', 'all'],
     'LH Adult Bean Destination Checks':         lambda world: world.settings.shuffle_interior_entrances == 'off',
-    'King Zora Items':                          lambda world: world.settings.adult_trade_shuffle,
+    'King Zora Items':                          lambda world: world.settings.adult_trade_shuffle and 'Eyeball Frog' in world.settings.adult_trade_start,
 
     'Fire Temple Lower Loop':                   lambda world: world.settings.tokensanity not in ['dungeons', 'all'],
     'Water Temple River Loop Chests':           lambda world: world.settings.tokensanity not in ['dungeons', 'all'],
@@ -622,7 +622,7 @@ hintTable: dict[str, tuple[list[str] | str, Optional[str], str | list[str]]] = {
     'Graveyard Royal Family Tomb Contents':                        ("inside the #Royal Family Tomb#, you will find...^", None, 'dual'),
     'DMC Child Upper Checks':                                      ("in the #crater, a spider in a crate and a single scrub# guard...^", None, 'dual'),
     'Haunted Wasteland Checks':                                    ("deep in the #wasteland a spider and a chest# hold...^", None, 'dual'),
-    'King Zora Items':                                             ("#unfreezing King Zora and giving him Prescription# rewards both...^", None, 'dual'),
+    'King Zora Items':                                             ("#unfreezing King Zora and giving him the Prescription# rewards...^", None, 'dual'),
 
     'Deku Tree MQ Basement GS':                                    ("in the back of the #basement of the Great Deku Tree# two spiders hold...^", None, 'dual'),
     'Dodongos Cavern Upper Business Scrubs':                       ("deep in #Dodongo's Cavern a pair of scrubs# sell...^", None, 'dual'),


### PR DESCRIPTION
Implements a highly requested conditionnal dual hint for turning in Prescription in adult trade shuffle.

If adult trade shuffle is off : 
- The sometimes hint for unfreezing King Zora is unchanged

If adult trade shuffle is on : 
- The sometimes hint for unfreezing King Zora is removed
- A dual hint is added for both unfreezing King Zora and turning in Prescription

Here are some of the hints generated with the new text : 

`{"text": "They say that #unfreezing King Zora and giving him Prescription# rewards both...^ #a Purple Rupee# and #a Deku Shield#.", "colors": ["Red", "Green", "Green"], "hinted_locations": ["ZD King Zora Thawed", "ZD Trade Prescription"], "hinted_items": ["Rupees (50)", "Deku Shield"]},`

`{"text": "They say that #unfreezing King Zora and giving him Prescription# rewards both...^ #Bombs (10 pieces)# and #a Purple Rupee#.", "colors": ["Red", "Green", "Green"], "hinted_locations": ["ZD King Zora Thawed", "ZD Trade Prescription"], "hinted_items": ["Bombs (10)", "Rupees (50)"]},`

`{"text": "They say that #unfreezing King Zora and giving him Prescription# rewards both...^ #a Huge Rupee# and #a Piece of Heart#.", "colors": ["Red", "Green", "Green"], "hinted_locations": ["ZD King Zora Thawed", "ZD Trade Prescription"], "hinted_items": ["Rupees (200)", "Piece of Heart"]},`