### PR TITLE
Fix THIEVES_HIDEOUT scene index incorrect and setting the wrong flags

### DIFF
--- a/SaveContext.py
+++ b/SaveContext.py
@@ -27,7 +27,7 @@ class Scenes(IntEnum):
     WATER_TEMPLE = 0x05
     SPIRIT_TEMPLE = 0x06
     SHADOW_TEMPLE = 0x07
-    THIEVES_HIDEOUT = 0x0F
+    THIEVES_HIDEOUT = 0x0C
     # Various overworld scenes
     WINDMILL = 0x48
     HYRULE_FIELD = 0x51


### PR DESCRIPTION
THIEVES_HIDEOUT is incorrectly assigned in the Scenes enum in SaveContext.py. Should be 0x0C not 0x0F. This causes incorrect flags be to set in write_settings_dependent_save_context_flags

think this occurred in the flags cleanup 5af3d25fcbf0a82c1ba26fd9e0343db3adaa8c57