### PR TITLE
New Misc Hint : Market 10 Big Poes

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -214,7 +214,7 @@ def tokens_required_by_settings(world: World) -> int:
 
 # Hints required under certain settings
 conditional_always: dict[str, Callable[[World], bool]] = {
-    'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3,
+    'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3 and 'big_poes' not in world.settings.misc_hints,
     'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest and 'Mask of Truth' not in world.settings.shuffle_child_trade,
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
     'HF Ocarina of Time Item':      lambda world: stones_required_by_settings(world) < 2,
@@ -1893,6 +1893,13 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'ZR Frogs Ocarina Game',
         'location_text': "Some frogs holding \x05\x42{item}\x05\x40 are looking at you from underwater...",
         'location_fallback': "Some frogs are looking at you from underwater...",
+    },
+    'big_poes': {
+        'id': 0x70F5,
+        'hint_location': 'Market 10 Big Poes Hint',
+        'item_location': 'Market 10 Big Poes',
+        'location_text': "\x08Hey, young man. What's happening \x01today? Do you want\x01\x05\x41{item}\x05\x40?\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
+        'location_fallback': "\x08Hey, young man. What's happening \x01today? If you have a \x05\x41Poe\x05\x40, I will \x01buy it.\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
     },
 }
 

--- a/Hints.py
+++ b/Hints.py
@@ -1813,11 +1813,23 @@ def build_misc_item_hints(world: World, messages: list[Message], allow_duplicate
 def build_misc_location_hints(world: World, messages: list[Message]) -> None:
     for hint_type, data in misc_location_hint_table.items():
         text = data['location_fallback']
-        if hint_type in world.settings.misc_hints:
-            if hint_type in world.misc_hint_location_items:
-                item = world.misc_hint_location_items[hint_type]
+        if hint_type == 'big_poes':
+            # Special cased because we need to insert the big poes number.
+            item = world.misc_hint_location_items[hint_type]
+            poe_points = world.settings.big_poe_count * 100
+            if hint_type in world.settings.misc_hints:
                 text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
-                                                                  world.settings.clearer_hints).text)
+                                                                    world.settings.clearer_hints).text, poe_points=poe_points)
+            else:
+                text = data['location_fallback'].format(poe_points=poe_points)
+            update_message_by_id(messages, data['id'], text)
+            return
+        else:
+            if hint_type in world.settings.misc_hints:
+                if hint_type in world.misc_hint_location_items:
+                    item = world.misc_hint_location_items[hint_type]
+                    text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
+                                                                        world.settings.clearer_hints).text)
 
         update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), 0x23)
 

--- a/LocationList.py
+++ b/LocationList.py
@@ -2604,6 +2604,7 @@ location_table: dict[str, tuple[str, Optional[int], LocationDefault, LocationAdd
     ("40 Skulltulas Reward Hint",                                    ("Hint",         None,  None, None,                            None,                                    None)),
     ("50 Skulltulas Reward Hint",                                    ("Hint",         None,  None, None,                            None,                                    None)),
     ("ZR Frogs Ocarina Minigame Hint",                               ("Hint",         None,  None, None,                            None,                                    None)),
+    ("Market 10 Big Poes Hint",                                      ("Hint",         None,  None, None,                            None,                                    None)),
     ("Ganondorf Hint",                                               ("Hint",         None,  None, None,                            None,                                    None)),
 ])
 

--- a/Patches.py
+++ b/Patches.py
@@ -1371,8 +1371,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     poe_points = world.settings.big_poe_count * 100
     rom.write_int16(0xEE69CE, poe_points)
     # update dialogue
-    new_message = "\x08Hey, young man. What's happening \x01today? If you have a \x05\x41Poe\x05\x40, I will \x01buy it.\x04\x1AIf you earn \x05\x41%d points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02" % poe_points
-    update_message_by_id(messages, 0x70F5, new_message)
+    # 0x70F5 is done in build_misc_location_hints
     if world.settings.big_poe_count != 10:
         new_message = "\x1AOh, you brought a Poe today!\x04\x1AHmmmm!\x04\x1AVery interesting!\x01This is a \x05\x41Big Poe\x05\x40!\x04\x1AI'll buy it for \x05\x4150 Rupees\x05\x40.\x04On top of that, I'll put \x05\x41100\x01points \x05\x40on your card.\x04\x1AIf you earn \x05\x41%d points\x05\x40, you'll\x01be a happy man! Heh heh." % poe_points
         update_message_by_id(messages, 0x70f7, new_message)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3486,6 +3486,7 @@ class SettingInfos:
             'frogs2':         'Frogs Ocarina Game',
             'mask_shop':  'Shuffled Mask Shop',
             'unique_merchants':  'Unique Merchants',
+            'big_poes':  'Market Big Poes',
         },
         gui_tooltip    = '''\
             This setting adds some hints at locations
@@ -3539,6 +3540,9 @@ class SettingInfos:
             If Shuffle Magic Beans is enabled, the Magic bean
             salesman will tell what the reward is for buying
             the 60 Rupees item.
+
+            The Poe collector will tell the reward for selling
+            him Big Poes.
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -527,7 +527,7 @@
             "Market 10 Big Poes": "
                 is_adult and
                 (Big_Poe or (Bottle_with_Big_Poe, big_poe_count))",
-            "Market 10 Big Poes Hint": "True",
+            "Market 10 Big Poes Hint": "is_adult",
             "Market GS Guard House": "is_child"
         }
     },

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -527,6 +527,7 @@
             "Market 10 Big Poes": "
                 is_adult and
                 (Big_Poe or (Bottle_with_Big_Poe, big_poe_count))",
+            "Market 10 Big Poes Hint": "True",
             "Market GS Guard House": "is_child"
         }
     },

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1436,7 +1436,7 @@
         "locations": {
             "Market 10 Big Poes": "
                 is_adult and (Big_Poe or (Bottle_with_Big_Poe, big_poe_count))",
-            "Market 10 Big Poes Hint": "True",
+            "Market 10 Big Poes Hint": "is_adult",
             "Market Guard House Child Crate 1": "is_child and can_break_crate",
             "Market Guard House Child Crate 2": "is_child and can_break_crate",
             "Market Guard House Child Crate 3": "is_child and can_break_crate",

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -1436,6 +1436,7 @@
         "locations": {
             "Market 10 Big Poes": "
                 is_adult and (Big_Poe or (Bottle_with_Big_Poe, big_poe_count))",
+            "Market 10 Big Poes Hint": "True",
             "Market Guard House Child Crate 1": "is_child and can_break_crate",
             "Market Guard House Child Crate 2": "is_child and can_break_crate",
             "Market Guard House Child Crate 3": "is_child and can_break_crate",


### PR DESCRIPTION
Adds a new Misc Hint to the list, that changes the textbox of Ghost Hunter to display his reward for bringing him Big Poes: 

![poe_hint](https://github.com/user-attachments/assets/e4169b47-9aba-4419-b98e-309abd4a51e3)

For the implementation I had to special case build_misc_location_hints because this textbox was already changed by rando to display the number of big poes needed. So this change is now done there rather than in Patches.py, even of course if the misc hint is off, to keep the current behaviour.