### PR TITLE
Consider free scarecrow in logic without ocarina buttons

### DIFF
--- a/State.py
+++ b/State.py
@@ -183,7 +183,7 @@ class State:
     def has_all_notes_for_song(self, song: str) -> bool:
         # Scarecrow needs 2 different notes
         if song == 'Scarecrow Song':
-            return self.has_ocarina_buttons(2)
+            return self.world.settings.free_scarecrow or self.has_ocarina_buttons(2)
 
         notes = str(self.world.song_notes[song])
         if 'A' in notes:


### PR DESCRIPTION
As pointed out by @r0bd0g in #dev-glitchless-logic today, you don't actually need any ocarina buttons to summon Pierre in free scarecrow. So this PR adjusts the logic accordingly.