### PR TITLE
Add an override to `one_hint_per_goal` in the hint distribution

### DIFF
--- a/World.py
+++ b/World.py
@@ -343,6 +343,9 @@ class World:
                 if goal_list1 != [goal.name for goal in category.goals] and category.name not in minor_goal_categories:
                     self.one_hint_per_goal = False
 
+        if self.hint_dist_user['one_hint_per_goal']:
+            self.one_hint_per_goal = self.hint_dist_user['one_hint_per_goal']
+
         # initialize category check for first rounds of goal hints
         self.hinted_categories = []
 

--- a/World.py
+++ b/World.py
@@ -343,7 +343,7 @@ class World:
                 if goal_list1 != [goal.name for goal in category.goals] and category.name not in minor_goal_categories:
                     self.one_hint_per_goal = False
 
-        if self.hint_dist_user['one_hint_per_goal']:
+        if 'one_hint_per_goal' in self.hint_dist_user:
             self.one_hint_per_goal = self.hint_dist_user['one_hint_per_goal']
 
         # initialize category check for first rounds of goal hints


### PR DESCRIPTION
Allows the `one_hint_per_goal` setting to be overridden when the value is explicitly defined in the hint distribution file.  If the value is omitted, the flag will default to the existing behavior that sets it based on whether the goal categories contain the same goals.

[Usage](https://github.com/Elagatua/OoT-Randomizer/blob/633b813d2583e03522e4a84e0a60217fb95bed80/data/Hints/sgl2024.json#L38):
```
    "one_hint_per_goal":     true,
```

This code has been in use for the SGL settings since 2023, so it is relatively well tested.