### PR TITLE
Only display song name for .mmrs files

### DIFF
--- a/MusicHelpers.py
+++ b/MusicHelpers.py
@@ -84,7 +84,7 @@ def process_sequence_mmrs(filepath: str, file_name: str, seq_type: str, include_
                 instrument_set = '-'
             else:
                 instrument_set = int(seq_file.split(".zseq")[0], 16) # Get the instrument set from the .zseq file name
-            cosmetic_name = filepath
+            cosmetic_name, _ext = os.path.splitext(file_name)
             # Create new sequence
             seq = Sequence(filepath, cosmetic_name, seq_type=seq_type, seq_file = seq_file, instrument_set = instrument_set)
             if zbank_file:


### PR DESCRIPTION
Currently, the full path to the file is displayed in game and in the cosmetics spoiler for .mmrs files. This PR makes it so that only the track name is displayed. Track name is determined by taking the file name before the .mmrs extension because .mmrs doesn't use a metadata file containing a cosmetic name like we have for .ootrs