### PR TITLE
Fix boss keys being shuffled when they shouldn't be

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -497,7 +497,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
                     pending_junk_pool.append(f"Small Key ({dungeon})")
         if world.settings.shuffle_bosskeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
             for dungeon in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
-                if not world.settings.keyring_give_bk or dungeon not in world.settings.key_rings or world.settings.shuffle_smallkeys in ['remove', 'vanilla']:
+                if not world.settings.keyring_give_bk or dungeon not in world.settings.key_rings or world.settings.shuffle_smallkeys == 'vanilla':
                     pending_junk_pool.append(f"Boss Key ({dungeon})")
         if world.settings.shuffle_ganon_bosskey in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
             pending_junk_pool.append('Boss Key (Ganons Castle)')
@@ -760,7 +760,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
 
             # Boss Key
             if location.vanilla_item == dungeon.item_name("Boss Key"):
-                if (world.settings.shuffle_smallkeys not in ['remove', 'vanilla']
+                if (world.settings.shuffle_smallkeys != 'vanilla'
                         and dungeon.name in world.settings.key_rings and world.settings.keyring_give_bk
                         and dungeon.name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']):
                     item = get_junk_item()[0]

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -497,7 +497,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
                     pending_junk_pool.append(f"Small Key ({dungeon})")
         if world.settings.shuffle_bosskeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
             for dungeon in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']:
-                if not world.settings.keyring_give_bk or dungeon not in world.settings.key_rings or world.settings.shuffle_smallkeys not in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
+                if not world.settings.keyring_give_bk or dungeon not in world.settings.key_rings or world.settings.shuffle_smallkeys in ['remove', 'vanilla']:
                     pending_junk_pool.append(f"Boss Key ({dungeon})")
         if world.settings.shuffle_ganon_bosskey in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
             pending_junk_pool.append('Boss Key (Ganons Castle)')
@@ -760,7 +760,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
 
             # Boss Key
             if location.vanilla_item == dungeon.item_name("Boss Key"):
-                if (world.settings.shuffle_smallkeys in ['any_dungeon', 'overworld', 'keysanity', 'regional']
+                if (world.settings.shuffle_smallkeys not in ['remove', 'vanilla']
                         and dungeon.name in world.settings.key_rings and world.settings.keyring_give_bk
                         and dungeon.name in ['Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple']):
                     item = get_junk_item()[0]

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1115,8 +1115,6 @@ class WorldDistribution:
                     add_starting_item_with_ammo(items, loc.item.name)
             # With small keysy, key rings, and key rings give boss key, but boss keysy
             # is not on, boss keys are still required in the game to open boss doors.
-            # The boss key is also shuffled in the world, but may not be reachable as
-            # logic assumes the boss key was already obtained with the free keysy keyring.
             for dungeon in world.dungeons:
                 if (dungeon.name in world.settings.key_rings and dungeon.name != 'Ganons Castle'
                     and dungeon.shuffle_smallkeys == 'remove' and dungeon.shuffle_bosskeys != 'remove'


### PR DESCRIPTION
If the following conditions were true:
* Key rings were on for a dungeon
* Key rings were set to give boss keys
* Small keys were set to own dungeon or keysy

Then the boss keys would still be shuffled into the item pool, even though they shouldn't be.

As `vanilla` overrides the key ring setting, it's correct to still shuffle the BK in this case. However, `dungeon` and `remove` were excluded from this as well. You could argue that it makes sense to still shuffle the BKs under `remove` since BKs have their own keysy setting, but under current behavior you'll still start with the BK in this situation, so it doesn't make sense to also shuffle it. I changed both times this is checked for (for the base and plentiful item pool) to specifically check for `vanilla`.