### PR TITLE
Exclude long recording scarecrow message ID from instant text speed-up

### DIFF
--- a/Messages.py
+++ b/Messages.py
@@ -818,7 +818,9 @@ class Message:
         instant_text_code = TextCode(0x08, 0)
 
         # # speed the text
-        if speed_up_text:
+        if (speed_up_text
+                and self.id != 0x4078  # long recording scarecrow message after playback
+        ):
             text_codes.append(instant_text_code) # allow instant
 
         # write the message


### PR DESCRIPTION
Let's get as many scarecrow annoyances out of the way as possible. Fixes #1346

## Testing

I've tried my best to get the scarecrow to softlock me after putting in this change and could not get it to happen. Behaves like vanilla. Quick test zpf attached.
[OoT_157B3_GCRB2ZRUXX.zpf.zip](https://github.com/user-attachments/files/24412377/OoT_157B3_GCRB2ZRUXX.zpf.zip)

