### PR TITLE
Potential route to fix issues revealed by new armips

### DIFF
--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -3,7 +3,7 @@ LD = mips64-ld
 OBJDUMP = mips64-objdump
 
 CFLAGS = -O1 -fno-reorder-blocks -march=vr4300 -mtune=vr4300 -mabi=32 -mno-gpopt -mdivide-breaks \
-	-mexplicit-relocs
+	-mexplicit-relocs -fno-zero-initialized-in-bss
 CPPFLAGS = -DF3DEX_GBI_2
 
 OUTDIR := build

--- a/ASM/build.py
+++ b/ASM/build.py
@@ -77,7 +77,10 @@ with open('build/c_symbols.txt', 'r') as f:
         if m:
             sym_type = m.group(1)
             name = m.group(2)
-            c_sym_types[name] = 'code' if sym_type == 'text' else 'data'
+            if sym_type == "bss" or sym_type == "sbss":
+                print(f"{name} is in the .bss or .sbss section, initialize it to 0 or use __attribute__ to move it to the .keep section")
+                exit(1)
+            c_sym_types[name] = 'code' if sym_type == 'text' or sym_type == 'keep' else 'data'
 
 symbols = {}
 

--- a/ASM/c/bombchu_bowling.c
+++ b/ASM/c/bombchu_bowling.c
@@ -17,7 +17,7 @@ uint32_t EXTRA_BOWLING_SHUFFLE = 0;
 */
 
 int16_t select_bombchu_bowling_prize(int16_t prizeSelect) {
-    int16_t prizeTemp;
+    int16_t prizeTemp = 0;
 
     uint32_t prizeFlag = (1 << prizeSelect);
 

--- a/ASM/c/dungeon_info.c
+++ b/ASM/c/dungeon_info.c
@@ -241,7 +241,7 @@ void draw_dungeon_info(z64_disp_buf_t *db) {
                 // Medal color index was changed to hint order,
                 // moving Light from the end to the beginning.
                 // Spirit/Shadow are also swapped.
-                int reward_index;
+                int reward_index = 0;
                 if (reward < 3) {
                     reward_index = reward + 1;
                 } else if (reward == 3) {

--- a/ASM/c/file_icons.c
+++ b/ASM/c/file_icons.c
@@ -286,7 +286,7 @@ typedef struct {
 } file_info_t;
 
 // File data structure
-static file_info_t draw_data;
+static file_info_t draw_data __attribute__ ((section (".keep")));
 
 
 /*=============================================================================

--- a/ASM/c/get_items.c
+++ b/ASM/c/get_items.c
@@ -44,17 +44,17 @@ uint8_t satisified_pending_frames = 0;
 
 // This table contains the offset (in bytes) of the start of a particular scene/room/setup flag space in collectible_override_flags.
 // Call get_collectible_flag_offset to retrieve the desired offset.
-uint8_t collectible_scene_flags_table[600];
-alt_override_t alt_overrides[64];
+uint8_t collectible_scene_flags_table[600] = { 0 };
+alt_override_t alt_overrides[64] = { 0 };
 
 extern int8_t curr_scene_setup;
 extern uint16_t CURR_ACTOR_SPAWN_INDEX;
 
 // Total amount of memory required for each flag table (in bytes).
-uint16_t num_override_flags;
+uint16_t num_override_flags = 0;
 
 // Pointer to a variable length array that will contain the collectible flags for each scene.
-uint8_t *collectible_override_flags;
+uint8_t *collectible_override_flags __attribute__ ((section (".keep")));
 
 // Initialize the override flag tables on the heap.
 void override_flags_init() {
@@ -415,7 +415,7 @@ void get_item(z64_actor_t *from_actor, z64_link_t *link, int8_t incoming_item_id
     override_t override = { 0 };
     int incoming_negative = incoming_item_id < 0;
     int8_t item_id = 0;
-    item_row_t *row;
+    item_row_t *row = 0;
 
     if (from_actor && incoming_item_id != 0) {
         item_id = incoming_negative ? -incoming_item_id : incoming_item_id;
@@ -521,7 +521,7 @@ uint8_t items[] = {
 
 EnItem00 *collectible_mutex = 0;
 
-override_t collectible_override;
+override_t collectible_override __attribute__ ((section (".keep")));
 
 void reset_collectible_mutex() {
     collectible_mutex = NULL;

--- a/ASM/c/save.c
+++ b/ASM/c/save.c
@@ -25,7 +25,7 @@ extern uint16_t SRAM_SLOTS[6];
 
 typedef void (*Sram_InitNewSave_Func)(void);
 Sram_InitNewSave_Func Sram_InitNewSave = (Sram_InitNewSave_Func)(0x8008FFC0);
-extended_savecontext_static_t extended_savectx;
+extended_savecontext_static_t extended_savectx __attribute__ ((section (".keep")));
 
 void SsSram_ReadWrite_Safe(uint32_t addr, void *dramAddr, size_t size, uint32_t direction);
 

--- a/ASM/c/scene.c
+++ b/ASM/c/scene.c
@@ -1,6 +1,6 @@
 #include "z64.h"
 
-int8_t curr_scene_setup; // Global containing the current scene setup.
+int8_t curr_scene_setup = 0; // Global containing the current scene setup.
 
 // Determine the current scene setup and set it in the curr_scene_setup global.
 // See https://wiki.cloudmodding.com/oot/Scenes_and_Rooms#Alternate_Header_List:


### PR DESCRIPTION
ASM/Makefile: Have the compiler not put zero
initialized variables into the .sbss or .bss sections of the elf binary.

ASM/build.py: Error out of the compile if a symbol is located in either the .bss or .sbss section of the binary. armips will place these in the binary in
places where they will cause a crash. Both methods mention (mainly the __attribute__ method) are used in fixes to the C code in this branch.

C/*: These files have been modified so that nothing in them gets placed into the problematic sections of the binary. Both initializing normal variables to 0 and changing the attributes of pointers and structs are done, so the latter can be referenced as an
example in new code that necessitates it.

I have tested this with the both the old armips and the latest updated one. Both seem to work. I'm not currently including the compiled files, but if someone desires they are added to make testing easier (which is probably a good idea) I can do so.

Another route to fixing this is probably using a linker file which would be less hacky but I don't have any experience with.