### PR TITLE
Prioritize songs on Song from Impa when Skip Child Zelda internal setting is enabled

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -182,11 +182,15 @@ def distribute_items_restrictive(worlds: list[World], fill_locations: Optional[l
         # gets a song and not some other type of item when songs on songs is
         # enabled.
         impas: list[Location] = []
+        impas_songs: list[Item] = []
         for world in worlds:
             if world.skip_child_zelda and world.settings.shuffle_song_items == 'song':
-                impas.append(world.get_location('Song from Impa'))
-        if impas:
-            fill_ownworld_restrictive(worlds, search, impas, songitempool, progitempool, "song")
+                own_songs = [song for song in songitempool if song.world.id == world.id]
+                if own_songs:
+                    impas.append(world.get_location('Song from Impa'))
+                    impas_songs.append(random.choice(own_songs))
+        if impas and impas_songs:
+            fill_ownworld_restrictive(worlds, search, impas, impas_songs, progitempool, "song")
         fill_ownworld_restrictive(worlds, search, song_locations, songitempool, progitempool, "song")
         search.collect_locations()
         fill_locations += [location for location in song_locations if location.item is None]

--- a/Fill.py
+++ b/Fill.py
@@ -184,7 +184,7 @@ def distribute_items_restrictive(worlds: list[World], fill_locations: Optional[l
         impas: list[Location] = []
         impas_songs: list[Item] = []
         for world in worlds:
-            if world.skip_child_zelda and world.settings.shuffle_song_items == 'song':
+            if world.skip_child_zelda:
                 own_songs = [song for song in songitempool if song.world.id == world.id]
                 impa = world.get_location('Song from Impa')
                 if own_songs and impa.item is None:

--- a/Fill.py
+++ b/Fill.py
@@ -186,8 +186,9 @@ def distribute_items_restrictive(worlds: list[World], fill_locations: Optional[l
         for world in worlds:
             if world.skip_child_zelda and world.settings.shuffle_song_items == 'song':
                 own_songs = [song for song in songitempool if song.world.id == world.id]
-                if own_songs:
-                    impas.append(world.get_location('Song from Impa'))
+                impa = world.get_location('Song from Impa')
+                if own_songs and impa.item is None:
+                    impas.append(impa)
                     impas_songs.append(random.choice(own_songs))
         if impas and impas_songs:
             fill_ownworld_restrictive(worlds, search, impas, impas_songs, progitempool, "song")

--- a/Fill.py
+++ b/Fill.py
@@ -356,8 +356,8 @@ def fill_dungeon_unique_item(worlds: list[World], search: Search, fill_locations
 def fill_ownworld_restrictive(worlds: list[World], search: Search, locations: list[Location], ownpool: list[Item],
                               itempool: list[Item], description: str = "Unknown", attempts: int = 15) -> None:
     # look for preplaced items
-    placed_prizes = [loc.item.name for loc in locations if loc.item is not None]
-    unplaced_prizes = [item for item in ownpool if item.name not in placed_prizes]
+    placed_prizes = [loc.item for loc in locations if loc.item is not None]
+    unplaced_prizes = [item for item in ownpool if item not in placed_prizes]
     empty_locations = [loc for loc in locations if loc.item is None]
 
     prizepool_dict = {world.id: [item for item in unplaced_prizes if item.world.id == world.id] for world in worlds}

--- a/Fill.py
+++ b/Fill.py
@@ -178,6 +178,15 @@ def distribute_items_restrictive(worlds: list[World], fill_locations: Optional[l
     # the song locations only.
     if worlds[0].settings.shuffle_song_items != 'any':
         logger.info('Placing song items.')
+        # Prioritize Song from Impa when skip child zelda is on to ensure it
+        # gets a song and not some other type of item when songs on songs is
+        # enabled.
+        impas: list[Location] = []
+        for world in worlds:
+            if world.skip_child_zelda and world.settings.shuffle_song_items == 'song':
+                impas.append(world.get_location('Song from Impa'))
+        if impas:
+            fill_ownworld_restrictive(worlds, search, impas, songitempool, progitempool, "song")
         fill_ownworld_restrictive(worlds, search, song_locations, songitempool, progitempool, "song")
         search.collect_locations()
         fill_locations += [location for location in song_locations if location.item is None]

--- a/Main.py
+++ b/Main.py
@@ -127,7 +127,7 @@ def generate(settings: Settings) -> Spoiler:
 
 def build_world_graphs(settings: Settings) -> list[World]:
     logger = logging.getLogger('')
-    worlds = []
+    worlds: list[World] = []
     for i in range(0, settings.world_count):
         worlds.append(World(i, settings.copy()))
 
@@ -264,7 +264,7 @@ def generate_wad(wad_file: str, rom_file: str, output_file: str, channel_title: 
         with open(wad_file, 'rb') as wad_stream:
             wad_buffer = bytearray(wad_stream.read(0xFC0))
     except FileNotFoundError as ex:
-            raise FileNotFoundError(f'Invalid path to Base WAD: "{input_file}"')
+            raise FileNotFoundError(f'Invalid path to Base WAD: "{wad_file}"')
 
     wad_app1_sha1_usa = [
         [0x76, 0x3D, 0x4D, 0x3D, 0x07, 0x13, 0xE4, 0xD1, 0x0E, 0x44, 0x54, 0x0C, 0xCF, 0xA3, 0x25, 0x5E, 0x19, 0xF2, 0x8A, 0xF7], # US Wad App1

--- a/Rules.py
+++ b/Rules.py
@@ -26,7 +26,15 @@ def set_rules(world: World) -> None:
 
     for location in world.get_locations():
         if world.settings.shuffle_song_items == 'song':
-            if location.type == 'Song':
+            if location.name == 'Song from Impa' and location.world.skip_child_zelda \
+            and not all(name in world.settings.starting_items.keys() and world.settings.starting_items[name].count >= 1 for name in song_list):
+                # Enforce songs on Song from Impa when skip child zelda in
+                # effect to ensure a starting song as expected, in addition to
+                # any starting songs from other settings or plando. Exception
+                # if all songs are already starting items.
+                add_item_rule(location, lambda location, item:
+                    (item.type == 'Song' and item.world.id == location.world.id))
+            elif location.type == 'Song':
                 # allow junk items, but songs must still have matching world
                 add_item_rule(location, lambda location, item:
                     ((location.world.distribution.songs_as_items or any(name in song_list and record.count for name, record in world.settings.starting_items.items()))

--- a/Rules.py
+++ b/Rules.py
@@ -26,15 +26,7 @@ def set_rules(world: World) -> None:
 
     for location in world.get_locations():
         if world.settings.shuffle_song_items == 'song':
-            if location.name == 'Song from Impa' and location.world.skip_child_zelda \
-            and not all(name in world.settings.starting_items.keys() and world.settings.starting_items[name].count >= 1 for name in song_list):
-                # Enforce songs on Song from Impa when skip child zelda in
-                # effect to ensure a starting song as expected, in addition to
-                # any starting songs from other settings or plando. Exception
-                # if all songs are already starting items.
-                add_item_rule(location, lambda location, item:
-                    (item.type == 'Song' and item.world.id == location.world.id))
-            elif location.type == 'Song':
+            if location.type == 'Song':
                 # allow junk items, but songs must still have matching world
                 add_item_rule(location, lambda location, item:
                     ((location.world.distribution.songs_as_items or any(name in song_list and record.count for name, record in world.settings.starting_items.items()))


### PR DESCRIPTION
If songs are shuffled on songs, skip child zelda is enabled, and there is at least one starting song from another source, it is possible for the Song from Impa location to have a non-song item shuffled on it. This has the consequence with major random starting items of sometimes placing junk items on Song from Impa and reducing the total expected starting major items based on settings.

This PR adds an extra step to shuffle the Song from Impa location first during the song shuffle stage for this particular settings combination. If there are no songs remaining in the pool, Song from Impa will receive a fallback item as before.

## Testing

Tested with the following settings combos:
* No skip child zelda + 11 starting songs + songs shuffled on songs
    * Song from Impa receives either a song or alternate item as expected
* Skip child zelda + 11 starting songs + songs shuffled on songs
    * Song from Impa consistently gets the last song
* Skip child zelda + 10 starting songs + songs shuffled on songs
    * Song from Impa consistently gets a random choice of remaining songs
* Skip child zelda + 12 starting songs + songs shuffled on songs
    * Song from Impa always has a non-song item
* Skip child zelda + 12 starting songs + songs shuffled on songs + plentiful item pool
    * Plentiful pool does not add additional songs to the pool with songs on songs. Song from Impa has a non-song item as expected.
* S9 tournament preset
    * Seeds generate. I did not bulk generate to empirically check if Song from Impa could still get a non-song item.