### PR TITLE
Clearer hint text for bridge condition

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1658,9 +1658,8 @@ def build_boss_string(reward: str, color: str, world: World) -> str:
 
 
 def build_bridge_reqs_string(world: World) -> str:
-    string = "\x13\x12" # Light Arrow Icon
     if world.settings.bridge == 'open':
-        string += "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
+        string = "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
     else:
         if world.settings.bridge == 'vanilla':
             item_req_string = "the #Shadow and Spirit Medallions# as well as the #Light Arrows#"
@@ -1673,7 +1672,10 @@ def build_bridge_reqs_string(world: World) -> str:
                 'hearts':     (world.settings.bridge_hearts,     "#heart#",                        "#hearts#"),
             }[world.settings.bridge]
             item_req_string = f'{count} {singular if count == 1 else plural}'
-        string += f"The awakened ones will await for the Hero to collect {item_req_string}."
+        if world.settings.clearer_hints:
+            string = f"The rainbow bridge will be built once the Hero collects {item_req_string}."
+        else:
+            string = f"The awakened ones will await for the Hero to collect {item_req_string}."
     return str(GossipText(string, ['Green'], prefix=''))
 
 

--- a/Hints.py
+++ b/Hints.py
@@ -1658,8 +1658,9 @@ def build_boss_string(reward: str, color: str, world: World) -> str:
 
 
 def build_bridge_reqs_string(world: World) -> str:
+    string = "\x13\x3C" # Master Sword icon
     if world.settings.bridge == 'open':
-        string = "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
+        string += "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
     else:
         if world.settings.bridge == 'vanilla':
             item_req_string = "the #Shadow and Spirit Medallions# as well as the #Light Arrows#"
@@ -1673,9 +1674,9 @@ def build_bridge_reqs_string(world: World) -> str:
             }[world.settings.bridge]
             item_req_string = f'{count} {singular if count == 1 else plural}'
         if world.settings.clearer_hints:
-            string = f"The rainbow bridge will be built once the Hero collects {item_req_string}."
+            string += f"The rainbow bridge will be built once the Hero collects {item_req_string}."
         else:
-            string = f"The awakened ones will await for the Hero to collect {item_req_string}."
+            string += f"The awakened ones will await for the Hero to collect {item_req_string}."
     return str(GossipText(string, ['Green'], prefix=''))
 
 


### PR DESCRIPTION
This makes 2 changes to the text box that gives the rainbow bridge condition as part of the message shown when reading the Temple of Time altar as adult:

* If the “Clearer Hints” setting is enabled, the text is changed from “The awakened ones will await for the Hero to collect” to “The rainbow bridge will be built once the Hero collects”.
    * The text for open bridge is unchanged, since it already mentions the bridge: “The awakened ones will have _already created a bridge_ to the castle where the evil dwells.”
* Regardless of settings, the light arrow icon, which has misled some people into thinking the text was hinting the location of the light arrows, is removed. This is similar to the change made to the child altar text in #1102.

Fixes #1473. 

![image](https://github.com/OoTRandomizer/OoT-Randomizer/assets/641386/27bd30ba-e98d-4c85-a09a-0a03a3e5f374)

There's something weird going on with the indentation in this text box. Maybe our line wrapping algorithm is getting confused by the previous boxes in this message having icons?