### PR TITLE
Better error message for fill failure with 1 major item per dungeon

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -328,7 +328,7 @@ def fill_dungeon_unique_item(worlds: list[World], search: Search, fill_locations
     # Error out if we have any items that won't be placeable in the overworld left.
     for item in major_items:
         if not item.world.get_region('Root').can_fill(item):
-            raise FillError(f"No more dungeon locations available for {item.name} to be placed with 'Dungeons Have One Major Item' enabled.")
+            raise FillError(f"No more dungeon locations available for {item.name} to be placed with 'Dungeons Have One Major Item' enabled. To fix this, either disable 'Dungeons Have One Major Item' or enable some settings that add more locations for shuffled items in the overworld.")
 
     logger.info("Unique dungeon items placed")
 


### PR DESCRIPTION
This message, which is shown when no more major items can be placed, will now suggest two ways of working around it. Based on today's discussion in #dev-public-talk.