### PR TITLE
Fix Mask of Truth Always hint in child trade

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -215,7 +215,7 @@ def tokens_required_by_settings(world: World) -> int:
 # Hints required under certain settings
 conditional_always: dict[str, Callable[[World], bool]] = {
     'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3,
-    'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest,
+    'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest and 'Mask of Truth' not in world.settings.shuffle_child_trade,
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
     'HF Ocarina of Time Item':      lambda world: stones_required_by_settings(world) < 2,
     'Sheik in Kakariko':            lambda world: medallions_required_by_settings(world) < 5,


### PR DESCRIPTION
Fixes #1923

Makes Mask of Truth turn-in only a sometimes hint if it is shuffled.
It stays as an always hint if it is vanilla.