### PR TITLE
Co-Op S3: Enable DC Scarecrow Gold Skulltulla trick

### DIFF
--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -2050,6 +2050,7 @@
             "logic_child_deadhand",
             "logic_man_on_roof",
             "logic_dc_jump",
+            "logic_dc_scarecrow_gs",
             "logic_rusted_switches",
             "logic_windmill_poh",
             "logic_crater_bean_poh_with_hovers",


### PR DESCRIPTION
Not adding this was an oversight. The trick allows DC to end up in adult-only dungeon entrances.