### PR TITLE
Better error message for “Dungeons Have One Major Item” with excluded locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -311,7 +311,10 @@ def fill_dungeon_unique_item(worlds: list[World], search: Search, fill_locations
                 major_items.append(item)
 
         # place 1 item into the dungeon
-        fill_restrictive(worlds, base_search, dungeon_locations, major_items, 1)
+        try:
+            fill_restrictive(worlds, base_search, dungeon_locations, major_items, 1)
+        except FillError as e:
+            raise FillError(f'Could not place a major item in {dungeon} because there are no remaining locations in the dungeon. If you have excluded some of the locations in this dungeon, try reincluding one.') from e
 
         # update the location and item pool, removing any placed items and filled locations
         # the fact that you can remove items from a list you're iterating over is python magic


### PR DESCRIPTION
This came up in #setup-support yesterday: Someone was playing with “Dungeons Have One Major Item” and had all locations in the Shadow temple excluded, and got a cryptic error message:

> Could not place the specified number of item. 1 remaining to be placed.

With this PR, the error is changed to:

> Could not place a major item in Shadow Temple because there are no remaining locations in the dungeon. If you have excluded some of the locations in this dungeon, try reincluding one.

Ideally, the fix here would be to detect that the dungeon has been completely excluded and skip placing a major item here. But I was unable to differentiate that scenario from one where all locations have simply already been filled at this point, e.g. with own-dungeon items.