### PR TITLE
Add display_custom_song_names to web patcher GUI

### DIFF
--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -537,6 +537,7 @@
           "settings": [
             "custom_music_directorypicker",
             "background_music",
+            "display_custom_song_names",
             "fanfares",
             "ocarina_fanfares",
             "credits_music"


### PR DESCRIPTION
This cosmetic setting was added in #2147 but was unintentionally omitted from the patcher view.