### PR TITLE
[GUI] fix: prevent label from overlapping with scrollbar

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -262,6 +262,7 @@
     position: relative;
     display: block;
     left: 10px;
+    width: calc(100% - 10px); 
 
     &.oneLineComboBox {
       left: 0;


### PR DESCRIPTION
fixes #2286

![gui](https://github.com/user-attachments/assets/8e7cf838-357e-4be9-9c48-0117d9fd8c5d)
