### PR TITLE
Add warning when rolling no logic seed via GUI

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -153,7 +153,7 @@ export class GeneratorComponent implements OnInit {
     return filteredTabList;
   }
 
-  generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false, goalHintsConfirmed: boolean = false) {
+  generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false, goalHintsConfirmed: boolean = false, noLogicConfirmed: boolean = false) {
 
     this.generateSeedButtonEnabled = false;
     this.seedString = this.seedString.trim().replace(/[^a-zA-Z0-9_-]/g, '');
@@ -176,6 +176,7 @@ export class GeneratorComponent implements OnInit {
     }
 
     let goalErrorText = "The selected hint distribution includes the Goal hint type. This can drastically increase generation time for large multiworld seeds. Continue?";
+    let noLogicErrorText = "You have selected No Logic. This can produce unbeatable seeds. Continue?";
     let goalDistros = this.global.getGlobalVar('generatorGoalDistros');
 
     if (!goalHintsConfirmed && goalDistros.indexOf(this.global.generator_settingsMap["hint_dist"]) > -1 && this.global.generator_settingsMap["world_count"] > 5) {
@@ -185,6 +186,23 @@ export class GeneratorComponent implements OnInit {
         //User acknowledged increased generation time for multiworld seeds with goal hints
         if (confirmed) {
           this.generateSeed(fromPatchFile, webRaceSeed, true);
+        }
+      });
+
+      this.generateSeedButtonEnabled = true;
+      this.cd.markForCheck();
+      this.cd.detectChanges();
+
+      return;
+    }
+
+    if (!noLogicConfirmed && this.global.generator_settingsMap["logic_rules"] === "none") {
+      this.dialogService.open(ConfirmationWindowComponent, {
+        autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "No Logic Warning", dialogMessage: noLogicErrorText }
+      }).onClose.subscribe(confirmed => {
+        //User acknowledged possible unbeatability of no logic seeds
+        if (confirmed) {
+          this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed, true);
         }
       });
 
@@ -824,7 +842,7 @@ export class GeneratorComponent implements OnInit {
   onDirectorySelectedWeb(event, setting: any) { //Web only
 
     let dirPickerMode: boolean = this.global.getGlobalVar("webSupportDirectoryPicker");
-    
+
     let fileList = event.currentTarget.files;
 
     if (!fileList || fileList.length < 1)
@@ -850,7 +868,7 @@ export class GeneratorComponent implements OnInit {
       if (nameParts.length > 0)
         displayName = `${nameParts.join(", ")} and ${lastNamePart}`;
       else
-        displayName = `${lastNamePart}`;   
+        displayName = `${lastNamePart}`;
     }
 
     //Set setting

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -153,7 +153,7 @@ export class GeneratorComponent implements OnInit {
     return filteredTabList;
   }
 
-  generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false, goalHintsConfirmed: boolean = false, noLogicConfirmed: boolean = false) {
+  generateSeed(fromPatchFile: boolean = false, webRaceSeed: boolean = false, goalHintsConfirmed: boolean = false) {
 
     this.generateSeedButtonEnabled = false;
     this.seedString = this.seedString.trim().replace(/[^a-zA-Z0-9_-]/g, '');
@@ -196,13 +196,15 @@ export class GeneratorComponent implements OnInit {
       return;
     }
 
-    if (!noLogicConfirmed && this.global.generator_settingsMap["logic_rules"] === "none") {
+    let noLogicConfirmed = localStorage.getItem("noLogicConfirmed")
+    if ((!noLogicConfirmed || noLogicConfirmed == "false") && this.global.generator_settingsMap["logic_rules"] === "none") {
       this.dialogService.open(ConfirmationWindowComponent, {
         autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "No Logic Warning", dialogMessage: noLogicErrorText }
       }).onClose.subscribe(confirmed => {
         //User acknowledged possible unbeatability of no logic seeds
         if (confirmed) {
-          this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed, true);
+          localStorage.setItem("noLogicConfirmed", JSON.stringify(true))
+          this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed);
         }
       });
 

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -196,14 +196,14 @@ export class GeneratorComponent implements OnInit {
       return;
     }
 
-    let noLogicConfirmed = localStorage.getItem("noLogicConfirmed")
+    let noLogicConfirmed = localStorage.getItem("noLogicConfirmed");
     if ((!noLogicConfirmed || noLogicConfirmed == "false") && this.global.generator_settingsMap["logic_rules"] === "none") {
       this.dialogService.open(ConfirmationWindowComponent, {
         autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "No Logic Warning", dialogMessage: noLogicErrorText }
       }).onClose.subscribe(confirmed => {
         //User acknowledged possible unbeatability of no logic seeds
         if (confirmed) {
-          localStorage.setItem("noLogicConfirmed", JSON.stringify(true))
+          localStorage.setItem("noLogicConfirmed", JSON.stringify(true));
           this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed);
         }
       });

--- a/GUI/src/app/pages/generator/generator.component.ts
+++ b/GUI/src/app/pages/generator/generator.component.ts
@@ -196,23 +196,27 @@ export class GeneratorComponent implements OnInit {
       return;
     }
 
-    let noLogicConfirmed = localStorage.getItem("noLogicConfirmed");
-    if ((!noLogicConfirmed || noLogicConfirmed == "false") && this.global.generator_settingsMap["logic_rules"] === "none") {
-      this.dialogService.open(ConfirmationWindowComponent, {
-        autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "No Logic Warning", dialogMessage: noLogicErrorText }
-      }).onClose.subscribe(confirmed => {
-        //User acknowledged possible unbeatability of no logic seeds
-        if (confirmed) {
-          localStorage.setItem("noLogicConfirmed", JSON.stringify(true));
-          this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed);
-        }
-      });
+    try {
+      let noLogicConfirmed = localStorage.getItem("noLogicConfirmed");
+      if ((!noLogicConfirmed || noLogicConfirmed == "false") && this.global.generator_settingsMap["logic_rules"] === "none") {
+        this.dialogService.open(ConfirmationWindowComponent, {
+          autoFocus: true, closeOnBackdropClick: false, closeOnEsc: false, hasBackdrop: true, hasScroll: false, context: { dialogHeader: "No Logic Warning", dialogMessage: noLogicErrorText }
+        }).onClose.subscribe(confirmed => {
+          //User acknowledged possible unbeatability of no logic seeds
+          if (confirmed) {
+            localStorage.setItem("noLogicConfirmed", JSON.stringify(true));
+            this.generateSeed(fromPatchFile, webRaceSeed, goalHintsConfirmed);
+          }
+        });
 
-      this.generateSeedButtonEnabled = true;
-      this.cd.markForCheck();
-      this.cd.detectChanges();
+        this.generateSeedButtonEnabled = true;
+        this.cd.markForCheck();
+        this.cd.detectChanges();
 
-      return;
+        return;
+      }
+    } catch (e) {
+      //Browser doesn't allow localStorage access
     }
 
     if (this.global.getGlobalVar('electronAvailable')) { //Electron

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -1536,6 +1536,21 @@ export class GUIGlobal implements OnDestroy {
         throw err;
     }
 
+    //If no logic was intentionally enabled, warn user one time about the consequences
+    try {
+      let logicWarningSeen = localStorage.getItem("logicWarningSeen");
+
+      if ((!logicWarningSeen || logicWarningSeen == "false") && settingsFile["logic_rules"] == "none") {
+        localStorage.setItem("logicWarningSeen", JSON.stringify(true));
+        throw { error_no_logic_enabled: "Choosing no logic can require glitches to complete the seed or in very unlikely cases be unbeatable. Continue?" };
+      }
+    }
+    catch (err) { //Bubble through in case the warning should be displayed, ignore if local storage is not available
+      if (err.hasOwnProperty('error_no_logic_enabled'))
+        throw err;
+    }
+
+
     console.log(settingsFile);
     console.log("Race Seed:", raceSeed);
 

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -1536,21 +1536,6 @@ export class GUIGlobal implements OnDestroy {
         throw err;
     }
 
-    //If no logic was intentionally enabled, warn user one time about the consequences
-    try {
-      let logicWarningSeen = localStorage.getItem("logicWarningSeen");
-
-      if ((!logicWarningSeen || logicWarningSeen == "false") && settingsFile["logic_rules"] == "none") {
-        localStorage.setItem("logicWarningSeen", JSON.stringify(true));
-        throw { error_no_logic_enabled: "Choosing no logic can require glitches to complete the seed or in very unlikely cases be unbeatable. Continue?" };
-      }
-    }
-    catch (err) { //Bubble through in case the warning should be displayed, ignore if local storage is not available
-      if (err.hasOwnProperty('error_no_logic_enabled'))
-        throw err;
-    }
-
-
     console.log(settingsFile);
     console.log("Race Seed:", raceSeed);
 


### PR DESCRIPTION
When generating a seed with no logic, the GUI now asks “You have selected No Logic. This can produce unbeatable seeds. Continue?” before rolling the seed. I think this will be useful for new players, especially with #2245 adding a no logic preset which means you're even less likely to see the warning in the tooltip.

Has been tested to ensure it works correctly when combined with the multiworld goal count warning.