### PR TITLE
Clarify error message for unshuffled starting trade item

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -583,7 +583,7 @@ class WorldDistribution:
                         except KeyError:
                             raise KeyError('Tried to start with a Pocket Egg but could not remove it from the item pool. Are both Pocket Egg and Pocket Cucco shuffled?')
                     elif 'Pocket Cucco' not in world.settings.adult_trade_start:
-                        raise RuntimeError('An unshuffled trade item was included as a starting item. Please remove %s from starting items' % item_name)
+                        raise RuntimeError(f'An unshuffled trade item was included as a starting item. Please either remove {item_name} from starting items or add it to Adult Trade Sequence Items.')
                     else:
                         self.pool_remove_item([pool], "Pocket Cucco", record.count)
                 except KeyError:
@@ -597,7 +597,7 @@ class WorldDistribution:
                     if 'Weird Egg' in world.settings.shuffle_child_trade:
                         self.pool_remove_item([pool], "Weird Egg", record.count)
                     elif 'Chicken' not in world.settings.shuffle_child_trade:
-                        raise RuntimeError('An unshuffled trade item was included as a starting item. Please remove %s from starting items' % item_name)
+                        raise RuntimeError(f'An unshuffled trade item was included as a starting item. Please either remove {item_name} from starting items or add it to Shuffled Child Trade Sequence Items.')
                     else:
                         self.pool_remove_item([pool], "Chicken", record.count)
                 except KeyError:
@@ -1122,7 +1122,7 @@ class WorldDistribution:
                         effective_adult_trade_item_index = trade_items.index(item_name)
                         effective_adult_trade_item = items[item_name]
                 else:
-                    raise RuntimeError('An unshuffled trade item was included as a starting item. Please remove %s from starting items' % item_name)
+                    raise RuntimeError(f'An unshuffled trade item was included as a starting item. Please either remove {item_name} from starting items or add it to Adult Trade Sequence Items.')
                 del items[item_name]
             if item_name in child_trade_items:
                 if item_name in world.settings.shuffle_child_trade or item_name == 'Zeldas Letter':
@@ -1130,7 +1130,7 @@ class WorldDistribution:
                         effective_child_trade_item_index = child_trade_items.index(item_name)
                         effective_child_trade_item = items[item_name]
                 else:
-                    raise RuntimeError('An unshuffled trade item was included as a starting item. Please remove %s from starting items' % item_name)
+                    raise RuntimeError(f'An unshuffled trade item was included as a starting item. Please either remove {item_name} from starting items or add it to Shuffled Child Trade Sequence Items.')
                 del items[item_name]
 
         if effective_child_trade_item_index >= 0:


### PR DESCRIPTION
Motivated by yesterday's conversation in #setup-support, this PR edits the error message shown when a trade sequence item is included as a starting item but not included in the set of shuffled trade items. Previously, the error message only suggested to remove the item from the starting items, but another way to fix the error is to add it to the shuffled trade items. The new error message gives both options.