### PR TITLE
CI check to ensure spoiler logs are created on release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Python
+
+on:
+  push:
+    branches: [ "release" ]
+  pull_request:
+    branches: [ "release" ]
+
+jobs:
+  release_ci_checks:
+    name: Release CI Checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.x"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run checks
+        run: python CI.py --no_unit_tests --release

--- a/CI.py
+++ b/CI.py
@@ -108,6 +108,22 @@ def check_hell_mode_tricks(fix_errors: bool = False) -> None:
             print(file=file)
 
 
+def check_release_presets(fix_errors: bool = False) -> None:
+    # Check to make sure spoiler logs are enabled for all presets.
+    with open(data_path('presets_default.json'), encoding='utf-8') as f:
+        presets = json.load(f)
+
+    for preset_name, preset in presets.items():
+        if not preset['create_spoiler']:
+            error(f'{preset_name} preset does not create spoiler logs', True)
+            preset['create_spoiler'] = True
+
+    if fix_errors:
+        with open(data_path('presets_default.json'), 'w', encoding='utf-8', newline='') as file:
+            json.dump(presets, file, indent=4)
+            print(file=file)
+
+
 def check_code_style(fix_errors: bool = False) -> None:
     # Check for code style errors
     repo_dir = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -175,6 +191,7 @@ def run_ci_checks() -> NoReturn:
     parser = argparse.ArgumentParser()
     parser.add_argument('--no_unit_tests', help="Skip unit tests", action='store_true')
     parser.add_argument('--only_unit_tests', help="Only run unit tests", action='store_true')
+    parser.add_argument('--release', help="Include checks for release branch", action='store_true')
     parser.add_argument('--fix', help='Automatically apply fixes where possible', action='store_true')
     args = parser.parse_args()
 
@@ -185,6 +202,8 @@ def run_ci_checks() -> NoReturn:
         check_hell_mode_tricks(args.fix)
         check_code_style(args.fix)
         check_presets_formatting(args.fix)
+        if args.release:
+            check_release_presets(args.fix)
 
     exit_ci(args.fix)
 

--- a/CI.py
+++ b/CI.py
@@ -1,6 +1,8 @@
 # This script is called by GitHub Actions, see .github/workflows/python.yml
 # To fix code style errors, run: python3 ./CI.py --fix --no_unit_tests
 
+from __future__ import annotations
+
 import argparse
 import json
 import os.path


### PR DESCRIPTION
As discussed today in #setup-support, it would be helpful for casual players and support staff if release builds always had spoiler logs enabled in all presets. Currently, there are 4 presets which disable them: Standard Weekly, Scrub Tournament, League, and Co-Op. All of these are racing presets that use the Dev branch, or were using it at the time they were introduced. Races on the release branch can use the “GENERATE RACE SEED!” button on <https://ootrandomizer.com/generator> to hide spoiler logs instead.

This PR adds a new `--release` command-line flag to the CI script and a new GitHub Actions workflow that runs CI with this flag on the release branch. The new CI check simply checks that all bundled presets have spoiler logs enabled.

If this PR is accepted, maintainers should make sure to add this check to the release process. **Edit:** @TreZc0 has confirmed that this has been/will be taken care of.