### PR TITLE
Fix League Hint Distribution to workaround potential bug

### DIFF
--- a/data/Hints/league.json
+++ b/data/Hints/league.json
@@ -80,10 +80,10 @@
             "ToT (Right)"
         ]},
         "entrance":        {"order": 6, "weight": 0.0, "fixed": 0, "copies": 2},
-        "dual":            {"order": 7, "weight": 0.0, "fixed": 2, "copies": 2}, "remove_stones": [
+        "dual":            {"order": 7, "weight": 0.0, "fixed": 2, "copies": 2, "remove_stones": [
             "HF (Cow Grotto)",
             "HC (Storms Grotto)"
-        ],
+        ]},
         "sometimes":       {"order": 8, "weight": 1.0, "fixed": 5, "copies": 2, "remove_stones": [
             "HF (Cow Grotto)",
             "HC (Storms Grotto)"

--- a/data/Hints/league.json
+++ b/data/Hints/league.json
@@ -79,13 +79,19 @@
             "ToT (Right-Center)",
             "ToT (Right)"
         ]},
-        "junk":            {"order": 6, "weight": 0.0, "fixed": 2, "copies": 1, "priority_stones": [
+        "entrance":        {"order": 6, "weight": 0.0, "fixed": 0, "copies": 2},
+        "dual":            {"order": 7, "weight": 0.0, "fixed": 2, "copies": 2}, "remove_stones": [
+            "HF (Cow Grotto)",
+            "HC (Storms Grotto)"
+        ],
+        "sometimes":       {"order": 8, "weight": 1.0, "fixed": 5, "copies": 2, "remove_stones": [
             "HF (Cow Grotto)",
             "HC (Storms Grotto)"
         ]},
-        "entrance":        {"order": 7, "weight": 0.0, "fixed": 0, "copies": 2},
-        "dual":            {"order": 8, "weight": 0.0, "fixed": 2, "copies": 2},
-        "sometimes":       {"order": 9, "weight": 1.0, "fixed": 5, "copies": 2},
+        "junk":            {"order": 9, "weight": 0.0, "fixed": 2, "copies": 1, "priority_stones": [
+            "HF (Cow Grotto)",
+            "HC (Storms Grotto)"
+        ]},
         "random":          {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "item":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "song":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},


### PR DESCRIPTION
There is a possible bug (or unintended side effect) of Priority Hint Stones and Junk hints w/ Required Only as a setting.

This hint distro places junk hints on HC Storms Grotto and HF Cow Grotto hint stones, but if those hint stones are inaccessible as a result of Required Only, then the randomizer instead places a copy of a different hint there and puts the junk hint somewhere else, which is completely against the point of what we are trying to do.