### PR TITLE
Fix Big Poe misc hint making the generation fail in some settings combination

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1821,11 +1821,11 @@ def build_misc_item_hints(world: World, messages: list[Message], allow_duplicate
 def build_misc_location_hints(world: World, messages: list[Message]) -> None:
     for hint_type, data in misc_location_hint_table.items():
         text = data['location_fallback']
+        # Special cased because we need to insert the big poes number.
         if hint_type == 'big_poes':
-            # Special cased because we need to insert the big poes number.
-            item = world.misc_hint_location_items[hint_type]
             poe_points = world.settings.big_poe_count * 100
-            if hint_type in world.settings.misc_hints:
+            if hint_type in world.misc_hint_location_items and hint_type in world.settings.misc_hints:
+                item = world.misc_hint_location_items[hint_type]
                 text = data['location_text'].format(item=get_hint(get_item_generic_name(item),
                                                                     world.settings.clearer_hints).text, poe_points=poe_points)
             else:


### PR DESCRIPTION
Regression introduced in #2318
The function build_misc_location_hints that now handles changing the Ghost Hunter textbox didn't check for the emptiness of the world.misc_hint_location_items array.
This can be empty if:
* Spoiler log is disabled
* Hints are disabled
* No misc. hint are enabled.

In this case, the generation failed in this function when trying to access world.misc_hint_location_items[hint_type].
The PR handle this case more properly.