### PR TITLE
build.py: Make `--compile-c` the default

### DIFF
--- a/ASM/README.md
+++ b/ASM/README.md
@@ -11,7 +11,7 @@ Advanced modifications to the Randomzier source require a bit more software than
   - On other platforms you'll need either `clang` or `gcc`, `cmake`, and either `ninja` or `make` installed. All of these should be available in the package repositories of every major Linux distribution and Homebrew on macOS. After, follow the [building from source instructions](https://github.com/Kingcom/armips#22-building-from-source).
 - Put the armips executable in the `tools` directory, or somewhere in your PATH.
 - Put the ROM you want to patch at `roms/base.z64`. This needs to be an uncompressed ROM; OoTRandomizer will produce one at ZOOTDEC.z64 when you run it with a compressed ROM.
-- Run `python build.py`, which will:
+- Run `python build.py --no-compile-c`, which will:
   - create `roms/patched.z64`
   - update some `txt` files in `build/` and in `../data/generated/`. Check `git status` to see which ones have changed. Make sure you submit them all together!
 
@@ -45,7 +45,7 @@ Recompiling the C code for randomizer requires the N64 development tools to be i
 
 You can substitute using the `tools` folder with adding the `n64/bin` folder to your environment PATH if you need an advanced setup.
 ### Running
-To recompile the C modules, use `python build.py --compile-c` in this directory, or adjust the path to `build.py` relative to your terminal's working directory.
+To recompile the C modules, use `python build.py` in this directory, or adjust the path to `build.py` relative to your terminal's working directory.
 
 ## Debugging Symbols for Project64
 To generate symbols for the Project64 debugger, use the `--pj64sym` option:

--- a/ASM/build.py
+++ b/ASM/build.py
@@ -13,13 +13,14 @@ from crc import calculate_crc
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--pj64sym', help="Output path for Project64 debugging symbols")
-parser.add_argument('--compile-c', action='store_true', help="Recompile C modules")
-parser.add_argument('--dump-obj', action='store_true', help="Dumps extra object info for debugging purposes. Does nothing without --compile-c")
+parser.add_argument('--compile-c', action='store_true', help="Recompile C modules. This is the default")
+parser.add_argument('--no-compile-c', action='store_true', help="Do not recompile C modules")
+parser.add_argument('--dump-obj', action='store_true', help="Dumps extra object info for debugging purposes. Does nothing with --no-compile-c")
 parser.add_argument('--diff-only', action='store_true', help="Creates diff output without running armips")
 
 args = parser.parse_args()
 pj64_sym_path = args.pj64sym
-compile_c = args.compile_c
+compile_c = not args.no_compile_c
 dump_obj = args.dump_obj
 diff_only = args.diff_only
 

--- a/Notes/vscode.md
+++ b/Notes/vscode.md
@@ -88,8 +88,7 @@ Instead of manually running the build script in a terminal, you can add a build 
             "type": "shell",
             "command": "python3",
             "args": [
-                "${workspaceFolder}/ASM/build.py",
-                "--compile-c",
+                "${workspaceFolder}/ASM/build.py"
             ],
             "group": {
                 "kind": "build",


### PR DESCRIPTION
This PR changes the behavior of the `ASM/build.py` script to recompile the C code by default. The `--compile-c` option which previously enabled this functionality is kept for backwards compatibility with existing wrapper scripts, but no longer does anything. A new `--no-compile-c` option is added to skip compiling the C code.

I'm proposing this change because most of the romhacking happens in C now so it's almost always required anyway, and it's easy to forget the option, which leads to cryptic compiler errors at best or possibly even a broken build.