### PR TITLE
Fix TypeError during debug logging in hint placement

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1650,7 +1650,10 @@ def build_world_gossip_hints(spoiler: Spoiler, world: World, checked_locations: 
                 else:
                     logging.getLogger('').debug('Placed %s hint for %s.', hint_type, ', '.join([location.name for location in locations]))
             if not place_ok and custom_fixed:
-                logging.getLogger('').debug('Failed to place %s fixed hint for %s.', hint_type, ', '.join([location.name for location in locations]))
+                if locations is None:
+                    logging.getLogger('').debug('Failed to place %s fixed hint.', hint_type)
+                else:
+                    logging.getLogger('').debug('Failed to place %s fixed hint for %s.', hint_type, ', '.join([location.name for location in locations]))
                 fixed_hint_types.insert(0, hint_type)
 
 


### PR DESCRIPTION
This fixes a bug where the log message formatting assumes that the variable `locations` is an iterable, but it can also be `None`. This bug causes a 9% failure rate for League S9 settings on the `release` branch; cherry-picking this commit onto `release` reduces the failure rate to 0%.