### PR TITLE
Option to randomize the Frogs 2 melody

### DIFF
--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -408,7 +408,7 @@ def generate_song_list(world: World, frog: bool, warp: bool, frogs2: bool) -> di
             if len(song1.activation) > 8:
                 raise ValueError(f'{name1} is too long (maximum is 8 notes)')
         for name2, song2 in fixed_songs.items():
-            if name1 != name2 and subsong(song1, song2):
+            if name2 != 'ZR Frogs Ocarina Game' and name1 != name2 and subsong(song1, song2):
                 raise ValueError(f'{name2} is unplayable because it contains {name1}')
     random_songs = []
 
@@ -419,7 +419,7 @@ def generate_song_list(world: World, frog: bool, warp: bool, frogs2: bool) -> di
             # test the song against all existing songs
             is_good = True
 
-            for other_song in chain(fixed_songs.values(), random_songs):
+            for other_song in chain((song for name, song in fixed_songs.items() if name != 'ZR Frogs Ocarina Game'), random_songs):
                 if subsong(song, other_song):
                     is_good = False
             if is_good:

--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -87,14 +87,14 @@ SONG_TABLE: dict[str, tuple[Optional[int], str, str]] = {
 }
 
 
-# checks if one list is a sublist of the other (in either direction)
+# checks if the first list is a sublist of the second
 # python is magic.....
 def subsong(song1: Song, song2: Song) -> bool:
     # convert both lists to strings
-    s1 = ''.join( map(chr, song1.activation))
-    s2 = ''.join( map(chr, song2.activation))
-    # check if either is a substring of the other
-    return (s1 in s2) or (s2 in s1)
+    s1 = ''.join(map(chr, song1.activation))
+    s2 = ''.join(map(chr, song2.activation))
+    # check if the first is a substring of the second
+    return s1 in s2
 
 
 # give random durations and volumes to the notes
@@ -420,7 +420,7 @@ def generate_song_list(world: World, frog: bool, warp: bool, frogs2: bool) -> di
             is_good = True
 
             for other_song in chain((song for name, song in fixed_songs.items() if name != 'ZR Frogs Ocarina Game'), random_songs):
-                if subsong(song, other_song):
+                if subsong(song, other_song) or subsong(other_song, song):
                     is_good = False
             if is_good:
                 random_songs.append(song)

--- a/OcarinaSongs.py
+++ b/OcarinaSongs.py
@@ -449,7 +449,7 @@ def patch_songs(world: World, rom: Rom) -> None:
             continue  # song activation is vanilla (possibly because this row wasn't randomized), don't randomize playback
 
         if name == 'ZR Frogs Ocarina Game':
-            rom.write_bytes(0xB78AA0, [note['note'] for note in song.playback])
+            rom.write_bytes(0xB78AA0, song.activation)
             continue
 
         # fix the song of time

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3584,7 +3584,7 @@ class SettingInfos:
             Placing yourself on the log at Zora River
             where you play the songs for the frogs will
             tell you what the reward is for playing all
-            six non warp songs.
+            six non-warp songs.
 
             If shuffled, right side items in the mask
             shop will be visible but not obtainable
@@ -3781,20 +3781,33 @@ class SettingInfos:
         },
     )
 
-    ocarina_songs = Combobox(
+    ocarina_songs = MultipleSelect(
         gui_text       = 'Randomize Ocarina Melodies',
-        default        = 'off',
+        default        = [],
         choices        = {
-            'off': 'Off',
-            'frog': 'Frog Songs Only',
-            'warp': 'Warp Songs Only',
-            'all':  'All Songs',
+            'frog':   'Top Row Songs',
+            'warp':   'Warp Songs',
+            'frogs2': 'Frogs Ocarina Game',
         },
         gui_tooltip    = '''\
             Will need to memorize a new set of songs.
             Can be silly, but difficult. All songs are
             generally sensible, but warp songs are
-            typically more difficult than frog songs.
+            typically more difficult than top row
+            songs.
+
+            "Top Row Songs": Randomizes Zelda's Lullaby,
+            Epona's Song, Saria's Song, Sun's Song,
+            Song of Time, and Song of Storms.
+
+            "Warp Songs": Randomizes Minuet of Forest,
+            Bolero of Fire, Serenade of Water, Requiem
+            of Spirit, Nocturne of Shadow, and Prelude
+            of Light.
+
+            "Frogs Ocarina Game": Randomizes the 14
+            notes of the final song of the Fabulous
+            Five Froggish Tenors.
             ''',
         shared         = True,
     )

--- a/World.py
+++ b/World.py
@@ -155,8 +155,9 @@ class World:
             self.resolve_random_settings()
 
         self.song_notes: dict[str, Song] = generate_song_list(self,
-            frog=settings.ocarina_songs in ('frog', 'all'),
-            warp=settings.ocarina_songs in ('warp', 'all'),
+            frog='frog' in settings.ocarina_songs,
+            warp='warp' in settings.ocarina_songs,
+            frogs2='frogs2' in settings.ocarina_songs,
         )
 
         if len(settings.hint_dist_user) == 0:

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1094,7 +1094,8 @@
             "ZR Frogs Ocarina Game": "
                 is_child and can_play(Zeldas_Lullaby) and can_play(Sarias_Song) and
                 can_play(Suns_Song) and can_play(Eponas_Song) and
-                can_play(Song_of_Time) and can_play(Song_of_Storms)",
+                can_play(Song_of_Time) and can_play(Song_of_Storms) and
+                has_all_notes_for_song('ZR Frogs Ocarina Game')",
             "ZR Frogs Zeldas Lullaby": "is_child and can_play(Zeldas_Lullaby)",
             "ZR Frogs Eponas Song": "is_child and can_play(Eponas_Song)",
             "ZR Frogs Sarias Song": "is_child and can_play(Sarias_Song)",
@@ -1108,7 +1109,7 @@
             "ZR GS Above Bridge": "can_use(Hookshot) and at_night",
             "ZR Near Grottos Gossip Stone": "True",
             "ZR Near Domain Gossip Stone": "True",
-            "ZR Frogs Ocarina Minigame Hint": "True"
+            "ZR Frogs Ocarina Minigame Hint": "is_child"
         },
         "exits": {
             "ZR Front": "True",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2502,9 +2502,10 @@
         "locations": {
             "ZR Magic Bean Salesman": "is_child",
             "ZR Frogs Ocarina Game": "
-                is_child and can_play(Zeldas_Lullaby) and can_play(Eponas_Song) and
-                can_play(Sarias_Song) and can_play(Suns_Song) and can_play(Song_of_Time) and can_play(Song_of_Storms) and
-                Ocarina_A_Button and Ocarina_C_left_Button and Ocarina_C_right_Button and Ocarina_C_down_Button",
+                is_child and
+                can_play(Zeldas_Lullaby) and can_play(Eponas_Song) and can_play(Sarias_Song) and
+                can_play(Suns_Song) and can_play(Song_of_Time) and can_play(Song_of_Storms) and
+                has_all_notes_for_song('ZR Frogs Ocarina Game')",
             "ZR Frogs Zeldas Lullaby": "is_child and can_play(Zeldas_Lullaby)",
             "ZR Frogs Eponas Song": "is_child and can_play(Eponas_Song)",
             "ZR Frogs Sarias Song": "is_child and can_play(Sarias_Song)",
@@ -2556,7 +2557,7 @@
             "Bug Shrub": "
                 (is_child or here(can_plant_bean) or Hover_Boots or logic_zora_river_lower) and
                 can_cut_shrubs and has_bottle",
-            "ZR Frogs Ocarina Minigame Hint": "True"
+            "ZR Frogs Ocarina Minigame Hint": "is_child"
         },
         "exits": {
             "ZR Front": "True",

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -179,7 +179,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -385,7 +385,7 @@
         "key_appearance_match_dungeon": false,
         "potcrate_textures_specific": [],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -598,7 +598,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -815,7 +815,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -1026,7 +1026,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -1239,7 +1239,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -1625,7 +1625,11 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "all",
+        "ocarina_songs": [
+            "frog",
+            "warp",
+            "frogs2"
+        ],
         "text_shuffle": "complete",
         "damage_multiplier": "ohko",
         "deadly_bonks": "ohko",
@@ -1821,7 +1825,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -2048,7 +2052,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -2265,7 +2269,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",
@@ -2463,7 +2467,7 @@
             "hearts"
         ],
         "soa_unlocks_potcrate_texture": false,
-        "ocarina_songs": "off",
+        "ocarina_songs": [],
         "text_shuffle": "none",
         "damage_multiplier": "normal",
         "deadly_bonks": "none",

--- a/tests/plando/plando-table-tests.json
+++ b/tests/plando/plando-table-tests.json
@@ -182,7 +182,7 @@
     "big_poe_count":                           1,
     "easier_fire_arrow_entry":                 false,
     "ruto_already_f1_jabu":                    false,
-    "ocarina_songs":                           "off",
+    "ocarina_songs":                           [],
     "correct_chest_appearances":               "both",
     "minor_items_as_major_chest":              [],
     "invisible_chests":                        false,


### PR DESCRIPTION
This PR turns the “Randomize Ocarina Melodies” setting into a multiselect and adds a 3rd option “Frogs Ocarina Game” which randomizes the song that needs to be played for the “ZR Frogs Ocarina Game” check. The notes appear in the spoiler log and can be plando'd like the other melodies, but the melody is locked to a length of exactly 14 notes. Rather than using the existing algorithm for generating random songs, a fully random sequence of notes with even weights is generated.

Special thanks to @rrealmuto whose [`random_frog_song` branch](https://github.com/rrealmuto/OoT-Randomizer/tree/random_frog_song) served as the basis for this PR.

I've also included a drive-by fix where the misc. location hint for frogs 2 was incorrectly assumed to be reachable as adult.