### PR TITLE
New Timesaver option : Fast Shadow Boat

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from Rom import Rom
+from Settings import Settings
 
 def delete_cutscene(rom: Rom, address: int) -> None:
     # Address is the start of the cutscene commands.
@@ -69,7 +70,7 @@ def patch_cutscene_misc_command(rom: Rom, address: int, start_frame:int, end_fra
     rom.write_int16(address + 2, start_frame)
     rom.write_int16(address + 4, end_frame)
 
-def patch_cutscenes(rom: Rom, songs_as_items:bool) -> None:
+def patch_cutscenes(rom: Rom, songs_as_items:bool, settings:Settings) -> None:
     # Speed scene after Deku Tree
     # Deku Tree talking to Link.
     # Cut to 1 frame and redirect destination to the get Emerald cutscene (0x07).
@@ -378,6 +379,22 @@ def patch_cutscenes(rom: Rom, songs_as_items:bool) -> None:
     patch_cutscene_destination_and_length(rom, 0x2001110, 3)
     # Set the "Drain Well" flag at the second frame (first frame is used by the "Fast Windmill" flag).
     patch_cutscene_misc_command(rom, 0x20010D8, 2, 3)
+
+    # This cutscene is not written in the shadow temple scene or in the boat actor, but directly in z_onepointdemo.c instead.
+    # So not compatible with our functions.
+    if settings.fast_shadow_boat:
+        # bg_haka_ship changes to make the boat go faster.
+        rom.write_int16(0xD1923E, 0x0000) # Timer to start moving
+        rom.write_int16(0xD19426, 0x4348) # Speed x10
+        rom.write_int16(0xD19436, 0x447A) # Speed x10
+        # Cutscene changes so that it lasts just long enough to prevent jumping to the skulltula.
+        # Remove all camera cues of the cutscene past the first one by changing the size of keyFrameCount to 1.
+        rom.write_int16(0xAE010E, 0x0001)
+        # Change first camera cue point of view to be less awkward.
+        # New value : { 4290.0f, -1075.0f, -1900.0f }, { 4155.0f, -1100.0f, -1840.0f }
+        rom.write_int32s(0xB69804, [0x4583B800, 0xC4866000, 0xC502F000, 0x457E6000, 0xC4898000, 0xC4FD2000])
+        # First camera cue last 4 sec instead of 2 sec.
+        rom.write_int16(0xB697F8, 0x0050)
 
     # Speed scene after Shadow Temple
     # Impa becomes a Sage cutscene.

--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -70,7 +70,7 @@ def patch_cutscene_misc_command(rom: Rom, address: int, start_frame:int, end_fra
     rom.write_int16(address + 2, start_frame)
     rom.write_int16(address + 4, end_frame)
 
-def patch_cutscenes(rom: Rom, songs_as_items:bool, settings:Settings) -> None:
+def patch_cutscenes(rom: Rom, songs_as_items: bool, settings: Settings) -> None:
     # Speed scene after Deku Tree
     # Deku Tree talking to Link.
     # Cut to 1 frame and redirect destination to the get Emerald cutscene (0x07).
@@ -391,10 +391,13 @@ def patch_cutscenes(rom: Rom, songs_as_items:bool, settings:Settings) -> None:
         # Remove all camera cues of the cutscene past the first one by changing the size of keyFrameCount to 1.
         rom.write_int16(0xAE010E, 0x0001)
         # Change first camera cue point of view to be less awkward.
-        # New value : { 4290.0f, -1075.0f, -1900.0f }, { 4155.0f, -1100.0f, -1840.0f }
-        rom.write_int32s(0xB69804, [0x4583B800, 0xC4866000, 0xC502F000, 0x457E6000, 0xC4898000, 0xC4FD2000])
-        # First camera cue last 4 sec instead of 2 sec.
+        # Change viewFlags to 2121, this will make the camera focus on Link.
+        rom.write_int16(0xB697F6, 0x2121)
+        # Change the length to 4 sec instead of 2 sec.
         rom.write_int16(0xB697F8, 0x0050)
+        # Change the at/eye camera values to follow Link from behind.
+        # New value : { 0.0f, 0.0f, 0.0f }, { 50.0f, 30.0f, -200.0f}
+        rom.write_int32s(0xB69804, [0x00000000, 0x00000000, 0x00000000, 0x42480000, 0x42480000, 0xC3480000])
 
     # Speed scene after Shadow Temple
     # Impa becomes a Sage cutscene.

--- a/Patches.py
+++ b/Patches.py
@@ -436,7 +436,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     if songs_as_items:
         rom.write_byte(rom.sym('SONGS_AS_ITEMS'), 1)
 
-    patch_cutscenes(rom, songs_as_items)
+    patch_cutscenes(rom, songs_as_items, world.settings)
 
     if world.settings.shuffle_ocarinas:
         symbol = rom.sym('OCARINAS_SHUFFLED')

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3281,6 +3281,8 @@ class SettingInfos:
         gui_text       = 'Fast Shadow Boat',
         gui_tooltip    = '''\
             The boat sequence in Shadow Temple will be massively sped up.
+            The two Stalfos will still fall on the boat, but you
+            won't have time to fight them.
         ''',
         default        = False,
         shared         = True,

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3277,6 +3277,15 @@ class SettingInfos:
         shared         = True,
     )
 
+    fast_shadow_boat = Checkbutton(
+        gui_text       = 'Fast Shadow Boat',
+        gui_tooltip    = '''\
+            The boat sequence in Shadow Temple will be massively sped up.
+        ''',
+        default        = False,
+        shared         = True,
+    )
+
     ocarina_songs = Combobox(
         gui_text       = 'Randomize Ocarina Melodies',
         default        = 'off',

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -127,6 +127,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "off",
         "chest_textures_specific": [
@@ -331,6 +332,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "both",
         "chest_textures_specific": [
@@ -531,6 +533,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "both",
         "chest_textures_specific": [
@@ -734,6 +737,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "off",
         "chest_textures_specific": [
@@ -943,6 +947,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": true,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "textures",
         "chest_textures_specific": [
@@ -1142,6 +1147,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": true,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "textures",
         "chest_textures_specific": [
@@ -1515,6 +1521,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "all",
         "correct_chest_appearances": "off",
         "chest_textures_specific": [
@@ -1703,6 +1710,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "off",
         "chest_textures_specific": [
@@ -1903,6 +1911,7 @@
         "easier_fire_arrow_entry": false,
         "fae_torch_count": 3,
         "ruto_already_f1_jabu": true,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "both",
         "chest_textures_specific": [
@@ -2112,6 +2121,7 @@
         "easier_fire_arrow_entry": true,
         "fae_torch_count": 5,
         "ruto_already_f1_jabu": false,
+        "fast_shadow_boat": false,
         "ocarina_songs": "off",
         "correct_chest_appearances": "off",
         "chest_textures_specific": [

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -345,7 +345,8 @@
             "big_poe_count",
             "easier_fire_arrow_entry",
             "fae_torch_count",
-            "ruto_already_f1_jabu"
+            "ruto_already_f1_jabu",
+            "fast_shadow_boat"
           ]
         },
         {


### PR DESCRIPTION
This new option massively speeds up the boat ride sequence from around 1 min to 10 sec.
The cutscene at the start has been changed to both : 
* Better fit the new behaviour by changing up the starting camera view and cutting the length short.
* Last long enough to prevent jumping directly to the skulltula on the left, which would break logic.

https://github.com/OoTRandomizer/OoT-Randomizer/assets/65768236/3fdb3acd-f6e8-452d-ae69-1ffa2b86e6d6

