### PR TITLE
Add CI check to ensure no presets are password-locked

### DIFF
--- a/CI.py
+++ b/CI.py
@@ -113,12 +113,15 @@ def check_hell_mode_tricks(fix_errors: bool = False) -> None:
             print(file=file)
 
 
-def check_preset_spoilers(fix_errors: bool = False) -> None:
-    # Check to make sure spoiler logs are enabled for all presets.
+def check_preset_settings(fix_errors: bool = False) -> None:
+    # Check to make sure password lock is disabled and spoiler logs are enabled for all presets.
     with open(data_path('presets_default.json'), encoding='utf-8') as f:
         presets = json.load(f)
 
     for preset_name, preset in presets.items():
+        if preset['password_lock']:
+            error(f'{preset_name} preset is password-locked', True)
+            preset['password_lock'] = False
         if not preset['create_spoiler']:
             error(f'{preset_name} preset does not create spoiler logs', True)
             preset['create_spoiler'] = True
@@ -258,7 +261,7 @@ def run_ci_checks() -> NoReturn:
         check_code_style(args.fix)
         check_presets_formatting(args.fix)
         check_table_sizes()
-        check_preset_spoilers(args.fix)
+        check_preset_settings(args.fix)
         check_message_duplicates()
 
     exit_ci(args.fix)


### PR DESCRIPTION
Adds a check to the CI script to prevent contributors from making the same mistake I made in #2385, where I accidentally enabled the `password_lock` setting when updating the multiworld tournament preset. The `password_lock` setting should always be disabled in presets since the password can only be obtained when rolling seeds via the API (or by looking at the spoiler log).