### PR TITLE
feat: add preparation for custom music patching on web

### DIFF
--- a/Music.py
+++ b/Music.py
@@ -117,6 +117,7 @@ fileselect_sequence_id: tuple[tuple[str, int], ...] = (
     ("File Select", 0x57),
 )
 
+
 class Bank:
     def __init__(self, index: int, meta: bytearray, data: bytes) -> None:
         self.index: int = index
@@ -645,6 +646,7 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: di
     sequences = fanfare_sequences = target_sequences = target_fanfare_sequences = bgm_groups = fanfare_groups = {}
     disabled_source_sequences = log.src_dict.get('bgm_groups', {}).get('exclude', []).copy()
     disabled_target_sequences = {}
+    available_sequences = log.src_dict.get('sequences_available', {}) if not settings.generating_patch_file else {}
     music_mapping = log.src_dict.get('bgm', {}).copy()
     bgm_ids = {bgm[0]: bgm for bgm in bgm_sequence_ids}
     ff_ids = {bgm[0]: bgm for bgm in fanfare_sequence_ids}
@@ -666,6 +668,10 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: di
         if compare_version(rom_version, '4.11.13') < 0:
             log.errors.append("Custom music is not supported by this patch version. Only randomizing vanilla music.")
             custom_sequences_enabled = False
+
+    # If "sequences_available" is in the cosmetics plando, don't bother trying to scan for custom sequences.
+    if available_sequences:
+        custom_sequences_enabled = False
 
     # Check if we have mapped music for BGM, Fanfares, Ocarina Songs or Credits Sequences
     bgm_mapped = any(name in music_mapping for name in bgm_ids)
@@ -698,7 +704,7 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: di
     if settings.fanfares == 'normal' and ocarina_mapped:
         normal_ids += [music_id for music_id in ocarina_ids.values()]
     if settings.credits_music == 'false' and credits_mapped:
-        normal_ids += [music_id for music_id in credits_mapped.values()]
+        normal_ids += [music_id for music_id in credits_ids.values()]
     for bgm in normal_ids:
         if bgm[0] not in music_mapping:
             music_mapping[bgm[0]] = bgm[0]
@@ -716,11 +722,17 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: di
         sequences, target_sequences, bgm_groups = process_sequences(rom, bgm_ids.values(), 'bgm', disabled_source_sequences, disabled_target_sequences, custom_sequences_enabled, include_custom_audiobanks=custom_audiobanks_enabled)
         if settings.background_music == 'random_custom_only':
             sequences = {name: seq for name, seq in sequences.items() if name not in bgm_ids or name in music_mapping.values()}
+        if available_sequences:
+            for sequence_name in available_sequences.get("bgm", []):
+                sequences[sequence_name] = Sequence(sequence_name, sequence_name)
 
     if settings.fanfares in ['random', 'random_custom_only'] or ff_mapped or ocarina_mapped:
         fanfare_sequences, target_fanfare_sequences, fanfare_groups = process_sequences(rom, ff_ids.values(), 'fanfare', disabled_source_sequences, disabled_target_sequences, custom_sequences_enabled, include_custom_audiobanks=custom_audiobanks_enabled)
         if settings.fanfares == 'random_custom_only':
             fanfare_sequences = {name: seq for name, seq in fanfare_sequences.items() if name not in ff_ids or name in music_mapping.values()}
+        if available_sequences:
+            for sequence_name in available_sequences.get("fanfare", []):
+                fanfare_sequences[sequence_name] = Sequence(sequence_name, sequence_name)
 
     # Handle groups.
     plando_groups = {n: s for n, s in log.src_dict.get('bgm_groups', {}).get('groups', {}).items()}
@@ -743,7 +755,6 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: di
             continue
 
         source = mapping
-        group = group_name = None
         if isinstance(mapping, list):
             # Try to find a valid source in the defined list
             while len(mapping) > 0:
@@ -802,6 +813,10 @@ def randomize_music(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: di
     if fanfare_sequences and target_fanfare_sequences:
         shuffled_fanfare_sequences = shuffle_music(log, fanfare_sequences, target_fanfare_sequences, music_mapping, "fanfares")
 
+    # If "sequences_available" is in the cosmetic plando, just skip the actual patching portion and leave that to the web patcher
+    if available_sequences:
+        return
+
     # Patch the randomized sequences into the ROM.
     patch_music = rebuild_sequences if custom_sequences_enabled else rebuild_pointers_table
     patch_music(rom, shuffled_sequences + shuffled_fanfare_sequences, log, symbols)
@@ -841,6 +856,7 @@ def restore_music(rom: Rom) -> None:
         # Zero out old audioseq
         rom.write_bytes(start, [0] * size)
         dma_entry.update(orig_start, orig_end, start)
+
 
 def chain_groups(group_list: list[tuple[str, list[str] | str]], sequences: dict[str, Sequence]) -> dict[str, list[str]]:
     result = {}

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4453,8 +4453,8 @@ class SettingInfos:
         ''',
         default        = False,
         disable    = {
-            True : {'sections' : [ "musicsfx_section", "generalsfx_section", "UIsfx_section", "itemsfx_section" ],
-            'settings' : ["sfx_navi_overworld", "sfx_navi_enemy", "sfx_horse_neigh", "sfx_cucco"]
+            True : {'sections' : [ "generalsfx_section", "UIsfx_section", "itemsfx_section" ],
+            'settings' : ["sfx_navi_overworld", "sfx_navi_enemy", "sfx_horse_neigh", "sfx_cucco", "background_music", "fanfares", "ocarina_fanfares", "credits_music"]
             }
         }
     )
@@ -4505,8 +4505,7 @@ class SettingInfos:
             'randomize_key': 'randomize_all_sfx',
             'distribution':  [
                 ('random', 1),
-            ],
-            'web:option_remove': ['random_custom_only'],
+            ]
         },
     )
 
@@ -4534,8 +4533,7 @@ class SettingInfos:
             'randomize_key': 'randomize_all_sfx',
             'distribution': [
                 ('random', 1),
-            ],
-            'web:option_remove': ['random_custom_only'],
+            ]
         },
     )
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4557,7 +4557,7 @@ class SettingInfos:
         default        = False,
     )
     
-    custom_music_directorypicker = Fileinput(
+    custom_music_directorypicker = Directoryinput(
         gui_text   = "Custom Music",
         shared     = False,
         cosmetic   = True,
@@ -4565,7 +4565,7 @@ class SettingInfos:
             Upload custom music files in OoTR's dedicated .ootrs format.
             You can upload individual files or directories consisting of multiple
             custom sequences. Implementation into the seed is controlled by 
-            the background_music setting above.
+            the background_music setting.
             Note: Multiple directories at once can only be uploaded by dragging them
             onto the text field.
         ''',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -75,6 +75,13 @@ class SettingInfos:
         },
     )
 
+    custom_music_unavailable_msg = Textbox(
+        gui_text   = "Custom music can only be added when patching.",
+        gui_params = {
+            "hide_when_disabled": True,
+        },
+    )
+
     # Web Only Settings
 
     web_wad_file = Fileinput(
@@ -213,13 +220,13 @@ class SettingInfos:
                         'web_wad_file', 'web_common_key_file', 'web_common_key_string',
                         'web_wad_channel_id', 'web_wad_channel_title', 'web_wad_legacy_mode',
                         'model_adult', 'model_child', 'model_adult_filepicker', 'model_child_filepicker',
-                        'sfx_link_adult', 'sfx_link_child',
+                        'sfx_link_adult', 'sfx_link_child', 'custom_music_directorypicker'
                     ],
                 },
                 True: {
                     'settings': [
                         'model_adult', 'model_child', 'model_unavailable_msg',
-                        'sfx_link_unavailable_msg',
+                        'sfx_link_unavailable_msg', 'custom_music_unavailable_msg'
                     ],
                 },
             },
@@ -227,13 +234,13 @@ class SettingInfos:
                 False: {
                     'settings': [
                         'model_adult_filepicker', 'model_child_filepicker', 'model_unavailable_msg',
-                        'sfx_link_unavailable_msg',
+                        'sfx_link_unavailable_msg', 'custom_music_directorypicker', 'custom_music_unavailable_msg'
                     ],
                 },
                 True: {
                     'settings': [
                         'model_adult_filepicker', 'model_child_filepicker', 'model_unavailable_msg',
-                        'sfx_link_unavailable_msg',
+                        'sfx_link_unavailable_msg', 'custom_music_directorypicker', 'custom_music_unavailable_msg'
                     ],
                 },
             },
@@ -4550,6 +4557,29 @@ class SettingInfos:
             ],
         },
         default        = False,
+    )
+    
+    custom_music_directorypicker = Fileinput(
+        gui_text   = "Custom Music",
+        shared     = False,
+        cosmetic   = True,
+        gui_tooltip = '''\
+            Upload custom music files in OoTR's dedicated .ootrs format.
+            You can upload individual files or directories consisting of multiple
+            custom sequences. Implementation into the seed is controlled by 
+            the background_music setting above.
+            Note: Multiple directories at once can only be uploaded by dragging them
+            onto the text field.
+        ''',
+        gui_params = {
+            "file_types": [
+                {
+                  "name": "OoTR Sequence Files",
+                  "extensions": ["ootrs"]
+                }
+            ],
+            "hide_when_disabled": True,
+        },
     )
 
     credits_music = Checkbutton(

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -511,8 +511,9 @@
           "col_span": 2,
           "row_span": [2,2,2],
           "settings": [
-            "background_music",
+            "custom_music_directorypicker",
             "custom_music_unavailable_msg",
+            "background_music",
             "fanfares",
             "ocarina_fanfares",
             "credits_music"
@@ -527,8 +528,8 @@
           "col_span": 2,
           "row_span": [2,2,2],
           "settings": [
-            "background_music",
             "custom_music_directorypicker",
+            "background_music",
             "fanfares",
             "ocarina_fanfares",
             "credits_music"

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -504,13 +504,31 @@
           ]
         },
         {
-          "name": "musicsfx_section",
+          "name": "musicsfx_section_generator",
           "text": "Music",
+          "app_type": ["generator"],
           "is_sfx": true,
           "col_span": 2,
           "row_span": [2,2,2],
           "settings": [
             "background_music",
+            "custom_music_unavailable_msg",
+            "fanfares",
+            "ocarina_fanfares",
+            "credits_music"
+          ]
+        },
+        {
+          "name": "musicsfx_section_patcher",
+          "text": "Music",
+          "exclude_from_electron": true,
+          "app_type": ["patcher"],
+          "is_sfx": true,
+          "col_span": 2,
+          "row_span": [2,2,2],
+          "settings": [
+            "background_music",
+            "custom_music_directorypicker",
             "fanfares",
             "ocarina_fanfares",
             "credits_music"

--- a/version.py
+++ b/version.py
@@ -1,14 +1,14 @@
 __version__ = '7.1.202'
 
 # This is a supplemental version number for branches based off of main dev.
-supplementary_version = 3
+supplementary_version = 0
 
 # Pick a unique identifier byte for your fork if you are intending to have a long-lasting branch.
 # This will be 0x00 for main releases and 0x01 for main dev.
-branch_identifier = 0x9c
+branch_identifier = 0x01
 
 # URL to your branch on GitHub.
-branch_url = 'https://github.com/TreZc0/OoT-Randomizer/tree/Dev'
+branch_url = 'https://github.com/TestRunnerSRL/OoT-Randomizer/tree/Dev'
 
 # This is named __version__ at the top for compatability with older versions trying to version check.
 base_version = __version__

--- a/version.py
+++ b/version.py
@@ -1,14 +1,14 @@
 __version__ = '7.1.202'
 
 # This is a supplemental version number for branches based off of main dev.
-supplementary_version = 0
+supplementary_version = 3
 
 # Pick a unique identifier byte for your fork if you are intending to have a long-lasting branch.
 # This will be 0x00 for main releases and 0x01 for main dev.
-branch_identifier = 0x01
+branch_identifier = 0x9c
 
 # URL to your branch on GitHub.
-branch_url = 'https://github.com/TestRunnerSRL/OoT-Randomizer/tree/Dev'
+branch_url = 'https://github.com/TreZc0/OoT-Randomizer/tree/Dev'
 
 # This is named __version__ at the top for compatability with older versions trying to version check.
 base_version = __version__


### PR DESCRIPTION
Until now, custom music patching was offline only.
Together with the changes in 394ed2812c2a6b907648bb688bed264f3fc16192,
this allows for directory picking on web.

Cuphat added cosmetic plando support to input a list of available music which will be used to shuffle the sequence list. That list is then returned as cosmetics plando log for the web patcher to use.

Note: This should be part of the 8.0 release, even if the web C patcher is not ready for the actual patching process yet.