### PR TITLE
Fix patching error when randomized starting items include songs

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -448,7 +448,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         world.settings.shuffle_song_items != 'song'
         or world.distribution.songs_as_items
         or any(name in song_list and record.count for name, record in world.settings.starting_items.items())
-        or any(name in song_list and record.count for name, record in world.randomized_starting_items.items())
+        or any(name in song_list and count for name, count in world.randomized_starting_items.items())
         or world.settings.shuffle_individual_ocarina_notes
     )
     if songs_as_items:

--- a/Patches.py
+++ b/Patches.py
@@ -448,6 +448,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         world.settings.shuffle_song_items != 'song'
         or world.distribution.songs_as_items
         or any(name in song_list and record.count for name, record in world.settings.starting_items.items())
+        or any(name in song_list and record.count for name, record in world.randomized_starting_items.items())
         or world.settings.shuffle_individual_ocarina_notes
     )
     if songs_as_items:


### PR DESCRIPTION
Fixes a bug introduced in #2444 where if the new setting rolls any songs as starting items, and songs as items wasn't already enabled for another reason, patching the rom would fail with an error “KeyError: `item_id`”.