### PR TITLE
Fix order in Makefile

### DIFF
--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -47,7 +47,7 @@ $(OBJECTS): | $(OBJDIR)
 
 $(RESOURCES): | $(RESOURCEDIR)
 
-bundle: $(RESOURCES) $(OBJECTS)
+bundle: $(OBJECTS) $(RESOURCES)
 	$(LD) -T linker_script.ld -T ootSymbols.ld -o $(OUTDIR)/bundle.o -i -L. $(patsubst %.o,-l:%.o,$(OBJECTS) $(RESOURCES))
 
 symbols: bundle

--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -43,11 +43,7 @@ $(OBJDIR)/%_bin.o: $(RESOURCEDIR)/%.bin
 $(RESOURCEDIR):
 	mkdir -p $@
 
-$(OBJECTS): | $(OBJDIR)
-
-$(RESOURCES): | $(RESOURCEDIR)
-
-bundle: $(OBJECTS) $(RESOURCES)
+bundle: $(OBJDIR) $(OBJECTS) $(RESOURCEDIR) $(RESOURCES)
 	$(LD) -T linker_script.ld -T ootSymbols.ld -o $(OUTDIR)/bundle.o -i -L. $(patsubst %.o,-l:%.o,$(OBJECTS) $(RESOURCES))
 
 symbols: bundle

--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -39,11 +39,14 @@ $(OBJDIR)/%_bin.o: $(RESOURCEDIR)/%.bin
 	$(OBJCOPY) --redefine-sym _binary_resources_$*_bin_end=$(call UC,$*)_RESOURCE_END $@
 	$(OBJCOPY) --redefine-sym _binary_resources_$*_bin_size=$(call UC,$*)_RESOURCE_SIZE $@
 
-
 $(RESOURCEDIR):
 	mkdir -p $@
 
-bundle: $(OBJDIR) $(OBJECTS) $(RESOURCEDIR) $(RESOURCES)
+$(OBJECTS): | $(OBJDIR)
+
+$(RESOURCES): | $(OBJDIR) $(RESOURCEDIR)
+
+bundle: $(RESOURCES) $(OBJECTS)
 	$(LD) -T linker_script.ld -T ootSymbols.ld -o $(OUTDIR)/bundle.o -i -L. $(patsubst %.o,-l:%.o,$(OBJECTS) $(RESOURCES))
 
 symbols: bundle


### PR DESCRIPTION
This should solve the issue where if the `build/bin` directory doesn't exist the build will fail.