### PR TITLE
Better exception message for invalid JSON in hint distro file

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1800,7 +1800,10 @@ def hint_dist_list() -> dict[str, str]:
     dists = {}
     for d in hint_dist_files():
         with open(d, 'r') as dist_file:
-            dist = json.load(dist_file)
+            try:
+                dist = json.load(dist_file)
+            except json.JSONDecodeError as e:
+                raise ValueError(f'Could not parse hint distribution file {os.path.basename(d)!r}. Make sure the file is valid JSON or reach out to Support on Discord for help. Details: {e}') from e
         dists[dist['name']] = dist['gui_name']
     return dists
 


### PR DESCRIPTION
A user of my fork DM'd me today because they had run into an issue where the randomizer showed this error message:

> json.decoder.JSONDecodeError: Expecting value: line 25 column 5 (char 1556)

The problem was a syntax error in one of their custom hint distribution files. The error message does not mention this; you need to read the traceback to find the cause of the issue. This PR changes the error message to the following:

> ValueError: Could not parse hint distribution file 'syntax_error.json'. Make sure the file is valid JSON or reach out to Support on Discord for help. Details: Expecting value: line 25 column 5 (char 1556)

This can be tested by placing a hint distribution that's not valid JSON (e.g. an empty file) into `data/Hints`.