### PR TITLE
Allow SOA to be hinted foolish on glitched/no logic

### DIFF
--- a/World.py
+++ b/World.py
@@ -1248,7 +1248,7 @@ class World:
             self.settings.shuffle_scrubs == 'off' and not self.settings.shuffle_grotto_entrances):
             # nayru's love may be required to prevent forced damage
             exclude_item_list.append('Nayrus Love')
-        if 'logic_grottos_without_agony' in self.settings.allowed_tricks and self.settings.hints != 'agony':
+        if ('logic_grottos_without_agony' in self.settings.allowed_tricks or self.settings.logic_rules != 'glitchless') and self.settings.hints != 'agony':
             # Stone of Agony skippable if not used for hints or grottos
             exclude_item_list.append('Stone of Agony')
         if not self.shuffle_special_interior_entrances and not self.settings.shuffle_overworld_entrances and not self.settings.warp_songs:


### PR DESCRIPTION
Minor oversight - since the SOA trick can never be on in glitched/no logic (since glitchless tricks are never actually enabled in that case, despite being implied) it couldn't be hinted foolish even when it was useless. This should fix that behavior to be consistent across the board.