### PR TITLE
fix: _MACOSX directory in ootr archive can cause issues loading tracks

### DIFF
--- a/Music.py
+++ b/Music.py
@@ -244,8 +244,8 @@ def process_sequences(rom: Rom, ids: Iterable[tuple[str, int]], seq_type: str = 
                     seq_file = None
                     zbank_file = None
                     bankmeta_file = None
-                    for f in zip.namelist(): # Only read files in the root of the archive
-                        if '/' in f:
+                    for f in zip.namelist(): 
+                        if '/' in f: # Only read files in the root of the archive
                             continue   
                         if f.endswith(".meta"):
                             meta_file = f

--- a/Music.py
+++ b/Music.py
@@ -244,7 +244,9 @@ def process_sequences(rom: Rom, ids: Iterable[tuple[str, int]], seq_type: str = 
                     seq_file = None
                     zbank_file = None
                     bankmeta_file = None
-                    for f in zip.namelist():
+                    for f in zip.namelist(): # Only read files in the root of the archive
+                        if '/' in f:
+                            continue   
                         if f.endswith(".meta"):
                             meta_file = f
                             continue

--- a/Music.py
+++ b/Music.py
@@ -244,7 +244,7 @@ def process_sequences(rom: Rom, ids: Iterable[tuple[str, int]], seq_type: str = 
                     seq_file = None
                     zbank_file = None
                     bankmeta_file = None
-                    for f in zip.namelist(): 
+                    for f in zip.namelist():
                         if '/' in f: # Only read files in the root of the archive
                             continue   
                         if f.endswith(".meta"):


### PR DESCRIPTION
In the Darunia's Joy discord, there was a user who was getting an error reading the .meta file for one of their songs.

I eventually figured out that it was because the ootrs archive also contained the author's `_MACOSX` dir and a `._<filename>.meta` that was being read instead of the .meta file at the root.

I think an easy way to fix this for future users, besides having authors making sure their ootrs archives only have files, is to add a check in Music.py so only root files are processed: