### PR TITLE
Fix weekly hint distro

### DIFF
--- a/data/Hints/weekly.json
+++ b/data/Hints/weekly.json
@@ -28,7 +28,7 @@
     ],
     "add_items":             [],
     "remove_items":          [
-        { "item": "Zeldas Lullaby", "types": ["goal"] }
+        { "item": "Zeldas Lullaby", "types": ["woth"] }
     ],
     "dungeons_woth_limit":   2,
     "dungeons_barren_limit": 1,

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -392,13 +392,13 @@
             "Claim Check"
         ]
     },
-    "Standard Weekly (2024-09-20)": {
+    "Standard Weekly (2024-09-21)": {
         "aliases": [
             "Standard Weekly (Latest)",
             "weekly"
         ],
         "show_seed_info": true,
-        "user_message": "Standard Weekly (2024-09-20)",
+        "user_message": "Standard Weekly (2024-09-21)",
         "world_count": 1,
         "create_spoiler": true,
         "password_lock": false,


### PR DESCRIPTION
Removes ZL from WOTH hints. This was an oversight and should have been in place with the last weekly update.