### PR TITLE
Fixes the weird text alignment when going from a textbox with an icon…

### DIFF
--- a/ASM/src/hacks.asm
+++ b/ASM/src/hacks.asm
@@ -4143,7 +4143,7 @@ DemoEffect_DrawJewel_AfterHook:
 ;================================================================================
 ; Replaces sh   $zero, 0x4c0(at)
 ;          lhu  a3, 0x4c0(a3)
-.org 0x800da34c
+.org 0x800DA34C
     j Message_Decode_reset_msgCtx.textPosX
     nop
 

--- a/ASM/src/hacks.asm
+++ b/ASM/src/hacks.asm
@@ -4137,6 +4137,16 @@ DemoEffect_DrawJewel_AfterHook:
     jal     volvagia_flying_hitbox
     nop
 
+;================================================================================
+; Reset choiceNum when decoding a new message
+; prevents weird text alignment when going from message box with icon to no icon
+;================================================================================
+; Replaces sh   $zero, 0x4c0(at)
+;          lhu  a3, 0x4c0(a3)
+.org 0x800da34c
+    j Message_Decode_reset_msgCtx.textPosX
+    nop
+
 .include "hacks/en_item00.asm"
 .include "hacks/ovl_bg_gate_shutter.asm"
 .include "hacks/ovl_bg_haka_tubo.asm"

--- a/ASM/src/messages.asm
+++ b/ASM/src/messages.asm
@@ -131,8 +131,8 @@ shooting_gallery_no_bow:
     addiu   sp, sp, 0x20
 
 Message_Decode_reset_msgCtx.textPosX:
-    sb      $zero, 0x4be(at)
-    sh      $zero, 0x4c0(at)
-    lhu     a3, 0x4c0(a3)
-    j       0x800da354
+    sb      $zero, 0x4BE(at)
+    sh      $zero, 0x4C0(at)
+    lhu     a3, 0x4C0(a3)
+    j       0x800DA354
     nop

--- a/ASM/src/messages.asm
+++ b/ASM/src/messages.asm
@@ -129,3 +129,10 @@ shooting_gallery_no_bow:
 
     jr      ra
     addiu   sp, sp, 0x20
+
+Message_Decode_reset_msgCtx.textPosX:
+    sb      $zero, 0x4be(at)
+    sh      $zero, 0x4c0(at)
+    lhu     a3, 0x4c0(a3)
+    j       0x800da354
+    nop

--- a/Hints.py
+++ b/Hints.py
@@ -1706,9 +1706,8 @@ def build_boss_string(reward: str, color: str, world: World) -> str:
 
 
 def build_bridge_reqs_string(world: World) -> str:
-    string = "\x13\x3C" # Master Sword icon
     if world.settings.bridge == 'open':
-        string += "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
+        string = "The awakened ones will have #already created a bridge# to the castle where the evil dwells."
     else:
         if world.settings.bridge == 'vanilla':
             item_req_string = "the #Shadow and Spirit Medallions# as well as the #Light Arrows#"
@@ -1722,9 +1721,9 @@ def build_bridge_reqs_string(world: World) -> str:
             }[world.settings.bridge]
             item_req_string = f'{count} {singular if count == 1 else plural}'
         if world.settings.clearer_hints:
-            string += f"The rainbow bridge will be built once the Hero collects {item_req_string}."
+            string = f"The rainbow bridge will be built once the Hero collects {item_req_string}."
         else:
-            string += f"The awakened ones will await for the Hero to collect {item_req_string}."
+            string = f"The awakened ones will await for the Hero to collect {item_req_string}."
     return str(GossipText(string, ['Green'], prefix=''))
 
 


### PR DESCRIPTION
… to one with no icon

Also removes the Master Sword icon from the altar hint mentioning the bridge condition which was only added because of this bug.

https://github.com/user-attachments/assets/176874c0-ef8d-46a4-99ef-4c9abc8f0aad

now the "once" text overflows the right border that normally exists, but that's normal for `GossipText`.