### PR TITLE
Limit CFG_SONG_NAMES to the first 47 bgm entries

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -984,8 +984,8 @@ def patch_song_names(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: d
         if settings.display_custom_song_names == 'pause':
             rom.write_byte(symbols['CFG_SONG_NAME_POSITION'], 0x01)
 
-
-    for area, song_name in log.bgm.items():
+    for index in range(47):
+        song_name = list(log.bgm.values())[index]
         if len(song_name) > 50:
             song_name_cropped = song_name[:50]
             text_bytes = [ord(c) for c in song_name_cropped]


### PR DESCRIPTION
The function patch_song_names dumped the full content of log.bgm into an area supposed to have enough room to store all music tracks shuffled.
However, shuffling fanfares also add all fanfares to the same log.bgm dictionary, which make the function write a lot more than expected in the cosmetic context, and make all data stored after that completely wrong.
Since the music is stored first then fanfares, we can safely limit the data written to the first 47 elements of the dictionary, which ensure we won't write past the intended allocated memory.