### PR TITLE
Go back to file select screen after entering the correct password instead of file information screen

### DIFF
--- a/ASM/c/file_select.c
+++ b/ASM/c/file_select.c
@@ -179,6 +179,8 @@ void manage_password(z64_disp_buf_t* db, z64_menudata_t* menu_data) {
                     extended->password[i] = buffer_password[i];
                 }
                 Sram_WriteSave(NULL, file);
+                // Go back to main file select to avoid starting the game by error.
+                menu_data->menu_transition++;
                 return;
             } else {
                 if (z64_game.common.input[0].pad_pressed.a) {


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
This was actually an early feedback from last year when the password feature was first implemented, but i never PR'd the change.
This makes it so that instead of going to the Yes/No screen after succesfully inputing the password, you go back to the main file select screen instead, which lowers the chance of starting the game too early by mashing too fast.
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. -->
Plando'd a password on a seed, checked that entering it goes back to the main file select instead of file confirmation screen.