### PR TITLE
Add plandomized_locations as a presets option

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -281,6 +281,9 @@ class Settings(SettingInfos):
         for location in self.disabled_locations:
             self.distribution.add_location(location, '#Junk')
 
+        for location in self.plandomized_locations:
+            self.distribution.add_location(location, self.plandomized_locations[location])
+
     def check_dependency(self, setting_name: str, check_random: bool = True) -> bool:
         return self.get_dependency(setting_name, check_random) is None
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3416,6 +3416,7 @@ class SettingInfos:
     )
 
     hint_dist_user = SettingInfoDict(None, None, True, {})
+    plandomized_locations = SettingInfoDict("Plandomized Locations", None, True, {})
 
     misc_hints = MultipleSelect(
         gui_text        = 'Misc. Hints',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -178,7 +178,8 @@
             "triforce_count_per_world",
             "triforce_goal_per_world",
             "free_bombchu_drops",
-            "one_item_per_dungeon"
+            "one_item_per_dungeon",
+            "plandomized_locations"
           ]
         },
         {


### PR DESCRIPTION
Adds support for a `plandomized_locations` dictionary in a settings preset.  This dictionary takes a map of locations and items and adds it to the distribution before the seed is rolled.

Example that forces Link to start with the Light Medallion:
```
"plandomized_locations": {
    "Links Pocket": "Light Medallion"
},
```