### PR TITLE
Fix error generating compass messages in glitched logic

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -2355,7 +2355,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
                     area = GossipText(area.text(world.settings.clearer_hints, preposition=True), [area.color], prefix='')
                     compass_message = "\x13\x75\x08You found the \x05\x41Compass\x05\x40\x01for %s\x05\x40!\x01The %s can be found\x01%s!\x09" % (dungeon_name, vanilla_reward, area) #TODO figure out why the player name isn't being displayed
                 else:
-                    boss_location = next(filter(lambda loc: loc.type == 'Boss', world.get_entrance(f'{dungeon} Before Boss -> {boss_name} Boss Room').connected_region.locations))
+                    if world.settings.logic_rules == 'glitched':
+                        boss_location = world.get_location(boss_name)
+                    else:
+                        boss_location = next(filter(lambda loc: loc.type == 'Boss', world.get_entrance(f'{dungeon} Before Boss -> {boss_name} Boss Room').connected_region.locations))
                     dungeon_reward = reward_list[boss_location.item.name]
                     compass_message = "\x13\x75\x08You found the \x05\x41Compass\x05\x40\x01for %s\x05\x40!\x01It holds the %s!\x09" % (dungeon_name, dungeon_reward)
                 update_message_by_id(messages, compass_id, compass_message)


### PR DESCRIPTION
There is a bug that can be reproduced using this plando:

```json
{
    "settings": {
        "logic_rules": "glitched",
        "enhance_map_compass": true
    }
}
```

This throws an exception in the code for generating compass messages complaining that the `Deku Tree Before Boss -> Queen Gohma Boss Room` entrance is missing. This is because glitched logic does not support boss ER and therefore does not define this entrance (or the other boss entrances). With this PR, the code bypasses the entrance check in glitched logic and directly uses the vanilla boss location of the dungeon.