### PR TITLE
Ensure Forest Boss Key dummy chest is gilded if correct_chest_appearances is off

### DIFF
--- a/ASM/c/chests.c
+++ b/ASM/c/chests.c
@@ -180,6 +180,10 @@ void get_dummy_chest(Chest* dummy_chest) {
     dummy_actor.actor_id = 0x000A;
     dummy_actor.variable = 0x27EE;
     dummy_chest->en_box.dyna.actor = dummy_actor;
+    // If vanilla chest appearance, keep displaying a gilded chest.
+    if (!CHEST_SIZE_MATCH_CONTENTS && !CHEST_SIZE_TEXTURE && !CHEST_TEXTURE_MATCH_CONTENTS) {
+        dummy_chest->en_box.type = GOLD_CHEST;
+    }
 }
 
 void draw_forest_hallway_chest_base() {

--- a/ASM/c/chests.c
+++ b/ASM/c/chests.c
@@ -180,10 +180,8 @@ void get_dummy_chest(Chest* dummy_chest) {
     dummy_actor.actor_id = 0x000A;
     dummy_actor.variable = 0x27EE;
     dummy_chest->en_box.dyna.actor = dummy_actor;
-    // If vanilla chest appearance, keep displaying a gilded chest.
-    if (!CHEST_SIZE_MATCH_CONTENTS && !CHEST_SIZE_TEXTURE && !CHEST_TEXTURE_MATCH_CONTENTS) {
-        dummy_chest->en_box.type = GOLD_CHEST;
-    }
+    // Init the type at gold, this way it will keep its vanilla appearance if we do not override it later in get_chest_override.
+    dummy_chest->en_box.type = GOLD_CHEST;
 }
 
 void draw_forest_hallway_chest_base() {


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
Fixes #2463

If correct_chest_appearances is set to Off, then the dummy chest actor in Forest twisted hallway room that was added back in #1806 to make it match content will never set the color and size in get_chest_override. 
So it defaults to type 0, which is a big brown chest. Which is different from the vanilla game where it shows a fake gilded chest instead.

In that case, when initializing our dummy chest actor, we can put its type directly at Gold chest.
If any CAMC setting is on, it will be overwritten later in get_chest_override. In the other case, it will just keep its vanilla appearance.
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. -->
Put correct_chest_appearances to Off, then went to Forest BK room and checked that in the twisted state, the dummy BK chest was now gilded instead of brown.