### PR TITLE
Add GitHub Actions workflow to build the offline release

### DIFF
--- a/.github/workflows/offline-build.yml
+++ b/.github/workflows/offline-build.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build_windows:
-    name: Offline Build - Windows
-    runs-on: windows-latest
+    name: Offline Build - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
@@ -22,7 +25,8 @@ jobs:
           mkdir GUI/python
           cp *.py GUI/python
           cd GUI
-          mv -Force package_release.json package.json
+          mv package_release.json package.json
           npm i
           npm run ng-prod
           npm run dist
+        shell: bash

--- a/.github/workflows/offline-build.yml
+++ b/.github/workflows/offline-build.yml
@@ -1,0 +1,28 @@
+name: Offline Build
+
+on:
+  push:
+    branches: [ "release" ]
+  pull_request: #TODO remove, included to test this workflow
+    branches: [ "Dev" ]
+
+jobs:
+  build_windows:
+    name: Offline Build - Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Build Offline Release
+        run: |
+          python SettingsToJson.py
+          mkdir GUI/python
+          cp *.py GUI/python
+          cd GUI
+          mv -Force package_release.json package.json
+          npm i
+          npm run ng-prod
+          npm run dist

--- a/GUI/package_release.json
+++ b/GUI/package_release.json
@@ -75,7 +75,14 @@
       "executableName": "oot-randomizer-gui"
     },
     "mac": {
-      "target": "dmg",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "universal"
+          ]
+        }
+      ],
       "category": "public.app-category.utilities"
     }
   },


### PR DESCRIPTION
Automates building the offline releases for <https://ootrandomizer.com/downloads> so they can hopefully be made available sooner/immediately after future releases.

@TreZc0 @dragonbane0 a couple questions for the website maintainers:

1. Is there any particular reason there are separate macOS downloads for Apple Silicon and Intel right now? If not, I'd propose having GHA build a Universal binary instead.
2. What would be the best way to pass the build artifacts to the website?

## Testing

The workflow is temporarily enabled on PRs to Dev as well, so it should run for this PR. Once the PR is done and CI passes, I'll remove that trigger so it only runs for actual releases.