### PR TITLE
Fix path in CI help message

### DIFF
--- a/CI.py
+++ b/CI.py
@@ -286,7 +286,7 @@ def exit_ci(fix_errors: bool = False) -> NoReturn:
                     which_errors = 'some of these errors'
                 else:
                     which_errors = 'these errors'
-                print(f'Run `CI.py --fix --no_unit_tests{release_arg}` to automatically fix {which_errors}.', file=sys.stderr)
+                print(f'Run `./CI.py --fix --no_unit_tests{release_arg}` to automatically fix {which_errors}.', file=sys.stderr)
             sys.exit(1)
     else:
         print(f'CI checks successful.')


### PR DESCRIPTION
This changes the suggested command from `CI.py` to `./CI.py` to make it work in shell environments that don't include `.` in the `PATH`, which is the default for most shells. This also works on Windows, which accepts `/` as a path separator even though `\` is the default.