### PR TITLE
Fix first bigocto room cutscene skip

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -184,7 +184,7 @@ def patch_cutscenes(rom: Rom, songs_as_items:bool) -> None:
     patch_cutscene_destination_and_length(rom, 0xCA0784, 1)
 
     # Ruto pointing to the Zora Sapphire when you enter Big Octo's room.
-    delete_cutscene(rom, 0xD03BAC)
+    delete_cutscene(rom, 0xD03BA8)
 
     # Speed scene after Jabu Jabu's Belly
     # Cut Ruto talking to Link when entering the blue warp.


### PR DESCRIPTION
I did a slight address mistake in the cutscene refactoring in #2219 on the one when you enter Bigocto room in Jabu with Ruto. The CS_END instruction is written 4 bytes later than before.
On main dev this still skips the cutscene properly, but on some branches with other changes in this room like the version used currently for the 3rd mixed pools tournament, this wrong offset seems to somehow make the cutscene last 62 sec instead.