### PR TITLE
Fix to issue #2184. Current function deletes heart pieces when you go…

### DIFF
--- a/ASM/c/item_effects.c
+++ b/ASM/c/item_effects.c
@@ -216,7 +216,7 @@ void fill_wallet_upgrade(z64_file_t* save, int16_t arg1, int16_t arg2) {
 }
 
 void clear_excess_hearts(z64_file_t* save, int16_t arg1, int16_t arg2) {
-    if (save->energy_capacity >= 19 * 0x10)  // Giving a Heart Container at 19 hearts.
+    if (save->energy_capacity >= 20 * 0x10)  // Giving a Heart Container at 19 hearts.
         save->heart_pieces = 0;
     save->refill_hearts = 20 * 0x10;
 }


### PR DESCRIPTION
Fix to issue #2184. Current function deletes heart pieces when you go from 18 -> 19 heart containers by picking up a heart container. Now it will still erase extra heart pieces when you hit 20, but not at 19. Video of the change in action is here on my google drive since its too big for github to let me upload it directly.

https://drive.google.com/file/d/1dDbmapi0tYDyGdoJnGp7Md0iRinVy8vv/view?usp=drive_link