### PR TITLE
Fix songs as items to only depend on settings

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -448,7 +448,7 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         world.settings.shuffle_song_items != 'song'
         or world.distribution.songs_as_items
         or any(name in song_list and record.count for name, record in world.settings.starting_items.items())
-        or any(name in song_list and count for name, count in world.randomized_starting_items.items())
+        or (world.settings.random_starting_items_count > 0 and 'songs' not in world.settings.random_starting_items_exclude)
         or world.settings.shuffle_individual_ocarina_notes
     )
     if songs_as_items:


### PR DESCRIPTION
This fixes an inconsistency where the songs-as-items flag could be determined by randomization rather than just the settings since it was checking the final set of randomized starting items. With this PR, it's always enabled when the settings _could_ cause a song location to have a non-song item (i.e. when randomized starting items are on and don't exclude songs).

This is similar to how we handle other conditional behavior; it almost always only depends on the settings and not item placement or other randomized values. For example, we always enable ocarinas as items if overworld entrances are randomized, not just if LW bridge → HF one-ways you. Or we always enable rewards as items if a reward is explicitly selected as a starting item, even if the non-reward item is placed on Rauru.

## Testing

~~Not yet tested. Recommend testing by rolling a seed with songs as possible randomized starting items but not actually starting with a song (making sure that songs-as-items is enabled), and also rolling one with songs excluded (making sure that songs-as-items is disabled).~~ Tested by Hyper.