### PR TITLE
Fix intermittent alignment error with resources

### DIFF
--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -34,7 +34,7 @@ $(OBJDIR):
 	mkdir -p $@
 
 $(OBJDIR)/%_bin.o: $(RESOURCEDIR)/%.bin
-	$(OBJCOPY) -I binary -O elf32-bigmips --rename-section .data=.rodata,alloc,load,readonly,data,contents $< $@
+	$(OBJCOPY) -I binary -O elf32-bigmips --set-section-alignment .data=8 --rename-section .data=.rodata,alloc,load,readonly,data,contents $< $@
 	$(OBJCOPY) --redefine-sym _binary_resources_$*_bin_start=$(call UC,$*)_RESOURCE $@
 	$(OBJCOPY) --redefine-sym _binary_resources_$*_bin_end=$(call UC,$*)_RESOURCE_END $@
 	$(OBJCOPY) --redefine-sym _binary_resources_$*_bin_size=$(call UC,$*)_RESOURCE_SIZE $@


### PR DESCRIPTION
Fix intermittent alignment error with resources

[Found over a month ago in @rrealmuto's enemy shuffle branch](https://discord.com/channels/274180765816848384/512048482677424138/1294388047860859012)

Seems to have fixed the original issue due to many change made to his enemy shuffle branch not triggering it again. This is a port of the most succinct fix to main Dev now that it has been tested.