### PR TITLE
Fix race condition creating log directory

### DIFF
--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -26,8 +26,7 @@ def start() -> None:
         ts = time.time()
         st = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H-%M-%S')
         log_dir = local_path('Logs')
-        if not os.path.exists(log_dir):
-            os.makedirs(log_dir)
+        os.makedirs(log_dir, exist_ok=True)
         log_path = os.path.join(log_dir, '%s.log' % st)
         log_file = logging.FileHandler(log_path)
         log_file.setFormatter(logging.Formatter('[%(asctime)s] %(message)s', datefmt='%H:%M:%S'))


### PR DESCRIPTION
This fixes a bug where, if 2 instances of the randomizer are running simultaneously, one may check for the existence of the log directory, the other then creates it, and then the first throws an exception because it already exists.

I am collecting stats on the failure rate of the randomizer to try to debug an issue with mixed pools bosses, and the bug fixed here is artificially inflating the failure rates.