### PR TITLE
Move BotW ladder silver rupee if silver rupees are shuffled

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1468,6 +1468,13 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         if world.dungeon_mq['Spirit Temple']: # Patch Spirit MQ Lobby front right chest to use permanent switch flag 0x1F
             rom.write_byte(0x2b08ce4 + 13, 0x1F)
 
+        if not world.dungeon_mq['Bottom of the Well']:
+            # Collecting the final BotW basement silver rupee and activating the cutscene of the door unlocking while on the ladder causes a softlock.
+            # Move slightly the X coordinate of this actor so that it cannot be collected while climbing.
+            # This is a vanilla bug tracked at https://github.com/OoTRandomizer/OoT-Randomizer/issues/2004
+            # If and when that bug is fixed in rando, this displacement can be removed.
+            rom.write_int16(0x32E92C6, 0xFD78)
+
     # Write flag table data
     collectible_flag_table, alt_list = get_collectible_flag_table(world)
     collectible_flag_table_bytes, num_collectible_flags = get_collectible_flag_table_bytes(collectible_flag_table)

--- a/Rules.py
+++ b/Rules.py
@@ -58,13 +58,6 @@ def set_rules(world: World) -> None:
         else:
             add_item_rule(location, lambda location, item: item.type != 'Shop')
 
-        if world.shuffle_silver_rupees and location.name == 'Bottom of the Well Basement Silver Rupee Ladders Middle':
-            # Collecting the final BotW basement silver rupee and activating the cutscene of the door unlocking while on the ladder causes a softlock.
-            # This is a vanilla bug tracked at https://github.com/OoTRandomizer/OoT-Randomizer/issues/2004
-            # If and when that bug is fixed in rando, this item restriction can be removed.
-            forbid_item(location, 'Silver Rupee (Bottom of the Well Basement)')
-            forbid_item(location, 'Silver Rupee Pouch (Bottom of the Well Basement)')
-
         if world.skip_child_zelda and location.name == 'Song from Impa':
             if world.settings.triforce_hunt and world.total_starting_triforce_count >= world.triforce_goal - world.settings.world_count:
                 # We have enough starting Triforce pieces that putting a piece on every world's Song from Impa would hit the goal count


### PR DESCRIPTION
An alternate to #2163
Instead of preventing this location to be a silver rupee or a pouch, sligthly move the actor so that it cannot be collected while climbing.
Vanilla position : 
![silver_rupee_botw_ladder_before](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/d861136f-bdfb-41a0-8eef-dd3d7080c3ba)
With this change : 
![silver_rupee_botw_ladder_after](https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/fb0539fb-9f0b-41f9-a0df-a7a37242b737)

While still not ideal (which of course, would be to fix the cutscene/ladder softlock), this solution is imo more elegant than an item restriction.

To test the fix, add this to your plando : 
` "Bottom of the Well Basement Silver Rupee Ladders Middle":                           "Silver Rupee Pouch (Bottom of the Well Basement)",`