### PR TITLE
Update League Hint File and Settings For Season 6

### DIFF
--- a/data/Hints/league.json
+++ b/data/Hints/league.json
@@ -57,7 +57,14 @@
     "distribution":          {
         "trial":           {"order": 1, "weight": 0.0, "fixed": 0, "copies": 2},
         "entrance_always": {"order": 2, "weight": 0.0, "fixed": 0, "copies": 2},
-        "always":          {"order": 3, "weight": 0.0, "fixed": 0, "copies": 2},
+        "always":          {"order": 3, "weight": 0.0, "fixed": 0, "copies": 2, "remove_stones": [
+            "ToT (Left)",
+            "ToT (Left-Center)",
+            "ToT (Right-Center)",
+            "ToT (Right)",
+            "HF (Cow Grotto)",
+            "HC (Storms Grotto)"
+        ]},
         "goal":            {"order": 4, "weight": 0.0, "fixed": 5, "copies": 2, "remove_stones": [
             "ToT (Left)",
             "ToT (Left-Center)",

--- a/data/Hints/league.json
+++ b/data/Hints/league.json
@@ -1,7 +1,7 @@
 {
     "name":                  "league",
     "gui_name":              "League",
-    "description":           "Hint Distribution for the S5 of League. 5 Always, 5 Path, 3 Barren, 7 Sometimes & Dual Hints weighted towards sometimes, 30/40/50 skull hints in house of skulltula",
+    "description":           "Hint Distribution for the S6 of League. 5 Always, 5 Path, 4 Barren at ToT, 5 Sometimes, 2 Dual Hints, HC Storms & HF Cow Hints Junked, 30/40/50 skull hints in house of skulltula",
     "add_locations":         [
         { "location": "Deku Theater Skull Mask", "types": ["always"] },
         { "location": "Sheik in Kakariko", "types": ["always"] }
@@ -58,17 +58,32 @@
         "trial":           {"order": 1, "weight": 0.0, "fixed": 0, "copies": 2},
         "entrance_always": {"order": 2, "weight": 0.0, "fixed": 0, "copies": 2},
         "always":          {"order": 3, "weight": 0.0, "fixed": 0, "copies": 2},
-        "goal":            {"order": 4, "weight": 0.0, "fixed": 5, "copies": 2},
-        "barren":          {"order": 5, "weight": 0.0, "fixed": 3, "copies": 2},
-        "entrance":        {"order": 6, "weight": 0.0, "fixed": 4, "copies": 2},
-        "dual":            {"order": 7, "weight": 1.5, "fixed": 0, "copies": 2},
-        "sometimes":       {"order": 8, "weight": 5.5, "fixed": 0, "copies": 2},
+        "goal":            {"order": 4, "weight": 0.0, "fixed": 5, "copies": 2, "remove_stones": [
+            "ToT (Left)",
+            "ToT (Left-Center)",
+            "ToT (Right-Center)",
+            "ToT (Right)",
+            "HF (Cow Grotto)",
+            "HC (Storms Grotto)"
+        ]},
+        "barren":          {"order": 5, "weight": 0.0, "fixed": 4, "copies": 1, "priority_stones": [
+            "ToT (Left)",
+            "ToT (Left-Center)",
+            "ToT (Right-Center)",
+            "ToT (Right)"
+        ]},
+        "junk":            {"order": 6, "weight": 0.0, "fixed": 2, "copies": 1, "priority_stones": [
+            "HF (Cow Grotto)",
+            "HC (Storms Grotto)"
+        ]},
+        "entrance":        {"order": 7, "weight": 0.0, "fixed": 0, "copies": 2},
+        "dual":            {"order": 8, "weight": 0.0, "fixed": 2, "copies": 2},
+        "sometimes":       {"order": 9, "weight": 1.0, "fixed": 5, "copies": 2},
         "random":          {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "item":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "song":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "overworld":       {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "dungeon":         {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
-        "junk":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "named-item":      {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "woth":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "dual_always":     {"order": 0, "weight": 0.0, "fixed": 0, "copies": 0},

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -1581,9 +1581,9 @@
             "Claim Check"
         ]
     },
-    "League S5": {
+    "League S6": {
         "show_seed_info": true,
-        "user_message": "OoTR League S5",
+        "user_message": "OoTR League S6",
         "world_count": 1,
         "create_spoiler": false,
         "randomize_settings": false,
@@ -1631,7 +1631,7 @@
         "gerudo_fortress": "fast",
         "dungeon_shortcuts_choice": "off",
         "dungeon_shortcuts": [],
-        "starting_age": "random",
+        "starting_age": "adult",
         "mq_dungeons_mode": "vanilla",
         "mq_dungeons_specific": [],
         "mq_dungeons_count": 0,
@@ -1714,7 +1714,7 @@
         "complete_mask_quest": false,
         "useful_cutscenes": false,
         "fast_chests": true,
-        "free_scarecrow": false,
+        "free_scarecrow": true,
         "fast_bunny_hood": true,
         "auto_equip_masks": false,
         "plant_beans": false,
@@ -1724,7 +1724,7 @@
         "big_poe_count": 1,
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
-        "ruto_already_f1_jabu": false,
+        "ruto_already_f1_jabu": true,
         "ocarina_songs": "off",
         "correct_chest_appearances": "both",
         "minor_items_as_major_chest": [],


### PR DESCRIPTION
As title, updated hint file to use 4 tot barren hints and junk HC Storms and HF Cow grotto stones.

Updated settings for S6