### PR TITLE
Don't count duplicate dungeon rewards or ocarina buttons

### DIFF
--- a/State.py
+++ b/State.py
@@ -65,11 +65,8 @@ class State:
                 return False
         return True
 
-    def count_of(self, items: Iterable[int]) -> int:
-        s = 0
-        for i in items:
-            s += self.solv_items[i]
-        return s
+    def count_distinct(self, items: Iterable[int]) -> int:
+        return sum(1 for i in items if self.solv_items[i] > 0)
 
     def item_count(self, item: int) -> int:
         return self.solv_items[item]
@@ -93,17 +90,17 @@ class State:
         )
 
     def has_medallions(self, count: int) -> bool:
-        return self.count_of(ItemInfo.medallion_ids) >= count
+        return self.count_distinct(ItemInfo.medallion_ids) >= count
 
     def has_stones(self, count: int) -> bool:
-        return self.count_of(ItemInfo.stone_ids) >= count
+        return self.count_distinct(ItemInfo.stone_ids) >= count
 
 
     def has_dungeon_rewards(self, count: int) -> bool:
-        return (self.count_of(ItemInfo.medallion_ids) + self.count_of(ItemInfo.stone_ids)) >= count
+        return self.count_distinct(ItemInfo.medallion_ids) + self.count_distinct(ItemInfo.stone_ids) >= count
 
     def has_ocarina_buttons(self, count: int) -> bool:
-        return (self.count_of(ItemInfo.ocarina_buttons_ids)) >= count
+        return self.count_distinct(ItemInfo.ocarina_buttons_ids) >= count
 
     # TODO: Store the item's solver id in the goal
     def has_item_goal(self, item_goal: dict[str, Any]) -> bool:


### PR DESCRIPTION
This fixes a bug originally reported at <https://old.reddit.com/r/zootr/comments/1ga2v43> where the logic would count multiple copies of the same dungeon reward (from plentiful or plando) for things like bridge conditions, even though the game doesn't, resulting in unbeatable seeds. For example, with this PR, the following plando fails to generate as it should:

```json
{
  "settings":                  {
    "bridge":                                  "medallions",
    "bridge_medallions":                       6,
    "shuffle_dungeon_rewards":                 "anywhere",
    "item_pool_value":                         "plentiful"
  },
  "locations":                 {
    "Ganons Castle Light Trial First Right Chest":                       "Fire Medallion",
    "Ganons Castle Light Trial First Left Chest":                       "Fire Medallion"
  }
}
```

This also affected the check requiring at least 2 ocarina note buttons for the scarecrow's song.

With this, the previous behavior of `State.count_of` (counting multiple copies of an item separately) is no longer used anywhere, so it has been fully removed. The new behavior has been renamed to `State.count_distinct` for clarity.