### PR TITLE
Fix doubled location color tag in Important Check hint

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1187,7 +1187,7 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
     else:
         numcolor = 'Green'
 
-    return GossipText('#%s# has #%d# major item%s.' % (hint_loc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None
+    return GossipText('%s has #%d# major item%s.' % (hint_loc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None
 
 
 hint_func: dict[str, HintFunc | BarrenFunc] = {


### PR DESCRIPTION
The format string for Important Check hints was wrapping the hint area text in `#` even though `HintArea.text` already does that, causing the hint area to be missing its green highlight color.