### PR TITLE
Fix Randomized Starting Items

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1117,5 +1117,4 @@ def add_random_starting_items_ammo(randomized_starting_items: dict[str, int]) ->
     for item in StartingItems.inventory.values():
         if item.item_name in randomized_starting_items and item.ammo:
             for ammo, qty in item.ammo.items():
-                if ammo not in randomized_starting_items:
-                    randomized_starting_items[ammo] = qty[randomized_starting_items[item.item_name] - 1]
+                randomized_starting_items[ammo] = qty[randomized_starting_items[item.item_name] - 1]

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 from Item import Item, ItemInfo, ItemFactory
 from Location import DisableType
+import StartingItems
 
 if TYPE_CHECKING:
     from Plandomizer import ItemPoolRecord
@@ -1019,6 +1020,7 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         world.randomized_starting_items[selected_item] = world.randomized_starting_items.get(selected_item, 0) + 1
         pool.remove(selected_item)
         pool.extend(get_junk_item())
+    add_random_starting_items_ammo(world.randomized_starting_items)
     for item, count in world.randomized_starting_items.items():
         item = ItemFactory(item, world)
         for _ in range(count):
@@ -1108,4 +1110,12 @@ def configure_random_starting_items_pool(world: World, pool: list[str]) -> list[
     if 'junk' in world.settings.random_starting_items_exclude:
         exclude_list.extend(ItemInfo.junk_weight)
 
-    return sorted({item for item in pool if item not in exclude_list}) # give each item the same weight regardless of how many copies there are
+    return sorted({item for item in pool if item not in exclude_list and ItemInfo.items[item].type != 'Shop'}) # give each item the same weight regardless of how many copies there are
+
+
+def add_random_starting_items_ammo(randomized_starting_items: dict[str, int]) -> None:
+    for item in StartingItems.inventory.values():
+        if item.item_name in randomized_starting_items and item.ammo:
+            for ammo, qty in item.ammo.items():
+                if ammo not in randomized_starting_items:
+                    randomized_starting_items[ammo] = qty[randomized_starting_items[item.item_name] - 1]


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
Fixes #2484 

Also addresses a bug where "Buy" item events were considered as valid items to be selected. We now exclude those items by filtering the "Shop" type.

## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. -->
Rolled multiple seeds to ensure the correct ammo amount was added for the affected items and confirmed in-game as well.
