### PR TITLE
Change Important Check Hint Behavior

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1191,7 +1191,7 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
     else:
         numcolor = 'Green'
 
-    return GossipText('#%s# has #%d# major item%s.' % (hint_loc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None
+    return GossipText('%s has #%d# major item%s.' % (hint_loc, item_count, "s" if item_count != 1 else ""), ['Green', numcolor]), None
 
 
 hint_func: dict[str, HintFunc | BarrenFunc] = {

--- a/Hints.py
+++ b/Hints.py
@@ -1145,10 +1145,12 @@ def get_junk_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintRetu
 
 def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) -> HintReturn:
     top_level_locations = []
+    empty_dungeons = [dungeon for dungeon in world.precompleted_dungeons if world.precompleted_dungeons[dungeon]]
     for location in world.get_filled_locations():
         if (HintArea.at(location).text(world.settings.clearer_hints) not in top_level_locations
                 and (HintArea.at(location).text(world.settings.clearer_hints) + ' Important Check') not in checked
                 and HintArea.at(location) != HintArea.ROOT
+                and HintArea.at(location).dungeon_name not in empty_dungeons # prevent pre-completed dungeons from being hinted
                 and not location.locked): # prevent areas with unshuffled checks from being hinted
             top_level_locations.append(HintArea.at(location).text(world.settings.clearer_hints))
     hint_loc = random.choice(top_level_locations)

--- a/Hints.py
+++ b/Hints.py
@@ -1148,7 +1148,8 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
     for location in world.get_filled_locations():
         if (HintArea.at(location).text(world.settings.clearer_hints) not in top_level_locations
                 and (HintArea.at(location).text(world.settings.clearer_hints) + ' Important Check') not in checked
-                and HintArea.at(location) != HintArea.ROOT):
+                and HintArea.at(location) != HintArea.ROOT
+                and not location.locked): # prevent areas with unshuffled checks from being hinted
             top_level_locations.append(HintArea.at(location).text(world.settings.clearer_hints))
     hint_loc = random.choice(top_level_locations)
     item_count = 0

--- a/Hints.py
+++ b/Hints.py
@@ -1153,14 +1153,14 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
                 and HintArea.at(location).dungeon_name not in empty_dungeons # prevent pre-completed dungeons from being hinted
                 and not location.locked): # prevent areas with unshuffled checks from being hinted
             top_level_locations.append(HintArea.at(location).text(world.settings.clearer_hints))
+    if not top_level_locations:
+        return None
     hint_loc = random.choice(top_level_locations)
     item_count = 0
     for location in world.get_filled_locations():
         region = HintArea.at(location).text(world.settings.clearer_hints)
         if region == hint_loc:
             if (location.item.majoritem
-                # exclude locked items
-                and not location.locked
                 # exclude triforce pieces as it defeats the idea of a triforce hunt
                 and not location.item.name == 'Triforce Piece'
                 and not (location.name == 'Song from Impa' and 'Zeldas Letter' in world.settings.starting_items and 'Zeldas Letter' not in world.settings.shuffle_child_trade)

--- a/Hints.py
+++ b/Hints.py
@@ -1161,6 +1161,8 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: set[str]) 
         region = HintArea.at(location).text(world.settings.clearer_hints)
         if region == hint_loc:
             if (location.item.majoritem
+                # exclude locked items
+                and not location.locked
                 # exclude triforce pieces as it defeats the idea of a triforce hunt
                 and not location.item.name == 'Triforce Piece'
                 and not (location.name == 'Song from Impa' and 'Zeldas Letter' in world.settings.starting_items and 'Zeldas Letter' not in world.settings.shuffle_child_trade)


### PR DESCRIPTION
This change excludes locked locations and their regions from being hinted by important checks, e.g. Thieves' Hideout in "standard" settings. The hint area would still be included with shuffled crates for instance.

Edit: This now also excludes pre-completed dungeons from being hinted as well