### PR TITLE
Bypass some events for world validation checks, or something

### DIFF
--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1606,6 +1606,7 @@
                         (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword))))",
             "Kak Backyard": "is_adult or at_day",
             "Graveyard": "True",
+            # The seemingly redundant `open_kakariko == 'open'` check is to allow supplementary searches, which can't collect events, to use this path.
             "Kak Behind Gate": "is_adult or 'Kakariko Village Gate Open' or open_kakariko == 'open'"
         }
     },

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1921,6 +1921,7 @@
         "scene": "Kakariko Village",
         "hint": "KAKARIKO_VILLAGE",
         "exits": {
+            # The seemingly redundant `open_kakariko == 'open'` check is to allow supplementary searches, which can't collect events, to use this path.
             "Kakariko Village": "
                 is_adult or logic_visible_collisions or 'Kakariko Village Gate Open' or open_kakariko == 'open'",
             "Death Mountain": "True"

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -326,6 +326,7 @@
         "exits": {
             "LW Forest Exit": "True",
             "GC Woods Warp": "True",
+            # The seemingly redundant `plant_beans` check is to allow supplementary searches, which can't collect events, to use this path.
             "LW Bridge": "
                 is_adult and
                 (Hover_Boots or Longshot or here(can_plant_bean) or plant_beans or logic_lost_woods_bridge)",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -518,6 +518,7 @@
             "Zoras Domain": "is_child and can_dive",
             "LH Owl Flight": "is_child",
             "LH Lab": "True",
+            # The seemingly redundant `plant_beans` check is to allow supplementary searches, which can't collect events, to use this path.
             "LH Fishing Island": "
                 is_child or can_use(Scarecrow) or
                 here(can_plant_bean) or plant_beans or 'Water Temple Clear'",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -305,7 +305,9 @@
             "LW Skull Kid": "is_child and can_play(Sarias_Song)",
             "LW Trade Cojiro": "'Odd Mushroom Access'",
             "LW Trade Odd Potion": "'Poachers Saw Access'",
-            "LW Ocarina Memory Game": "is_child and Ocarina and Ocarina_A_Button and Ocarina_C_down_Button and Ocarina_C_right_Button and Ocarina_C_left_Button and Ocarina_C_up_Button",
+            "LW Ocarina Memory Game": "
+                is_child and Ocarina and Ocarina_A_Button and Ocarina_C_down_Button and
+                Ocarina_C_right_Button and Ocarina_C_left_Button and Ocarina_C_up_Button",
             "LW Target in Woods": "can_use(Slingshot)",
             "LW Deku Scrub Near Bridge": "is_child and can_stun_deku",
             "LW Underwater Green Rupee 1": "is_child and (can_dive or Boomerang)",
@@ -326,7 +328,7 @@
             "GC Woods Warp": "True",
             "LW Bridge": "
                 is_adult and
-                (Hover_Boots or Longshot or here(can_plant_bean) or logic_lost_woods_bridge)",
+                (Hover_Boots or Longshot or here(can_plant_bean) or plant_beans or logic_lost_woods_bridge)",
             "LW Underwater Entrance": "is_child and (can_dive or Boomerang)",
             "Zora River": "can_leave_forest and (can_dive or can_use(Iron_Boots))",
             "LW Beyond Mido": "is_child or logic_mido_backflip or can_play(Sarias_Song)",
@@ -517,7 +519,7 @@
             "LH Lab": "True",
             "LH Fishing Island": "
                 is_child or can_use(Scarecrow) or
-                here(can_plant_bean) or 'Water Temple Clear'",
+                here(can_plant_bean) or plant_beans or 'Water Temple Clear'",
             "Water Temple Lobby": "
                 is_adult and Hookshot and
                 (Iron_Boots or ((Longshot or logic_water_hookshot_entry) and (Progressive_Scale, 2)))",
@@ -709,7 +711,7 @@
             # Can ask the Gerudo on the path to HBA to throw you in jail.
             "GF Break Room Entrance": "can_use(Hookshot)",
             "GF Outside Gate": "'GF Gate Open'",
-            "Gerudo Training Ground Lobby": "Gerudo_Membership_Card and is_adult"
+            "Gerudo Training Ground Lobby": "is_adult and Gerudo_Membership_Card"
         }
     },
     {
@@ -1195,7 +1197,7 @@
         "scene": "Temple of Time",
         "hint": "TEMPLE_OF_TIME",
         "events": {
-            # used for the "path of time" goal
+            # Used for the "path of time" goal
             "Temple of Time Access": "True"
         },
         "locations": {
@@ -1602,7 +1604,7 @@
                         (logic_kakariko_tower_gs and (Sticks or Kokiri_Sword))))",
             "Kak Backyard": "is_adult or at_day",
             "Graveyard": "True",
-            "Kak Behind Gate": "is_adult or 'Kakariko Village Gate Open'"
+            "Kak Behind Gate": "is_adult or 'Kakariko Village Gate Open' or open_kakariko == 'open'"
         }
     },
     {
@@ -1917,7 +1919,7 @@
         "hint": "KAKARIKO_VILLAGE",
         "exits": {
             "Kakariko Village": "
-                is_adult or logic_visible_collisions or 'Kakariko Village Gate Open'",
+                is_adult or logic_visible_collisions or 'Kakariko Village Gate Open' or open_kakariko == 'open'",
             "Death Mountain": "True"
         }
     },
@@ -1951,7 +1953,7 @@
             "Goron City": "True",
             "Death Mountain Summit": "
                 here(can_blast_or_smash) or
-                (is_adult and here(can_plant_bean and (plant_beans or Progressive_Strength_Upgrade))) or
+                (is_adult and (here(can_plant_bean and Progressive_Strength_Upgrade) or plant_beans)) or
                 (logic_dmt_climb_hovers and can_use(Hover_Boots))",
             "Dodongos Cavern Beginning": "
                 has_explosives or Progressive_Strength_Upgrade or is_adult",
@@ -2263,8 +2265,8 @@
         "exits": {
             "DMC Central Nearby": "True",
             "DMC Lower Nearby": "
-                is_adult and (Hover_Boots or Hookshot or here(can_plant_bean))",
-            "DMC Upper Nearby": "is_adult and here(can_plant_bean)",
+                is_adult and (Hover_Boots or Hookshot or here(can_plant_bean) or plant_beans)",
+            "DMC Upper Nearby": "is_adult and (here(can_plant_bean) or plant_beans)",
             "DMC Fire Temple Entrance": "
                 (is_child and shuffle_dungeon_entrances) or
                 (is_adult and (logic_fewer_tunic_requirements or Goron_Tunic))",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2267,6 +2267,7 @@
         },
         "exits": {
             "DMC Central Nearby": "True",
+            # The seemingly redundant `plant_beans` checks are to allow supplementary searches, which can't collect events, to use these paths.
             "DMC Lower Nearby": "
                 is_adult and (Hover_Boots or Hookshot or here(can_plant_bean) or plant_beans)",
             "DMC Upper Nearby": "is_adult and (here(can_plant_bean) or plant_beans)",


### PR DESCRIPTION
This fixes the most serious issue, but at the same time it barely fixes anything, at the cost of adding some redundancy into the logic. I don't know that it will ever be possible to fix it properly because it's so difficult to be sure that you're not breaking anything. I have gone through and moved some settings out of events so that world validation checks can pass through those entrances, since validation checks aren't allowed to collect anything, including those events. This PR applies some changes to the Kakariko Gate and to any passthroughs involving beans. I felt that especially the Kak gate issue was pretty serious (for example, it wasn't allowing child on only spawn ER to spawn in Death Mountain area), and the planted beans issue was also kind of rough, so I felt that something needed to be done to address those particular issues sooner than later.

Except for the check that confirms no-item access to Kokiriko, all validation checks (ToD, ToT, and Poe access) allow for the use of starting items. An obvious example of a problem that couldn't be addressed here might be starting with Hammer, if the grotto being opened is permanent, it will use an event and so the validation checks can't pass through, whereas a temporary grotto could have been entered. So for a specific example, if you were on mixed pools interiors and grottoes starting with a Hammer, you might find the Poe trader in the near Kak grotto, but never in the near Market grotto, which is of course pretty silly. It's unsustainable(?) to go around to every passthrough that uses an event that contains items that you might start with, and make non-event duplicates of that logic to allow the current age to pass through, so I opted not to deal with starting items at all. If you have to start with any item for any change to matter for the validation checks, I didn't do it, even though a lot of the time those items weren't even checked for inside of the problematic event, but were needed either to reach the event or to complete the passthrough after the event.

(I found some additional settings-only passthroughs that I opted not to address since there are a lot of items that could have been involved, but also they're not yet relevant on main branch without some currently work-in-progress features. If King Dodongo shortcuts and BONKO both enabled, you need no items to pass through that boss room. If the right tricks are enabled, no items are needed for adult to pass through the Morpha or Bongo boss rooms. There's also passing through the enemies in the entrance of MQ Ganon's, which requires no items as adult, with there being an open PR currently to shuffle the tower entrance. So you might want to add is_adult as an alternative to the large here() for clearing the enemies in the first room, if that gets accepted, idk.)

This resistance to using starting items ever puts some starting items in a bit of a weird spot. Starting with unshuffled Zelda's Letter is more of a setting than it is a starting item, but I still opted not to handle that. If your gate is set to open on Zelda and you start with unshuffled Zelda's Letter, the gate is just as open immediately as with open gate, but you know what that's your problem just pick open gate. Unshuffled Gerudo Card on open Gerudo Fortress is in a similar spot, which again I feel is more of a setting than a starting item. (I don't think the fact that it's a 'skipped location' matters or not for whether it can be used as a starting item?) The Card would matter for the Gerudo Gate, entering GTG, and also just general navigation around Fortress and Hideout. (You'd have to be careful about only checking the relevant settings in place of Gerudo Card, because that could allow you to enter GTG, which requires the rupees you might need from first finding Kokiriko. A bit hack-y, but also checking for Time Travel on a route intended to let the validation checks pass through the GTG entrance would allow all except the Kokiriko check to pass through, since all of those collect Time Travel.) And quickly pointing out another piece of jank -- because of the keysy implementation detail of logically starting with all of the keys, unlocked doors can't be used for the Kokiriko access check despite starting items not practically being involved.

Remote events, including many named events and also at()s can't usually be worked around in the manner that I used in this PR, since you don't know how the region with the event might be accessed. For example it's possible that Defeat Morpha and thus Water Temple Clear could be collected without needing any items at all as adult, with the right tricks and settings enabled, which would allow access into the fishing pond. But of course if your access to that event is not as the age that you want to use the event as...

The only way to solve these issues completely would be to allow events (and more?) to be collected during some world validations checks. But that is likely not going to be safe to allow in some instances, and I'm not entirely sure what all those instances are. You could imagine starting as adult and needing to Hammer open a grotto so that child could return to ToT later. Obviously that would break the point of the ToT access check, which confirms that the age you don't start as can return to the Temple of Time without potentially needing the age you do start as to contribute in some way. I think that, the way that validation check is currently written, merely adding in allowing events to be collected would likely break the check in the manner I've just described.

There's also the question of whether unshuffled or plando'd items might be safe to collect. (I'm not seeing either whether the ToD access check is doing anything special to prevent ToD-specific entrances from being used, so it seems likely none of the other checks are allowed to do anything ToD related either?) How deep does the rabbit hole go on what's safe to collect and what isn't? Honestly no idea. (Also the thought of having to think about how any changes here might interact with the shared Spirit Temple areas scares me a little.)

If you really want me to, I could be more rigorous and actually duplicate the logic for more obscure settings combos and starting items. (For example, I could replace all instances of "here(can_blast_or_smash)" on passthroughs with "(here(can_blast_or_smash) or can_blast_or_smash)", or even add an alternative to Water Temple Clear that confirms the necessary items to beat Morpha and that all relevant ERs that could move that boss somewhere else are also disabled.) It's all stuff that wouldn't break any of the validation checks when written correctly, but still would miss out on being able to handle several cases. And it would be a lot of code duplication and quite difficult to maintain. Something needs to be done to fix that Kak gate, but this rabbit hole is pretty deep.