### PR TITLE
Fix logic for Kak Granny Buy Blue Potion

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -647,9 +647,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         elif location.vanilla_item in trade_items:
             if not world.settings.adult_trade_shuffle:
                 if location.vanilla_item == 'Pocket Egg' and world.settings.adult_trade_start:
-                    potential_trade_items = world.settings.adult_trade_start
-                    item = random.choice(potential_trade_items)
-                    world.selected_adult_trade_item = item
+                    item = world.selected_adult_trade_item
                     shuffle_item = True
                 else:
                     shuffle_item = False

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -843,13 +843,6 @@ class WorldDistribution:
         if self.locations:
             locations = {loc: self.locations[loc] for loc in random.sample(sorted(self.locations), len(self.locations))}
         used_items = []
-        # Override the adult trade item used to control trade quest flags during patching.
-        # This has to run before placing other items because the selected trade
-        # item impacts logic for buying a blue potion from Granny's Potion shop.
-        adult_trade_matcher = self.pattern_matcher("#AdultTrade")
-        plando_adult_trade = list(filter(lambda location_record_pair: adult_trade_matcher(location_record_pair[1].item), self.pattern_dict_items(locations)))
-        if plando_adult_trade and not world.settings.adult_trade_shuffle and world.settings.adult_trade_start:
-            world.selected_adult_trade_item = plando_adult_trade[0][1].item # ugly but functional, see the loop below for how this is indexed
         record: LocationRecord
         for (location_name, record) in self.pattern_dict_items(locations):
             if record.item is None:

--- a/World.py
+++ b/World.py
@@ -78,8 +78,9 @@ class World:
         self.disable_trade_revert: bool = self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.adult_trade_shuffle
         self.skip_child_zelda: bool = 'Zeldas Letter' not in settings.shuffle_child_trade and \
                                       'Zeldas Letter' in self.distribution.starting_items
+        self.selected_adult_trade_item: str = None
         if not settings.adult_trade_shuffle and settings.adult_trade_start:
-            self.selected_adult_trade_item: str = random.choice(settings.adult_trade_start)
+            self.selected_adult_trade_item = random.choice(settings.adult_trade_start)
             # Override the adult trade item used to control trade quest flags during patching if any are placed in plando.
             # This has to run here because the rule parser caches world attributes and this attribute impacts logic for buying a blue potion from Granny's Potion shop.
             adult_trade_matcher = self.distribution.pattern_matcher("#AdultTrade")

--- a/World.py
+++ b/World.py
@@ -78,7 +78,16 @@ class World:
         self.disable_trade_revert: bool = self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.adult_trade_shuffle
         self.skip_child_zelda: bool = 'Zeldas Letter' not in settings.shuffle_child_trade and \
                                       'Zeldas Letter' in self.distribution.starting_items
-        self.selected_adult_trade_item: str = ''
+        self.selected_adult_trade_item: str = random.choice(settings.adult_trade_start) if settings.adult_trade_start else None
+        # Override the adult trade item used to control trade quest flags during patching if any are placed in plando.
+        # This has to run here because the rule parser caches world attributes and this attribute impacts logic for buying a blue potion from Granny's Potion shop.
+        locations = {}
+        if self.distribution.locations:
+            locations = {loc: self.distribution.locations[loc] for loc in random.sample(sorted(self.distribution.locations), len(self.distribution.locations))}
+        adult_trade_matcher = self.distribution.pattern_matcher("#AdultTrade")
+        plando_adult_trade = list(filter(lambda location_record_pair: adult_trade_matcher(location_record_pair[1].item), self.distribution.pattern_dict_items(locations)))
+        if plando_adult_trade and not settings.adult_trade_shuffle and settings.adult_trade_start:
+            self.selected_adult_trade_item = plando_adult_trade[0][1].item # ugly but functional, see the loop in Plandomizer.WorldDistribution.fill for how this is indexed
         self.adult_trade_starting_inventory: str = ''
 
         if (settings.open_forest == 'closed'

--- a/World.py
+++ b/World.py
@@ -78,16 +78,14 @@ class World:
         self.disable_trade_revert: bool = self.shuffle_interior_entrances or settings.shuffle_overworld_entrances or settings.adult_trade_shuffle
         self.skip_child_zelda: bool = 'Zeldas Letter' not in settings.shuffle_child_trade and \
                                       'Zeldas Letter' in self.distribution.starting_items
-        self.selected_adult_trade_item: str = random.choice(settings.adult_trade_start) if settings.adult_trade_start else None
-        # Override the adult trade item used to control trade quest flags during patching if any are placed in plando.
-        # This has to run here because the rule parser caches world attributes and this attribute impacts logic for buying a blue potion from Granny's Potion shop.
-        locations = {}
-        if self.distribution.locations:
-            locations = {loc: self.distribution.locations[loc] for loc in random.sample(sorted(self.distribution.locations), len(self.distribution.locations))}
-        adult_trade_matcher = self.distribution.pattern_matcher("#AdultTrade")
-        plando_adult_trade = list(filter(lambda location_record_pair: adult_trade_matcher(location_record_pair[1].item), self.distribution.pattern_dict_items(locations)))
-        if plando_adult_trade and not settings.adult_trade_shuffle and settings.adult_trade_start:
-            self.selected_adult_trade_item = plando_adult_trade[0][1].item # ugly but functional, see the loop in Plandomizer.WorldDistribution.fill for how this is indexed
+        if not settings.adult_trade_shuffle and settings.adult_trade_start:
+            self.selected_adult_trade_item: str = random.choice(settings.adult_trade_start)
+            # Override the adult trade item used to control trade quest flags during patching if any are placed in plando.
+            # This has to run here because the rule parser caches world attributes and this attribute impacts logic for buying a blue potion from Granny's Potion shop.
+            adult_trade_matcher = self.distribution.pattern_matcher("#AdultTrade")
+            plando_adult_trade = list(filter(lambda location_record_pair: adult_trade_matcher(location_record_pair[1].item), self.distribution.pattern_dict_items(self.distribution.locations)))
+            if plando_adult_trade:
+                self.selected_adult_trade_item = plando_adult_trade[0][1].item # ugly but functional, see the loop in Plandomizer.WorldDistribution.fill for how this is indexed
         self.adult_trade_starting_inventory: str = ''
 
         if (settings.open_forest == 'closed'

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1789,12 +1789,11 @@
         "locations": {
             "Kak Granny Trade Odd Mushroom": "'Odd Potion Access'",
             # Granny will not sell her item without turning in odd mushroom
-            # If the adult trade item(s) in the world are all after odd mushroom,
-            # allow any of the later sequence items to satisfy logic. The patcher
-            # sets the flag needed for her to sell stuff if odd mushroom can't be obtained.
-            "Kak Granny Buy Blue Potion": "Progressive_Wallet and is_adult and
-                (Odd_Mushroom or ((Odd_Potion or Poachers_Saw or Broken_Sword or
-                Prescription or Eyeball_Frog or Eyedrops or Claim_Check) and not adult_trade_shuffle))"
+            "Kak Granny Buy Blue Potion": "Progressive_Wallet and is_adult and ('Odd Potion Access' or
+                ((selected_adult_trade_item == 'Odd Potion' or selected_adult_trade_item == 'Poachers Saw' or
+                selected_adult_trade_item == 'Broken Sword' or selected_adult_trade_item == 'Prescription' or
+                selected_adult_trade_item == 'Eyeball Frog' or selected_adult_trade_item == 'Eyedrops' or
+                selected_adult_trade_item == 'Claim Check') and not adult_trade_shuffle))"
         },
         "exits": {
             "Kak Backyard": "True"


### PR DESCRIPTION
The logic previously required actually having obtained the trade quest item even if that item comes later in the sequence than the odd mushroom. The actual in-game flag is also set if adult trade shuffle is off and the starting trade item is the odd potion or later.

See discussion in #dev-bug-reports starting [here](https://discord.com/channels/274180765816848384/438698093354156032/1171215838439800923) for context.

Now includes a fix contributed by @mracsys to handle adult trade items being plando'd.