### PR TITLE
Replace non-ASCII characters in song names with question marks

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -989,9 +989,9 @@ def patch_song_names(rom: Rom, settings: Settings, log: CosmeticsLog, symbols: d
             break
         if len(song_name) > 50:
             song_name_cropped = song_name[:50]
-            text_bytes = [ord(c) for c in song_name_cropped]
+            text_bytes = [ord('?' if ord(c) >= 0x80 else c) for c in song_name_cropped]
         else:
-            text_bytes = [ord(c) for c in song_name] + [ord('\0')] * (50 - len(song_name))
+            text_bytes = [ord('?' if ord(c) >= 0x80 else c) for c in song_name] + [ord('\0')] * (50 - len(song_name))
         bytes_to_write += text_bytes
     rom.write_bytes(symbols['CFG_SONG_NAMES'], bytes_to_write)
     log.display_custom_song_names = settings.display_custom_song_names


### PR DESCRIPTION
This is a quick fix for two bugs with the song name display (#2147):

* Characters in the [Latin-1 Supplement](https://unicode.link/blocks/latin-1-supplement) block displaying as spaces
* Characters that are neither [Basic Latin](https://unicode.link/blocks/basic-latin) nor Latin-1 Supplement triggering a “ValueError: byte must be in range(0, 256)” exception while patching cosmetics — even if the song name display setting is off

A more proper fix would be to convert song names into the encoding used for text boxes and display them using the text box font, which is something @GSKirox has been investigating and which should replace this PR if it ends up working.