### PR TITLE
Logic support for “Invisible Chests” setting

### DIFF
--- a/Rules.py
+++ b/Rules.py
@@ -23,6 +23,7 @@ def set_rules(world: World) -> None:
 
     guarantee_hint = world.parser.parse_rule('guarantee_hint')
     is_child = world.parser.parse_rule('is_child')
+    can_see_chests = world.parser.parse_rule('logic_lens_invis or can_use(Lens_of_Truth)')
 
     for location in world.get_locations():
         if world.settings.shuffle_song_items == 'song':
@@ -35,7 +36,10 @@ def set_rules(world: World) -> None:
             else:
                 add_item_rule(location, lambda location, item: item.type != 'Song')
 
-        if location.type == 'Shop':
+        if location.type == 'Chest':
+            if world.settings.invisible_chests:
+                location.add_rule(can_see_chests) #TODO select trick based on region
+        elif location.type == 'Shop':
             if location.name in world.shop_prices:
                 add_item_rule(location, lambda location, item: item.type != 'Shop')
                 location.price = world.shop_prices[location.name]

--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -78,6 +78,14 @@ logic_tricks: dict[str, dict[str, str | tuple[str, ...]]] = {
                     - MQ Spirit Child Crawlspace Boulder
                     - MQ Spirit Trial Rusted Switch
                     '''},
+    'Normally Visible Chests without Lens of Truth': {
+        'name'    : 'logic_lens_invis',
+        'tags'    : ("General", "Lens of Truth", "Overworld", "Deku Tree", "Dodongo's Cavern", "Jabu Jabu's Belly", "Forest Temple", "Fire Temple", "Ice Cavern", "Water Temple", "Bottom of the Well", "Shadow Temple", "Gerudo Training Ground", "Spirit Temple",),
+        'tooltip' : '''\
+                    Applies only when "Invisible Chests" is enabled
+                    and removes the Lens of Truth requirements from
+                    all chests not covered by another trick.
+                    '''},
 
     # Overworld tricks
 

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -54,6 +54,8 @@
     "can_play(song)": "Ocarina and song and (not shuffle_individual_ocarina_notes or has_all_notes_for_song(song))",
     "can_open_bomb_grotto": "can_blast_or_smash and (Stone_of_Agony or logic_grottos_without_agony)",
     "can_open_storm_grotto": "can_play(Song_of_Storms) and (Stone_of_Agony or logic_grottos_without_agony)",
+    #TODO replace with regional lensless tricks
+    "can_see_chests": "not invisible_chests or logic_lens_invis or can_use(Lens_of_Truth)",
     # The last case in a conditional still needs a check, to prevent failure from falling through
     # into what should be the 'else' case.
     "can_use_projectile": "has_explosives or (is_adult and (Bow or Hookshot)) or (is_child and (Slingshot or Boomerang))",

--- a/data/World/Deku Tree.json
+++ b/data/World/Deku Tree.json
@@ -67,7 +67,7 @@
             "Deku Tree Basement Back Room": "is_child",
             "Deku Tree Before Boss": "
                 deku_tree_shortcuts or
-                here(has_fire_source_with_torch or (logic_deku_b1_webs_with_bow and can_use(Bow)))"
+                here(has_fire_source_with_torch or (logic_deku_b1_webs_with_bow and can_see_chests and can_use(Bow)))"
         }
     },
     {

--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -106,10 +106,18 @@
                 can_use(Boomerang) or at('Dodongos Cavern Far Bridge', True)"
         },
         "exits": {
+            "Dodongos Cavern Alcove Above Stairs": "can_use(Longshot)",
             "Dodongos Cavern Before Upper Lizalfos": "
                 here(can_blast_or_smash or Progressive_Strength_Upgrade)",
             "Dodongos Cavern Far Bridge": "
                 is_adult and (logic_dc_jump or Hover_Boots or (can_see_chests and Longshot))"
+        }
+    },
+    {
+        "region_name": "Dodongos Cavern Alcove Above Stairs",
+        "dungeon": "Dodongos Cavern",
+        "locations": {
+            "Dodongos Cavern GS Alcove Above Stairs": "True"
         }
     },
     {
@@ -143,12 +151,12 @@
             "Dodongos Cavern Bomb Bag Chest": "True",
             "Dodongos Cavern End of Bridge Chest": "can_blast_or_smash",
             "Dodongos Cavern Double Eye Switch Room Pot 1": "True",
-            "Dodongos Cavern Double Eye Switch Room Pot 2": "True",
-            "Dodongos Cavern GS Alcove Above Stairs": "can_use(Hookshot) or can_use(Boomerang)"
+            "Dodongos Cavern Double Eye Switch Room Pot 2": "True"
         },
         "exits": {
             "Dodongos Cavern Mouth": "has_explosives",
-            "Dodongos Cavern Upper Lizalfos": "True"
+            "Dodongos Cavern Upper Lizalfos": "True",
+            "Dodongos Cavern Alcove Above Stairs": "can_use(Hookshot) or can_use(Boomerang)"
         }
     },
     {

--- a/data/World/Dodongos Cavern.json
+++ b/data/World/Dodongos Cavern.json
@@ -109,7 +109,7 @@
             "Dodongos Cavern Before Upper Lizalfos": "
                 here(can_blast_or_smash or Progressive_Strength_Upgrade)",
             "Dodongos Cavern Far Bridge": "
-                is_adult and (logic_dc_jump or Hover_Boots or Longshot)"
+                is_adult and (logic_dc_jump or Hover_Boots or (can_see_chests and Longshot))"
         }
     },
     {

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -89,15 +89,15 @@
             "Fire Temple MQ Big Lava Room Right Pot": "Hookshot or logic_fire_mq_blocked_chest",
             "Fire Temple MQ Big Lava Room Alcove Pot": "True",
             "Fire Temple MQ Boss Key Chest Room Pot 1": "
-                has_fire_source and (Bow or logic_fire_mq_bk_chest) and Hookshot",
+                has_fire_source and (Bow or logic_fire_mq_bk_chest) and can_see_chests and Hookshot",
             "Fire Temple MQ Boss Key Chest Room Pot 2": "
-                has_fire_source and (Bow or logic_fire_mq_bk_chest) and Hookshot",
+                has_fire_source and (Bow or logic_fire_mq_bk_chest) and can_see_chests and Hookshot",
             "Fire Temple MQ GS Big Lava Room Open Door": "True",
             "Fire Temple MQ Boss Key Hookshot Wonderitem": "has_fire_source and (Bow or logic_fire_mq_bk_chest) and Hookshot",
             "Fire Temple MQ Boss Key Arrow Wonderitem": "has_fire_source and Hookshot and Bow",
             "Fairy Pot": "
                 has_bottle and has_fire_source and (Bow or logic_fire_mq_bk_chest) and
-                (Hookshot or logic_fire_song_of_time)"
+                ((can_see_chests and Hookshot) or (logic_fire_song_of_time and shuffle_pots != 'all' and shuffle_pots != 'dungeons'))"
 
         },
         "exits": {

--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -97,7 +97,8 @@
             "Fire Temple MQ Boss Key Arrow Wonderitem": "has_fire_source and Hookshot and Bow",
             "Fairy Pot": "
                 has_bottle and has_fire_source and (Bow or logic_fire_mq_bk_chest) and
-                ((can_see_chests and Hookshot) or (logic_fire_song_of_time and shuffle_pots != 'all' and shuffle_pots != 'dungeons'))"
+                (Hookshot or logic_fire_song_of_time) and
+                ((can_see_chests and Hookshot) or (shuffle_pots != 'all' and shuffle_pots != 'dungeons'))"
 
         },
         "exits": {

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -145,7 +145,7 @@
                 can_use(Hookshot) and
                 (can_use(Longshot) or can_use(Hover_Boots) or can_play(Song_of_Time) or
                     logic_forest_vines)",
-            "Forest Temple NE Outdoors Ledge": "can_use(Longshot)"
+            "Forest Temple NE Outdoors Ledge": "can_see_chests and can_use(Longshot)"
         }
     },
     {

--- a/data/World/Forest Temple.json
+++ b/data/World/Forest Temple.json
@@ -84,7 +84,7 @@
                 (logic_forest_outdoors_ledge and can_use(Hover_Boots) and
                     at('Forest Temple Outdoors High Balconies', True))",
             "Forest Temple GS Raised Island Courtyard": "
-                can_use(Hookshot) or (logic_forest_outdoor_east_gs and can_use(Boomerang)) or
+                (can_see_chests and can_use(Hookshot)) or (logic_forest_outdoor_east_gs and can_use(Boomerang)) or
                 at('Forest Temple Falling Room', can_use(Bow) or can_use(Dins_Fire) or has_explosives)",
             "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang",
             "Deku Baba Nuts": "

--- a/data/World/Ice Cavern MQ.json
+++ b/data/World/Ice Cavern MQ.json
@@ -49,7 +49,7 @@
         "dungeon": "Ice Cavern",
         "locations": {
             "Ice Cavern MQ Iron Boots Chest": "is_adult",
-            "Sheik in Ice Cavern": "is_adult",
+            "Sheik in Ice Cavern": "is_adult and can_see_chests",
             "Ice Cavern MQ Near End Pot 1": "is_adult",
             "Ice Cavern MQ Near End Pot 2": "is_adult",
             "Ice Cavern MQ GS Ice Block": "is_adult or can_child_attack",

--- a/data/World/Ice Cavern.json
+++ b/data/World/Ice Cavern.json
@@ -78,7 +78,7 @@
             "Ice Cavern Iron Boots Chest": "
                 is_adult or Slingshot or Sticks or Kokiri_Sword or can_use(Dins_Fire)",
             "Sheik in Ice Cavern": "
-                is_adult or Slingshot or Sticks or Kokiri_Sword or can_use(Dins_Fire)",
+                can_see_chests and (is_adult or Slingshot or Sticks or Kokiri_Sword or can_use(Dins_Fire))",
             "Ice Cavern Near End Pot 1": "True",
             "Ice Cavern Near End Pot 2": "True"
         }

--- a/data/World/Shadow Temple.json
+++ b/data/World/Shadow Temple.json
@@ -89,7 +89,7 @@
             "Shadow Temple Falling Spikes Lower Pot 2": "True",
             "Shadow Temple Falling Spikes Upper Pot 1": "logic_shadow_umbrella or Progressive_Strength_Upgrade",
             "Shadow Temple Falling Spikes Upper Pot 2": "logic_shadow_umbrella or Progressive_Strength_Upgrade",
-            "Shadow Temple GS Falling Spikes Room": "logic_shadow_umbrella_gs or Hookshot"
+            "Shadow Temple GS Falling Spikes Room": "(logic_shadow_umbrella_gs and can_see_chests) or Hookshot"
         }
     },
     {
@@ -109,7 +109,7 @@
             "Shadow Temple GS Single Giant Pot": "(Silver_Rupee_Shadow_Temple_Invisible_Spikes, 5)"
         },
         "exits": {
-            "Shadow Temple Wind Tunnel": "Hookshot and (Small_Key_Shadow_Temple, 3)",
+            "Shadow Temple Wind Tunnel": "((can_see_chests and Hookshot) or Longshot) and (Small_Key_Shadow_Temple, 3)",
             "Shadow Temple Huge Pit": "logic_lens_shadow_platform or can_use(Lens_of_Truth)"
         }
     },

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -1391,6 +1391,7 @@
             "logic_beehives_bombchus",
             "logic_boomerang_boulders",
             "logic_rusted_switches",
+            "logic_lens_invis",
             "logic_adult_kokiri_gs_hovers",
             "logic_adult_kokiri_gs_nothing",
             "logic_lost_woods_bridge",


### PR DESCRIPTION
Based on an old draft by @Maplesstar but updated for latest Dev and with the logic changes for chest locations moved to Python code, similar to how wallet requirements for shop locations and “Nighttime Skulltulas Expect Sun's Song” work. Still need to:

- [ ] replace the generic trick with regional tricks, some of which are being introduced by enemy drops/souls anyway
- [ ] decide what to do for the chests in Mido's house, where lens can't be used (can we change that in-game?)

Closes #1601.