### PR TITLE
Fix Behavior With Random Starting Items And Dungeon Reward Shuffle

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -6,6 +6,7 @@ from decimal import Decimal, ROUND_UP
 from typing import TYPE_CHECKING, Optional
 
 from Item import Item, ItemInfo, ItemFactory
+from ItemList import REWARD_COLORS
 from Location import DisableType
 import StartingItems
 
@@ -1022,6 +1023,8 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         pool.extend(get_junk_item())
     add_random_starting_items_ammo(world.randomized_starting_items)
     for item, count in world.randomized_starting_items.items():
+        if item in REWARD_COLORS and count > 0:
+            world.hinted_dungeon_reward_locations[item] = None
         item = ItemFactory(item, world)
         for _ in range(count):
             if item.solver_id is not None:


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
Fixes #2511 by setting any selected dungeon reward's hint area to ROOT
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. -->
Forced selection rewards with debugger and verified successful generation