### PR TITLE
Make the frogs ocarina minigame misc hint easier to re-read

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -473,7 +473,7 @@ def patch_cutscenes(rom: Rom, songs_as_items: bool, settings: Settings) -> None:
     # Remove the Navi textbox at the start of state 28 ("This time, we fight together!).
     rom.write_int16(0xE84C80, 0x1000)
 
-def patch_wondertalk2(rom: Rom) -> None:
+def patch_wondertalk2(rom: Rom, settings: Settings) -> None:
     # Wonder_talk2 is an actor that displays a textbox when near a certain spot, either automatically or by pressing A (button turns to Check).
     # We remove them by moving their Y coordinate far below their normal spot.
     wonder_talk2_y_coordinates = [
@@ -497,3 +497,9 @@ def patch_wondertalk2(rom: Rom) -> None:
     ]
     for address in wonder_talk2_y_coordinates:
         rom.write_byte(address, 0xFB)
+
+    if 'frogs2' in settings.misc_hints:
+        # Prevent setting the replaced textbox flag so that the hint is easily repeatible by walking over the spot again.
+        # And move the hint spot down the log so that it doesn't pop every time a song is played, and let some room to do ocarina item glitch.
+        rom.write_int16s(0x2059412, [0x03C0, 0x00E2, 0xFAA6]) # Move coordinates. Original value : 1000, 205, -1202. New value : 960, 226, -1370.
+        rom.write_byte(0x205941F, 0xBF) # Never set the flag.

--- a/Patches.py
+++ b/Patches.py
@@ -453,7 +453,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         rom.write_byte(rom.sym('OCARINAS_SHUFFLED'), 0x01)
 
     patch_cutscenes(rom, songs_as_items, world.settings)
-    patch_wondertalk2(rom)
+    patch_wondertalk2(rom, world.settings)
 
     # Speed Pushing of All Pushable Objects (other than armos statues, which are handled in ASM)
     rom.write_bytes(0xDD2B86, [0x40, 0x80])  # block speed


### PR DESCRIPTION
A tentative solution for #2125
This PR changes two things to the frogs ocarina minigame misc hint textbox : 
* Makes it repeatable instantly so you can walk over the spot again without reloading the area
* Moves the spot down the log because the first change makes the textbox show up every time you play a song to the frogs, which quickly becomes very annoying. This is enough far down so that Ocarina Item users can do the glitch without triggering it.

https://github.com/user-attachments/assets/a0ff1c97-6e69-43a9-8470-c5904c334be9

