### PR TITLE
Don't hint areas with only unfilled locations as barren

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -708,7 +708,7 @@ def get_barren_hint(spoiler: Spoiler, world: World, checked: set[str], all_check
             and location.name not in world.hint_exclusions
             and location.name not in hint_exclusions(world)
             and HintArea.at(location) == area
-            for location in world.get_locations()
+            for location in world.get_filled_locations()
         ),
         world.empty_areas))
 


### PR DESCRIPTION
#1594 added a check to only allow an area to be hintable as foolish if there's any locations there that aren't already hinted. But “location” includes things like gossip stones or, with #1641, the Temple of Time altar hints. So now ToT can once again be hinted foolish even if both LACS and Prelude are unshuffled, excluded, or Always hinted. This PR fixes that by only considering _filled_ locations.