### PR TITLE
Fix Plentiful item pool with no adult trade items selected

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -463,7 +463,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
             # Make the duplicate item consistent with that.
             if 'Pocket Egg' in world.settings.adult_trade_start and 'Pocket Cucco' in world.settings.adult_trade_start:
                 pending_junk_pool.remove('Pocket Cucco')
-        else:
+        elif world.settings.adult_trade_start:
             # With adult trade shuffle off, add a random extra adult trade item
             item = random.choice(world.settings.adult_trade_start)
             pending_junk_pool.append(item)


### PR DESCRIPTION
In the main item pool code, if `adult_trade_shuffle` is disabled, it checks for an entry in `adult_trade_start` before trying to do anything with it:
![image](https://github.com/OoTRandomizer/OoT-Randomizer/assets/30701749/7cad1478-70a1-4554-befb-d8c476407fad)

However, in the code for plentiful item pool, there's no such check:
![image](https://github.com/OoTRandomizer/OoT-Randomizer/assets/30701749/cba9a3f1-b917-475d-8bd8-7793477f5bcf)

This leads to an index out of bounds error if item pool is plentiful and there are no adult trade items selected.

This PR just adds a check for any items in the adult trade list before trying to choose one.