### PR TITLE
Fix new unit tests creating files that aren't ignored

### DIFF
--- a/Unittest.py
+++ b/Unittest.py
@@ -836,7 +836,7 @@ class TestValidSpoilers(unittest.TestCase):
                     self.verify_disables(spoiler)
 
     def test_advanced_tricks(self):
-        filename =  os.path.join(test_dir, 'glitched-standard.sav')
+        filename = 'glitched-standard.sav'
         settings = load_settings(filename, seed='TESTTESTTEST')
         # Enable all standard logic tricks
         settings.allowed_tricks = [trick['name'] for trick in logic_tricks.values()]
@@ -855,7 +855,7 @@ class TestValidSpoilers(unittest.TestCase):
                 self.verify_disables(spoiler)
 
     def test_advanced_tricks_entrances(self):
-        filename =  os.path.join(test_dir, 'glitched-entrances.sav')
+        filename = 'glitched-entrances.sav'
         settings = load_settings(filename, seed='TESTTESTTEST')
         # Enable all standard logic tricks
         settings.allowed_tricks = [trick['name'] for trick in logic_tricks.values()]


### PR DESCRIPTION
The new tests `test_advanced_tricks` and `test_advanced_tricks_entrances` were passing absolute paths to `load_settings`, causing the spoiler logs to be placed into `tests` rather than the gitignored `tests/Output`.