### PR TITLE
ci: Mention --no_unit_tests in --fix suggestion

### DIFF
--- a/CI.py
+++ b/CI.py
@@ -189,9 +189,9 @@ def exit_ci(fix_errors: bool = False) -> NoReturn:
         else:
             if getattr(error, 'can_fix', False):
                 if getattr(error, 'cannot_fix', False):
-                    print('Run `CI.py --fix` to automatically fix some of these errors.', file=sys.stderr)
+                    print('Run `CI.py --fix --no_unit_tests` to automatically fix some of these errors.', file=sys.stderr)
                 else:
-                    print('Run `CI.py --fix` to automatically fix these errors.', file=sys.stderr)
+                    print('Run `CI.py --fix --no_unit_tests` to automatically fix these errors.', file=sys.stderr)
             sys.exit(1)
     else:
         print(f'CI checks successful.')


### PR DESCRIPTION
This massively speeds up the runtime of the suggested `CI.py` call. Alternatively, `--fix` could be made to imply `--no_unit_tests`, but that could interfere with workflows where `--fix` is used as a combined check/fix.