### PR TITLE
Include triforce pieces in major item hints

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1151,9 +1151,8 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
         if region == hint_loc:
             if ((location.item.majoritem or location.item.name in ('Biggoron Sword', 'Double Defense'))
                 and not location.locked
-                and not (location.name == 'Song from Impa'
-                         and 'Zeldas Letter' in world.settings.starting_items
-                         and 'Zeldas Letter' not in world.settings.shuffle_child_trade)):
+                and not (location.name == 'Song from Impa' and world.skip_child_zelda)
+                and not (location.item.type == 'GanonBossKey' and not world.settings.shuffle_ganon_bosskey == 'on_lacs')):
                 item_count = item_count + 1
 
     checked.add(hint_loc + ' Important Check')

--- a/Hints.py
+++ b/Hints.py
@@ -1149,22 +1149,11 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
     for location in world.get_filled_locations():
         region = HintArea.at(location).text(world.settings.clearer_hints)
         if region == hint_loc:
-            if (location.item.majoritem
-                # exclude locked items
+            if ((location.item.majoritem or location.item.name in ('Biggoron Sword', 'Double Defense'))
                 and not location.locked
-                and not (location.name == 'Song from Impa' and 'Zeldas Letter' in world.settings.starting_items and 'Zeldas Letter' not in world.settings.shuffle_child_trade)
-                # Special cases where the item is only considered major for important checks hints
-                or location.item.name == 'Biggoron Sword'
-                or location.item.name == 'Double Defense'
-                # Handle make keys not in own dungeon major items
-                or (location.item.type in ('SmallKey', 'SmallKeyRing') and not (world.settings.shuffle_smallkeys == 'dungeon' or world.settings.shuffle_smallkeys == 'vanilla'))
-                or (location.item.type in ('HideoutSmallKey', 'HideoutSmallKeyRing') and not world.settings.shuffle_hideoutkeys == 'vanilla')
-                or (location.item.type in ('TCGSmallKey', 'TCGSmallKeyRing') and not world.settings.shuffle_tcgkeys == 'vanilla')
-                or (location.item.type == 'BossKey' and not (world.settings.shuffle_bosskeys == 'dungeon' or world.settings.shuffle_bosskeys == 'vanilla'))
-                or (location.item.type == 'GanonBossKey' and not (world.settings.shuffle_ganon_bosskey == 'vanilla'
-                    or world.settings.shuffle_ganon_bosskey == 'dungeon' or world.settings.shuffle_ganon_bosskey == 'on_lacs'
-                    or world.settings.shuffle_ganon_bosskey == 'stones' or world.settings.shuffle_ganon_bosskey == 'medallions'
-                    or world.settings.shuffle_ganon_bosskey == 'dungeons' or world.settings.shuffle_ganon_bosskey == 'tokens'))):
+                and not (location.name == 'Song from Impa'
+                         and 'Zeldas Letter' in world.settings.starting_items
+                         and 'Zeldas Letter' not in world.settings.shuffle_child_trade)):
                 item_count = item_count + 1
 
     checked.add(hint_loc + ' Important Check')

--- a/Hints.py
+++ b/Hints.py
@@ -1152,8 +1152,6 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
             if (location.item.majoritem
                 # exclude locked items
                 and not location.locked
-                # exclude triforce pieces as it defeats the idea of a triforce hunt
-                and not location.item.name == 'Triforce Piece'
                 and not (location.name == 'Song from Impa' and 'Zeldas Letter' in world.settings.starting_items and 'Zeldas Letter' not in world.settings.shuffle_child_trade)
                 # Special cases where the item is only considered major for important checks hints
                 or location.item.name == 'Biggoron Sword'


### PR DESCRIPTION
The `important_check` hint type says `X has N major items.` where `X` is the location and `N` is the number of important items. There is a big block of code to exclude things from the count of "important items" and they mostly make sense. Things are removed from the count to not confuse the player. Unfortunately, this include triforce pieces. Original feature author stated that it "defeats the idea of a triforce hunt" but I would argue it is dramatically more confusing to omit them.

These hints have been included in RSL for quite awhile but today someone ran into the case where they had a hint that said "Shadow Temple has 7 major items" and then collected what they were interpreting as 7 major items but the same room that had the 7th major item also had an 8th major item. I think that while excluding pieces may from the hints may have merit as the original author intended, but a player running a seed will need to specifically know that triforce pieces are removed or risks confusion.