### PR TITLE
Fixed some missed items[] comparisons to -1 after change to uint8

### DIFF
--- a/ASM/c/bombchu_bowling.c
+++ b/ASM/c/bombchu_bowling.c
@@ -34,7 +34,7 @@ int16_t select_bombchu_bowling_prize(int16_t prizeSelect) {
                 // Bombchu Bag has not been found, override to the 1
                 // Bomb prize if bomb bag is found, else the purple
                 // rupee prize.
-                if (!EXTRA_BOWLING_SHUFFLE && z64_file.items[Z64_SLOT_BOMBCHU] == -1 && FREE_BOMBCHU_DROPS) {
+                if (!EXTRA_BOWLING_SHUFFLE && z64_file.items[Z64_SLOT_BOMBCHU] == ITEM_NONE && FREE_BOMBCHU_DROPS) {
                     prizeTemp = z64_file.bomb_bag ? EXITEM_BOMBS_BOWLING : EXITEM_PURPLE_RUPEE_BOWLING;
                 } else {
                     prizeTemp = EXITEM_BOMBCHUS_BOWLING;
@@ -60,7 +60,7 @@ int16_t select_bombchu_bowling_prize(int16_t prizeSelect) {
         if (!EXTRA_BOWLING_SHUFFLE) {
             switch(prizeSelect) {
                 case 2:
-                    if (z64_file.items[Z64_SLOT_BOMBCHU] == -1 && FREE_BOMBCHU_DROPS) {
+                    if (z64_file.items[Z64_SLOT_BOMBCHU] == ITEM_NONE && FREE_BOMBCHU_DROPS) {
                         prizeTemp = z64_file.bomb_bag ? EXITEM_BOMBS_BOWLING : EXITEM_PURPLE_RUPEE_BOWLING;
                     } else {
                         prizeTemp = EXITEM_BOMBCHUS_BOWLING;

--- a/ASM/c/get_items.c
+++ b/ASM/c/get_items.c
@@ -752,11 +752,11 @@ int16_t get_override_drop_id(int16_t dropId) {
 
     // Chu bag drops, convert bomb drop to bombchu drop under certain circumstances
     if (FREE_BOMBCHU_DROPS && (dropId == ITEM00_BOMBS_A || dropId == ITEM00_BOMBS_SPECIAL || dropId == ITEM00_BOMBS_B)) {
-        if (z64_file.items[Z64_SLOT_BOMB] != -1 && z64_file.items[Z64_SLOT_BOMBCHU] != -1) { // we have bombs and chus
+        if (z64_file.items[Z64_SLOT_BOMB] != ITEM_NONE && z64_file.items[Z64_SLOT_BOMBCHU] != ITEM_NONE) { // we have bombs and chus
             return drop_bombs_or_chus(dropId);
-        } else if (z64_file.items[Z64_SLOT_BOMB] != -1) { // only have bombs
+        } else if (z64_file.items[Z64_SLOT_BOMB] != ITEM_NONE) { // only have bombs
             return dropId; // don't do anything because this is already the right drop ID
-        } else if (z64_file.items[Z64_SLOT_BOMBCHU] != -1) { // only have chus
+        } else if (z64_file.items[Z64_SLOT_BOMBCHU] != ITEM_NONE) { // only have chus
             return ITEM00_ARROWS_SINGLE; // override drop ID to use the one for chus
         } else {
             return -1;
@@ -764,16 +764,16 @@ int16_t get_override_drop_id(int16_t dropId) {
     }
 
     // This is convoluted but it seems like it must be a single condition to match
-    if ((dropId == ITEM00_BOMBS_A || dropId == ITEM00_BOMBS_SPECIAL || dropId == ITEM00_BOMBS_B) && z64_file.items[ITEM_BOMB] == -1) {
+    if ((dropId == ITEM00_BOMBS_A || dropId == ITEM00_BOMBS_SPECIAL || dropId == ITEM00_BOMBS_B) && z64_file.items[ITEM_BOMB] == ITEM_NONE) {
         return -1;
     }
-    if ((dropId == ITEM00_ARROWS_SMALL || dropId == ITEM00_ARROWS_MEDIUM || dropId == ITEM00_ARROWS_LARGE) && z64_file.items[ITEM_BOW] == -1) {
+    if ((dropId == ITEM00_ARROWS_SMALL || dropId == ITEM00_ARROWS_MEDIUM || dropId == ITEM00_ARROWS_LARGE) && z64_file.items[ITEM_BOW] == ITEM_NONE) {
         return -1;
     }
     if ((dropId == ITEM00_MAGIC_LARGE || dropId == ITEM00_MAGIC_SMALL) && z64_file.magic_capacity_set == 0) {
         return -1;
     }
-    if ((dropId == ITEM00_SEEDS) && z64_file.items[ITEM_SLINGSHOT] == -1) {
+    if ((dropId == ITEM00_SEEDS) && z64_file.items[ITEM_SLINGSHOT] == ITEM_NONE) {
         return -1;
     }
 

--- a/ASM/c/item_effects.c
+++ b/ASM/c/item_effects.c
@@ -53,7 +53,7 @@ void give_biggoron_sword(z64_file_t* save, int16_t arg1, int16_t arg2) {
 
 void give_bottle(z64_file_t* save, int16_t bottle_item_id, int16_t arg2) {
     for (int i = Z64_SLOT_BOTTLE_1; i <= Z64_SLOT_BOTTLE_4; i++) {
-        if (save->items[i] == -1) {
+        if (save->items[i] == ITEM_NONE) {
             save->items[i] = bottle_item_id;
             return;
         }

--- a/ASM/c/message.c
+++ b/ASM/c/message.c
@@ -132,7 +132,7 @@ void shooting_gallery_message() {
         return;
     }
     // Check if we have a bow.
-    if (z64_file.items[ITEM_BOW] != -1) {
+    if (z64_file.items[ITEM_BOW] != ITEM_NONE) {
         return;
     }
     // Check if the message was already displayed once.


### PR DESCRIPTION
#2115 changed the type of `items[]` to `uint8` making comparisons to -1 invalid because a unsigned integer can never be a negative number. Some of these were probably missed in that PR, but others likely got merged before it and broke implicitly once that PR was merged.

Existing PRs should also be checked for stale comparisons like these and fix them before merging.