### PR TITLE
Standardize on Unix line endings for generated files

### DIFF
--- a/ASM/build.py
+++ b/ASM/build.py
@@ -137,10 +137,10 @@ for (name, sym) in symbols.items():
         else:
             patch_symbols[name] = addr
 
-with open('../data/generated/symbols.json', 'w') as f:
+with open('../data/generated/symbols.json', 'w', newline='\n') as f:
     json.dump(data_symbols, f, indent=4, sort_keys=True)
 
-with open('../data/generated/patch_symbols.json', 'w') as f:
+with open('../data/generated/patch_symbols.json', 'w', newline='\n') as f:
     json.dump(patch_symbols, f, indent=4, sort_keys=True)
 
 if pj64_sym_path:

--- a/ASM/rom_diff.py
+++ b/ASM/rom_diff.py
@@ -37,7 +37,7 @@ def create_diff(base_path, compare_path, output_path):
                 if comp_words[j] != base_words[j]:
                     diffs.append((addr + 4*j, comp_words[j]))
 
-    with open(output_path, 'w') as out_f:
+    with open(output_path, 'w', newline='\n') as out_f:
         for (addr, word) in diffs:
             out_f.write('{0:x},{1:x}\n'.format(addr, word))
 


### PR DESCRIPTION
This avoids unnecessary changes to generated files caused by some contributors building on Windows and others on Unix.