### PR TITLE
feat(GUI): enable race seed button for dev with spoiler log lock

### DIFF
--- a/GUI/src/app/pages/generator/generator.component.html
+++ b/GUI/src/app/pages/generator/generator.component.html
@@ -289,14 +289,9 @@
             <input class="footerInputShort" nbInput type="text" maxlength="260" fieldSize="small" [(ngModel)]="seedString">
             <!--Padding-->
             <div class="tabsetPadding"></div>
-            <!--Release Versions Only-->
-            <ng-container *ngIf="global.getGlobalVar('webIsMasterVersion')">
+            <ng-container>
               <button class="footerGenerateButtonNormalSmall" nbButton status="success" [disabled]="!generateSeedButtonEnabled" (click)="generateSeed()">Generate Seed!</button>
               <button class="footerGenerateButtonRaceSmall" nbButton status="info" [disabled]="!generateSeedButtonEnabled" (click)="generateSeed(false, true)">Generate Race Seed!</button>
-            </ng-container>
-            <!--Dev Version-->
-            <ng-container *ngIf="!global.getGlobalVar('webIsMasterVersion')">
-              <button class="footerGenerateButton" nbButton fullWidth status="success" [disabled]="!generateSeedButtonEnabled" (click)="generateSeed()">Generate Seed!</button>
             </ng-container>
           </ng-container>
         </nb-tab>

--- a/GUI/src/app/providers/GUIGlobal.ts
+++ b/GUI/src/app/providers/GUIGlobal.ts
@@ -1506,9 +1506,17 @@ export class GUIGlobal implements OnDestroy {
     }
 
     if (raceSeed) {
+      let masterVersion = this.getGlobalVar("webIsMasterVersion");
+
       useStaticSeed = ""; //Static seeds aren't allowed in race mode
       settingsFile["create_spoiler"] = true; //Force spoiler mode to on
-      settingsFile["encrypt"] = true;
+      
+      if (masterVersion) {
+        settingsFile["encrypt"] = true;
+      }
+      else {
+        settingsFile["web_lock"] = true; //This is filtered out by the web endpoint before generation
+      }
     }
     else {
       delete settingsFile["encrypt"];


### PR DESCRIPTION
This adds the race seed button to the web UI for dev forks.
So far, this was disabled, as dev forks have no encryption.
However, in response, maybe competitive events disabled spoiler log generation on dev in their presets to streamline the process. This is no longer needed with this, as a dev seed can now be created as race seed.

As against release, the seed will still not be encrypted, but the spoiler log will be locked away and won't be available without admin interference.
In addition, a custom seed entered will be scraped and replaced with a random string, and the actual randomizer seed will not be visible by any means on the seed page or the settings log unless the spoiler log is unlocked.