### PR TITLE
Add C and ASM build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Build
+on:
+  push:
+    branches: [ "Dev" ]
+  pull_request:
+    branches: [ "Dev" ]
+
+jobs:
+  build-platforms:
+    name: Build N64 platform packages
+    uses: PracticeROM/gz-release/.github/workflows/build-platforms.yml@master
+    with:
+      repository: PracticeROM/gz-release
+      ref: master
+
+  test_assembly_build:
+    name: Build - Assembly
+    needs: build-platforms
+    runs-on: ubuntu-latest
+    container:
+      image: practicerom/practicerom-dev
+    strategy:
+      matrix:
+        python-version: ["3.x"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create fake base ROM
+        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
+      - name: Run build scripts
+        run: python ASM/build.py --no-compile-c
+  test_C_build:
+    name: Build - C
+    needs: build-platforms
+    runs-on: ubuntu-latest
+    container:
+      image: practicerom/practicerom-dev
+    strategy:
+      matrix:
+        python-version: [ "3.x" ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create fake base ROM
+        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
+      - name: Run build scripts
+        run: python ASM/build.py --diff-only
+  test_full_build:
+    name: Build - Full
+    needs: build-platforms
+    runs-on: ubuntu-latest
+    container:
+      image: practicerom/practicerom-dev
+    strategy:
+      matrix:
+        python-version: [ "3.x" ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create fake base ROM
+        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
+      - name: Run build scripts
+        run: python ASM/build.py
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           submodules: recursive
           repository: Kingcom/armips
-          ref: v0.11.0
+          ref: master
       - name: Build armips
         run: mkdir build && cd build && cmake .. && cmake --build . --config Release && sudo mv armips /usr/local/bin/armips && cd ..
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
         with:
           submodules: recursive
           repository: Kingcom/armips
-          ref: v0.11.0
+          ref: master
       - name: Build armips
         run: mkdir build && cd build && cmake .. && cmake --build . --config Release && sudo mv armips /usr/local/bin/armips && cd ..
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Create fake base ROM
-        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Install armips dependencies
         run: sudo apt-get install -y cmake
       - name: Checkout armips
@@ -33,6 +31,8 @@ jobs:
       - name: Build armips
         run: mkdir build && cd build && cmake .. && cmake --build . --config Release && sudo mv armips /usr/local/bin/armips && cd ..
       - uses: actions/checkout@v4
+      - name: Create fake base ROM
+        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Run build scripts
         run: python ASM/build.py --no-compile-c --mips-binutils-prefix mips64-ultra-elf-
   test_C_build:
@@ -71,8 +71,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Create fake base ROM
-        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Install armips dependencies
         run: sudo apt-get install -y cmake
       - name: Checkout armips
@@ -84,6 +82,8 @@ jobs:
       - name: Build armips
         run: mkdir build && cd build && cmake .. && cmake --build . --config Release && sudo mv armips /usr/local/bin/armips && cd ..
       - uses: actions/checkout@v4
+      - name: Create fake base ROM
+        run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Run build scripts
         run: python ASM/build.py --mips-binutils-prefix mips64-ultra-elf-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install armips dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake g++
       - name: Checkout armips
         uses: actions/checkout@v4
         with:
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install armips dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake g++
       - name: Checkout armips
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create fake base ROM
         run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Run build scripts
-        run: python ASM/build.py --no-compile-c
+        run: python ASM/build.py --no-compile-c --mips-binutils-prefix mips64-ultra-elf-
   test_C_build:
     name: Build - C
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
       - name: Create fake base ROM
         run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Run build scripts
-        run: python ASM/build.py --diff-only
+        run: python ASM/build.py --diff-only --mips-binutils-prefix mips64-ultra-elf-
   test_full_build:
     name: Build - Full
     runs-on: ubuntu-latest
@@ -62,5 +62,5 @@ jobs:
       - name: Create fake base ROM
         run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
       - name: Run build scripts
-        run: python ASM/build.py
+        run: python ASM/build.py --mips-binutils-prefix mips64-ultra-elf-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install armips dependencies
-        run: sudo apt-get install -y cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Checkout armips
         uses: actions/checkout@v4
         with:
@@ -72,7 +72,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install armips dependencies
-        run: sudo apt-get install -y cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Checkout armips
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,8 @@ on:
     branches: [ "Dev" ]
 
 jobs:
-  build-platforms:
-    name: Build N64 platform packages
-    uses: PracticeROM/gz-release/.github/workflows/build-platforms.yml@master
-    with:
-      repository: PracticeROM/gz-release
-      ref: master
-
   test_assembly_build:
     name: Build - Assembly
-    needs: build-platforms
     runs-on: ubuntu-latest
     container:
       image: practicerom/practicerom-dev
@@ -35,7 +27,6 @@ jobs:
         run: python ASM/build.py --no-compile-c
   test_C_build:
     name: Build - C
-    needs: build-platforms
     runs-on: ubuntu-latest
     container:
       image: practicerom/practicerom-dev
@@ -55,7 +46,6 @@ jobs:
         run: python ASM/build.py --diff-only
   test_full_build:
     name: Build - Full
-    needs: build-platforms
     runs-on: ubuntu-latest
     container:
       image: practicerom/practicerom-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,23 @@ jobs:
         python-version: ["3.x"]
 
     steps:
-      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Create fake base ROM
         run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
+      - name: Install armips dependencies
+        run: sudo apt-get install -y cmake
+      - name: Checkout armips
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          repository: Kingcom/armips
+          ref: v0.11.0
+      - name: Build armips
+        run: mkdir build && cd build && cmake .. && cmake --build . --config Release && sudo mv armips /usr/local/bin/armips && cd ..
+      - uses: actions/checkout@v4
       - name: Run build scripts
         run: python ASM/build.py --no-compile-c --mips-binutils-prefix mips64-ultra-elf-
   test_C_build:
@@ -42,6 +52,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Create fake base ROM
         run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
+      - name: Create fake patched ROM
+        run: dd if=/dev/zero of=ASM/roms/patched.z64 bs=64M count=1
       - name: Run build scripts
         run: python ASM/build.py --diff-only --mips-binutils-prefix mips64-ultra-elf-
   test_full_build:
@@ -61,6 +73,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Create fake base ROM
         run: dd if=/dev/zero of=ASM/roms/base.z64 bs=64M count=1
+      - name: Install armips dependencies
+        run: sudo apt-get install -y cmake
+      - name: Checkout armips
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          repository: Kingcom/armips
+          ref: v0.11.0
+      - name: Build armips
+        run: mkdir build && cd build && cmake .. && cmake --build . --config Release && sudo mv armips /usr/local/bin/armips && cd ..
+      - uses: actions/checkout@v4
       - name: Run build scripts
         run: python ASM/build.py --mips-binutils-prefix mips64-ultra-elf-
 

--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -1,7 +1,8 @@
-CC = mips64-gcc
-LD = mips64-ld
-OBJDUMP = mips64-objdump
-OBJCOPY = mips64-objcopy
+MIPS_BINUTILS_PREFIX ?= mips64-
+CC = $(MIPS_BINUTILS_PREFIX)gcc
+LD = $(MIPS_BINUTILS_PREFIX)ld
+OBJDUMP = $(MIPS_BINUTILS_PREFIX)objdump
+OBJCOPY = $(MIPS_BINUTILS_PREFIX)objcopy
 
 CFLAGS = -O1 -G0 -fno-reorder-blocks -march=vr4300 -mtune=vr4300 -mabi=32 -mno-gpopt -mdivide-breaks \
 	-mexplicit-relocs

--- a/ASM/build.py
+++ b/ASM/build.py
@@ -17,12 +17,14 @@ parser.add_argument('--compile-c', action='store_true', help="Recompile C module
 parser.add_argument('--no-compile-c', action='store_true', help="Do not recompile C modules")
 parser.add_argument('--dump-obj', action='store_true', help="Dumps extra object info for debugging purposes. Does nothing with --no-compile-c")
 parser.add_argument('--diff-only', action='store_true', help="Creates diff output without running armips")
+parser.add_argument('--mips-binutils-prefix', type=str, default="mips64-", help="Use a different prefix for N64 toolchain")
 
 args = parser.parse_args()
 pj64_sym_path = args.pj64sym
 compile_c = not args.no_compile_c
 dump_obj = args.dump_obj
 diff_only = args.diff_only
+mips_binutils_prefix = args.mips_binutils_prefix
 
 root_dir = os.path.dirname(os.path.realpath(__file__))
 tools_dir = os.path.join(root_dir, 'tools')
@@ -44,6 +46,7 @@ if base_rom_size != 0x400_0000:
 
 if compile_c:
     clist = ['make']
+    clist.append(f'MIPS_BINUTILS_PREFIX={mips_binutils_prefix}')
     if dump_obj:
         clist.append('RUN_OBJDUMP=1')
     call(clist)


### PR DESCRIPTION
This adds a workflow for doing an ASM build, a C build, and a ASM+C build at PR and merge time. Empty files of 64MB are used as fake ROM files for these processes to prevent them from giving errors without including copyrighted material or making major changes to the build scripts. What has been changed about the build scripts is allowing different prefixes for the mips binutils tools as the practice rom development tools installed from the practice ROM package repository uses the prefix "mips64-ultra-elf-" so the build.py args and Makefile have been adjusted to use `mips64-` by default but allow overriding it, much like the decomp Makefile allows.

This uses https://hub.docker.com/r/practicerom/practicerom-dev as a base image so no compiling or manual installation of the N64 toolkit is necessary. Should probably check with glank that there shouldn't be any issues with using this. Free docker seems to allow ~100 container pulls/hour though, so I don't think it should be an issue. EDIT: glank gave the ok [on the gz Discord](https://discord.com/channels/222786394798424064/222786394798424064/1421280778301739150)

Manual compiling of armips is necessary. Currently building right off of master, but a specific commit number should probably be used. Can't use the v0.11.0 tag because it fails to build in modern Ubuntu. Should probably pick a commit and use it specifically so random breakages in the future are less likely.

## Testing
The results of setting up the workflow are on my repository here: https://github.com/flagrama/OoT-Randomizer/actions/workflows/build.yml. If there is anything specific needing testing I can make more commits to that branch to do so, but I feel the existing failures before the working run are proof enough that everything is working right.

Looks like it will activate right away in this PR too, so let's check below!