### PR TITLE
Update to League Hint Distribution

### DIFF
--- a/data/Hints/league.json
+++ b/data/Hints/league.json
@@ -1,7 +1,7 @@
 {
     "name":                  "league",
     "gui_name":              "League",
-    "description":           "Hint Distribution for the S7 of League. 6 Always, 5 Path, 3 Barren, 3 Sometimes, 2 Dual Hints, HC Storms & HF Cow Hints Junked, 30/40/50 skull hints in house of skulltula",
+    "description":           "Hint Distribution for the S7 of League. 6 Always, 6 Path, 3 Barren, 3 Sometimes, 2 Dual Hints, 30/40/50 skull hints in house of skulltula",
     "add_locations":         [
         { "location": "Deku Theater Skull Mask", "types": ["always"] },
         { "location": "Sheik in Kakariko", "types": ["always"] },
@@ -59,31 +59,13 @@
     "distribution":          {
         "trial":           {"order": 1, "weight": 0.0, "fixed": 0, "copies": 2},
         "entrance_always": {"order": 2, "weight": 0.0, "fixed": 0, "copies": 2},
-        "always":          {"order": 3, "weight": 0.0, "fixed": 0, "copies": 2, "remove_stones": [
-            "HF (Cow Grotto)",
-            "HC (Storms Grotto)"
-        ]},
-        "goal":            {"order": 4, "weight": 0.0, "fixed": 5, "copies": 2, "remove_stones": [
-            "HF (Cow Grotto)",
-            "HC (Storms Grotto)"
-        ]},
-        "barren":          {"order": 5, "weight": 0.0, "fixed": 3, "copies": 2, "remove_stones": [
-            "HF (Cow Grotto)",
-            "HC (Storms Grotto)"
-        ]},
+        "always":          {"order": 3, "weight": 0.0, "fixed": 0, "copies": 2},
+        "goal":            {"order": 4, "weight": 0.0, "fixed": 6, "copies": 2},
+        "barren":          {"order": 5, "weight": 0.0, "fixed": 3, "copies": 2},
         "entrance":        {"order": 6, "weight": 0.0, "fixed": 0, "copies": 2},
-        "dual":            {"order": 7, "weight": 0.0, "fixed": 2, "copies": 2, "remove_stones": [
-            "HF (Cow Grotto)",
-            "HC (Storms Grotto)"
-        ]},
-        "sometimes":       {"order": 8, "weight": 1.0, "fixed": 3, "copies": 2, "remove_stones": [
-            "HF (Cow Grotto)",
-            "HC (Storms Grotto)"
-        ]},
-        "junk":            {"order": 9, "weight": 0.0, "fixed": 2, "copies": 1, "priority_stones": [
-            "HF (Cow Grotto)",
-            "HC (Storms Grotto)"
-        ]},
+        "dual":            {"order": 7, "weight": 0.0, "fixed": 2, "copies": 2},
+        "sometimes":       {"order": 8, "weight": 1.0, "fixed": 3, "copies": 2},
+        "junk":            {"order": 9, "weight": 0.0, "fixed": 0, "copies": 2},
         "random":          {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "item":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},
         "song":            {"order": 0, "weight": 0.0, "fixed": 0, "copies": 2},


### PR DESCRIPTION
Changes in case the PR to exclude path of the hero are not merged into Dev before the start of league