### PR TITLE
Better route to fix issues revealed by new armips

### DIFF
--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -2,7 +2,7 @@ CC = mips64-gcc
 LD = mips64-ld
 OBJDUMP = mips64-objdump
 
-CFLAGS = -O1 -fno-reorder-blocks -march=vr4300 -mtune=vr4300 -mabi=32 -mno-gpopt -mdivide-breaks \
+CFLAGS = -O1 -G0 -fno-reorder-blocks -march=vr4300 -mtune=vr4300 -mabi=32 -mno-gpopt -mdivide-breaks \
 	-mexplicit-relocs
 CPPFLAGS = -DF3DEX_GBI_2
 
@@ -31,7 +31,7 @@ $(OBJDIR):
 $(OBJECTS): | $(OBJDIR)
 
 bundle: $(OBJECTS)
-	$(LD) -o $(OUTDIR)/bundle.o -i -L. $(patsubst %.o,-l:%.o,$(OBJECTS))
+	$(LD) -T linker_script.ld -o $(OUTDIR)/bundle.o -i -L. $(patsubst %.o,-l:%.o,$(OBJECTS))
 
 symbols: bundle
 	$(OBJDUMP) -t $(OUTDIR)/bundle.o | tr -d '\015' > $(OUTDIR)/c_symbols.txt

--- a/ASM/linker_script.ld
+++ b/ASM/linker_script.ld
@@ -1,0 +1,31 @@
+SECTIONS
+{
+    /* Allocatable and important sections */
+    .text   : { *(.text*);   }
+    .rodata : { *(.rodata*); }
+
+    /*
+     * Put the NOLOAD sections (bss, sbss, etc) into data to
+     * force them to be in the ROM
+     */
+    .data   : { *(.data*);   *(.bss*);  *(COMMON);  }
+    .sdata  : { *(.sdata*); *(.sbss*); *(.scommon); }
+
+    /* Not allocatable sections that may be useful */
+    .reginfo          : { *(.reginfo); }
+    .pdr              : { *(.pdr); }
+    .gnu.attributes   : { KEEP (*(.gnu.attributes)); }
+    .mdebug           : { *(.mdebug); }
+    .mdebug.abi32     : { *(.mdebug.abi32); }
+
+    /* Useless allocatable sections */
+    /DISCARD/ : {
+        *(.MIPS.abiflags)
+        *(.MIPS.options)
+        *(.note.gnu.build-id)
+        *(.got)
+        *(.interp)
+        *(.eh_frame)
+        *(.reginfo)
+    }
+}


### PR DESCRIPTION
ASM/linker_script.ld: A linker script that prevents anything from ending up in the .bss or .sbss sections of the elf binary since newer armips will not
relocate those symbols which causes missing symbols in python and crashes in-game.

ASM/Makefile: Use the linker script. Also prevent the compiler from putting any code in .s* sections. They aren't relevant for randomizer code as the GP is not used due to `-mno-gpopt`

With the help of @AngheloAlf providing the linker script. This is probably the better way to handle the changes needed for newer armips to assemble everything in a way randomizer needs. A linker script also can be used to define symbols to address in the base ROM in a cleaner way than currently done.