### PR TITLE
clarify adult trade shuffle gui_text and gui_tooltip

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3911,7 +3911,7 @@ class SettingInfos:
         gui_text       = 'Shuffle All Selected Adult Trade Items',
         gui_tooltip    = '''\
             Enable to shuffle every selected Adult Trade Item.
-            
+
             If disabled and at least one of "Shuffle Adult Trade
             Sequence Items" is selected, Anju will always give
             a shuffled item even if Pocket Egg has not been shuffled.
@@ -3938,11 +3938,11 @@ class SettingInfos:
             'Claim Check':  'Claim Check',
         },
         gui_tooltip    = '''\
-            Select the Adult Trade Sequence items to shuffle. 
-            
-            If "Shuffle All Selected Adult Trade Items" is 
+            Select the Adult Trade Sequence items to shuffle.
+
+            If "Shuffle All Selected Adult Trade Items" is
             enabled, every selected item will be shuffled.
-            
+
             If "Shuffle All Selected Adult Trade Items" is
             disabled, only one of the selected items will be
             shuffled. If the Odd Mushroom, Eyeball Frog, or

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -2642,7 +2642,7 @@ class SettingInfos:
     )
 
     shuffle_child_trade = MultipleSelect(
-        gui_text       = 'Shuffled Child Trade Sequence Items',
+        gui_text       = 'Shuffle Child Trade Sequence Items',
         default        = [],
         choices        = {
             'Weird Egg':     'Weird Egg',
@@ -3908,18 +3908,20 @@ class SettingInfos:
     )
 
     adult_trade_shuffle = Checkbutton(
-        gui_text       = 'Shuffle All Adult Trade Items',
+        gui_text       = 'Shuffle All Selected Adult Trade Items',
         gui_tooltip    = '''\
-            Shuffle all adult trade sequence items. If disabled,
-            a random item will be selected, and Anju will always
-            give an item even if Pocket Egg is not shuffled.
+            Enable to shuffle every selected Adult Trade Item.
+            
+            If disabled and at least one of "Shuffle Adult Trade
+            Sequence Items" is selected, Anju will always give
+            a shuffled item even if Pocket Egg has not been shuffled.
         ''',
         shared         = True,
         default        = False,
     )
 
     adult_trade_start = MultipleSelect(
-        gui_text       = 'Adult Trade Sequence Items',
+        gui_text       = 'Shuffle Adult Trade Sequence Items',
         default        = ['Pocket Egg', 'Pocket Cucco', 'Cojiro', 'Odd Mushroom', 'Odd Potion', 'Poachers Saw',
                           'Broken Sword', 'Prescription', 'Eyeball Frog', 'Eyedrops', 'Claim Check'],
         choices        = {
@@ -3936,7 +3938,17 @@ class SettingInfos:
             'Claim Check':  'Claim Check',
         },
         gui_tooltip    = '''\
-            Select the items to shuffle in the adult trade sequence.
+            Select the Adult Trade Sequence items to shuffle. 
+            
+            If "Shuffle All Selected Adult Trade Items" is 
+            enabled, every selected item will be shuffled.
+            
+            If "Shuffle All Selected Adult Trade Items" is
+            disabled, only one of the selected items will be
+            shuffled. If the Odd Mushroom, Eyeball Frog, or
+            Eyedrops is removed from the player's inventory due
+            to an expired timer or game reset, that item can
+            be reacquired from its <i>non-shuffled</i> location.
         ''',
         shared         = True,
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "OoT-Randomizer",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "OoT-Randomizer",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Pull request for Issue 2259: Adult Trade Sequence Items - clarify SettingsList.py description
https://github.com/OoTRandomizer/OoT-Randomizer/issues/2259 

updated adult trade shuffle gui_text and gui_tooltips:
    • clarify dependencies between adult_trade_start & adult_trade_shuffle 
    • clarify edge cases & expiration items reverting to non shuffled location (++mracsys) 

updated "child trade shuffle" gui_text for consistency

tested and good on local generator gui and localhost (per web-gui-testing.md).

used double quotes for identifying a separate option for consistency (as opposed to bold html) because quotes seemed to be used more frequently across the generator GUI

accidentally created a package-lock.json file; it should not be in PR to OoTR-dev, but you might see it mentioned in commit history
