### PR TITLE
Fix default random distribution for multiselect settings

### DIFF
--- a/SettingTypes.py
+++ b/SettingTypes.py
@@ -59,7 +59,7 @@ class SettingInfo:
         self.disabled_default = self.default if disabled_default is None else disabled_default
 
         # used to when random options are set for this setting
-        if 'distribution' not in self.gui_params:
+        if 'distribution' not in self.gui_params and 'randomize_key' in self.gui_params:
             if self.gui_type == 'MultipleSelect':
                 self.gui_params['distribution'] = [(list(choice), 1) for choice in powerset(self.choice_list)]
             else:

--- a/SettingTypes.py
+++ b/SettingTypes.py
@@ -3,6 +3,8 @@ import math
 import operator
 from typing import Optional, Any
 
+from Utils import powerset
+
 
 # holds the info for a single setting
 class SettingInfo:
@@ -58,7 +60,10 @@ class SettingInfo:
 
         # used to when random options are set for this setting
         if 'distribution' not in self.gui_params:
-            self.gui_params['distribution'] = [(choice, 1) for choice in self.choice_list]
+            if self.gui_type == 'MultipleSelect':
+                self.gui_params['distribution'] = [(list(choice), 1) for choice in powerset(self.choice_list)]
+            else:
+                self.gui_params['distribution'] = [(choice, 1) for choice in self.choice_list]
 
     def __set_name__(self, owner, name: str) -> None:
         self.name = name

--- a/Utils.py
+++ b/Utils.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import urllib.request
 from collections.abc import Sequence
+from itertools import chain, combinations
 from typing import AnyStr, Optional, Any
 from urllib.error import URLError, HTTPError
 
@@ -230,3 +231,10 @@ def find_last(source_list: Sequence[Any], sought_element: Any) -> int:
     if last is None:
         raise Exception(f"Element {sought_element} not found in sequence {source_list}.")
     return last
+
+
+# https://docs.python.org/3.8/library/itertools.html#itertools-recipes
+def powerset(iterable):
+    "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+    s = list(iterable)
+    return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))


### PR DESCRIPTION
Fixes #2118. Tested to ensure this generates spoiler logs with correct values of `spawn_positions`.