### PR TITLE
Add missing MQ Jabu Like like room wonderitems

### DIFF
--- a/LocationList.py
+++ b/LocationList.py
@@ -1259,6 +1259,9 @@ location_table: dict[str, tuple[str, Optional[int], LocationDefault, LocationAdd
     ("Jabu Jabus Belly MQ Falling Like-Like Room Left Cow Wonderitem 1", ("Wonderitem",0x02, (11,0,23), None,                       'Recovery Heart',                        ("Jabu Jabu's Belly", "Master Quest", "Wonderitem"))),
     ("Jabu Jabus Belly MQ Falling Like-Like Room Left Cow Wonderitem 2", ("Wonderitem",0x02, (11,0,24), None,                       'Recovery Heart',                        ("Jabu Jabu's Belly", "Master Quest", "Wonderitem"))),
     ("Jabu Jabus Belly MQ Falling Like-Like Room Left Cow Wonderitem 3", ("Wonderitem",0x02, (11,0,25), None,                       'Recovery Heart',                        ("Jabu Jabu's Belly", "Master Quest", "Wonderitem"))),
+    ("Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 1", ("Wonderitem",0x02, (11,0,28), None,                     'Fairy Drop',                            ("Jabu Jabu's Belly", "Master Quest", "Wonderitem"))),
+    ("Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 2", ("Wonderitem",0x02, (11,0,29), None,                     'Fairy Drop',                            ("Jabu Jabu's Belly", "Master Quest", "Wonderitem"))),
+    ("Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 3", ("Wonderitem",0x02, (11,0,30), None,                     'Fairy Drop',                            ("Jabu Jabu's Belly", "Master Quest", "Wonderitem"))),
 
 
     # Jabu Jabu's Belly Shared

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -96,6 +96,9 @@
             "Jabu Jabus Belly MQ Falling Like-Like Room Left Cow Wonderitem 1": "True",
             "Jabu Jabus Belly MQ Falling Like-Like Room Left Cow Wonderitem 2": "True",
             "Jabu Jabus Belly MQ Falling Like-Like Room Left Cow Wonderitem 3": "True",
+            "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 1": "has_explosives",
+            "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 2": "has_explosives",
+            "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 3": "has_explosives",
             "Jabu Jabus Belly MQ Hallway Small Crate 1": "True",
             "Jabu Jabus Belly MQ Hallway Small Crate 2": "True"
         },


### PR DESCRIPTION
There are 3 wonderitems in MQ Jabu that are currently unshuffled. They're in the falling like like room on top of the piece of grass, and can be triggered with explosives. This PR shuffles them.

Proof below:

![Glide64_THE_LEGEND_OF_ZELDA_94](https://github.com/user-attachments/assets/6f17b38a-28f7-4863-83e3-ffccc209596d)

https://github.com/user-attachments/assets/9cedb771-69a1-430f-855f-d6be163d6bcc

From the spoiler:
`    "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 1": "Rupee (1)",
    "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 2": "Rupees (20)",
    "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 3": "Rupees (20)",`