### PR TITLE
Fix implicit count parsing for starting items

### DIFF
--- a/SaveContext.py
+++ b/SaveContext.py
@@ -288,7 +288,7 @@ class SaveContext:
 
     def give_item(self, world: World, item: str, count: int = 1) -> None:
         if item.endswith(')'):
-            item_base, implicit_count = item[:-1].split(' (', 1)
+            item_base, implicit_count = item[:-1].rsplit(' (', 1)
             if implicit_count.isdigit():
                 item = item_base
                 count *= int(implicit_count)


### PR DESCRIPTION
This fixes the error “Cannot give unknown starting item `Rupees (Treasure Chest Game) (5)`” that can occur if that item gets shuffled onto a skipped location.