### PR TITLE
Add a handful of __repr__ methods to improve debuggability

### DIFF
--- a/Goals.py
+++ b/Goals.py
@@ -79,6 +79,9 @@ class Goal:
             names.append(item_table[item][3]['alias'][0])
         return any(i['name'] in names and not i['hintable'] for i in self.items)
 
+    def __repr__(self) -> str:
+        return "W%d %s: %s" % (self.world.id, self.name, self.hint_text)
+
 
 class GoalCategory:
     def __init__(self, name: str, priority: int, goal_count: int = 0, minimum_goals: int = 0,

--- a/Goals.py
+++ b/Goals.py
@@ -80,7 +80,7 @@ class Goal:
         return any(i['name'] in names and not i['hintable'] for i in self.items)
 
     def __repr__(self) -> str:
-        return "W%d %s: %s" % (self.world.id, self.name, self.hint_text)
+        return "%s %s: %s" % (self.world.__repr__(), self.name, self.hint_text)
 
 
 class GoalCategory:

--- a/Item.py
+++ b/Item.py
@@ -191,6 +191,9 @@ class Item:
     def __unicode__(self) -> str:
         return '%s' % self.name
 
+    def __repr__(self) -> str:
+        return "W%d %s" % (self.world.id, self.name)
+
 
 @overload
 def ItemFactory(items: str, world: Optional[World] = None, event: bool = False) -> Item:

--- a/Item.py
+++ b/Item.py
@@ -192,7 +192,7 @@ class Item:
         return '%s' % self.name
 
     def __repr__(self) -> str:
-        return "W%d %s" % (self.world.id, self.name)
+        return "%s %s" % (self.world.__repr__(), self.name)
 
 
 @overload

--- a/Location.py
+++ b/Location.py
@@ -152,6 +152,9 @@ class Location:
     def __unicode__(self) -> str:
         return '%s' % self.name
 
+    def __repr__(self) -> str:
+        return "W%d %s with %s" % (self.world.id, self.name, self.item.__repr__() if self.item else "<empty>")
+
 
 @overload
 def LocationFactory(locations: str) -> Location:

--- a/Location.py
+++ b/Location.py
@@ -153,7 +153,7 @@ class Location:
         return '%s' % self.name
 
     def __repr__(self) -> str:
-        return "W%d %s with %s" % (self.world.id, self.name, self.item.__repr__() if self.item else "<empty>")
+        return "%s %s with %s" % (self.world.__repr__(), self.name, self.item.__repr__() if self.item else "<empty>")
 
 
 @overload

--- a/Region.py
+++ b/Region.py
@@ -158,4 +158,4 @@ class Region:
         return '%s' % self.name
 
     def __repr__(self) -> str:
-        return "W%d %s" % (self.world.id, self.name)
+        return "%s %s" % (self.world.__repr__(), self.name)

--- a/Region.py
+++ b/Region.py
@@ -156,3 +156,6 @@ class Region:
 
     def __unicode__(self) -> str:
         return '%s' % self.name
+
+    def __repr__(self) -> str:
+        return "W%d %s" % (self.world.id, self.name)

--- a/World.py
+++ b/World.py
@@ -1361,3 +1361,7 @@ class World:
 
             if useless_area:
                 self.empty_areas[area] = area_info
+
+
+    def __repr__(self) -> str:
+        return "W%d" % (self.id)


### PR DESCRIPTION
These customize what VSCode (and presumably other debuggers) displays to represent an object. So instead of "<Location.Location object at 0x1234123412341234>", you get "W0 KF Midos Bottom Left Chest with W1 Magic Meter".

Examples of the ones I added:
- World: "W0"
- Goal: "W0 Light Medallion: path to #Phantom Ganon#"
- Item: "W1 Magic Meter"
- Location: "W0 KF Midos Bottom Left Chest with W1 Magic Meter"
- Region: "W0 KF Midos House"

The level of thought that went into these was "this makes sense to me", and I only added them for the types that I happened to be debugging. No idea if this is useful enough to others to be worth putting in as-is, but figured I should at least offer it up.