### PR TITLE
Fix “Tokensanity” setting in multiworld tournament preset

### DIFF
--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -1109,7 +1109,7 @@
         "shuffle_song_items": "song",
         "shopsanity": "4",
         "shopsanity_prices": "random",
-        "tokensanity": "off",
+        "tokensanity": "dungeons",
         "shuffle_scrubs": "low",
         "shuffle_child_trade": [],
         "adult_trade_shuffle": false,


### PR DESCRIPTION
The default was changed from “Off” to “Dungeons Only” for season 5, but this was missed when copying the preset into the randomizer since this is a setting that can be modified in the draft.