### PR TITLE
Updated Scrubs S6 Settings & Hints

### DIFF
--- a/data/Hints/scrubs.json
+++ b/data/Hints/scrubs.json
@@ -1,6 +1,4 @@
 {
-    "settings":	{
-    "hint_dist_user":{
     "name":                  "scrubs",
     "gui_name":              "Scrubs",
     "description":           "Tournament hints used for Scrubs Races. Duplicates of each hint, HBA 1000, Ice Cavern Iron Boots and OGC Great Fairy are always hints, 4 Path, {3 Foolish (no Dungeons), 1 Item} (ToT), 9 sometimes, HC(Storms) & HF(Cow Grotto) disabled.",
@@ -58,6 +56,4 @@
     },
     "groups": [],
     "disabled": []
-    }
-    }
 }

--- a/data/Hints/scrubs.json
+++ b/data/Hints/scrubs.json
@@ -1,44 +1,63 @@
 {
+    "settings":	{
+    "hint_dist_user":{
     "name":                  "scrubs",
     "gui_name":              "Scrubs",
-    "description":           "Tournament hints used for Scrubs Races. Duplicates of each hint, HBA 1000, Ice Cavern Iron Boots and OGC Great Fairy are always hints, 5 WotH, 3 Foolish (no Dungeons), 7 sometimes.",
+    "description":           "Tournament hints used for Scrubs Races. Duplicates of each hint, HBA 1000, Ice Cavern Iron Boots and OGC Great Fairy are always hints, 4 Path, {3 Foolish (no Dungeons), 1 Item} (ToT), 9 sometimes, HC(Storms) & HF(Cow Grotto) disabled.",
     "add_locations":         [
-        { "location": "GF HBA 1000 Points", "types": ["always"] },
+        { "location": "Castle Fairy Checks", "types": ["dual_always"] },
+        { "location": "Ice Cavern Final Room", "types": ["dual_always"] },
+        { "location": "Deku Theater Skull Mask", "types": ["always"]}
+    ],
+    "remove_locations":      [
+        { "location": "Hyrule Castle", "types": ["barren"] }, 
         { "location": "OGC Great Fairy Reward", "types": ["always"] },
-        { "location": "Ice Cavern Iron Boots Chest", "types": ["always"] },
-        { "location": "Deku Theater Skull Mask", "types": ["always"] },
-        { "location": "Deku Theater Mask of Truth", "types": ["always"] }
+        { "location": "Sheik at Temple", "types": ["always", "sometimes"] },
+        { "location": "ZR Frogs Rewards", "types": ["dual_always", "dual"] },
+        { "location": "Sheik in Forest", "types": ["sometimes"]},
+        { "location": "Sheik in Crater", "types": ["sometimes"]},
+        { "location": "Sheik in Kakariko", "types": ["always","sometimes"]},
+        { "location": "Sheik in Ice Cavern", "types": ["sometimes"]},
+        { "location": "Sheik at Colossus", "types": ["sometimes"]},
+        { "location": "Song from Royal Familys Tomb", "types": ["sometimes"]},
+        { "location": "Song from Ocarina of Time", "types": ["always","sometimes"]},
+        { "location": "Deku Theater Rewards", "types": ["dual_always"] }
     ],
-    "remove_locations":      [],
-    "add_items":             [],
-    "remove_items":          [
-        { "item": "Zeldas Lullaby", "types": ["woth"] }
+    "add_items":             [ 
     ],
+    "remove_items":      [
+    { "item": "Zeldas Lullaby", "types": ["woth", "goal"] },
+    { "item": "Nocturne of Shadow", "types": ["woth", "goal"] }
+	
+    ],
+
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 0,
     "named_items_required":  true,
     "vague_named_items":     false,
     "use_default_goals":     true,
     "distribution":          {
-        "trial":           {"order": 1, "weight": 0.0, "fixed":   0, "copies": 2},
-        "entrance_always": {"order": 2, "weight": 0.0, "fixed":   0, "copies": 2},
-        "always":          {"order": 3, "weight": 0.0, "fixed":   0, "copies": 2},
-        "woth":            {"order": 4, "weight": 0.0, "fixed":   5, "copies": 2},
-        "barren":          {"order": 5, "weight": 0.0, "fixed":   3, "copies": 2},
-        "entrance":        {"order": 6, "weight": 0.0, "fixed":   3, "copies": 2},
-        "sometimes":       {"order": 7, "weight": 0.0, "fixed": 100, "copies": 2},
-        "random":          {"order": 8, "weight": 9.0, "fixed":   0, "copies": 2},
-        "named-item":      {"order": 9, "weight": 0.0, "fixed":   0, "copies": 2},
-        "item":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
-        "song":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
-        "overworld":       {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
-        "dungeon":         {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
-        "junk":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
-        "goal":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 1},
-        "dual_always":     {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0},
-        "dual":            {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0},
-        "important_check": {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0}
+        "trial":            {"order": 1, "weight": 0.0, "fixed":   0, "copies": 2, "remove_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)", "HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "always":           {"order": 2, "weight": 0.0, "fixed":   0, "copies": 2, "remove_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)", "HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "goal":             {"order": 5, "weight": 0.0, "fixed":   4, "copies": 2, "remove_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)", "HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "woth":             {"order": 6, "weight": 0.0, "fixed":   0, "copies": 2, "remove_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)", "HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "barren":           {"order": 4, "weight": 0.0, "fixed":   3, "copies": 1, "priority_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)"]},
+        "entrance":         {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2, "remove_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)", "HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "sometimes":        {"order": 9, "weight": 0.0, "fixed": 100, "copies": 2, "remove_stones": ["HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "random":           {"order": 0, "weight": 9.0, "fixed":   0, "copies": 2},
+        "junk":             {"order": 8, "weight": 0.0, "fixed":   1, "copies": 2, "priority_stones": ["HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "item":             {"order": 7, "weight": 0.0, "fixed":   1, "copies": 1, "priority_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)"]},
+        "song":             {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "overworld":        {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "dungeon":          {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "dual_always":      {"order": 3, "weight": 0.0, "fixed":   0, "copies": 2, "remove_stones": ["ToT (Left)", "ToT (Left-Center)", "ToT (Right)", "ToT (Right-Center)", "HC (Storms Grotto)", "HF (Cow Grotto)"]},
+        "dual":             {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0},
+        "named-item":       {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "entrance_always":  {"order": 0, "weight": 0.0, "fixed":   0, "copies": 2},
+        "important_check":  {"order": 0, "weight": 0.0, "fixed":   0, "copies": 0}
     },
     "groups": [],
     "disabled": []
+    }
+    }
 }

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -815,7 +815,7 @@
         "show_seed_info": true,
         "user_message": "Scrub Tournament",
         "world_count": 1,
-        "create_spoiler": false,
+        "create_spoiler": true,
         "password_lock": false,
         "randomize_settings": false,
         "logic_rules": "glitchless",
@@ -910,7 +910,6 @@
         "shuffle_loach_reward": "off",
         "logic_no_night_tokens_without_suns_song": false,
         "disabled_locations": [
-            "Sheik in Ice Cavern",
             "Deku Theater Mask of Truth",
             "Kak 40 Gold Skulltula Reward",
             "Kak 50 Gold Skulltula Reward",


### PR DESCRIPTION
* Update Scrubs S6 Hint-Distribution & Settings

* included workaround for Hyrule Castle foolish, even if all checks are hinted/disabled/start-with, it still hints area as barren.