### PR TITLE
Creation of Skull Mask/Mask of Truth Misc Hint

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -1875,6 +1875,7 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Kak 10 Gold Skulltula Reward',
         'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x4110 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
+        'text_style': 0x23,
     },
     '20_skulltulas': {
         'id': 0x9005,
@@ -1882,6 +1883,7 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Kak 20 Gold Skulltula Reward',
         'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x4120 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
+        'text_style': 0x23,
     },
     '30_skulltulas': {
         'id': 0x9006,
@@ -1889,6 +1891,7 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Kak 30 Gold Skulltula Reward',
         'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x4130 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
+        'text_style': 0x23,
     },
     '40_skulltulas': {
         'id': 0x9007,
@@ -1896,6 +1899,7 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Kak 40 Gold Skulltula Reward',
         'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x4140 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
+        'text_style': 0x23,
     },
     '50_skulltulas': {
         'id': 0x9008,
@@ -1903,6 +1907,15 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Kak 50 Gold Skulltula Reward',
         'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x4150 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
+        'text_style': 0x23,
+    },
+    '100_skulltulas': {
+        'id': 0x9009,
+        'hint_location': '100 Skulltulas Reward Hint',
+        'item_location': 'Kak 100 Gold Skulltula Reward',
+        'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x41100 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
+        'location_fallback': "Yeaaarrgh! I'm cursed!!",
+        'text_style': 0x23,
     },
     'frogs2': {
         'id': 0x022E,
@@ -1910,6 +1923,23 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'ZR Frogs Ocarina Game',
         'location_text': "Some frogs holding \x05\x42{item}\x05\x40 are looking at you from underwater...",
         'location_fallback': "Some frogs are looking at you from underwater...",
+        'text_style': 0x23,
+    },
+    'skull_mask': {
+        'id': 0x0344,
+        'hint_location': 'Deku Theater Skull Mask',
+        'item_location': 'Deku Theater Skull Mask',
+        'location_text': 'Bringing the \x05\x41Skull Mask\x05\x40 to Deku Theater will reward you with \x05\x42{item}\x05\x40',
+        'location_fallback': 'Forest Stage\x01\x01We are waiting to see your\x01beautiful face!\x01Win fabulous prizes!',
+        'text_style': 0x13,
+    },
+    'mask_of_truth': {
+        'id': 0x0344,
+        'hint_location': 'Deku Theater Mask of Truth',
+        'item_location': 'Deku Theater Mask of Truth',
+        'location_text': 'Bringing the \x05\x41Mask of Truth\x05\x40 to Deku Theater will reward you with \x05\x42{item}\x05\x40',
+        'location_fallback': 'Forest Stage\x01\x01We are waiting to see your\x01beautiful face!\x01Win fabulous prizes!',
+        'text_style': 0x13,
     },
     'big_poes': {
         'id': 0x70F5,
@@ -1917,6 +1947,20 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Market 10 Big Poes',
         'location_text': "\x08Hey, young man. What's happening \x01today? Do you want\x01\x05\x41{item}\x05\x40?\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
         'location_fallback': "\x08Hey, young man. What's happening \x01today? If you have a \x05\x41Poe\x05\x40, I will \x01buy it.\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
+    },
+}
+
+misc_dual_hint_table: dict[str, dict[str, Any]] = {
+    'mask_shop_dual': {
+        'id': 0x0344,
+        'hint_location_0': 'Deku Theater Skull Mask',
+        'item_location_0': 'Deku Theater Skull Mask',
+        'hint_location_1': 'Deku Theater Mask of Truth',
+        'item_location_1': 'Deku Theater Mask of Truth',
+        'location_text_0': 'Bringing the \x05\x41Skull Mask\x05\x40 to Deku Theater will reward you with \x05\x42{item_1}\x05\x40',
+        'location_text_1': 'Bringing the \x05\x41Mark of Truth\x05\x40 to Deku Theater will reward you with \x05\x42{item_2}\x05\x40',
+        'location_text_2': '\x01Bringing the \x05\x41Skull Mask\x05\x40 to Deku Theater will reward you with \x05\x42{item_1}\x05\x40\x04Bringing the \x05\x41Mask of Truth\x05\x40 to Deku Theater will reward you with \x05\x42{item_2}\x05\x40',
+        'location_fallback': 'Forest Stage\x04\x04We are waiting to see your\x04beautiful face!\x04Win fabulous prizes!',
     },
 }
 

--- a/HintList.py
+++ b/HintList.py
@@ -1919,17 +1919,17 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
     },
     'skull_mask': {
         'id': 0x0344,
-        'hint_location': 'Deku Theater Skull Mask',
+        'hint_location': 'Deku Theater Skull Mask Hint',
         'item_location': 'Deku Theater Skull Mask',
-        'location_text': 'Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item}\x05\x40',
+        'location_text': 'Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item}\x05\x40.',
         'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13,
     },
     'mask_of_truth': {
         'id': 0x0344,
-        'hint_location': 'Deku Theater Mask of Truth',
+        'hint_location': 'Deku Theater Mask of Truth Hint',
         'item_location': 'Deku Theater Mask of Truth',
-        'location_text': 'Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item}\x05\x40',
+        'location_text': 'Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item}\x05\x40.',
         'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13,
     },
@@ -1949,11 +1949,11 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
 misc_dual_hint_table: dict[str, dict[str, Any]] = {
     'mask_shop_dual': {
         'id': 0x0344,
-        'hint_location_0': 'Deku Theater Skull Mask',
+        'hint_location_0': 'Deku Theater Skull Mask Hint',
         'item_location_0': 'Deku Theater Skull Mask',
-        'hint_location_1': 'Deku Theater Mask of Truth',
+        'hint_location_1': 'Deku Theater Mask of Truth Hint',
         'item_location_1': 'Deku Theater Mask of Truth',
-        'location_text': '\x01Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item_1}\x05\x40\x04Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item_2}\x05\x40',
+        'location_text': '\x01Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item_1}\x05\x40.\x04Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item_2}\x05\x40.',
         'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13
     },

--- a/HintList.py
+++ b/HintList.py
@@ -1943,9 +1943,9 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
     },
 }
 
-#Adds capability for dual misc hints. Required keys "id" for text ID to replace. 'hint_location_0' and 'hint_location_1', name of the hint.  These must have _0 for the first hint and _1 for the second hint.
-#'item_location_0' and 'item_location_1' the location of the check per spoiler log.   This also must have _0 for the first location and _1 for the second location. 'location_text', is the text for the 
-#dual hint where item_1 is the item from item_location_0 and item_2 is the item from item_location_1.  'location_fallback', text to handle if the misc hint is not turned on. 'text_style', argument for text box style.
+# Adds capability for dual misc hints. Required keys "id" for text ID to replace. 'hint_location_0' and 'hint_location_1', name of the hint.  These must have _0 for the first hint and _1 for the second hint.
+# 'item_location_0' and 'item_location_1' the location of the check per spoiler log.   This also must have _0 for the first location and _1 for the second location. 'location_text', is the text for the
+# dual hint where item_1 is the item from item_location_0 and item_2 is the item from item_location_1.  'location_fallback', text to handle if the misc hint is not turned on. 'text_style', argument for text box style.
 misc_dual_hint_table: dict[str, dict[str, Any]] = {
     'mask_shop_dual': {
         'id': 0x0344,

--- a/HintList.py
+++ b/HintList.py
@@ -215,7 +215,7 @@ def tokens_required_by_settings(world: World) -> int:
 # Hints required under certain settings
 conditional_always: dict[str, Callable[[World], bool]] = {
     'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3 and 'big_poes' not in world.settings.misc_hints,
-    'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest and 'Mask of Truth' not in world.settings.shuffle_child_trade,
+    'Deku Theater Mask of Truth':   lambda world: (not world.settings.complete_mask_quest and 'Mask of Truth' not in world.settings.shuffle_child_trade) and not ('mask_of_truth' not in world.settings.misc_hints or 'mask_shop_dual' not in world.settings.misc_hints),
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
     'HF Ocarina of Time Item':      lambda world: stones_required_by_settings(world) < 2,
     'Sheik in Kakariko':            lambda world: medallions_required_by_settings(world) < 5,
@@ -1909,14 +1909,6 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'location_fallback': "Yeaaarrgh! I'm cursed!!",
         'text_style': 0x23,
     },
-    '100_skulltulas': {
-        'id': 0x9009,
-        'hint_location': '100 Skulltulas Reward Hint',
-        'item_location': 'Kak 100 Gold Skulltula Reward',
-        'location_text': "Yeaaarrgh! I'm cursed!! Please save me by destroying \x05\x41100 Spiders of the Curse\x05\x40 and I will give you \x05\x42{item}\x05\x40.",
-        'location_fallback': "Yeaaarrgh! I'm cursed!!",
-        'text_style': 0x23,
-    },
     'frogs2': {
         'id': 0x022E,
         'hint_location': 'ZR Frogs Ocarina Minigame Hint',
@@ -1929,16 +1921,16 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'id': 0x0344,
         'hint_location': 'Deku Theater Skull Mask',
         'item_location': 'Deku Theater Skull Mask',
-        'location_text': 'Bringing the \x05\x41Skull Mask\x05\x40 to Deku Theater will reward you with \x05\x42{item}\x05\x40',
-        'location_fallback': 'Forest Stage\x01\x01We are waiting to see your\x01beautiful face!\x01Win fabulous prizes!',
+        'location_text': 'Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item}\x05\x40',
+        'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13,
     },
     'mask_of_truth': {
         'id': 0x0344,
         'hint_location': 'Deku Theater Mask of Truth',
         'item_location': 'Deku Theater Mask of Truth',
-        'location_text': 'Bringing the \x05\x41Mask of Truth\x05\x40 to Deku Theater will reward you with \x05\x42{item}\x05\x40',
-        'location_fallback': 'Forest Stage\x01\x01We are waiting to see your\x01beautiful face!\x01Win fabulous prizes!',
+        'location_text': 'Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item}\x05\x40',
+        'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13,
     },
     'big_poes': {
@@ -1947,9 +1939,13 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Market 10 Big Poes',
         'location_text': "\x08Hey, young man. What's happening \x01today? Do you want\x01\x05\x41{item}\x05\x40?\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
         'location_fallback': "\x08Hey, young man. What's happening \x01today? If you have a \x05\x41Poe\x05\x40, I will \x01buy it.\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
+        'text_style': 0x03
     },
 }
 
+#Adds capability for dual misc hints. Required keys "id" for text ID to replace. 'hint_location_0' and 'hint_location_1', name of the hint.  These must have _0 for the first hint and _1 for the second hint.
+#'item_location_0' and 'item_location_1' the location of the check per spoiler log.   This also must have _0 for the first location and _1 for the second location. 'location_text', is the text for the 
+#dual hint where item_1 is the item from item_location_0 and item_2 is the item from item_location_1.  'location_fallback', text to handle if the misc hint is not turned on. 'text_style', argument for text box style.
 misc_dual_hint_table: dict[str, dict[str, Any]] = {
     'mask_shop_dual': {
         'id': 0x0344,
@@ -1957,10 +1953,9 @@ misc_dual_hint_table: dict[str, dict[str, Any]] = {
         'item_location_0': 'Deku Theater Skull Mask',
         'hint_location_1': 'Deku Theater Mask of Truth',
         'item_location_1': 'Deku Theater Mask of Truth',
-        'location_text_0': 'Bringing the \x05\x41Skull Mask\x05\x40 to Deku Theater will reward you with \x05\x42{item_1}\x05\x40',
-        'location_text_1': 'Bringing the \x05\x41Mark of Truth\x05\x40 to Deku Theater will reward you with \x05\x42{item_2}\x05\x40',
-        'location_text_2': '\x01Bringing the \x05\x41Skull Mask\x05\x40 to Deku Theater will reward you with \x05\x42{item_1}\x05\x40\x04Bringing the \x05\x41Mask of Truth\x05\x40 to Deku Theater will reward you with \x05\x42{item_2}\x05\x40',
-        'location_fallback': 'Forest Stage\x04\x04We are waiting to see your\x04beautiful face!\x04Win fabulous prizes!',
+        'location_text': '\x01Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item_1}\x05\x40\x04Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item_2}\x05\x40',
+        'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
+        'text_style': 0x13
     },
 }
 

--- a/HintList.py
+++ b/HintList.py
@@ -215,7 +215,7 @@ def tokens_required_by_settings(world: World) -> int:
 # Hints required under certain settings
 conditional_always: dict[str, Callable[[World], bool]] = {
     'Market 10 Big Poes':           lambda world: world.settings.big_poe_count > 3 and 'big_poes' not in world.settings.misc_hints,
-    'Deku Theater Mask of Truth':   lambda world: (not world.settings.complete_mask_quest and 'Mask of Truth' not in world.settings.shuffle_child_trade) and not ('mask_of_truth' not in world.settings.misc_hints or 'mask_shop_dual' not in world.settings.misc_hints),
+    'Deku Theater Mask of Truth':   lambda world: not world.settings.complete_mask_quest and 'Mask of Truth' not in world.settings.shuffle_child_trade and 'mask_of_truth' not in world.settings.misc_hints,
     'Song from Ocarina of Time':    lambda world: stones_required_by_settings(world) < 2,
     'HF Ocarina of Time Item':      lambda world: stones_required_by_settings(world) < 2,
     'Sheik in Kakariko':            lambda world: medallions_required_by_settings(world) < 5,
@@ -1922,7 +1922,6 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'hint_location': 'Deku Theater Skull Mask Hint',
         'item_location': 'Deku Theater Skull Mask',
         'location_text': 'Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item}\x05\x40.',
-        'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13,
     },
     'mask_of_truth': {
@@ -1930,7 +1929,6 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'hint_location': 'Deku Theater Mask of Truth Hint',
         'item_location': 'Deku Theater Mask of Truth',
         'location_text': 'Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item}\x05\x40.',
-        'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
         'text_style': 0x13,
     },
     'big_poes': {
@@ -1939,23 +1937,19 @@ misc_location_hint_table: dict[str, dict[str, Any]] = {
         'item_location': 'Market 10 Big Poes',
         'location_text': "\x08Hey, young man. What's happening \x01today? Do you want\x01\x05\x41{item}\x05\x40?\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
         'location_fallback': "\x08Hey, young man. What's happening \x01today? If you have a \x05\x41Poe\x05\x40, I will \x01buy it.\x04\x1AIf you earn \x05\x41{poe_points} points\x05\x40, you'll\x01be a happy man! Heh heh.\x04\x08Your card now has \x05\x45\x1E\x01 \x05\x40points.\x01Come back again!\x01Heh heh heh!\x02",
-        'text_style': 0x03
+        'text_style': 0x03,
     },
 }
 
-# Adds capability for dual misc hints. Required keys "id" for text ID to replace. 'hint_location_0' and 'hint_location_1', name of the hint.  These must have _0 for the first hint and _1 for the second hint.
-# 'item_location_0' and 'item_location_1' the location of the check per spoiler log.   This also must have _0 for the first location and _1 for the second location. 'location_text', is the text for the
-# dual hint where item_1 is the item from item_location_0 and item_2 is the item from item_location_1.  'location_fallback', text to handle if the misc hint is not turned on. 'text_style', argument for text box style.
+# Adds capability for dual misc hints. Only used when neither or both hints are enabled, uses corresponding misc_location_hint_table entries if only one is enabled.
+# 'location_text' is the text for the dual hint where item_1 is the item from item_location_0 and item_2 is the item from item_location_1.
+# 'location_fallback' is the text to handle if neither misc hint is turned on.
 misc_dual_hint_table: dict[str, dict[str, Any]] = {
-    'mask_shop_dual': {
+    ('skull_mask', 'mask_of_truth'): {
         'id': 0x0344,
-        'hint_location_0': 'Deku Theater Skull Mask Hint',
-        'item_location_0': 'Deku Theater Skull Mask',
-        'hint_location_1': 'Deku Theater Mask of Truth Hint',
-        'item_location_1': 'Deku Theater Mask of Truth',
         'location_text': '\x01Wearing the \x05\x41Skull Mask\x05\x40 will reward you with \x05\x42{item_1}\x05\x40.\x04Wearing the \x05\x41Mask of Truth\x05\x40 will reward you with \x05\x42{item_2}\x05\x40.',
         'location_fallback': '\x05\x42\x06\x3dForest Stage\x04\x01\x05\x40\x06\x14We are waiting to see your\x01\x06\x32beautiful face!\x01\x06\x28Win fabulous prizes!',
-        'text_style': 0x13
+        'text_style': 0x13,
     },
 }
 

--- a/Hints.py
+++ b/Hints.py
@@ -1839,13 +1839,13 @@ def build_misc_location_hints(world: World, messages: list[Message]) -> None:
                                                                         world.settings.clearer_hints).text)
 
                 update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
-            #Allows for other misc hints to use 'location_fallback, but avoids the mask hints from being overwritten.    
+            # Allows for other misc hints to use 'location_fallback, but avoids the mask hints from being overwritten.
             if hint_type not in ['skull_mask', 'mask_of_truth'] and hint_type not in world.settings.misc_hints:
-                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True) 
+                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
 
 def build_misc_dual_hints(world: World, messages: list[Message]) -> None:
     for hint_type, data in misc_dual_hint_table.items():
-        #Change misc_hints list to use the Skull Mask and Mask of Truth Dual hint
+        # Change misc_hints list to use the Skull Mask and Mask of Truth Dual hint
         if 'skull_mask' in world.settings.misc_hints and 'mask_of_truth' in world.settings.misc_hints:
             world.settings.misc_hints.remove('skull_mask')
             world.settings.misc_hints.remove('mask_of_truth')

--- a/Hints.py
+++ b/Hints.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Optional
 from urllib.error import URLError, HTTPError
 
 from HintList import Hint, get_hint, get_multi, get_hint_group, get_upgrade_hint_list, hint_exclusions, \
-    misc_item_hint_table, misc_location_hint_table
+    misc_item_hint_table, misc_location_hint_table, misc_dual_hint_table
 from Item import Item, make_event_item
 from ItemList import REWARD_COLORS
 from Messages import Message, COLOR_MAP, update_message_by_id
@@ -1829,7 +1829,7 @@ def build_misc_location_hints(world: World, messages: list[Message]) -> None:
                                                                     world.settings.clearer_hints).text, poe_points=poe_points)
             else:
                 text = data['location_fallback'].format(poe_points=poe_points)
-            update_message_by_id(messages, data['id'], text)
+            update_message_by_id(messages, data['id'], text, data['text_style'])
             return
         else:
             if hint_type in world.settings.misc_hints:
@@ -1838,19 +1838,20 @@ def build_misc_location_hints(world: World, messages: list[Message]) -> None:
                     text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
                                                                         world.settings.clearer_hints).text)
 
-            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
-        if hint_type not in ['skull_mask', 'mask_of_truth'] and hint_type not in world.settings.misc_hints:
-            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True) 
+                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
+            #Allows for other misc hints to use 'location_fallback, but avoids the mask hints from being overwritten.    
+            if hint_type not in ['skull_mask', 'mask_of_truth'] and hint_type not in world.settings.misc_hints:
+                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True) 
 
 def build_misc_dual_hints(world: World, messages: list[Message]) -> None:
     for hint_type, data in misc_dual_hint_table.items():
+        #Change misc_hints list to use the Skull Mask and Mask of Truth Dual hint
         if 'skull_mask' in world.settings.misc_hints and 'mask_of_truth' in world.settings.misc_hints:
             world.settings.misc_hints.remove('skull_mask')
             world.settings.misc_hints.remove('mask_of_truth')
             world.settings.misc_hints.append('mask_shop_dual')
         text = data['location_fallback']
         if hint_type in world.settings.misc_hints:
-            #if hint_type in world.misc_dual_hint_items:
             keys = list(world.misc_dual_hint_items.keys())
             items = []
             for key in keys:
@@ -1858,15 +1859,8 @@ def build_misc_dual_hints(world: World, messages: list[Message]) -> None:
                 items.append(item)
             item_1 = items[0]
             item_2 = items[1]
-            if data['item_location_0'] in world.settings.disabled_locations and data['item_location_1'] in world.settings.disabled_locations:
-                text = data['location_fallback']
-            elif data['item_location_0'] in world.settings.disabled_locations:
-                text = data['location_text_1'].format(item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text)
-            elif data['item_location_1'] in world.settings.disabled_locations:
-                text = data['location_text_0'].format(item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text)
-            else:
-                text = data['location_text_2'].format(item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text, item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text)
-            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), 0x13, allow_duplicates=True)
+            text = data['location_text'].format(item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text, item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text)
+            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
 
 
 

--- a/Hints.py
+++ b/Hints.py
@@ -1838,7 +1838,36 @@ def build_misc_location_hints(world: World, messages: list[Message]) -> None:
                     text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
                                                                         world.settings.clearer_hints).text)
 
-        update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), 0x23)
+            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
+        if hint_type not in ['skull_mask', 'mask_of_truth'] and hint_type not in world.settings.misc_hints:
+            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True) 
+
+def build_misc_dual_hints(world: World, messages: list[Message]) -> None:
+    for hint_type, data in misc_dual_hint_table.items():
+        if 'skull_mask' in world.settings.misc_hints and 'mask_of_truth' in world.settings.misc_hints:
+            world.settings.misc_hints.remove('skull_mask')
+            world.settings.misc_hints.remove('mask_of_truth')
+            world.settings.misc_hints.append('mask_shop_dual')
+        text = data['location_fallback']
+        if hint_type in world.settings.misc_hints:
+            #if hint_type in world.misc_dual_hint_items:
+            keys = list(world.misc_dual_hint_items.keys())
+            items = []
+            for key in keys:
+                item = world.misc_dual_hint_items[key]
+                items.append(item)
+            item_1 = items[0]
+            item_2 = items[1]
+            if data['item_location_0'] in world.settings.disabled_locations and data['item_location_1'] in world.settings.disabled_locations:
+                text = data['location_fallback']
+            elif data['item_location_0'] in world.settings.disabled_locations:
+                text = data['location_text_1'].format(item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text)
+            elif data['item_location_1'] in world.settings.disabled_locations:
+                text = data['location_text_0'].format(item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text)
+            else:
+                text = data['location_text_2'].format(item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text, item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text)
+            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), 0x13, allow_duplicates=True)
+
 
 
 def get_raw_text(string: str) -> str:

--- a/Hints.py
+++ b/Hints.py
@@ -1819,14 +1819,18 @@ def build_misc_item_hints(world: World, messages: list[Message], allow_duplicate
 
 def build_misc_location_hints(world: World, messages: list[Message]) -> None:
     for hint_type, data in misc_location_hint_table.items():
+        if any(hint_type in hint_types for hint_types in misc_dual_hint_table):
+            continue # handled in build_misc_dual_hints
         text = data['location_fallback']
         if hint_type == 'big_poes':
             # Special cased because we need to insert the big poes number.
             item = world.misc_hint_location_items[hint_type]
             poe_points = world.settings.big_poe_count * 100
             if hint_type in world.settings.misc_hints:
-                text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
-                                                                    world.settings.clearer_hints).text, poe_points=poe_points)
+                text = data['location_text'].format(
+                    item=get_hint(get_item_generic_name(item), world.settings.clearer_hints).text,
+                    poe_points=poe_points,
+                )
             else:
                 text = data['location_fallback'].format(poe_points=poe_points)
             update_message_by_id(messages, data['id'], text, data['text_style'])
@@ -1835,33 +1839,36 @@ def build_misc_location_hints(world: World, messages: list[Message]) -> None:
             if hint_type in world.settings.misc_hints:
                 if hint_type in world.misc_hint_location_items:
                     item = world.misc_hint_location_items[hint_type]
-                    text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
-                                                                        world.settings.clearer_hints).text)
+                    text = data['location_text'].format(
+                        item=get_hint(get_item_generic_name(item), world.settings.clearer_hints).text,
+                    )
+                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'])
 
-                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
-            # Allows for other misc hints to use 'location_fallback, but avoids the mask hints from being overwritten.
-            if hint_type not in ['skull_mask', 'mask_of_truth'] and hint_type not in world.settings.misc_hints:
-                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
 
 def build_misc_dual_hints(world: World, messages: list[Message]) -> None:
-    for hint_type, data in misc_dual_hint_table.items():
-        # Change misc_hints list to use the Skull Mask and Mask of Truth Dual hint
-        if 'skull_mask' in world.settings.misc_hints and 'mask_of_truth' in world.settings.misc_hints:
-            world.settings.misc_hints.remove('skull_mask')
-            world.settings.misc_hints.remove('mask_of_truth')
-            world.settings.misc_hints.append('mask_shop_dual')
-        text = data['location_fallback']
-        if hint_type in world.settings.misc_hints:
-            keys = list(world.misc_dual_hint_items.keys())
-            items = []
-            for key in keys:
-                item = world.misc_dual_hint_items[key]
-                items.append(item)
-            item_1 = items[0]
-            item_2 = items[1]
-            text = data['location_text'].format(item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text, item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text)
-            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'], allow_duplicates=True)
-
+    for (hint_type1, hint_type2), data in misc_dual_hint_table.items():
+        item_1 = world.misc_hint_location_items[hint_type1]
+        item_2 = world.misc_hint_location_items[hint_type2]
+        if hint_type1 in world.settings.misc_hints and hint_type1 in world.misc_hint_location_items:
+            if hint_type2 in world.settings.misc_hints and hint_type2 in world.misc_hint_location_items:
+                text = data['location_text'].format(
+                    item_1=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text,
+                    item_2=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text,
+                )
+            else:
+                text = misc_location_hint_table[hint_type1]['location_text'].format(
+                    item=get_hint(get_item_generic_name(item_1), world.settings.clearer_hints).text,
+                )
+        else:
+            if hint_type2 in world.settings.misc_hints and hint_type2 in world.misc_hint_location_items:
+                text = misc_location_hint_table[hint_type2]['location_text'].format(
+                    item=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text,
+                )
+            else:
+                if hint_type1 not in world.settings.misc_hints and hint_type2 not in world.settings.misc_hints:
+                    return
+                text = data['location_fallback']
+    update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'])
 
 
 def get_raw_text(string: str) -> str:

--- a/Location.py
+++ b/Location.py
@@ -150,8 +150,7 @@ class Location:
                 key = 'item_location_'+ str(i)
                 if key not in data:
                     break
-                item_location = data[key]
-                the_location = item_location
+                the_location = data[key]
                 if hint_type not in self.world.misc_dual_hint_items and self.name == the_location:
                     self.world.misc_dual_hint_items[hint_type + '_' + str(i)] = self.item
                     logging.getLogger('').debug(f'{the_location} [{self.world.id}] set to [{self.item.name}]')

--- a/Location.py
+++ b/Location.py
@@ -145,6 +145,16 @@ class Location:
             if hint_type not in self.world.misc_hint_location_items and self.name == the_location:
                 self.world.misc_hint_location_items[hint_type] = self.item
                 logging.getLogger('').debug(f'{the_location} [{self.world.id}] set to [{self.item.name}]')
+        for hint_type, data in misc_dual_hint_table.items():
+            for i in range(2):
+                key = 'item_location_'+ str(i)
+                if key not in data:
+                    break
+                item_location = data[key]
+                the_location = item_location
+                if hint_type not in self.world.misc_dual_hint_items and self.name == the_location:
+                    self.world.misc_dual_hint_items[hint_type + '_' + str(i)] = self.item
+                    logging.getLogger('').debug(f'{the_location} [{self.world.id}] set to [{self.item.name}]')
 
     def __str__(self) -> str:
         return self.name

--- a/Location.py
+++ b/Location.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Any, overload
 
-from HintList import misc_item_hint_table, misc_location_hint_table
+from HintList import misc_item_hint_table, misc_location_hint_table, misc_dual_hint_table
 from LocationList import location_table, location_is_viewable, LocationAddress, LocationDefault, LocationFilterTags
 
 if TYPE_CHECKING:

--- a/Location.py
+++ b/Location.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Any, overload
 
-from HintList import misc_item_hint_table, misc_location_hint_table, misc_dual_hint_table
+from HintList import misc_item_hint_table, misc_location_hint_table
 from LocationList import location_table, location_is_viewable, LocationAddress, LocationDefault, LocationFilterTags
 
 if TYPE_CHECKING:
@@ -145,15 +145,6 @@ class Location:
             if hint_type not in self.world.misc_hint_location_items and self.name == the_location:
                 self.world.misc_hint_location_items[hint_type] = self.item
                 logging.getLogger('').debug(f'{the_location} [{self.world.id}] set to [{self.item.name}]')
-        for hint_type, data in misc_dual_hint_table.items():
-            for i in range(2):
-                key = 'item_location_'+ str(i)
-                if key not in data:
-                    break
-                the_location = data[key]
-                if hint_type not in self.world.misc_dual_hint_items and self.name == the_location:
-                    self.world.misc_dual_hint_items[hint_type + '_' + str(i)] = self.item
-                    logging.getLogger('').debug(f'{the_location} [{self.world.id}] set to [{self.item.name}]')
 
     def __str__(self) -> str:
         return self.name

--- a/LocationList.py
+++ b/LocationList.py
@@ -2606,6 +2606,8 @@ location_table: dict[str, tuple[str, Optional[int], LocationDefault, LocationAdd
     ("50 Skulltulas Reward Hint",                                    ("Hint",         None,  None, None,                            None,                                    None)),
     ("ZR Frogs Ocarina Minigame Hint",                               ("Hint",         None,  None, None,                            None,                                    None)),
     ("Market 10 Big Poes Hint",                                      ("Hint",         None,  None, None,                            None,                                    None)),
+    ("Deku Theater Skull Mask Hint",                                 ("Hint",         None,  None, None,                            None,                                    None)),
+    ("Deku Theater Mask of Truth Hint",                              ("Hint",         None,  None, None,                            None,                                    None)),
     ("Ganondorf Hint",                                               ("Hint",         None,  None, None,                            None,                                    None)),
 ])
 

--- a/Patches.py
+++ b/Patches.py
@@ -13,7 +13,7 @@ from Cutscenes import patch_cutscenes, patch_wondertalk2
 from Entrance import Entrance
 from HintList import get_hint
 from Hints import GossipText, HintArea, write_gossip_stone_hints, build_altar_hints, \
-        build_ganon_text, build_misc_item_hints, build_misc_location_hints, get_simple_hint_no_prefix, get_item_generic_name
+        build_ganon_text, build_misc_item_hints, build_misc_location_hints, build_misc_dual_hints, get_simple_hint_no_prefix, get_item_generic_name
 from Item import Item
 from ItemList import REWARD_COLORS
 from ItemPool import reward_list, song_list, trade_items, child_trade_items
@@ -1432,6 +1432,9 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
 
     # build misc. location hints
     build_misc_location_hints(world, messages)
+
+    #build misc. dual hints
+    build_misc_dual_hints(world, messages)
 
     if 'mask_shop' in world.settings.misc_hints:
         rom.write_int32(rom.sym('CFG_MASK_SHOP_HINT'), 1)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3601,6 +3601,15 @@ class SettingInfos:
 
             The Poe collector will tell the reward for selling
             him Big Poes.
+
+            The sign in Deku Theater will tell the reward for showing
+            the Skull Mask.
+
+            The sign in Deku Theater will tell the reward for showing 
+            the Mask of Truth.
+
+            If both Skull Mask and Mask of Truth are selected, the sign
+            in Deku Theater will tell the reward for both items.
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3605,7 +3605,7 @@ class SettingInfos:
             The sign in Deku Theater will tell the reward for showing
             the Skull Mask.
 
-            The sign in Deku Theater will tell the reward for showing 
+            The sign in Deku Theater will tell the reward for showing
             the Mask of Truth.
 
             If both Skull Mask and Mask of Truth are selected, the sign
@@ -3614,7 +3614,7 @@ class SettingInfos:
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],
     )
-    
+
     correct_chest_appearances = Combobox(
         gui_text       = 'Chest Appearance Matches Contents',
         default        = 'off',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3543,6 +3543,8 @@ class SettingInfos:
             'mask_shop':  'Shuffled Mask Shop',
             'unique_merchants':  'Unique Merchants',
             'big_poes':  'Market Big Poes',
+            'skull_mask':     'Deku Theater Skull Mask',
+            'mask_of_truth':  'Deku Theater Mask of Truth',
         },
         gui_tooltip    = '''\
             This setting adds some hints at locations
@@ -3603,7 +3605,7 @@ class SettingInfos:
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],
     )
-
+    
     correct_chest_appearances = Combobox(
         gui_text       = 'Chest Appearance Matches Contents',
         default        = 'off',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3530,21 +3530,21 @@ class SettingInfos:
     misc_hints = MultipleSelect(
         gui_text        = 'Misc. Hints',
         choices         = {
-            'altar':       'Temple of Time Altar',
-            'dampe_diary': "Dampé's Diary (Hookshot)",
-            'ganondorf':   'Ganondorf (Light Arrows)',
-            'warp_songs_and_owls':  'Warp Songs and Owls',
-            '10_skulltulas':  'House of Skulltula: 10',
-            '20_skulltulas':  'House of Skulltula: 20',
-            '30_skulltulas':  'House of Skulltula: 30',
-            '40_skulltulas':  'House of Skulltula: 40',
-            '50_skulltulas':  'House of Skulltula: 50',
-            'frogs2':         'Frogs Ocarina Game',
-            'mask_shop':  'Shuffled Mask Shop',
-            'unique_merchants':  'Unique Merchants',
-            'big_poes':  'Market Big Poes',
-            'skull_mask':     'Deku Theater Skull Mask',
-            'mask_of_truth':  'Deku Theater Mask of Truth',
+            'altar':               'Temple of Time Altar',
+            'dampe_diary':         "Dampé's Diary (Hookshot)",
+            'ganondorf':           'Ganondorf (Light Arrows)',
+            'warp_songs_and_owls': 'Warp Songs and Owls',
+            '10_skulltulas':       'House of Skulltula: 10',
+            '20_skulltulas':       'House of Skulltula: 20',
+            '30_skulltulas':       'House of Skulltula: 30',
+            '40_skulltulas':       'House of Skulltula: 40',
+            '50_skulltulas':       'House of Skulltula: 50',
+            'frogs2':              'Frogs Ocarina Game',
+            'mask_shop':           'Shuffled Mask Shop',
+            'unique_merchants':    'Unique Merchants',
+            'big_poes':            'Market Big Poes',
+            'skull_mask':          'Deku Theater Skull Mask',
+            'mask_of_truth':       'Deku Theater Mask of Truth',
         },
         gui_tooltip    = '''\
             This setting adds some hints at locations
@@ -3603,13 +3603,7 @@ class SettingInfos:
             him Big Poes.
 
             The sign in Deku Theater will tell the reward for showing
-            the Skull Mask.
-
-            The sign in Deku Theater will tell the reward for showing
-            the Mask of Truth.
-
-            If both Skull Mask and Mask of Truth are selected, the sign
-            in Deku Theater will tell the reward for both items.
+            the Skull Mask and/or the Mask of Truth.
         ''',
         shared         = True,
         default        = ['altar', 'ganondorf', 'warp_songs_and_owls'],

--- a/World.py
+++ b/World.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from Dungeon import Dungeon
 from Entrance import Entrance
 from Goals import Goal, GoalCategory
-from HintList import get_required_hints, misc_item_hint_table, misc_location_hint_table
+from HintList import get_required_hints, misc_item_hint_table, misc_location_hint_table, misc_dual_hint_table
 from Hints import HintArea, hint_dist_keys, hint_dist_files
 from Item import Item, ItemFactory, ItemInfo, make_event_item
 from ItemList import REWARD_COLORS
@@ -50,6 +50,7 @@ class World:
         }
         self.misc_hint_item_locations: dict[str, Location] = {}
         self.misc_hint_location_items: dict[str, Item] = {}
+        self.misc_dual_hint_items: dict[str, Item] = {}
         self.triforce_count: int = 0
         self.total_starting_triforce_count: int = 0
         self.empty_areas: dict[HintArea, dict[str, Any]] = {}
@@ -263,7 +264,8 @@ class World:
         self.dungeon_rewards_hinted: bool = settings.shuffle_mapcompass != 'remove' if settings.enhance_map_compass else 'altar' in settings.misc_hints
         self.misc_hint_items: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_hint_items', {}).get(hint_type, data['default_item']) for hint_type, data in misc_item_hint_table.items()}
         self.misc_hint_locations: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_hint_locations', {}).get(hint_type, data['item_location']) for hint_type, data in misc_location_hint_table.items()}
-        self.misc_dual_hint: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_dual_hint', {}).get(hint_type, data) for hint_type, data in misc_dual_hint_table.items()}
+        for i in range(2):
+            self.misc_dual_hint: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_dual_hint', {}).get(hint_type, data['item_location' + '_' + str(i)]) for hint_type, data in misc_dual_hint_table.items()}
         self.state: State = State(self)
 
         # Allows us to cut down on checking whether some items are required

--- a/World.py
+++ b/World.py
@@ -263,7 +263,7 @@ class World:
         self.dungeon_rewards_hinted: bool = settings.shuffle_mapcompass != 'remove' if settings.enhance_map_compass else 'altar' in settings.misc_hints
         self.misc_hint_items: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_hint_items', {}).get(hint_type, data['default_item']) for hint_type, data in misc_item_hint_table.items()}
         self.misc_hint_locations: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_hint_locations', {}).get(hint_type, data['item_location']) for hint_type, data in misc_location_hint_table.items()}
-
+        self.misc_dual_hint: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_dual_hint', {}).get(hint_type, data) for hint_type, data in misc_dual_hint_table.items()}
         self.state: State = State(self)
 
         # Allows us to cut down on checking whether some items are required

--- a/World.py
+++ b/World.py
@@ -50,7 +50,6 @@ class World:
         }
         self.misc_hint_item_locations: dict[str, Location] = {}
         self.misc_hint_location_items: dict[str, Item] = {}
-        self.misc_dual_hint_items: dict[str, Item] = {}
         self.triforce_count: int = 0
         self.total_starting_triforce_count: int = 0
         self.empty_areas: dict[HintArea, dict[str, Any]] = {}
@@ -264,8 +263,6 @@ class World:
         self.dungeon_rewards_hinted: bool = settings.shuffle_mapcompass != 'remove' if settings.enhance_map_compass else 'altar' in settings.misc_hints
         self.misc_hint_items: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_hint_items', {}).get(hint_type, data['default_item']) for hint_type, data in misc_item_hint_table.items()}
         self.misc_hint_locations: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_hint_locations', {}).get(hint_type, data['item_location']) for hint_type, data in misc_location_hint_table.items()}
-        for i in range(2):
-            self.misc_dual_hint: dict[str, str] = {hint_type: self.hint_dist_user.get('misc_dual_hint', {}).get(hint_type, data['item_location' + '_' + str(i)]) for hint_type, data in misc_dual_hint_table.items()}
         self.state: State = State(self)
 
         # Allows us to cut down on checking whether some items are required

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1258,7 +1258,9 @@
         "region_name": "Deku Theater",
         "locations": {
             "Deku Theater Skull Mask": "is_child and Skull_Mask",
-            "Deku Theater Mask of Truth": "is_child and Mask_of_Truth"
+            "Deku Theater Mask of Truth": "is_child and Mask_of_Truth",
+            "Deku Theater Skull Mask Hint": "True",
+            "Deku Theater Mask of Truth Hint": "True"
         }
     },
     {

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2885,7 +2885,9 @@
         "scene": "Deku Theater",
         "locations": {
             "Deku Theater Skull Mask": "is_child and Skull_Mask",
-            "Deku Theater Mask of Truth": "is_child and Mask_of_Truth"
+            "Deku Theater Mask of Truth": "is_child and Mask_of_Truth",
+            "Deku Theater Skull Mask Hint": "True",
+            "Deku Theater Mask of Truth Hint": "True"
         },
         "exits": {
             "LW Beyond Mido": "True"


### PR DESCRIPTION
Creates a Skull Mask and Mask of Truth misc hint, located on the sign in the Deku Theater.   The hint will hint either one individually if they are selected, or both if both are selected as a dual hint.

![image](https://github.com/user-attachments/assets/bb917d63-6c0c-418c-93c1-d378cd8102f9)

![image](https://github.com/user-attachments/assets/c0b49ad7-cc14-4e1e-a7ce-c8e30394b6dd)
