### PR TITLE
Fix weekly hint distro

### DIFF
--- a/data/Hints/weekly.json
+++ b/data/Hints/weekly.json
@@ -1,7 +1,7 @@
 {
     "name":                  "weekly",
     "gui_name":              "Weekly",
-    "description":           "Hint distribution for the weekly races: 5 Always, 5 Goal, 3 Barren (ToT), 1 Song (ToT), 1 Named-Item (light arrows), 2 Dual, 5 Sometimes; House of Skulltula (30/40/50).",
+    "description":           "Hint distribution for the weekly races: 5 Always, 1 Named-Item (light arrows), 5 Goal, 3 Barren (ToT), 1 Song (ToT), 2 Dual, 5 Sometimes; House of Skulltula (30/40/50).",
     "add_locations":         [
         { "location": "Sheik in Kakariko", "types": ["always"] },
         { "location": "Deku Theater Skull Mask", "types": ["always"] }
@@ -49,21 +49,26 @@
             "ToT (Right-Center)",
             "ToT (Right)"
         ]},
-        "goal":            {"order": 3, "weight": 0.0, "fixed": 5, "copies": 2, "remove_stones": [
+        "named-item":      {"order": 3, "weight": 0.0, "fixed": 1, "copies": 2, "remove_stones": [
             "ToT (Left)",
             "ToT (Left-Center)",
             "ToT (Right-Center)",
             "ToT (Right)"
         ]},
-        "barren":          {"order": 4, "weight": 0.0, "fixed": 3, "copies": 1, "priority_stones": [
+        "goal":            {"order": 4, "weight": 0.0, "fixed": 5, "copies": 2, "remove_stones": [
+            "ToT (Left)",
+            "ToT (Left-Center)",
+            "ToT (Right-Center)",
+            "ToT (Right)"
+        ]},
+        "barren":          {"order": 5, "weight": 0.0, "fixed": 3, "copies": 1, "priority_stones": [
             "ToT (Left)",
             "ToT (Left-Center)",
             "ToT (Right-Center)"
         ]},
-        "song":            {"order": 5, "weight": 0.0, "fixed": 1, "copies": 1, "priority_stones": [
+        "song":            {"order": 6, "weight": 0.0, "fixed": 1, "copies": 1, "priority_stones": [
             "ToT (Right)"
         ]},
-        "named-item":      {"order": 6, "weight": 0.0, "fixed": 1, "copies": 2},
         "dual":            {"order": 7, "weight": 0.0, "fixed": 2, "copies": 2},
         "sometimes":       {"order": 8, "weight": 0.0, "fixed": 5, "copies": 2},
         "junk":            {"order": 9, "weight": 1.0, "fixed": 0, "copies": 1},


### PR DESCRIPTION
Fixes an issue where the light arrow hint was ignoring the hint distribution order and was appearing on ToT gossip stones.