### PR TITLE
Show hint type in spoiler log

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -92,9 +92,16 @@ class GossipText:
         self.colors: Optional[list[str]] = colors
         self.hinted_locations: Optional[list[str]] = hinted_locations
         self.hinted_items: Optional[list[str]] = hinted_items
+        self.hint_type: Optional[str] = None
 
     def to_json(self) -> dict:
-        return {'text': self.text, 'colors': self.colors, 'hinted_locations': self.hinted_locations, 'hinted_items': self.hinted_items}
+        return {
+            'text': self.text,
+            'colors': self.colors,
+            'hinted_locations': self.hinted_locations,
+            'hinted_items': self.hinted_items,
+            'hint_type': self.hint_type,
+        }
 
     def __str__(self) -> str:
         return get_raw_text(line_wrap(color_text(self)))
@@ -186,7 +193,9 @@ def is_restricted_dungeon_item(item: Item) -> bool:
 
 
 def add_hint(spoiler: Spoiler, world: World, groups: list[list[int]], gossip_text: GossipText, count: int,
-             locations: Optional[list[Location]] = None, force_reachable: bool = False, hint_type: str = None) -> bool:
+             locations: Optional[list[Location]] = None, force_reachable: bool = False, *, hint_type: str) -> bool:
+    gossip_text.hint_type = hint_type
+
     random.shuffle(groups)
     skipped_groups = []
     duplicates = []

--- a/Hints.py
+++ b/Hints.py
@@ -1363,7 +1363,7 @@ def build_world_gossip_hints(spoiler: Spoiler, world: World, checked_locations: 
 
     stone_ids = list(gossipLocations.keys())
 
-    world.distribution.configure_gossip(spoiler, stone_ids)
+    world.distribution.configure_gossip(spoiler, world, stone_ids, checked_locations, checked_always_locations)
 
     # If all gossip stones already have plando'd hints, do not roll any more
     if len(stone_ids) == 0:

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -13,7 +13,7 @@ import StartingItems
 from Entrance import Entrance
 from EntranceShuffle import EntranceShuffleError, change_connections, confirm_replacement, validate_world, check_entrances_compatibility
 from Fill import FillError
-from Hints import HintArea, gossipLocations, GossipText
+from Hints import HintArea, gossipLocations, GossipText, hint_func
 from Item import ItemFactory, ItemInfo, ItemIterator, is_item, Item
 from ItemPool import item_groups, get_junk_item, song_list, trade_items, child_trade_items
 from JSONDump import dump_obj, CollapseList, CollapseDict, AlignedDict, SortedDict
@@ -1018,7 +1018,7 @@ class WorldDistribution:
             if can_cloak(location.item, model):
                 location.item.looks_like_item = model
 
-    def configure_gossip(self, spoiler: Spoiler, stone_ids: list[int]) -> None:
+    def configure_gossip(self, spoiler: Spoiler, world: World, stone_ids: list[int], checked_locations: set[str], checked_always_locations: set[str]) -> None:
         for (name, record) in self.pattern_dict_items(self.gossip_stones):
             matcher = self.pattern_matcher(name)
             stone_id = pull_random_element([stone_ids], lambda id: matcher(gossipLocations[id].name))
@@ -1029,7 +1029,21 @@ class WorldDistribution:
                     stone_id = int(match[1], base=16)
                 else:
                     raise RuntimeError('Gossip stone unknown or already assigned in world %d: %r. %s' % (self.id + 1, name, build_close_match(name, 'stone')))
-            spoiler.hints[self.id][stone_id] = GossipText(text=record.text, colors=record.colors, prefix='')
+            if record.text is not None:
+                spoiler.hints[self.id][stone_id] = GossipText(text=record.text, colors=record.colors, prefix='')
+            else:
+                all_checked_locations = checked_locations | checked_always_locations
+                if record.hint_type == 'barren':
+                    hint = hint_func[record.hint_type](spoiler, world, checked_locations, all_checked_locations)
+                else:
+                    hint = hint_func[record.hint_type](spoiler, world, all_checked_locations)
+                    checked_locations.update(all_checked_locations - checked_always_locations)
+                if hint is None:
+                    raise RuntimeError(f'Attempted to plando unavailable hint type {record.hint_type}')
+                gossip_text, _ = hint
+                gossip_text.hint_type = record.hint_type
+                spoiler.hints[self.id][stone_id] = gossip_text
+
 
     def give_items(self, world: World, save_context: SaveContext) -> None:
         # copy Triforce pieces to all worlds

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -113,7 +113,9 @@ class GossipRecord(Record):
         self.colors: Optional[Sequence[str]] = None
         self.hinted_locations: Optional[Sequence[str]] = None
         self.hinted_items: Optional[Sequence[str]] = None
-        super().__init__({'text': None, 'colors': None, 'hinted_locations': None, 'hinted_items': None}, src_dict)
+        self.hint_type: Optional[str] = None
+
+        super().__init__({'text': None, 'colors': None, 'hinted_locations': None, 'hinted_items': None, 'hint_type': None}, src_dict)
 
     def to_json(self) -> dict[str, Any]:
         if self.colors is not None:


### PR DESCRIPTION
This adds a field `hint_type` to `GossipRecord`s, which serves two purposes:

* The hint type is now explicitly listed in the spoiler log, which should be helpful for external tools parsing the `gossip_stones` section of a spoiler log, e.g. the simulator mode of [TOoTR](https://github.com/mracsys/tootr).
* Plando authors can now specify the hint type to place on a specific gossip stone as an alternative to directly specifying the text. This behaves differently compared to setting priority stones in the hint distribution: the plando'd hint doesn't count for the distro's fixed hint counts, and attempting to plando a hint type that can't be generated (which currently includes the hardcoded hint types Trial, Always, Dual Always, and Entrance Always) raises an exception rather than falling back to the next hint type.