### PR TITLE
Document wonder_talk2 and remove the ones in Thieves' hideout

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -503,23 +503,24 @@ def patch_cutscenes(rom: Rom, songs_as_items:bool) -> None:
 def patch_wondertalk2(rom: Rom) -> None:
     # Wonder_talk2 is an actor that displays a textbox when near a certain spot, either automatically or by pressing A (button turns to Check).
     # We remove them by moving their Y coordinate far below their normal spot.
-    wonder_talk2_y_coordinates = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, # Shadow Temple Whispering Wall Maze (Room 0)
-                   0x27CE080, 0x27CE090, # Shadow Temple Truthspinner (Room 2)
-                   0x2887070, 0x2887080, 0x2887090, # GTG Entrance Room (Room 0)
-                   0x2897070, # GTG Stalfos Room (Room 1)
-                   0x28A1144, # GTG Flame Wall Maze (Room 2)
-                   0x28A60F4, 0x28A6104, # GTG Pushblock Room (Room 3)
-                   0x28AE084, # GTG Rotating Statue Room (Room 4)
-                   0x28B9174, # GTG Megaton Statue Room (Room 5)
-                   0x28BF168, 0x28BF178, 0x28BF188, # GTG Lava Room (Room 6)
-                   0x28C7134, # GTG Dinolfos Room (Room 7)
-                   0x28D0094, # GTG Ice Arrow Room (Room 8)
-                   0x28D91BC, # GTG Shellblade Room (Room 9)
-                   0x225E7E0, # Death Mountain Crater (Room 1)
-                   0x32A50E4, # Thieves' Hideout Green Cell Room 3 torches (Room 1)
-                   0x32AD0E4, # Thieves' Hideout Red Cell Room 1 torch (Room 2)
-                   0x32BD102, # Thieves' Hideout Green Cell Room 4 torches (Room 4)
-                   0x32C1134, # Thieves' Hideout Blue Cell Room 2 torches (Room 5)
-                   ]
+    wonder_talk2_y_coordinates = [
+        0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, # Shadow Temple Whispering Wall Maze (Room 0)
+        0x27CE080, 0x27CE090, # Shadow Temple Truthspinner (Room 2)
+        0x2887070, 0x2887080, 0x2887090, # GTG Entrance Room (Room 0)
+        0x2897070, # GTG Stalfos Room (Room 1)
+        0x28A1144, # GTG Flame Wall Maze (Room 2)
+        0x28A60F4, 0x28A6104, # GTG Pushblock Room (Room 3)
+        0x28AE084, # GTG Rotating Statue Room (Room 4)
+        0x28B9174, # GTG Megaton Statue Room (Room 5)
+        0x28BF168, 0x28BF178, 0x28BF188, # GTG Lava Room (Room 6)
+        0x28C7134, # GTG Dinolfos Room (Room 7)
+        0x28D0094, # GTG Ice Arrow Room (Room 8)
+        0x28D91BC, # GTG Shellblade Room (Room 9)
+        0x225E7E0, # Death Mountain Crater (Room 1)
+        0x32A50E4, # Thieves' Hideout Green Cell Room 3 torches (Room 1)
+        0x32AD0E4, # Thieves' Hideout Red Cell Room 1 torch (Room 2)
+        0x32BD102, # Thieves' Hideout Green Cell Room 4 torches (Room 4)
+        0x32C1134, # Thieves' Hideout Blue Cell Room 2 torches (Room 5)
+    ]
     for address in wonder_talk2_y_coordinates:
         rom.write_byte(address, 0xFB)

--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -499,3 +499,27 @@ def patch_cutscenes(rom: Rom, songs_as_items:bool) -> None:
     rom.write_int32(0xE83D28, 0x00000000)
     # Remove the Navi textbox at the start of state 28 ("This time, we fight together!).
     rom.write_int16(0xE84C80, 0x1000)
+
+def patch_wondertalk2(rom: Rom) -> None:
+    # Wonder_talk2 is an actor that displays a textbox when near a certain spot, either automatically or by pressing A (button turns to Check).
+    # We remove them by moving their Y coordinate far below their normal spot.
+    wonder_talk2_y_coordinates = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, # Shadow Temple Whispering Wall Maze (Room 0)
+                   0x27CE080, 0x27CE090, # Shadow Temple Truthspinner (Room 2)
+                   0x2887070, 0x2887080, 0x2887090, # GTG Entrance Room (Room 0)
+                   0x2897070, # GTG Stalfos Room (Room 1)
+                   0x28A1144, # GTG Flame Wall Maze (Room 2)
+                   0x28A60F4, 0x28A6104, # GTG Pushblock Room (Room 3)
+                   0x28AE084, # GTG Rotating Statue Room (Room 4)
+                   0x28B9174, # GTG Megaton Statue Room (Room 5)
+                   0x28BF168, 0x28BF178, 0x28BF188, # GTG Lava Room (Room 6)
+                   0x28C7134, # GTG Dinolfos Room (Room 7)
+                   0x28D0094, # GTG Ice Arrow Room (Room 8)
+                   0x28D91BC, # GTG Shellblade Room (Room 9)
+                   0x225E7E0, # Death Mountain Crater (Room 1)
+                   0x32A50E4, # Thieves' Hideout Green Cell Room 3 torches (Room 1)
+                   0x32AD0E4, # Thieves' Hideout Red Cell Room 1 torch (Room 2)
+                   0x32BD102, # Thieves' Hideout Green Cell Room 4 torches (Room 4)
+                   0x32C1134, # Thieves' Hideout Blue Cell Room 2 torches (Room 5)
+                   ]
+    for address in wonder_talk2_y_coordinates:
+        rom.write_byte(address, 0xFB)

--- a/Patches.py
+++ b/Patches.py
@@ -9,7 +9,7 @@ import zlib
 from collections.abc import Callable, Iterable
 from typing import Optional, Any
 
-from Cutscenes import patch_cutscenes
+from Cutscenes import patch_cutscenes, patch_wondertalk2
 from Entrance import Entrance
 from HintList import get_hint
 from Hints import GossipText, HintArea, write_gossip_stone_hints, build_altar_hints, \
@@ -437,6 +437,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         rom.write_byte(rom.sym('SONGS_AS_ITEMS'), 1)
 
     patch_cutscenes(rom, songs_as_items)
+    patch_wondertalk2(rom)
 
     if world.settings.shuffle_ocarinas:
         symbol = rom.sym('OCARINAS_SHUFFLED')
@@ -587,9 +588,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     # Fix "...???" textbox outside Child Colossus Fairy to use the right flag and disappear once the wall is destroyed
     rom.write_byte(0x21A026F, 0xDD)
 
-    # Remove the "...???" textbox outside the Crater Fairy (change it to an actor that does nothing)
-    rom.write_int16s(0x225E7DC, [0x00B5, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xFFFF])
-
     # Forbid Sun's Song from a bunch of cutscenes
     Suns_scenes = [0x2016FC9, 0x2017219, 0x20173D9, 0x20174C9, 0x2017679, 0x20C1539, 0x20C15D9, 0x21A0719, 0x21A07F9, 0x2E90129, 0x2E901B9, 0x2E90249, 0x225E829, 0x225E939, 0x306D009]
     for address in Suns_scenes:
@@ -599,13 +597,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     rom.write_int32(0xC7B9C0, 0x00000000)
     rom.write_int32(0xC7BAEC, 0x00000000)
     rom.write_int32(0xc7BCA4, 0x00000000)
-
-    # Remove disruptive text from Gerudo Training Ground and early Shadow Temple (vanilla)
-    wonder_text = [0x27C00BC, 0x27C00CC, 0x27C00DC, 0x27C00EC, 0x27C00FC, 0x27C010C, 0x27C011C, 0x27C012C, 0x27CE080,
-                   0x27CE090, 0x2887070, 0x2887080, 0x2887090, 0x2897070, 0x28C7134, 0x28D91BC, 0x28A60F4, 0x28AE084,
-                   0x28B9174, 0x28BF168, 0x28BF178, 0x28BF188, 0x28A1144, 0x28A6104, 0x28D0094]
-    for address in wonder_text:
-        rom.write_byte(address, 0xFB)
 
     # Speed dig text for Dampe
     rom.write_bytes(0x9532F8, [0x08, 0x08, 0x08, 0x59])


### PR DESCRIPTION
Wonder_talk2 is an actor that displays a textbox when near a certain spot, either automatically or by pressing A (button turns to Check). They're mostly present at the start of Shadow Temple and in every room of Gerudo Training Ground, and have been removed in randomizer years ago for convenience.

This PR adds information on how they are removed, move this process out of Patches.py in Cutscenes.py (it's not really cutscenes but it fits here imo), and use the same method to remove the ones in Thieves' Hideout when you get near a Carpenter's cell : 
_Hey, you! Young man, over there!
Look over here, inside the cell!_

The wonder_talk2 at the Crater Fairy entrance was patched differently from the other ones, but as far as i can see, there's no real advantage to this, so i changed it to use the same method as the other ones.