### PR TITLE
Python 3.13: Fix Deprecation Warnings

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -2641,7 +2641,7 @@ def create_fake_name(name: str) -> str:
     # keeping the game E...
     new_name = ''.join(list_name)
     censor = ['cum', 'cunt', 'dike', 'penis', 'puss', 'rape', 'shit']
-    new_name_az = re.sub(r'[^a-zA-Z]', '', new_name.lower(), re.UNICODE)
+    new_name_az = re.sub(r'[^a-zA-Z]', '', new_name.lower())
     for cuss in censor:
         if cuss in new_name_az:
             return create_fake_name(name)

--- a/Settings.py
+++ b/Settings.py
@@ -243,7 +243,7 @@ class Settings(SettingInfos):
 
     def sanitize_seed(self) -> None:
         # leave only alphanumeric and some punctuation
-        self.seed = re.sub(r'[^a-zA-Z0-9_-]', '', self.seed, re.UNICODE)
+        self.seed = re.sub(r'[^a-zA-Z0-9_-]', '', self.seed)
 
     def update_seed(self, seed: str) -> None:
         if seed is None or seed == '':

--- a/Utils.py
+++ b/Utils.py
@@ -125,10 +125,10 @@ class VersionError(Exception):
 
 def check_version(checked_version: str) -> None:
     if not hasattr(check_version, "base_regex"):
-        check_version.base_regex = re.compile("""^[ \t]*__version__ = ['"](.+)['"]""", re.MULTILINE)
-        check_version.supplementary_regex = re.compile(r"^[ \t]*supplementary_version = (\d+)$", re.MULTILINE)
-        check_version.full_regex = re.compile("""^[ \t]*__version__ = f['"]*(.+)['"]""", re.MULTILINE)
-        check_version.url_regex = re.compile("""^[ \t]*branch_url = ['"](.+)['"]""", re.MULTILINE)
+        check_version.base_regex = re.compile("""^[ \t]*__version__ = ['"](.+)['"]""", flags=re.MULTILINE)
+        check_version.supplementary_regex = re.compile(r"^[ \t]*supplementary_version = (\d+)$", flags=re.MULTILINE)
+        check_version.full_regex = re.compile("""^[ \t]*__version__ = f['"]*(.+)['"]""", flags=re.MULTILINE)
+        check_version.url_regex = re.compile("""^[ \t]*branch_url = ['"](.+)['"]""", flags=re.MULTILINE)
 
     if compare_version(checked_version, __version__) < 0:
         try:


### PR DESCRIPTION
Fixes "DeprecationWarning: 'count' is passed as positional argument" on regular expression functions. These seemingly were intended to be passed as flags, not as count anyway.