### PR TITLE
Fix King Dobonko hack

### DIFF
--- a/ASM/src/bonk.asm
+++ b/ASM/src/bonk.asm
@@ -144,10 +144,10 @@ KING_DODONGO_BONKS:
     nop
 
     ; Set King Dodongo health to zero
-    lh      t1, 0x0198(s0)          ; this->numWallCollisions
+    lh      t1, 0x0198(s1)          ; this->numWallCollisions
     beqz    t1, @@return_bonk_kd
     nop
-    sh      $zero, 0x0184(s0)       ; this->health
+    sh      $zero, 0x0184(s1)       ; this->health
 
 @@return_bonk_kd:
     ; displaced code


### PR DESCRIPTION
This hack has a small mistake. It makes the assumption that register s0 will always contain the king dodongo actor pointer. s1 should be used as it is the register that the function which calls this hack stores the pointer in.

![image](https://github.com/OoTRandomizer/OoT-Randomizer/assets/5086838/a8291405-d485-4616-ac54-eda957734703)

In the ASM snippet attached, which is the start of the bossdodongo_update (decomp name) function you can see on the 3rd instruction - A0, which contains the actor pointer for KD, is stored into S1.

This doesn't fix anything currently broken on main Dev. However this hack breaks if you hack the Actor_Update call chain. 