### PR TITLE
Add a better error message for the incompatibility between Scarce/Minimal and high heart win conditions

### DIFF
--- a/World.py
+++ b/World.py
@@ -71,8 +71,8 @@ class World:
             'scarce': settings.starting_hearts + 9 - math.ceil((settings.starting_hearts - 3) / 2),
             'minimal': settings.starting_hearts,
         }[settings.item_pool_value]
-        if required_hearts < available_hearts:
-            raise ValueError("Not enough heart pieces/containers in item pool for win conditions. Decrease the number of required hearts or increase the item pool.")
+        if required_hearts > available_hearts:
+            raise ValueError(f"Not enough heart pieces/containers in item pool for win conditions ({available_hearts} available but {required_hearts} required). Decrease the number of required hearts or increase the item pool.")
 
         # rename a few attributes...
         self.keysanity: bool = settings.shuffle_smallkeys in ('keysanity', 'remove', 'any_dungeon', 'overworld', 'regional')

--- a/World.py
+++ b/World.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import math
 import os
 import random
 from collections import OrderedDict, defaultdict
@@ -54,6 +55,24 @@ class World:
         self.event_items: set[str] = set()
         self.settings: Settings = settings
         self.distribution: WorldDistribution = settings.distribution.world_dists[world_id]
+
+        # errors for setting incompatibilities not yet caught by the GUI, see also https://github.com/OoTRandomizer/OoT-Randomizer/issues/1827
+        required_hearts = 0
+        if settings.lacs_condition == 'hearts':
+            required_hearts = max(required_hearts, settings.lacs_hearts)
+        if settings.bridge == 'hearts':
+            required_hearts = max(required_hearts, settings.bridge_hearts)
+        if settings.shuffle_ganon_bosskey == 'hearts':
+            required_hearts = max(required_hearts, settings.ganon_bosskey_hearts)
+        available_hearts = {
+            'ludicrous': 20,
+            'plentiful': 20,
+            'balanced': 20,
+            'scarce': settings.starting_hearts + 9 - math.ceil((settings.starting_hearts - 3) / 2),
+            'minimal': settings.starting_hearts,
+        }[settings.item_pool_value]
+        if required_hearts < available_hearts:
+            raise ValueError("Not enough heart pieces/containers in item pool for win conditions. Decrease the number of required hearts or increase the item pool.")
 
         # rename a few attributes...
         self.keysanity: bool = settings.shuffle_smallkeys in ('keysanity', 'remove', 'any_dungeon', 'overworld', 'regional')


### PR DESCRIPTION
Fixes #1644. The fix chosen here is to add an explicit check for the incompatible settings to the world constructor and inform the user how to fix it. My opinion is that allowing the user to choose which fix to apply (changing item pool vs changing wincons) is better than silently changing the number of hearts in the item pool, which the user may not expect, especially if we end up separating the heart pool from the remaining item pool, which is a common suggestion and probably a good idea. Besides, even if we want to change the behavior later, this is an easy fix that should be included until then.