### PR TITLE
Count milk bottle as bottle for bingo hints

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -43,7 +43,7 @@ BarrenFunc: TypeAlias = "Callable[[Spoiler, World, set[str], set[str]], HintRetu
 bingoBottlesForHints: set[str] = {
     "Bottle", "Bottle with Red Potion", "Bottle with Green Potion", "Bottle with Blue Potion",
     "Bottle with Fairy", "Bottle with Fish", "Bottle with Blue Fire", "Bottle with Bugs",
-    "Bottle with Big Poe", "Bottle with Poe",
+    "Bottle with Big Poe", "Bottle with Poe", "Bottle with Milk",
 }
 
 defaultHintDists: list[str] = [


### PR DESCRIPTION
This fixes the 12 remaining failures mentioned in #2391, which occurred when every bottle other than Ruto's letter was a milk bottle.