### PR TITLE
Take effective starting items into account for hint reachability

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -307,7 +307,7 @@ def can_reach_hint(worlds: list[World], hint_location: Location, location: Locat
 
     old_item = location.item
     location.item = None
-    search = Search.max_explore([world.state for world in worlds])
+    search = Search.max_explore([world.state for world in worlds], collect_pseudo_starting_items=True)
     location.item = old_item
 
     return (search.spot_access(hint_location)

--- a/Search.py
+++ b/Search.py
@@ -84,10 +84,12 @@ class Search:
         self.state_list[item.world.id].collect(item)
 
     @classmethod
-    def max_explore(cls, state_list: Iterable[State], itempool: Optional[Iterable[Item]] = None) -> Search:
+    def max_explore(cls, state_list: Iterable[State], itempool: Optional[Iterable[Item]] = None, *, collect_pseudo_starting_items: bool = False) -> Search:
         p = cls(state_list)
         if itempool:
             p.collect_all(itempool)
+        if collect_pseudo_starting_items:
+            p.collect_pseudo_starting_items()
         p.collect_locations()
         return p
 


### PR DESCRIPTION
This fixes a false negative in the `can_reach_hint` function (which determines whether a hint can be reached without the item it's hinting) caused by the search it uses not collecting effective starting items (e.g. the rewards of precompleted dungeons).