### PR TITLE
Error if Decompress or Compress fails

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -237,7 +237,7 @@ def compress_rom(input_file: str, output_file: str, delete_input: bool = False) 
         logger.info("OS not supported for ROM compression.")
         raise Exception("This operating system does not support ROM compression. You may only output patch files or uncompressed ROMs.")
 
-    run_process(logger, [compressor_path, input_file, output_file])
+    run_process(logger, [compressor_path, input_file, output_file], check=True)
     if delete_input:
         os.remove(input_file)
 

--- a/Rom.py
+++ b/Rom.py
@@ -126,7 +126,7 @@ class Rom(BigStream):
         else:
             raise RuntimeError('Unsupported operating system for decompression. Please supply an already decompressed ROM.')
 
-        subprocess.call(subcall, **subprocess_args())
+        subprocess.check_call(subcall, **subprocess_args())
         self.read_rom(output_file, verify_crc=verify_crc)
 
     def write_byte(self, address: int, value: int) -> None:


### PR DESCRIPTION
Currently, the invocations of the `Decompress` and `Compress` subprocesses aren't checked:

* If the `Decompress` program fails, the randomizer ignores the error and tries to open the decompressed rom anyway, which raises an exception misleadingly saying “Invalid path to Base ROM: ".../ZOOTDEC.z64"”. With this PR, the exception message is changed to point directly to the cause of the error.
* If the `Compress` program fails, the randomizer continues as if it had succeeded, reporting the path of the nonexistent compressed rom on stderr and deleting the uncompressed rom. With this PR, the randomizer raises an exception and keeps the uncompressed rom.