### PR TITLE
Add missing BOTW MQ GS Basement

### DIFF
--- a/data/Glitched World/Bottom of the Well MQ.json
+++ b/data/Glitched World/Bottom of the Well MQ.json
@@ -40,6 +40,7 @@
                         or (can_gdv and can_isg))
                 )
                 or can_use(Boomerang)",
+            "Bottom of the Well MQ GS Basement": "can_child_attack or is_adult",
             "Bottom of the Well MQ GS Coffin Room": "
                 (Small_Key_Bottom_of_the_Well, 2) and (can_child_attack or is_adult)",
             "Wall Fairy": "has_bottle and can_use(Slingshot)",


### PR DESCRIPTION
This GS was accidentally removed when rebasing the advanced logic PR and removing enemy drops.