### PR TITLE
Randomizer Arrow Toggle

### DIFF
--- a/ASM/c/arrow_cycle.c
+++ b/ASM/c/arrow_cycle.c
@@ -1,0 +1,296 @@
+#include "arrow_cycle.h"
+
+typedef void(*playsfx_t)(uint16_t sfx, z64_xyzf_t *unk_00_, int8_t unk_01_ , float *unk_02_, float *unk_03_, float *unk_04_);
+
+struct arrow_cycle_state {
+	uint16_t     frameDelay;
+	int8_t       magicCost;
+	z64_actor_t* arrow;
+};
+
+static struct arrow_cycle_state g_arrow_cycle_state = {
+	.frameDelay = 0,
+	.magicCost  = 0,
+	.arrow      = NULL,
+};
+
+struct arrow_info {
+	uint8_t  item;
+	uint8_t  slot;
+	uint8_t  icon;
+	uint8_t  action;
+	uint16_t var;
+};
+
+static struct arrow_info g_arrows[4] = {
+	{ Z64_ITEM_BOW,         Z64_SLOT_BOW,         Z64_ITEM_BOW,             0x8, 0x2, },
+	{ Z64_ITEM_FIRE_ARROW,  Z64_SLOT_FIRE_ARROW,  Z64_ITEM_BOW_FIRE_ARROW,  0x9, 0x3, },
+	{ Z64_ITEM_ICE_ARROW,   Z64_SLOT_ICE_ARROW,   Z64_ITEM_BOW_ICE_ARROW,   0xA, 0x4, },
+	{ Z64_ITEM_LIGHT_ARROW, Z64_SLOT_LIGHT_ARROW, Z64_ITEM_BOW_LIGHT_ARROW, 0xB, 0x5, },
+};
+
+static const struct arrow_info* get_info(uint16_t variable) {
+	for (int i=0; i<4; i++) {
+		if (g_arrows[i].var == variable)
+			return (const struct arrow_info*)&g_arrows[i];
+	}
+	return NULL;
+}
+
+static uint16_t get_next_arrow_variable(uint16_t variable) {
+	switch (variable) {
+		case 2:  return 3; // Normal -> Fire
+		case 3:  return 4; // Fire   -> Ice
+		case 4:  return 5; // Ice    -> Light
+		case 5:  return 2; // Light  -> Normal
+		default: return variable;
+	}
+}
+
+static int8_t get_magic_cost_by_info(const struct arrow_info *info) {
+	switch (info->item) {
+		case Z64_ITEM_FIRE_ARROW:  return arrow_cycle_get_magic_cost(0);
+		case Z64_ITEM_ICE_ARROW:   return arrow_cycle_get_magic_cost(1);
+		case Z64_ITEM_LIGHT_ARROW: return arrow_cycle_get_magic_cost(2);
+		default:                   return 0;
+	}
+}
+
+static const struct arrow_info* get_next_info(uint16_t variable) {
+	// Get magic cost of current arrow type.
+	int8_t       magicCost = get_magic_cost_by_info(get_info(variable));
+	uint16_t     current   = variable;
+	const struct arrow_info* info;
+	for (int i=0; i<4; i++) {
+		current = get_next_arrow_variable(current);
+		info    = get_info(current);
+		// Calculate difference in magic cost and ensure that the player has enough magic to switch.
+		if (info != NULL && info->item == z64_file.items[info->slot] && z64_file.magic >= (magicCost - get_magic_cost_by_info(info)))
+			return info;
+	}
+	return NULL;
+}
+
+/**
+ * Call the En_Arrow actor constructor on an existing En_Arrow instance.
+ *
+ * This will re-copy the data used to draw the arrow trail color, and thus it will appear as it should.
+ **/
+static uint8_t call_arrow_actor_ctor(z64_actor_t* arrow, z64_game_t* ctxt) {
+	z64_actor_ovl_t*  ovl  = &z64_actor_ovl_table[ACTOR_EN_ARROW];
+	z64_actor_init_t* init = reloc_resolve_actor_init(ovl);
+	if (init != NULL && init->init != NULL) {
+		init->destroy(arrow, ctxt);
+		init->init(arrow, ctxt);
+		return 1;
+	}
+	return 0;
+}
+
+static uint8_t is_arrow_item(uint8_t item) {
+	switch (item) {
+		case Z64_ITEM_BOW:
+		case Z64_ITEM_BOW_FIRE_ARROW:
+		case Z64_ITEM_BOW_ICE_ARROW:
+		case Z64_ITEM_BOW_LIGHT_ARROW:
+			return 1;
+		default:
+			return 0;
+	}
+}
+
+/**
+ * Helper function used to update the arrow type on the current C button.
+ **/
+static void update_c_button(z64_link_t* player, z64_game_t* ctxt, const struct arrow_info* info) {
+	// Update the C button value & texture.
+	z64_file.button_items[player->item_button] = info->icon;
+	z64_UpdateItemButton(ctxt, player->item_button);
+	// Update player fields for new action type.
+	player->item_action_param      = info->action;
+	player->held_item_action_param = info->action;
+}
+
+uint8_t actor_helper_does_actor_exist(const z64_actor_t* target, const z64_game_t* ctxt, uint8_t actorCategory) {
+	const z64_actor_t* actor = ctxt->actor_list[actorCategory].first;
+	// Iterate actor linked list for each entry.
+	while (actor != NULL) {
+		if (actor == target)
+			return 1;
+		actor = actor->next;
+	}
+	return 0;
+}
+
+/**
+ * Function called on delayed frame to finish processing the arrow cycle.
+ **/
+static void handle_frame_delay(z64_link_t* player, z64_game_t* ctxt, z64_actor_t* arrow) {
+	// Sanity check: Ensure arrow is still an allocated actor after delay frame.
+	if (!actor_helper_does_actor_exist(arrow, ctxt, ACTORTYPE_ITEMACTION))
+		return;
+
+	const struct arrow_info* curInfo = get_info(arrow->variable);
+	if (arrow != NULL && curInfo != NULL) {
+		z64_actor_t* special = arrow->child;
+		// Deconstruct and remove special arrow actor.
+		if (special != NULL) {
+			z64_DeleteActor(ctxt, &ctxt->actor_ctxt, special);
+			arrow->child = NULL;
+		}
+		
+		// Handle magic consume state.
+		
+		// Make sure the game is aware that a special arrow effect is happening when switching
+		// from normal arrow -> elemental arrow. Uses value 2 to make sure the magic cost is
+		// consumed this frame.
+		if (curInfo->item != Z64_ITEM_BOW)
+			z64_file.magic_consume_state = 3;
+		else z64_file.magic_consume_state = 0;
+		
+		// Refund magic cost of previous arrow type.
+		z64_file.magic += g_arrow_cycle_state.magicCost;
+		
+		// Set magic cost value to be subtracted.
+		z64_file.magic -= get_magic_cost_by_info(curInfo);
+	}
+}
+
+/**
+ * Helper function used to find the En_Arrow actor if attached to player.
+ **/
+z64_actor_t* arrow_cycle_find_arrow(z64_link_t* player, z64_game_t* ctxt) {
+	z64_actor_t* attached = player->common.child;
+	if (attached != NULL && attached->actor_id == ACTOR_EN_ARROW && attached->parent == &player->common)
+		return attached;
+	else return NULL;
+}
+
+/**
+ * Get the magic cost by index from the array in player_actor.
+ **/
+int8_t arrow_cycle_get_magic_cost(uint8_t index) {
+	if (index < 3) {
+		// TODO: Vanilla MM RDRAM: 0x8077A448, find for OoT
+		// 4-byte array for each cost: [Fire Arrow, Ice Arrow, Light Arrow]
+		const int8_t costArray[3] = { 4, 4, 8 }; // TODO: const int8_t* costArray = (const int8_t*)reloc_resolve_player_overlay(&s801D0B70.playerActor, 0x8085CFB8);
+		return costArray[index];
+	}
+	else return 0;
+}
+
+/**
+ * Handle arrow cycling.
+ *
+ * Note: A "delay frame" is necessary because we cannot free the special arrow actor immediately.
+ * This is due to the double-buffer nature of the game's DLists, where each one is processed every
+ * other frame, and if we free the actor immediately the next DList will still contain pointers to
+ * data which requires the special arrow actor file to be loaded.
+ *
+ * Thus, we must set the draw pointer to NULL and let one frame process before freeing the actor.
+ **/
+void handle_arrow_cycle(z64_link_t* player, z64_game_t* ctxt) {
+	// Check if processing arrow cycling on delay frame.
+	if (g_arrow_cycle_state.frameDelay >= 1) {
+		handle_frame_delay(player, ctxt, g_arrow_cycle_state.arrow);
+		g_arrow_cycle_state.arrow      = NULL;
+		g_arrow_cycle_state.frameDelay = 0;
+		g_arrow_cycle_state.magicCost  = 0;
+		return;
+	}
+	
+	// Check if buttons state is normal, otherwise we are possibly in a minigame or on Epona.
+	if (z64_file.hud_visibility_mode != HUD_VISIBILITY_ALL)
+		return;
+	
+	// Find the arrow currently attached to the player.
+	z64_actor_t* arrow = arrow_cycle_find_arrow(player, ctxt);
+	if (arrow == NULL)
+		return;
+	
+	// Ensure arrow has an appropriate variable (cannot be a slingshot deku seed).
+	if (!(2 <= arrow->variable && arrow->variable < 6))
+		return;
+	
+	// Check if current button pressed corresponds to an arrow item.
+	if (!is_arrow_item(z64_file.button_items[player->item_button]))
+		return;
+	
+	// Check if R is pressed.
+	if (!z64_game.common.input[0].pad_pressed.r)
+		return;
+	z64_game.common.input[0].raw.pad.r = z64_game.common.input[0].pad_pressed.r = 0;
+	
+	// Get info for arrow types.
+	const struct arrow_info *curInfo, *nextInfo;
+	curInfo  = get_info(arrow->variable);
+	nextInfo = get_next_info(arrow->variable);
+	
+	// Check if there is nothing to cycle to and return early.
+	if (curInfo == NULL || nextInfo == NULL || curInfo->var == nextInfo->var) {
+		if (curInfo->var == 2 && z64_file.button_items[player->item_button] != Z64_ITEM_BOW && z64_file.items[Z64_SLOT_BOW] == Z64_ITEM_BOW)
+			update_c_button(player, ctxt, &g_arrows[0]);
+		z64_playsfx(0x4806, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		return;
+	}
+	
+	// Check if we are switching from normal arrow -> elemental arrow, and if so verify that an
+    // existing effect is not active. Otherwise the game may crash by attempting to load the actor
+    // code file for one effect while an existing effect is still processing.
+    // This also prevents from switching when Lens of Truth is activated.
+	if (curInfo->item == Z64_ITEM_BOW && z64_file.magic < get_magic_cost_by_info(nextInfo)) {
+		z64_playsfx(0x4806, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		return;
+	}
+	
+	// Update the existing actor variable.
+	arrow->variable = nextInfo->var;
+	
+	// Call arrow actor constructor so that the arrow trail color data is re-copied.
+	call_arrow_actor_ctor(arrow, ctxt);
+	
+	// If found, NULL out special arrow actor's draw function to prevent it from writing to DList.
+	z64_actor_t* special = arrow->child;
+	if (special != NULL)
+		special->draw_proc = NULL;
+	
+	// Update C button.
+	update_c_button(player, ctxt, nextInfo);
+	
+	// Prepare for finishing cycle next frame.
+	g_arrow_cycle_state.arrow = arrow;
+	g_arrow_cycle_state.frameDelay++;
+	g_arrow_cycle_state.magicCost = get_magic_cost_by_info(curInfo);
+	
+	// If cycling from normal arrow -> elemental arrow, reserve magic consume state.
+    // This prevents using Lens between now and processing the delay frame, and thus prevents
+    // mutating the magic consume state while Lens is active.
+    //if (curInfo->item == Z64_ITEM_BOW)
+    //    z64_file.magic_consume_state = 3;
+}
+
+struct resolve_info {
+	void* ram;
+    uint32_t virtStart;
+    uint32_t virtEnd;
+};
+
+#define create_info(Ram, Start, End) { .ram = (Ram), .virtStart = (uint32_t)(Start), .virtEnd = (uint32_t)(End), }
+
+static void* resolve(struct resolve_info info, uint32_t vram) {
+    if (info.ram && info.virtStart <= vram && vram < info.virtEnd) {
+        uint32_t offset = vram - info.virtStart;
+        return (void*)((char*)info.ram + offset);
+    } else {
+        return NULL;
+    }
+}
+
+void* reloc_resolve_actor_overlay(z64_actor_ovl_t* ovl, uint32_t vram) {
+    struct resolve_info info = create_info(ovl->loaded_ram_addr, ovl->vram_start, ovl->vram_end);
+    return resolve(info, vram);
+}
+
+z64_actor_init_t* reloc_resolve_actor_init(z64_actor_ovl_t* ovl) {
+    return reloc_resolve_actor_overlay(ovl, (uint32_t)ovl->init_info);
+}

--- a/ASM/c/arrow_cycle.h
+++ b/ASM/c/arrow_cycle.h
@@ -1,0 +1,16 @@
+#ifndef ARROW_CYCLE_H
+#define ARROW_CYCLE_H
+
+#include "z64.h"
+#include <stdio.h>
+
+/* Functions */
+#define z64_playsfx	((playsfx_t) 0x800C806C)
+
+z64_actor_t* arrow_cycle_find_arrow(z64_link_t* player, z64_game_t* ctxt);
+int8_t arrow_cycle_get_magic_cost(uint8_t index);
+void handle_arrow_cycle(z64_link_t* player, z64_game_t* ctxt);
+z64_actor_init_t* reloc_resolve_actor_init(z64_actor_ovl_t* ovl);
+uint8_t actor_helper_does_actor_exist(const z64_actor_t* target, const z64_game_t* ctxt, uint8_t actorCategory);
+
+#endif

--- a/ASM/c/main.c
+++ b/ASM/c/main.c
@@ -8,6 +8,7 @@
 #include "text.h"
 #include "util.h"
 #include "dpad.h"
+#include "arrow_cycle.h"
 #include "misc_colors.h"
 #include "hud_colors.h"
 #include "z64.h"
@@ -35,6 +36,7 @@ void c_init() {
 void before_game_state_update() {
     handle_pending_items();
     handle_dpad();
+    handle_arrow_cycle(&z64_link, &z64_game);
     update_misc_colors();
     update_hud_colors();
     process_extern_ctxt();

--- a/ASM/c/z64.h
+++ b/ASM/c/z64.h
@@ -770,7 +770,13 @@ typedef struct
   char            unk_14_[0x000A];          /* 0x13D6 */
   int8_t          seq_index;                /* 0x13E0 */
   int8_t          night_sfx;                /* 0x13E1 */
-  char            unk_15_[0x0012];          /* 0x13E2 */
+  char            unk_15_[0x0006];          /* 0x13E2 */
+  uint16_t        next_hud_visibility_mode; /* 0x13E8 */
+  uint16_t        hud_visibility_mode;      /* 0x13EA */
+  uint16_t        hud_visibility_mode_timer; /* 0x13EC */
+  uint16_t        prev_hud_visibility_mode; /* 0x13EE */
+  int16_t         magic_consume_state;      /* 0x13F0 */
+  char            unk_15_1[0x0002];         /* 0x13F2 */
   uint16_t        magic_meter_size;         /* 0x13F4 */
   char            unk_16_[0x0004];          /* 0x13F6 */
   uint16_t        event_inf[4];             /* 0x13FA */
@@ -995,7 +1001,13 @@ struct z64_actor_s
 typedef struct
 {
   z64_actor_t  common;               /* 0x0000 */
-  char         unk_00_[0x0013];      /* 0x013C */
+  char         unk_00_[0x0004];      /* 0x013C */
+  uint8_t      item_button;          /* 0x0140 */
+  int8_t       item_action_param;    /* 0x0141 */
+  uint8_t      held_item_id;         /* 0x0142 */
+  int8_t       boots;                /* 0x0143 */
+  int8_t       held_item_action_param; /* 0x0144 */
+  char         unk_00_1[0x000A];     /* 0x0145 */
   uint8_t      current_mask;         /* 0x014F */
   char         unk_01_[0x02D4];      /* 0x0150 */
   int8_t       incoming_item_id;     /* 0x0424 */
@@ -1726,6 +1738,29 @@ typedef enum {
     /* 0xFF */ ITEM_NONE = 0xFF
 } ItemID;
 
+typedef enum {
+	ACTOR_EN_ARROW = 0x0016,
+} ActorID;
+
+typedef enum {
+	HUD_VISIBILITY_NO_CHANGE       = 0,
+	HUD_VISIBILITY_NOTHING,
+	HUD_VISIBILITY_NOTHING_ALT,
+	HUD_VISIBILITY_HEARTS_FORCE,
+	HUD_VISIBILITY_A,
+	HUD_VISIBILITY_A_HEARTS_MAGIC_FORCE,
+	HUD_VISIBILITY_A_HEARTS_MAGIC_MINIMAP_FORCE,
+	HUD_VISIBILITY_ALL_NO_MINIMAP_BY_BTN_STATUS,
+	HUD_VISIBILITY_B,
+	HUD_VISIBILITY_HEARTS_MAGIC,
+	HUD_VISIBILITY_B_ALT,
+	HUD_VISIBILITY_HEARTS,
+	HUD_VISIBILITY_A_B_MINIMAP,
+	HUD_VISIBILITY_HEARTS_MAGIC_FORCE,
+	HUD_VISIBILITY_ALL             = 50,
+	HUD_VISIBILITY_NOTHING_INSTANT = 52
+} HUDVisibilityMode;
+
 typedef struct EnGSwitch
 {
   /* 0x0000 */ z64_actor_t actor;
@@ -1830,6 +1865,7 @@ typedef struct EnGSwitch
 #define Rupees_ChangeBy_addr                    0x800721CC
 #define Message_ContinueTextbox_addr            0x800DCE80
 #define PlaySFX_addr                            0x800646F0
+#define z64_actor_ovl_table_addr                0x800E8530
 
 /* rom addresses */
 #define z64_icon_item_static_vaddr              0x007BD000
@@ -1909,6 +1945,36 @@ typedef void(*Rupees_ChangeBy_proc)         (int16_t rupeeChange);
 typedef void(*Message_ContinueTextbox_proc) (z64_game_t *play, uint16_t textId);
 
 typedef void(*PlaySFX_proc) (uint16_t sfxId);
+typedef void(*z64_Actor_proc)               (z64_actor_t *actor, z64_game_t *ctxt);
+
+typedef struct
+{
+   int16_t        id;           /* 0x00 */ 
+   uint8_t        type;         /* 0x02 */
+   uint32_t       flags;        /* 0x04 */ 
+   int16_t        objectId;     /* 0x08 */ 
+   uint32_t       instanceSize; /* 0x0C */ 
+   z64_Actor_proc init;         /* 0x10 */ 
+   z64_Actor_proc destroy;      /* 0x14 */ 
+   z64_Actor_proc update;       /* 0x18 */ 
+   z64_Actor_proc draw;         /* 0x1C */ 
+                                /* 0x20 */ 
+} z64_actor_init_t;
+
+typedef struct
+{
+   uint32_t          vrom_start;      /* 0x00 */ 
+   uint32_t          vrom_end;        /* 0x04 */
+   void*             vram_start;      /* 0x08 */ 
+   void*             vram_end;        /* 0x0C */ 
+   void*             loaded_ram_addr; /* 0x10 */ 
+   z64_actor_init_t* init_info;       /* 0x14 */ 
+   char*             name;            /* 0x18 */ 
+   uint16_t          alloc_type;      /* 0x1C */ 
+   int8_t            nb_loaded;       /* 0x1E */ 
+   char              unk_01_[0x1];    /* 0x1F */ 
+                                      /* 0x20 */ 
+} z64_actor_ovl_t;
 
 /* data */
 #define z64_file_mq             (*(OSMesgQueue*)      z64_file_mq_addr)
@@ -1934,6 +2000,7 @@ typedef void(*PlaySFX_proc) (uint16_t sfxId);
 #define z64_state_ovl_tab       (*(z64_state_ovl_t(*)[6])                     \
                                                       z64_state_ovl_tab_addr)
 #define z64_event_state_1       (*(uint32_t*)         z64_event_state_1_addr)
+#define z64_actor_ovl_table     ((z64_actor_ovl_t*)   z64_actor_ovl_table_addr)
 
 
 /* functions */


### PR DESCRIPTION
New Arrow Toggle function for using the Fairy Bow with Adult Link. Ported over from the Majora's Mask Randomizer: https://github.com/ZoeyZolotova/mm-rando

Uses rewritten code files from MM Rando:
https://github.com/ZoeyZolotova/mm-rando/blob/dev/assembly/c/ArrowCycle.c
https://github.com/ZoeyZolotova/mm-rando/blob/dev/assembly/c/ArrowCycle.h
https://github.com/ZoeyZolotova/mm-rando/blob/dev/assembly/c/ActorHelper.c
https://github.com/ZoeyZolotova/mm-rando/blob/dev/assembly/c/ArrowCycle.h
https://github.com/ZoeyZolotova/mm-rando/blob/dev/assembly/c/Reloc.c
https://github.com/ZoeyZolotova/mm-rando/blob/dev/assembly/c/Reloc.h

Pull out the Fairy Bow in First Person View, draw the toggle by using the item button the Fairy Bow is mapped to and press R to toggle between arrow types, given you have those and the magic for it. Like it does in the Majora's Mask Randomizer.

Currently this feature is broken. It can cycle to the subsequent magic types fine on the first cycle (using each magic arrow type for the first time). After you switched back to the start of the cycle, only normal arrows and the last magic arrow type still works, which in this case prevents the Fire and Ice Arrows from working. Video is included below to showcase the concept and what's broken about it.

https://github.com/OoTRandomizer/OoT-Randomizer/assets/8747034/f9a210f9-508d-4b82-95f2-b05874c1c7d9

I would appreciate if someone could look at it and see what's wrong with it as I don't seem to be able to figure out how to quite solve this issue. I don't need to claim commit credits for this as I am more interested in seeing this fully work, so feel free to just copy the commit and claim it for yourself. It is certainly an awesome feature to have, even if the different magic arrow types are less useful than they are in the sequel Majora's Mask.

Not GUI elements have been added as of now (ex. checkbox to enable/disable this feature).