### PR TITLE
MQ Logic fixes

### DIFF
--- a/data/Glitched World/Dodongos Cavern MQ.json
+++ b/data/Glitched World/Dodongos Cavern MQ.json
@@ -277,7 +277,7 @@
             "Dodongos Cavern Lower Lizalfos": "True",
             "Dodongos Cavern Lower Lizalfos Enemies": "True",
             "Dodongos Cavern Lower Scrubs Room": "can_use(Bow) or has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire)
-                or can_gdv_stick or (can_gdv_ledge and can_isg)"
+                or can_gdv_stick or (can_gdv_empty and can_isg)"
         }
     },
     {

--- a/data/Glitched World/Jabu Jabus Belly MQ.json
+++ b/data/Glitched World/Jabu Jabus Belly MQ.json
@@ -5,19 +5,19 @@
         "locations": {
             "Jabu Jabus Belly MQ Map Chest": "can_blast_or_smash",
             "Jabu Jabus Belly MQ First Room Side Chest": "can_use(Slingshot)
-                or (can_isg and (can_gdv_stick or ('Jabu Jabus Belly MQ Map Chest' and can_gdv_empty)))",
+                or (can_isg and (can_gdv_stick or (can_blast_or_smash and can_gdv_empty)))",
             "Jabu Jabus Belly MQ First Room Pot 1": "True",
             "Jabu Jabus Belly MQ First Room Pot 2": "True",
             "Jabu Jabus Belly MQ Entryway Left Cow Wonderitem": "can_use(Slingshot)
-                or (can_isg and (can_gdv_stick or ('Jabu Jabus Belly MQ Map Chest' and can_gdv_empty)))",
+                or (can_isg and (can_gdv_stick or (can_blast_or_smash and can_gdv_empty)))",
             "Jabu Jabus Belly MQ Entryway Right Cow Wonderitem": "can_use(Slingshot)
-                or (can_isg and (can_gdv_stick or ('Jabu Jabus Belly MQ Map Chest' and can_gdv_empty)))",
+                or (can_isg and (can_gdv_stick or (can_blast_or_smash and can_gdv_empty)))",
             "Nut Pot": "True"
         },
         "exits": {
             "Zoras Fountain": "True",
             "Jabu Jabus Belly Elevator Room": "jabu_shortcuts or here(can_use(Slingshot)
-                or (can_isg and (can_gdv_stick or ('Jabu Jabus Belly MQ Map Chest' and can_gdv_empty))))",
+                or (can_isg and (can_gdv_stick or (can_blast_or_smash and can_gdv_empty))))",
             "Farores Wind Warp": "can_use(Farores_Wind)"
         }
     },


### PR DESCRIPTION
Jabu Jabus MQ Map Chest attempt to collect the location changed to just the same logic as that location.
Fixed the DC MQ can_gdv_ledge to use the appropriate can_gdv_empty.