### PR TITLE
Fix for TEXT ID ERROR!

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1866,8 +1866,6 @@ def build_misc_dual_hints(world: World, messages: list[Message]) -> None:
                     item=get_hint(get_item_generic_name(item_2), world.settings.clearer_hints).text,
                 )
             else:
-                if hint_type1 not in world.settings.misc_hints and hint_type2 not in world.settings.misc_hints:
-                    return
                 text = data['location_fallback']
     update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'])
 

--- a/Hints.py
+++ b/Hints.py
@@ -1843,7 +1843,7 @@ def build_misc_location_hints(world: World, messages: list[Message]) -> None:
                     text = data['location_text'].format(
                         item=get_hint(get_item_generic_name(item), world.settings.clearer_hints).text,
                     )
-                update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'])
+            update_message_by_id(messages, data['id'], str(GossipText(text, ['Green'], prefix='')), data['text_style'])
 
 
 def build_misc_dual_hints(world: World, messages: list[Message]) -> None:


### PR DESCRIPTION
Fix the text ID error due to an errant indentation causing the code to never set fallback text if the misc hint was off.