### PR TITLE
feat(GUI): Adapt to new Windows pylauncher alias concept

### DIFF
--- a/GUI/electron/src/main.ts
+++ b/GUI/electron/src/main.ts
@@ -48,7 +48,12 @@ async function createApp() {
   }
 
   if (!("python" in programOpts)) {
-    programOpts["python"] = await determineDefaultPyPath();
+    try {
+      programOpts["python"] = await determineDefaultPyPath();
+    }
+    catch(ex) {
+      programOpts["criticalBootError"] = ex;
+    }
   }
 
   global["commandLineArgs"] = programOpts;
@@ -282,11 +287,11 @@ function determineDefaultPyPath() {
         const [semVer, major, minor, patch, prerelease, buildmetadata] = version.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/) ?? [];
 
         if (!semVer)
-          reject("Python could not be found. Please install Python 3.8+");
+          resolve("");
         else if ((major != "3") || (parseInt(minor) < 11)) {
           resolve("py");
         }
-        
+
         resolve(defaultWindowsExec);
       }
         

--- a/GUI/electron/src/main.ts
+++ b/GUI/electron/src/main.ts
@@ -266,31 +266,27 @@ function determineDefaultPyPath() {
       error = data.toString();
     });
 
-    
     pythonExec.stdout.on('data', data => {
       version = data.toString();
 
       if (version.toLowerCase().includes("python"))
         version = version.toLowerCase().split("python")[1].trim();
-
     });
     
     promiseFromChildProcess(pythonExec).then(function () {
-
       pythonExec = null;
 
       if (error)
         reject(error);
       else {
         const [semVer, major, minor, patch, prerelease, buildmetadata] = version.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/) ?? [];
-        console.log(semVer,major,minor)
 
         if (!semVer)
           reject("Python could not be found. Please install Python 3.8+");
         else if ((major != "3") || (parseInt(minor) < 11)) {
           resolve("py");
         }
-
+        
         resolve(defaultWindowsExec);
       }
         

--- a/GUI/electron/src/preload.ts
+++ b/GUI/electron/src/preload.ts
@@ -9,6 +9,12 @@ import * as post from 'post-robot';
 const generator = remote.require(path.join(__dirname, '../src/modules/generator.js'));
 const commander = remote.getGlobal("commandLineArgs");
 
+if ("criticalBootError" in commander)
+{
+   alert(commander.criticalBootError);
+   remote.app.quit();
+}
+
 var testMode = commander.release || remote.app.isPackaged ? false : true;
 console.log("Test Mode:", testMode);
 

--- a/GUI/electron/src/preload.ts
+++ b/GUI/electron/src/preload.ts
@@ -266,6 +266,10 @@ post.on('updateDynamicSetting', function (event) {
       post.send(window, 'updateDynamicSettingSuccess', res);
       
   }).catch((err) => {
+
+      if (os.platform() == "win32")
+        alert("The Python version used to run the GUI is not supported! If you have python 3.8+ installed, make sure app execution aliases for python are disabled.");
+
       post.send(window, 'updateDynamicSettingError', err);
   })
 })

--- a/Gui.py
+++ b/Gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import sys
 if sys.version_info < (3, 8):
     print("OoT Randomizer requires Python version 3.8 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))

--- a/Gui.py
+++ b/Gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 import sys
 if sys.version_info < (3, 8):
     print("OoT Randomizer requires Python version 3.8 or newer and you are using %s" % '.'.join([str(i) for i in sys.version_info[0:3]]))


### PR DESCRIPTION
Ever since python 3.11, pylauncher for Windows was adjusted to scan the Windows path instead of the prefered exec from env variables, ini files and such.
This sadly leads to a couple of edge cases, as early in path, Windows is injecting special app execution aliases for "py" and "python".

This PR addresses this. While the solution is not perfect and comes with **certain disadvantages**, especially breaking direct script calls of Gui.py on unix systems with a non default python3 path (so not /usr/bin/python3), it seems to be the way lesser evil, especially given the majority of our userbase being on Windows.
On Mac, the adjusted shebang will lead to the default python3 version shipped with the OS being used, which currently is Python 3.9.

In addition, this includes a fix for the bundled electron version of the UI. 

It moves the python testing function from preload.ts, which needs to run in sync and is not waited for, to the main.ts. 
Since the new default executable for python 3.11 and newer on Windows is "python", this was changed to be the new default. If python doesn't work or it is recognized as being python 2.7, "py" will be used instead as before.

This approach likely has several edge cases as well, but will still allow for a way improved experience for the average user.

In addition, through addition of the _ criticalBootError_ parameter, we can at least output those errors to the user through a system dialog alert box.

Testing on different systems before merge would be appreciated.