### PR TITLE
Fix Starting Health in SaveContext

### DIFF
--- a/SaveContext.py
+++ b/SaveContext.py
@@ -288,7 +288,7 @@ class SaveContext:
 
         self.addresses['health_capacity'].value       = int(health) * 0x10
         self.addresses['health'].value                = int(health) * 0x10
-        self.addresses['quest']['heart_pieces'].value = int((health % 1) * 4) * 0x10
+        self.addresses['quest']['heart_pieces'].value = int((health % 1) * 4)
 
     def give_item(self, world: World, item: str, count: int = 1) -> None:
         if item.endswith(')'):
@@ -689,7 +689,7 @@ class SaveContext:
                 'stone_of_agony'         : Address(0x00A4, mask=0x00200000),
                 'gerudos_card'           : Address(0x00A4, mask=0x00400000),
                 'gold_skulltula'         : Address(0x00A4, mask=0x00800000),
-                'heart_pieces'           : Address(0x00A4, mask=0xFF000000),
+                'heart_pieces'           : Address(0x00A4, mask=0xF0000000),
             },
 
             # Dungeon Items


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
Fixes #2514 

After a discussion in [#dev-bug-reports](https://discord.com/channels/274180765816848384/438698093354156032/1457801298941579359) (thanks @flagrama @GSKirox, @aofengen) we've uncovered the issue where starting health was miscalcuated due to a bug in determining how much health to add relative to the number of currently collected heart pieces in save context. This change corrects this miscalcuation, while also updating the mask value to mirror decomp
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. -->
Rolled a few seeds with a bunch of starting health items, both Pieces of Heart and Heart Containers, and observed the health value written to save context during generation. Also tested in-game to make sure the correct health value was written.