### PR TITLE
Reduce boss doors side range to prevent voiding out in Forest temple

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -2222,7 +2222,8 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     rom.write_byte(0xCDA723, 0x1E)
 
     # Boss doors side range (1.0 value is 0x46)
-    # This was reduced to 0x32 in 1.1, likely to fix the Phantom Ganon door bug.
+    # This was reduced to 0x32 in 1.1, either to fix the Phantom Ganon door bug or just to match better visually the door textures.
+    # See https://github.com/OoTRandomizer/OoT-Randomizer/pull/2331 for more information.
     rom.write_byte(0xC57AE2, 0x32)
 
     # actually write the save table to rom

--- a/Patches.py
+++ b/Patches.py
@@ -2221,6 +2221,10 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     # Meg respawns after 30 frames instead of 100 frames after getting hit
     rom.write_byte(0xCDA723, 0x1E)
 
+    # Boss doors side range (1.0 value is 0x46)
+    # This was reduced to 0x32 in 1.1, likely to fix the Phantom Ganon door bug.
+    rom.write_byte(0xC57AE2, 0x32)
+
     # actually write the save table to rom
     world.distribution.give_items(world, save_context)
     if world.settings.starting_age == 'adult':


### PR DESCRIPTION
Boss doors in 1.0 have a wider range than what the door textures actually shows. Which can lead to this unfortunate scenario in Forest temple : https://www.twitch.tv/yoyocarina/clip/ExquisiteSaltyPheasantSquadGoals-dl0ccNnxWglRkDiz
For the other boss doors this is not a problem because they all have some sort of floor collision that extend to at least match this range.
According to decomp, this was fixed in 1.1 by reducing the side range activation in the door_shutter actor. Likely to avoid this Forest voidout, or maybe just to make it match the texture better.
This PR ports back the value used in 1.1.
This actually impacts all boss doors and not only Forest since they all use the same actor. We could restrict it but that would involve a far more complex hack.
But this is a really small change which 99% of players won't probably ever notice, and it does make more sense visually. See the examples below : 

Fire Boss door max side range at 70
![fire_before](https://github.com/user-attachments/assets/837d438a-d6d0-43e7-9fe3-097d2531526d)

Max side range at 50
![fire_after](https://github.com/user-attachments/assets/a2823024-728d-4a0b-92b5-9dc15a4aeb59)

Water Boss door 1.0 max side range at 70
![water_before](https://github.com/user-attachments/assets/59e3adfc-0f91-45c2-90a4-23beec3f1ebb)

Max side range at 50
![water_after](https://github.com/user-attachments/assets/ac770fcd-16e7-48c9-8e0a-0f7c82414f21)



