### PR TITLE
Fix Hyrule Castle courtyard exit matching Ganon's Castle exit

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -966,6 +966,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
 
         scene_table = 0x00B71440
         for scene in range(0x00, 0x65):
+            if scene in (0x45, 0x46):
+                # skip castle hedge maze scenes to avoid Ganon's Castle ER messing with the exit
+                continue
             scene_start = rom.read_int32(scene_table + (scene * 0x14))
             add_scene_exits(scene_start)
 


### PR DESCRIPTION
Fixes #2200. The fix is accomplished by simply skipping scenes 0x45 (Castle Hedge Maze — Day) and 0x46 (Castle Hedge Maze — Night) when patching exit tables. This would have to be changed if we ever want to include this scene in entrance rando, but it works for now.