### PR TITLE
Logic for repeatable blue warp ToD changes

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -385,14 +385,14 @@ entrance_shuffle_table = [
     ('WarpSong',        ('Nocturne of Shadow Warp -> Graveyard Warp Pad Region',            { 'index': 0x0568, 'addresses': [0xBF0244] })),
     ('WarpSong',        ('Prelude of Light Warp -> Temple of Time',                         { 'index': 0x05F4, 'addresses': [0xBF0246] })),
 
-    ('BlueWarp',        ('Queen Gohma Boss Room -> KF Outside Deku Tree',                   { 'index': 0x0457, 'addresses': [0xAC93A2, 0xCA3142, 0xCA316A] })),
-    ('BlueWarp',        ('King Dodongo Boss Room -> Death Mountain',                        { 'index': 0x047A, 'addresses': [0xAC9336, 0xCA30CA, 0xCA30EA] })),
-    ('BlueWarp',        ('Barinade Boss Room -> Zoras Fountain',                            { 'index': 0x010E, 'addresses': [0xAC936A, 0xCA31B2, 0xCA3702] })),
-    ('BlueWarp',        ('Phantom Ganon Boss Room -> Sacred Forest Meadow',                 { 'index': 0x0608, 'addresses': [0xAC9F96, 0xCA3D66, 0xCA3D5A, 0xCA3D32], 'child_index': 0x0600 })),
-    ('BlueWarp',        ('Volvagia Boss Room -> DMC Central Local',                         { 'index': 0x0564, 'addresses': [0xACA516, 0xCA3DF2, 0xCA3DE6, 0xCA3DBE], 'child_index': 0x04F6 })),
-    ('BlueWarp',        ('Morpha Boss Room -> Lake Hylia',                                  { 'index': 0x060C, 'addresses': [0xAC995A, 0xCA3E82, 0xCA3E76, 0xCA3E4A], 'child_index': 0x0604 })),
-    ('BlueWarp',        ('Bongo Bongo Boss Room -> Graveyard Warp Pad Region',              { 'index': 0x0580, 'addresses': [0xACA496, 0xCA3FA2, 0xCA3F96, 0xCA3F6A], 'child_index': 0x0568 })),
-    ('BlueWarp',        ('Twinrova Boss Room -> Desert Colossus',                           { 'index': 0x0610, 'addresses': [0xACA402, 0xCA3F12, 0xCA3F06, 0xCA3EDA], 'child_index': 0x01F1 })),
+    ('BlueWarp',        ('Queen Gohma Blue Warp -> KF Outside Deku Tree',                   { 'index': 0x0457, 'addresses': [0xAC93A2, 0xCA3142, 0xCA316A] })),
+    ('BlueWarp',        ('King Dodongo Blue Warp -> Death Mountain',                        { 'index': 0x047A, 'addresses': [0xAC9336, 0xCA30CA, 0xCA30EA] })),
+    ('BlueWarp',        ('Barinade Blue Warp -> Zoras Fountain',                            { 'index': 0x010E, 'addresses': [0xAC936A, 0xCA31B2, 0xCA3702] })),
+    ('BlueWarp',        ('Phantom Ganon Blue Warp -> Sacred Forest Meadow',                 { 'index': 0x0608, 'addresses': [0xAC9F96, 0xCA3D66, 0xCA3D5A, 0xCA3D32], 'child_index': 0x0600 })),
+    ('BlueWarp',        ('Volvagia Blue Warp -> DMC Central Local',                         { 'index': 0x0564, 'addresses': [0xACA516, 0xCA3DF2, 0xCA3DE6, 0xCA3DBE], 'child_index': 0x04F6 })),
+    ('BlueWarp',        ('Morpha Blue Warp -> Lake Hylia',                                  { 'index': 0x060C, 'addresses': [0xAC995A, 0xCA3E82, 0xCA3E76, 0xCA3E4A], 'child_index': 0x0604 })),
+    ('BlueWarp',        ('Bongo Bongo Blue Warp -> Graveyard Warp Pad Region',              { 'index': 0x0580, 'addresses': [0xACA496, 0xCA3FA2, 0xCA3F96, 0xCA3F6A], 'child_index': 0x0568 })),
+    ('BlueWarp',        ('Twinrova Blue Warp -> Desert Colossus',                           { 'index': 0x0610, 'addresses': [0xACA402, 0xCA3F12, 0xCA3F06, 0xCA3EDA], 'child_index': 0x01F1 })),
 
     ('Extra',           ('ZD Eyeball Frog Timeout -> Zoras Domain',                         { 'index': 0x0153 })),
     ('Extra',           ('ZR Top of Waterfall -> Zora River',                               { 'index': 0x0199 })),
@@ -565,7 +565,7 @@ def shuffle_random_entrances(worlds: list[World]) -> None:
             elif pool_type == 'Spawn':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
                 # Restrict spawn entrances from linking to regions with no or extremely specific glitchless itemless escapes.
-                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Volvagia Boss Room -> DMC Central Local', 'Bolero of Fire Warp -> DMC Central Local', 'Queen Gohma Boss Room -> KF Outside Deku Tree'])
+                one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types, exclude=['Volvagia Blue Warp -> DMC Central Local', 'Bolero of Fire Warp -> DMC Central Local', 'Queen Gohma Blue Warp -> KF Outside Deku Tree'])
             elif pool_type == 'WarpSong':
                 valid_target_types = ('Spawn', 'WarpSong', 'BlueWarp', 'OwlDrop', 'OverworldOneWay', 'Overworld', 'Interior', 'SpecialInterior', 'Extra')
                 one_way_target_entrance_pools[pool_type] = build_one_way_targets(world, valid_target_types)
@@ -639,25 +639,25 @@ def shuffle_random_entrances(worlds: list[World]) -> None:
         }
         # if a boss room is inside a dungeon entrance (or inside a dungeon which is inside a dungeon entrance), make the blue warp go to that dungeon's blue warp target
         dungeon_exits = {
-            'Deku Tree Lobby -> KF Outside Deku Tree': world.get_entrance('Queen Gohma Boss Room -> KF Outside Deku Tree'),
-            'Dodongos Cavern Beginning -> Death Mountain': world.get_entrance('King Dodongo Boss Room -> Death Mountain'),
-            'Jabu Jabus Belly Beginning -> Zoras Fountain': world.get_entrance('Barinade Boss Room -> Zoras Fountain'),
-            'Forest Temple Lobby -> SFM Forest Temple Entrance Ledge': world.get_entrance('Phantom Ganon Boss Room -> Sacred Forest Meadow'),
-            'Fire Temple Lower -> DMC Fire Temple Entrance': world.get_entrance('Volvagia Boss Room -> DMC Central Local'),
-            'Water Temple Lobby -> Lake Hylia': world.get_entrance('Morpha Boss Room -> Lake Hylia'),
-            'Shadow Temple Entryway -> Graveyard Warp Pad Region': world.get_entrance('Bongo Bongo Boss Room -> Graveyard Warp Pad Region'),
-            'Spirit Temple Lobby -> Desert Colossus From Spirit Lobby': world.get_entrance('Twinrova Boss Room -> Desert Colossus'),
+            'Deku Tree Lobby -> KF Outside Deku Tree': world.get_entrance('Queen Gohma Blue Warp -> KF Outside Deku Tree'),
+            'Dodongos Cavern Beginning -> Death Mountain': world.get_entrance('King Dodongo Blue Warp -> Death Mountain'),
+            'Jabu Jabus Belly Beginning -> Zoras Fountain': world.get_entrance('Barinade Blue Warp -> Zoras Fountain'),
+            'Forest Temple Lobby -> SFM Forest Temple Entrance Ledge': world.get_entrance('Phantom Ganon Blue Warp -> Sacred Forest Meadow'),
+            'Fire Temple Lower -> DMC Fire Temple Entrance': world.get_entrance('Volvagia Blue Warp -> DMC Central Local'),
+            'Water Temple Lobby -> Lake Hylia': world.get_entrance('Morpha Blue Warp -> Lake Hylia'),
+            'Shadow Temple Entryway -> Graveyard Warp Pad Region': world.get_entrance('Bongo Bongo Blue Warp -> Graveyard Warp Pad Region'),
+            'Spirit Temple Lobby -> Desert Colossus From Spirit Lobby': world.get_entrance('Twinrova Blue Warp -> Desert Colossus'),
         }
 
         for (blue_warp, boss_door_exit) in (
-            (world.get_entrance('Queen Gohma Boss Room -> KF Outside Deku Tree'), world.get_entrance('Queen Gohma Boss Room -> Deku Tree Before Boss')),
-            (world.get_entrance('King Dodongo Boss Room -> Death Mountain'), world.get_entrance('King Dodongo Boss Room -> Dodongos Cavern Mouth')),
-            (world.get_entrance('Barinade Boss Room -> Zoras Fountain'), world.get_entrance('Barinade Boss Room -> Jabu Jabus Belly Before Boss')),
-            (world.get_entrance('Phantom Ganon Boss Room -> Sacred Forest Meadow'), world.get_entrance('Phantom Ganon Boss Room -> Forest Temple Before Boss')),
-            (world.get_entrance('Volvagia Boss Room -> DMC Central Local'), world.get_entrance('Volvagia Boss Room -> Fire Temple Before Boss')),
-            (world.get_entrance('Morpha Boss Room -> Lake Hylia'), world.get_entrance('Morpha Boss Room -> Water Temple Before Boss')),
-            (world.get_entrance('Bongo Bongo Boss Room -> Graveyard Warp Pad Region'), world.get_entrance('Bongo Bongo Boss Room -> Shadow Temple Before Boss')),
-            (world.get_entrance('Twinrova Boss Room -> Desert Colossus'), world.get_entrance('Twinrova Boss Room -> Spirit Temple Before Boss')),
+            (world.get_entrance('Queen Gohma Blue Warp -> KF Outside Deku Tree'), world.get_entrance('Queen Gohma Boss Room -> Deku Tree Before Boss')),
+            (world.get_entrance('King Dodongo Blue Warp -> Death Mountain'), world.get_entrance('King Dodongo Boss Room -> Dodongos Cavern Mouth')),
+            (world.get_entrance('Barinade Blue Warp -> Zoras Fountain'), world.get_entrance('Barinade Boss Room -> Jabu Jabus Belly Before Boss')),
+            (world.get_entrance('Phantom Ganon Blue Warp -> Sacred Forest Meadow'), world.get_entrance('Phantom Ganon Boss Room -> Forest Temple Before Boss')),
+            (world.get_entrance('Volvagia Blue Warp -> DMC Central Local'), world.get_entrance('Volvagia Boss Room -> Fire Temple Before Boss')),
+            (world.get_entrance('Morpha Blue Warp -> Lake Hylia'), world.get_entrance('Morpha Boss Room -> Water Temple Before Boss')),
+            (world.get_entrance('Bongo Bongo Blue Warp -> Graveyard Warp Pad Region'), world.get_entrance('Bongo Bongo Boss Room -> Shadow Temple Before Boss')),
+            (world.get_entrance('Twinrova Blue Warp -> Desert Colossus'), world.get_entrance('Twinrova Boss Room -> Spirit Temple Before Boss')),
         ):
             target = boss_door_exit.replaces or boss_door_exit
             if True: #TODO not world.settings.decouple_entrances

--- a/World.py
+++ b/World.py
@@ -585,8 +585,8 @@ class World:
             if 'time_passes' in region:
                 new_region.time_passes = region['time_passes']
                 new_region.provides_time = TimeOfDay.ALL
-            if new_region.name == 'Ganons Castle Grounds':
-                new_region.provides_time = TimeOfDay.DAMPE
+            if 'provides_time' in region:
+                new_region.provides_time = getattr(TimeOfDay, region['provides_time'])
             if 'locations' in region:
                 for location, rule in region['locations'].items():
                     new_location = LocationFactory(location)

--- a/data/World/Bosses.json
+++ b/data/World/Bosses.json
@@ -15,7 +15,15 @@
         },
         "exits": {
             "Deku Tree Before Boss": "True",
-            "KF Outside Deku Tree": "'Defeat Queen Gohma'"
+            "Queen Gohma Blue Warp": "'Defeat Queen Gohma'"
+        }
+    },
+    {
+        "region_name": "Queen Gohma Blue Warp",
+        "scene": "Deku Tree Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "KF Outside Deku Tree": "at_day"
         }
     },
     {
@@ -35,7 +43,15 @@
         },
         "exits": {
             "Dodongos Cavern Mouth": "True",
-            "Death Mountain": "'Defeat King Dodongo'"
+            "King Dodongo Blue Warp": "'Defeat King Dodongo'"
+        }
+    },
+    {
+        "region_name": "King Dodongo Blue Warp",
+        "scene": "Dodongos Cavern Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "Death Mountain": "at_day"
         }
     },
     {
@@ -57,7 +73,15 @@
         },
         "exits": {
             "Jabu Jabus Belly Before Boss": "False",
-            "Zoras Fountain": "'Defeat Barinade'"
+            "Barinade Blue Warp": "'Defeat Barinade'"
+        }
+    },
+    {
+        "region_name": "Barinade Blue Warp",
+        "scene": "Jabu Jabus Belly Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "Zoras Fountain": "at_day"
         }
     },
     {
@@ -74,7 +98,15 @@
         },
         "exits": {
             "Forest Temple Before Boss": "False",
-            "Sacred Forest Meadow": "'Defeat Phantom Ganon'"
+            "Phantom Ganon Blue Warp": "'Defeat Phantom Ganon'"
+        }
+    },
+    {
+        "region_name": "Phantom Ganon Blue Warp",
+        "scene": "Forest Temple Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "Sacred Forest Meadow": "at_day"
         }
     },
     {
@@ -90,7 +122,15 @@
         },
         "exits": {
             "Fire Temple Before Boss": "False",
-            "DMC Central Local": "'Defeat Volvagia'"
+            "Volvagia Blue Warp": "'Defeat Volvagia'"
+        }
+    },
+    {
+        "region_name": "Volvagia Blue Warp",
+        "scene": "Fire Temple Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "DMC Central Local": "at_day"
         }
     },
     {
@@ -108,7 +148,15 @@
         },
         "exits": {
             "Water Temple Before Boss": "False",
-            "Lake Hylia": "'Defeat Morpha'"
+            "Morpha Blue Warp": "'Defeat Morpha'"
+        }
+    },
+    {
+        "region_name": "Morpha Blue Warp",
+        "scene": "Water Temple Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "Lake Hylia": "at_day"
         }
     },
     {
@@ -127,7 +175,15 @@
         },
         "exits": {
             "Shadow Temple Before Boss": "False",
-            "Graveyard Warp Pad Region": "'Defeat Bongo Bongo'"
+            "Bongo Bongo Blue Warp": "'Defeat Bongo Bongo'"
+        }
+    },
+    {
+        "region_name": "Bongo Bongo Blue Warp",
+        "scene": "Shadow Temple Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "Graveyard Warp Pad Region": "at_day"
         }
     },
     {
@@ -143,7 +199,15 @@
         },
         "exits": {
             "Spirit Temple Before Boss": "False",
-            "Desert Colossus": "'Defeat Twinrova'"
+            "Twinrova Blue Warp": "'Defeat Twinrova'"
+        }
+    },
+    {
+        "region_name": "Twinrova Blue Warp",
+        "scene": "Spirit Temple Boss",
+        "provides_time": "DAY",
+        "exits": {
+            "Desert Colossus": "at_day"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1408,6 +1408,7 @@
         "region_name": "Ganons Castle Grounds",
         "scene": "Castle Grounds",
         "hint": "OUTSIDE_GANONS_CASTLE",
+        "provides_time": "DAMPE",
         "locations": {
             "OGC GS": "True"
         },


### PR DESCRIPTION
Fixes #2235. Part 2 of 2.

This puts the repeatable time-of-day changes from blue warps that were introduced in #2287 into logic. The logic is handled in the same way as for outside Ganon's Castle, which was previously a hardcoded special case.