### PR TITLE
Remove Deku Sprout Cutscene 3 after Phantom Ganon Blue Warp

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -260,6 +260,10 @@ def patch_cutscenes(rom: Rom, songs_as_items: bool, settings: Settings) -> None:
     # Last part is 250 frames.
     rom.write_int32(0xC94594, 0x00000000)
 
+    # Speed scene after Forest Temple
+    # Blue warp brings us to right before Deku Sprout cutscene number 3.
+    delete_cutscene(rom, 0x207B9D0)
+
     # Speed learning Prelude of Light
     if songs_as_items:
         delete_cutscene(rom, 0x0252FD20)


### PR DESCRIPTION
The Defeat Morpha PR #2270 removed unneeded cutscene skips since Dungeon Rewards was merged, because the new blue warp behavior took care of skipping them.
But for some reason the PG Blue warp goes to right before the short ending cutscene of Link talking to Deku Sprout.
This PR adds this cutscene skip back to restore the previous behavior.