### PR TITLE
Fix has_projectile_adult

### DIFF
--- a/data/Glitched World/Water Temple MQ.json
+++ b/data/Glitched World/Water Temple MQ.json
@@ -369,7 +369,7 @@
             "Water Temple Bottom Gates Switch": "can_use(Iron_Boots) and Hookshot",
             "Water Temple Boss Key Spout": "can_weirdshot or can_gdv or has_fire_source",
             "Water Temple Dragon Head Room": "can_weirdshot or
-                ((can_gdv or has_fire_source) and (can_use(Hover_Boots) or has_projectile_adult)
+                ((can_gdv or has_fire_source) and (can_use(Hover_Boots) or has_projectile(adult))
                 )"
         }
     },


### PR DESCRIPTION
Looks like this was typo'd in the glitched logic.