### PR TITLE
Logic framework for alternate dungeon exits

### DIFF
--- a/data/World/Bosses.json
+++ b/data/World/Bosses.json
@@ -153,6 +153,7 @@
             "Ganons Tower Boss Key Chest": "is_adult or Kokiri_Sword"
         },
         "exits": {
+            "Ganons Castle Main": "True",
             "Ganons Castle Tower Below Boss": "
                 (is_adult or Kokiri_Sword) and
                 (Boss_Key_Ganons_Castle or (shuffle_pots != 'off'))"

--- a/data/World/Ganons Castle.json
+++ b/data/World/Ganons Castle.json
@@ -4,6 +4,14 @@
         "dungeon": "Ganons Castle",
         "exits": {
             "Castle Grounds From Ganons Castle": "True",
+            "Ganons Castle Main": "True",
+            "Farores Wind Warp": "can_use(Farores_Wind)"
+        }
+    },
+    {
+        "region_name": "Ganons Castle Main",
+        "dungeon": "Ganons Castle",
+        "exits": {
             "Ganons Castle Forest Trial": "True",
             "Ganons Castle Water Trial": "True",
             "Ganons Castle Shadow Trial": "True",
@@ -17,8 +25,7 @@
                 (skipped_trials[Water] or 'Water Trial Clear') and
                 (skipped_trials[Shadow] or 'Shadow Trial Clear') and
                 (skipped_trials[Spirit] or 'Spirit Trial Clear') and
-                (skipped_trials[Light] or 'Light Trial Clear')",
-            "Farores Wind Warp": "can_use(Farores_Wind)"
+                (skipped_trials[Light] or 'Light Trial Clear')"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1102,12 +1102,21 @@
         }
     },
     {
-        "region_name": "Desert Colossus Hands",
+        "region_name": "Desert Colossus Right Hand",
         "scene": "Desert Colossus",
         "time_passes": true,
-        "savewarp": "Desert Colossus -> Spirit Temple Lobby",
         "exits": {
-            "Desert Colossus": "True"
+            "Desert Colossus": "True",
+            "Spirit Temple Right Hand Iron Knuckle": "True"
+        }
+    },
+    {
+        "region_name": "Desert Colossus Left Hand",
+        "scene": "Desert Colossus",
+        "time_passes": true,
+        "exits": {
+            "Desert Colossus": "True",
+            "Spirit Temple Left Hand Iron Knuckle": "True"
         }
     },
     {

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -126,11 +126,30 @@
                 is_adult"
         },
         "exits": {
-            "Desert Colossus Hands": "
-                ((Small_Key_Spirit_Temple, 7) and
-                    (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot or is_adult)) or
-                ((Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and (has_explosives or Nuts) and
-                    (logic_lens_spirit_mq or can_use(Lens_of_Truth)) and is_adult)"
+            "Spirit Temple Right Hand Iron Knuckle": "
+                (Small_Key_Spirit_Temple, 7) and
+                    (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot or is_adult)",
+            "Spirit Temple Left Hand Iron Knuckle": "
+                (Small_Key_Spirit_Temple, 4) and can_play(Song_of_Time) and (has_explosives or Nuts) and
+                    (logic_lens_spirit_mq or can_use(Lens_of_Truth)) and is_adult"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Right Hand Iron Knuckle",
+        "dungeon": "Spirit Temple",
+        "savewarp": "Desert Colossus -> Spirit Temple Lobby",
+        "exits": {
+            "Spirit Temple Shared": "False",
+            "Desert Colossus Right Hand": "True"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Left Hand Iron Knuckle",
+        "dungeon": "Spirit Temple",
+        "savewarp": "Desert Colossus -> Spirit Temple Lobby",
+        "exits": {
+            "Spirit Temple Shared": "False",
+            "Desert Colossus Left Hand": "True"
         }
     },
     {

--- a/data/World/Spirit Temple.json
+++ b/data/World/Spirit Temple.json
@@ -204,9 +204,28 @@
                 (Longshot or (logic_spirit_platform_hookshot and Hookshot))",
             # Age-unknown logic is incompatible with the rest of the world.
             # Because adult might unlock all doors, child must require all 5 keys to pass.
-            "Desert Colossus Hands": "
-                (Small_Key_Spirit_Temple, 5) or
-                (is_adult and has_explosives and (Small_Key_Spirit_Temple, 3))"
+            "Spirit Temple Right Hand Iron Knuckle": "
+                (Small_Key_Spirit_Temple, 5)",
+            "Spirit Temple Left Hand Iron Knuckle": "
+                is_adult and has_explosives and (Small_Key_Spirit_Temple, 3)"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Right Hand Iron Knuckle",
+        "dungeon": "Spirit Temple",
+        "savewarp": "Desert Colossus -> Spirit Temple Lobby",
+        "exits": {
+            "Spirit Temple Central Chamber": "False",
+            "Desert Colossus Right Hand": "True"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Left Hand Iron Knuckle",
+        "dungeon": "Spirit Temple",
+        "savewarp": "Desert Colossus -> Spirit Temple Lobby",
+        "exits": {
+            "Spirit Temple Central Chamber": "False",
+            "Desert Colossus Left Hand": "True"
         }
     },
     {


### PR DESCRIPTION
Reconciles exits from Ganon's Castle (vanilla and MQ) to Ganon's Tower, and adds a reverse entrance from Ganon's Tower. 

The ER framework depends on common interfaces between regions. 
This enables alternate branches to add options to more easily shuffle these entrances without touching the logic. No impact to the main branch functionality.

I'm aware Spirit access from the hands entrances breaks everything logically. Reverse entrances further into the dungeon are set to False to prevent the game somehow requiring it. Further logic rework is left to other contributors. This PR is only to establish common region and exit names.