### PR TITLE
[GUI] Fix width regression in cosmetics tab

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.scss
+++ b/GUI/src/app/pages/generator/generator.component.scss
@@ -261,11 +261,10 @@
   .comboBoxLabel {
     position: relative;
     display: block;
-    left: 10px;
-    width: calc(100% - 10px); 
+    padding-left: 10px;
 
     &.oneLineComboBox {
-      left: 0;
+      padding-left: 0;
     }
   }
 


### PR DESCRIPTION
#2288 introduced a regression on in-lined settings labels as shown in the below screenshot from Discord:

![image](https://github.com/user-attachments/assets/3cf16611-4f45-4470-bf95-a263432164c1)

This PR reverts the change in #2288 and replaces the `left` styles with `padding-left`:

![image](https://github.com/user-attachments/assets/f4b5e4dd-620e-4960-94a8-e7b02e7d15ae)

Original problem from #2286 remains fixed:

![image](https://github.com/user-attachments/assets/354893ef-0ae3-408b-93c6-43a4bb281145)
