### PR TITLE
Preset CLI Aliases

### DIFF
--- a/CI.py
+++ b/CI.py
@@ -75,7 +75,7 @@ def check_presets_formatting(fix_errors: bool = False) -> None:
             # sort the settings within each preset
             setting_name: preset[setting_name]
             for setting_name, setting in SettingInfos.setting_infos.items()
-            if setting_name != 'starting_items' and setting.shared and setting_name in preset
+            if setting_name != 'starting_items' and (setting.shared or setting_name == 'aliases') and setting_name in preset
         }
         for preset_name, preset in presets.items()
     }

--- a/Settings.py
+++ b/Settings.py
@@ -407,6 +407,17 @@ def get_settings_from_command_line_args() -> tuple[Settings, bool, str, bool, st
         for fn in presetsFiles:
             with open(fn, encoding='utf-8') as f:
                 presets = json.load(f)
+
+                # Deal with preset aliases.
+                for name, preset in copy.copy(presets).items():
+                    if 'aliases' not in preset:
+                        continue
+                    for alias in preset['aliases']:
+                        if alias in presets:
+                            logging.getLogger('').warning(f"Preset {name}, alias {alias} collides with existing preset or alias. Ignoring.")
+                            continue
+                        presets[alias] = preset
+
                 if args.settings_preset in presets:
                     settings_base.update(presets[args.settings_preset])
                     break

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 class SettingInfos:
     # Internal & Non-GUI Settings
+    aliases = SettingInfoList(None, None, False)
     cosmetics_only = Checkbutton(None)
     check_version = Checkbutton(None)
     checked_version = SettingInfoStr(None, None)
@@ -5115,6 +5116,8 @@ def validate_settings(settings_dict: dict[str, Any], *, check_conflicts: bool = 
             raise TypeError('Supplied choice %r for setting %r is of type %r, expecting %r' % (choice, setting, type(choice).__name__, info.type.__name__))
         # If setting is a list, must check each element
         if isinstance(choice, list):
+            if not info.choice_list:
+                continue
             for element in choice:
                 if element not in info.choice_list:
                     raise ValueError('%r is not a valid choice for setting %r. %s' % (element, setting, build_close_match(element, 'choice', info.choice_list)))

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -532,7 +532,8 @@
     },
     "DDR Weekly (2023-06-12)": {
         "aliases": [
-            "ddr"
+            "ddr",
+            "ddrweekly"
         ],
         "show_seed_info": true,
         "user_message": "DDR Season 2",
@@ -1796,7 +1797,8 @@
     "Co-Op Tournament Season 3": {
         "aliases": [
             "co-op",
-            "co-op_s3"
+            "co-op_s3",
+            "coop"
         ],
         "show_seed_info": true,
         "user_message": "Co-Op Tournament Season 3",

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -1,5 +1,8 @@
 {
     "Easy Mode": {
+        "aliases": [
+            "easy"
+        ],
         "show_seed_info": true,
         "user_message": "Easy Mode",
         "world_count": 1,
@@ -164,6 +167,10 @@
         ]
     },
     "S7 Tournament": {
+        "aliases": [
+            "s7",
+            "tournament"
+        ],
         "show_seed_info": true,
         "user_message": "S7 Tournament",
         "world_count": 1,
@@ -341,7 +348,11 @@
             "Claim Check"
         ]
     },
-    "Standard Weekly (Latest)": {
+    "Standard Weekly (2023-08-12)": {
+        "aliases": [
+            "Standard Weekly (Latest)",
+            "weekly"
+        ],
         "show_seed_info": true,
         "user_message": "Standard Weekly (Latest)",
         "world_count": 1,
@@ -520,6 +531,9 @@
         ]
     },
     "DDR Weekly (2023-06-12)": {
+        "aliases": [
+            "ddr"
+        ],
         "show_seed_info": true,
         "user_message": "DDR Season 2",
         "world_count": 1,
@@ -704,6 +718,9 @@
         ]
     },
     "Scrub Tournament": {
+        "aliases": [
+            "scrub"
+        ],
         "show_seed_info": true,
         "user_message": "Scrub Tournament",
         "world_count": 1,
@@ -884,6 +901,10 @@
         ]
     },
     "Multiworld Tournament Season 4": {
+        "aliases": [
+            "mw",
+            "mw_s4"
+        ],
         "show_seed_info": true,
         "user_message": "Multiworld Tournament Season 4",
         "world_count": 3,
@@ -1064,6 +1085,9 @@
         ]
     },
     "Hell Mode": {
+        "aliases": [
+            "hell"
+        ],
         "show_seed_info": true,
         "user_message": "Hell Mode",
         "world_count": 1,
@@ -1418,6 +1442,9 @@
         ]
     },
     "Bingo": {
+        "aliases": [
+            "bingo"
+        ],
         "show_seed_info": true,
         "user_message": "Bingo",
         "world_count": 1,
@@ -1582,6 +1609,10 @@
         ]
     },
     "League S6": {
+        "aliases": [
+            "league",
+            "league_s6"
+        ],
         "show_seed_info": true,
         "user_message": "OoTR League S6",
         "world_count": 1,
@@ -1763,6 +1794,10 @@
         ]
     },
     "Co-Op Tournament Season 3": {
+        "aliases": [
+            "co-op",
+            "co-op_s3"
+        ],
         "show_seed_info": true,
         "user_message": "Co-Op Tournament Season 3",
         "world_count": 1,


### PR DESCRIPTION
Adds aliases to each preset that can be used instead of the full display name when specifying a setting preset in the CLI using `--setting_preset`

I did this rather quick so feel free to look over it and make sure I am not doing something dumb.