### PR TITLE
Meg respawns after 30 frames instead of 100

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -2589,6 +2589,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
             rom.write_byte(0x280CDDE, 0)
             rom.write_byte(0x280CDEE, 0)
 
+    # Meg respawns after 30 frames instead of 100 frames after getting hit
+    rom.write_byte(0xCDA723, 0x1E)
+
     # actually write the save table to rom
     world.distribution.give_items(world, save_context)
     if world.settings.starting_age == 'adult':


### PR DESCRIPTION
Inspired by SoH's implementation of this timesave.
This PR changes the initial value of the variable used to count when Meg the purple poe in Forest should respawn after getting hit, from 100 to 30.
Variable in question is unk_19C in func_80AD9C24 in current decomp : https://github.com/zeldaret/oot/blob/main/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c#L425
The proposed value of 30 is the one that gathered the most positive reactions in the Ootr Discord after showing different values.
Here is what it looks like in action : 

https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/80bdedf2-9fac-47b6-add6-af3118aba719

This modification was done in Patches.py to help an eventual future Cutscene/QoL enabler tab settings, since it's a ton easier to make them toggleable if all done in Python.
Can port it to asm though if preferred.

P.S. : to help testing this change without having to do all three other poes, here is a little code to add to hacks.asm that make Meg spawn on first time visiting the room (it's just nop-ing the tests in this function : https://github.com/zeldaret/oot/blob/main/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.c#L99 ). Shoutouts to flagrama !
```
.orga 0xDD5FEC
    nop
.orga 0xDD5FFC
    nop
.orga 0xDD600C
    nop
```