### PR TITLE
Fix missing randomized data in spoilers

### DIFF
--- a/World.py
+++ b/World.py
@@ -54,7 +54,7 @@ class World:
 
         self.parser: Rule_AST_Transformer = Rule_AST_Transformer(self)
         self.event_items: set[str] = set()
-        self.settings: Settings = settings
+        self.settings: Settings = settings.copy()
         self.distribution: WorldDistribution = settings.distribution.world_dists[world_id]
 
         # rename a few attributes...


### PR DESCRIPTION
Fixes #1962 and fenhl#23

Currently, world initialization uses a reference to the global settings object. Settings with the `random` option are randomized to a "real" value in the world constructor. This mutates the world's settings, which in turn mutates the global settings object.

If the global retry is triggered, the randomizer will rebuild the worlds from scratch. Instead of re-resolving random settings, the settings remain as they are since they aren't set to `random` anymore. For filling the world this is fine. However, `resolve_random_settings` also builds the `randomized_list` property that is referenced when building the `randomized_settings` section of the spoiler. Since settings like `starting_age` and `starting_tod` are no longer set to `random`, they are no longer picked up by `randomized_list` for display in the spoiler. On top of this, the `settings` section of the spoiler is derived from the `_settings` key of the distribution, which is a copy of the original settings pre-retry, so this will still show `random` in the spoiler settings instead of the resolved value from the world.

This only really comes up with multiple ER settings enabled on the main branch, but it can happen if global retry is triggered. It's more common on dev branches with more ER options that are more difficult to roll successfully.

The easiest fix to this (this PR) is to copy the settings in the world constructor so that the initial value is consistent on global retry. However, this will likely not retry the same settings if any of them were randomized, which could lead to certain random settings combinations being less likely to show up in the final output.

An alternative that would always preserve the same settings for retry would cache the randomized settings in global settings on a per-world basis, maybe `_randomized_settings` to mirror the already existing `_settings` key.