### PR TITLE
Fix path to the tower in tower ER

### DIFF
--- a/World.py
+++ b/World.py
@@ -1025,7 +1025,7 @@ class World:
             # trials are reduced to one goal with six items to obtain.
             if self.settings.shuffle_ganon_tower:
                 trial_goal.items.append({'name': 'Ganons Tower Access', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trial_goal.goal_count += 1
+                trials.goal_count += 1
 
                 trials.add_goal(trial_goal)
                 self.goal_categories[trials.name] = trials

--- a/World.py
+++ b/World.py
@@ -796,7 +796,7 @@ class World:
         trials = GoalCategory('trials', 30, minimum_goals=1)
         th = GoalCategory('triforce_hunt', 30, goal_count=round(self.settings.triforce_goal_per_world / 10), minimum_goals=1)
         ganon = GoalCategory('ganon', 40, goal_count=1)
-        trial_goal = Goal(self, 'the Tower', 'path to #the Tower#', 'White', items=[], create_empty=True)
+        trial_goal = Goal(self, 'the Tower', 'path to #the Tower#', 'White', items=[{'name': 'Ganons Tower Access', 'quantity': 1, 'minimum': 1, 'hintable': True}])
 
         if self.settings.triforce_hunt and self.settings.triforce_goal_per_world > 0:
             # "Hintable" value of False means the goal items themselves cannot
@@ -1023,32 +1023,27 @@ class World:
 
             # To avoid too many goals in the hint selection phase,
             # trials are reduced to one goal with six items to obtain.
-            if not self.skipped_trials['Forest']:
-                trial_goal.items.append({'name': 'Forest Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trials.goal_count += 1
-            if not self.skipped_trials['Fire']:
-                trial_goal.items.append({'name': 'Fire Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trials.goal_count += 1
-            if not self.skipped_trials['Water']:
-                trial_goal.items.append({'name': 'Water Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trials.goal_count += 1
-            if not self.skipped_trials['Shadow']:
-                trial_goal.items.append({'name': 'Shadow Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trials.goal_count += 1
-            if not self.skipped_trials['Spirit']:
-                trial_goal.items.append({'name': 'Spirit Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trials.goal_count += 1
-            if not self.skipped_trials['Light']:
-                trial_goal.items.append({'name': 'Light Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
-                trials.goal_count += 1
-
-            # Trials category is finalized and saved only if at least one trial is on
-            # If random trials are on and one world in multiworld gets 0 trials, still
-            # add the goal to prevent key errors. Since no items fulfill the goal, it
-            # will always be invalid for that world and not generate hints.
-            if self.settings.trials > 0 or self.settings.trials_random:
-                trials.add_goal(trial_goal)
-                self.goal_categories[trials.name] = trials
+            if not self.settings.shuffle_ganon_tower:
+                if not self.skipped_trials['Forest']:
+                    trial_goal.items.append({'name': 'Forest Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                    trials.goal_count += 1
+                if not self.skipped_trials['Fire']:
+                    trial_goal.items.append({'name': 'Fire Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                    trials.goal_count += 1
+                if not self.skipped_trials['Water']:
+                    trial_goal.items.append({'name': 'Water Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                    trials.goal_count += 1
+                if not self.skipped_trials['Shadow']:
+                    trial_goal.items.append({'name': 'Shadow Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                    trials.goal_count += 1
+                if not self.skipped_trials['Spirit']:
+                    trial_goal.items.append({'name': 'Spirit Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                    trials.goal_count += 1
+                if not self.skipped_trials['Light']:
+                    trial_goal.items.append({'name': 'Light Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                    trials.goal_count += 1
+            trials.add_goal(trial_goal)
+            self.goal_categories[trials.name] = trials
 
             # In glitched logic or if trials are off, it's possible that some items required to beat the game
             # (such as bow, magic, light arrows, or anything required to reach Ganon's Castle)

--- a/World.py
+++ b/World.py
@@ -796,7 +796,7 @@ class World:
         trials = GoalCategory('trials', 30, minimum_goals=1)
         th = GoalCategory('triforce_hunt', 30, goal_count=round(self.settings.triforce_goal_per_world / 10), minimum_goals=1)
         ganon = GoalCategory('ganon', 40, goal_count=1)
-        trial_goal = Goal(self, 'the Tower', 'path to #the Tower#', 'White', items=[{'name': 'Ganons Tower Access', 'quantity': 1, 'minimum': 1, 'hintable': True}])
+        trial_goal = Goal(self, 'the Tower', 'path to #the Tower#', 'White', items=[], create_empty=True)
 
         if self.settings.triforce_hunt and self.settings.triforce_goal_per_world > 0:
             # "Hintable" value of False means the goal items themselves cannot
@@ -1023,7 +1023,13 @@ class World:
 
             # To avoid too many goals in the hint selection phase,
             # trials are reduced to one goal with six items to obtain.
-            if not self.settings.shuffle_ganon_tower:
+            if self.settings.shuffle_ganon_tower:
+                trial_goal.items.append({'name': 'Ganons Tower Access', 'quantity': 1, 'minimum': 1, 'hintable': True})
+                trial_goal.goal_count += 1
+
+                trials.add_goal(trial_goal)
+                self.goal_categories[trials.name] = trials
+            else:
                 if not self.skipped_trials['Forest']:
                     trial_goal.items.append({'name': 'Forest Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
                     trials.goal_count += 1
@@ -1042,8 +1048,14 @@ class World:
                 if not self.skipped_trials['Light']:
                     trial_goal.items.append({'name': 'Light Trial Clear', 'quantity': 1, 'minimum': 1, 'hintable': True})
                     trials.goal_count += 1
-            trials.add_goal(trial_goal)
-            self.goal_categories[trials.name] = trials
+
+                # Trials category is finalized and saved only if at least one trial is on
+                # If random trials are on and one world in multiworld gets 0 trials, still
+                # add the goal to prevent key errors. Since no items fulfill the goal, it
+                # will always be invalid for that world and not generate hints.
+                if self.settings.trials > 0 or self.settings.trials_random:
+                    trials.add_goal(trial_goal)
+                    self.goal_categories[trials.name] = trials
 
             # In glitched logic or if trials are off, it's possible that some items required to beat the game
             # (such as bow, magic, light arrows, or anything required to reach Ganon's Castle)

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1234,6 +1234,10 @@
     {
         "region_name": "Ganons Castle Tower",
         "dungeon": "Ganons Castle",
+        "events": {
+            # Used for the "path to the tower" goal
+            "Ganons Tower Access": "is_adult"
+        },
         "locations": {
             "Ganons Tower Boss Key Chest": "True",
             "Ganondorf Hint": "Boss_Key_Ganons_Castle",

--- a/data/World/Bosses.json
+++ b/data/World/Bosses.json
@@ -150,6 +150,10 @@
         "region_name": "Ganons Castle Tower",
         "scene": "Ganons Castle Tower",
         "is_boss_room": true,
+        "events": {
+            # Used for the "path to the tower" goal
+            "Ganons Tower Access": "is_adult"
+        },
         "locations": {
             "Ganons Tower Boss Key Chest": "is_adult or Kokiri_Sword"
         },


### PR DESCRIPTION
This addresses an oversight from #2063 where the requirements for the “path to the tower” goal weren't adjusted for Ganon's Tower ER, leading to hints for completing the trials even if they lead to something completely irrelevant to beating the seed, such as a stone boss in medallion wincons.

Instead, a requirement is added to the goal checking for reachability of the `Ganons Castle Tower` region as adult. This can technically affect seeds without tower ER (e.g. with Ganon's Castle ER and no trials) but I think it makes sense since it parallels how the “path of time” goal checks for Temple of Time access.