### PR TITLE
Add water hop to morpha and compass chest + MQ

### DIFF
--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -2872,6 +2872,18 @@ advanced_logic_tricks: dict[str, dict[str, str | tuple[str, ...]]] = {
                     You can also do the same by abusing invincibility frames
                     if not on ohko.
                     '''},
+    '(Advanced) Water Hop': {
+        'name'    : 'adv_water_hop',
+        'tags'    : ("Advanced",),
+        'tooltip' : '''\
+                    By equipping the Iron Boots right before surfacing,
+                    you can keep the momentum from the swim up from a dive
+                    to propel yourself out of the water higher than usual
+                    allowing ledges to be grabbed.
+
+                    Notably allows for access to Morpha's ledge and the
+                    Eastern Middle Layer ledge in Water Temple.
+                    '''},
     '(Glitch) Water Temple Antigrav to Boss Key Area': {
         'name'    : 'glitch_water_bk_area_antigrav',
         'tags'    : ("Glitch","Adult","Water Temple","Water Temple MQ",),

--- a/data/Glitched World/Water Temple MQ.json
+++ b/data/Glitched World/Water Temple MQ.json
@@ -51,9 +51,11 @@
                 is_adult and (Zora_Tunic or logic_fewer_tunic_requirements) and Iron_Boots
                 )",
             "Water Temple Storage Room": "is_adult and Iron_Boots and
-                (Zora_Tunic or logic_fewer_tunic_requirements) and Hookshot",
+                (Zora_Tunic or logic_fewer_tunic_requirements) and
+                (Hookshot or adv_water_hop)",
             "Water Temple Before Boss Lower": "can_use(Longshot) or
                 (adv_hovers_recoil and can_use(Hover_Boots) and Megaton_Hammer) or
+                (adv_water_hop and can_use(Iron_Boots) and Raise_Water_Level) or
                 ((can_mega or can_hess or can_superslide) and can_use(Hover_Boots)) or
                 can_hover",
             "Water Temple After Waterfall Room": "

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -33,9 +33,13 @@
                 ((logic_water_temple_torch_longshot and Longshot) or Iron_Boots)
                 )",
             "Water Temple Compass Room": "is_adult and Iron_Boots and
-                (Zora_Tunic or logic_fewer_tunic_requirements) and Hookshot",
+                (Zora_Tunic or logic_fewer_tunic_requirements) and
+                (Hookshot
+                    or (adv_water_hop and can_live_dmg(1.0,false,false))
+                )",
             "Water Temple Before Boss": "can_use(Longshot) or
                 (adv_hovers_recoil and can_use(Hover_Boots) and Megaton_Hammer) or
+                (adv_water_hop and can_use(Iron_Boots) and Raise_Water_Level) or
                 ((can_mega or can_hess or can_superslide) and can_use(Hover_Boots)) or
                 can_hover",
             "Water Temple North Basement": "can_use(Iron_Boots) and (Zora_Tunic or logic_fewer_tunic_requirements)


### PR DESCRIPTION
Adding the new water hop tech to advanced logic. The damage check for the compass chest in vanilla water is to give a little leniency on damage with the stingers without requiring additional items.  Essentially takes the trick out of logic for ohko and quad damage.