### PR TITLE
Allow non-items to be hinted via plando

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3412,7 +3412,7 @@ class SettingInfos:
         gui_type       = None,
         gui_text       = None,
         shared         = True,
-        choices        = [name for name, item in ItemInfo.items.items() if item.type == 'Item']
+        choices        = [name for name, item in ItemInfo.items.items() if item.type not in ('Drop', 'Event', 'Refill', 'Shop')]
     )
 
     hint_dist_user = SettingInfoDict(None, None, True, {})


### PR DESCRIPTION
Currently hint plandos only allow for things defined as items in ItemList.py as valid choices for the "item_hints" block. However other locations in the project allow for non-item defined options to be added to this block (see data/Bingo/generic_bingo_hints"). This PR allows for non-item defined choices to be used in a hint plando (songs, keys, etc). This can be tested via the following plando currently:

```json
"settings": {
	"item_hints":                              ["Zeldas Lullaby"]
}
```

Valid types will be those that have an item declared that type in ItemList.py and a hint for that item in HintList.py