### PR TITLE
Add `boss_goal_names` hint distro option

### DIFF
--- a/Goals.py
+++ b/Goals.py
@@ -148,7 +148,7 @@ class GoalCategory:
 
 def replace_goal_names(worlds: list[World]) -> None:
     for world in worlds:
-        if world.settings.shuffle_dungeon_rewards in ('vanilla', 'reward'):
+        if world.hint_dist_user['boss_goal_names'] and world.settings.shuffle_dungeon_rewards in ('vanilla', 'reward'):
             bosses = [
                 location
                 for location in world.get_filled_locations()

--- a/World.py
+++ b/World.py
@@ -179,6 +179,8 @@ class World:
             self.hint_dist_user['upgrade_hints'] = 'off'
         if 'combine_trial_hints' not in self.hint_dist_user:
             self.hint_dist_user['combine_trial_hints'] = False
+        if 'boss_goal_names' not in self.hint_dist_user:
+            self.hint_dist_user['boss_goal_names'] = True
 
         # Validate hint distribution format
         # Originally built when I was just adding the type distributions


### PR DESCRIPTION
Adds a new field `boss_goal_names` to hint distributions which can be set to `false` to force Goal hints to use the wording “path to the _Water Medallion_” rather than “path to _King Dodongo_”. The field is optional and defaults to `true` to match previous behavior. It does nothing when dungeon rewards are shuffled, since that already forces the “path to the _Water Medallion_” wording.