### PR TITLE
Remove password from settings log

### DIFF
--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1306,7 +1306,7 @@ class Distribution:
             'settings': self.settings.to_json(),
         }
 
-        if not self.settings.password_lock:
+        if not self.settings.password_lock or not spoiler:
             self_dict.pop('password')
 
         if spoiler:


### PR DESCRIPTION
Now the password should be only written in the spoiler log and not anywhere else.