### PR TITLE
Improve after collapse cutscene skip

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -463,8 +463,16 @@ def patch_cutscenes(rom: Rom, songs_as_items: bool, settings: Settings) -> None:
     patch_cutscene_destination_and_length(rom, 0x33FB328, 1)
 
     # After tower collapse
-    # Jump from csState 1 to csState 4, 100 frames before giving back control. Next state only starts when Link gets near Ganon.
+    # Delete a bunch of camera instructions to avoid sudden movement when getting control back.
+    # Put subCamId at 0 in csState 0
+    rom.write_byte(0xE82DE9, 0x00)
+    # Jump from csState 1 to csState 4.
     rom.write_byte(0xE82E0F, 0x04)
+    # Remove all main camera changes in csState 4.
+    for byte in range(0, 80):
+        rom.write_byte(0xE8343C + byte, 0x00)
+    # Reduce the 100 frames wait in state 4 to 1. Next cutscene state only starts when Link gets close to Ganon.
+    rom.write_int16(0xE8341A, 0x0001)
     # Ganon intro
     # Jump from state 14 to 15 instantly instead of waiting 60 frames.
     rom.write_int32(0xE83B5C, 0x00000000)


### PR DESCRIPTION
Small improvement to the cutscene skip after collapse (or after beating Ganondorf if you have tower escape off). Shoutouts to Celeste on the discord for the idea !

https://github.com/user-attachments/assets/03523d98-6851-477e-bd38-281dbf9a441a

Current version for reference

https://github.com/user-attachments/assets/9fcd7e40-e137-4c68-b720-3641503d8e5c

The proposed improvement is 99 frames faster, and the camera ends up facing the next direction you want to take to continue the fight.
This will mess a bit with muscle memory for racers for a few seeds, but surely they will manage :p

