### PR TITLE
Change Important Check Hints for Single-Location Areas

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1158,7 +1158,7 @@ def get_junk_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, 
 def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, set[CheckedKind]]) -> HintReturn:
     top_level_locations = []
     empty_dungeons = [dungeon for dungeon in world.precompleted_dungeons if world.precompleted_dungeons[dungeon]]
-    locations = {location for location in world.get_filled_locations()}
+    locations = [location for location in world.get_filled_locations()]
 
     for location in locations:
         hint_area = HintArea.at(location)
@@ -1170,7 +1170,7 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
             and hint_area.dungeon_name not in empty_dungeons # prevent pre-completed dungeons from being hinted
             and not location.locked # prevent areas with unshuffled checks from being hinted
         ):
-            shuffled_locations_in_region = set(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, locations))
+            shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, locations))
 
             # Don't hint areas with all locations already hinted
             if shuffled_locations_in_region and all(map(lambda loc: is_checked([loc], checked), shuffled_locations_in_region)):
@@ -1185,7 +1185,7 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
 
     for location in locations:
         if HintArea.at(location) == hint_area:
-            shuffled_locations_in_region = set(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, locations))
+            shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, locations))
 
             if (location.item.majoritem
                 # exclude locked items

--- a/Hints.py
+++ b/Hints.py
@@ -1161,11 +1161,6 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
 
     for location in world.get_filled_locations():
         hint_area = HintArea.at(location)
-        shuffled_locations_in_region = filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations())
-
-        # Don't hint areas with all locations already hinted
-        if shuffled_locations_in_region and all(map(lambda loc: is_checked([loc], checked), shuffled_locations_in_region)):
-            continue
 
         if (
             hint_area not in top_level_locations
@@ -1174,6 +1169,11 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
             and hint_area.dungeon_name not in empty_dungeons # prevent pre-completed dungeons from being hinted
             and not location.locked # prevent areas with unshuffled checks from being hinted
         ):
+            shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations()))
+
+            # Don't hint areas with all locations already hinted
+            if shuffled_locations_in_region and all(map(lambda loc: is_checked([loc], checked), shuffled_locations_in_region)):
+                continue
             top_level_locations.append(hint_area)
 
     if not top_level_locations:
@@ -1183,9 +1183,10 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
     item_count = 0
 
     for location in world.get_filled_locations():
-        shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations()))
 
         if HintArea.at(location) == hint_area:
+            shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations()))
+
             if (location.item.majoritem
                 # exclude locked items
                 and not location.locked

--- a/Hints.py
+++ b/Hints.py
@@ -1158,8 +1158,15 @@ def get_junk_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, 
 def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, set[CheckedKind]]) -> HintReturn:
     top_level_locations = []
     empty_dungeons = [dungeon for dungeon in world.precompleted_dungeons if world.precompleted_dungeons[dungeon]]
+
     for location in world.get_filled_locations():
         hint_area = HintArea.at(location)
+        shuffled_locations_in_region = filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations())
+
+        # Don't hint areas with all locations already hinted
+        if shuffled_locations_in_region and all(map(lambda loc: is_checked([loc], checked), shuffled_locations_in_region)):
+            continue
+
         if (
             hint_area not in top_level_locations
             and hint_area not in checked
@@ -1168,11 +1175,16 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
             and not location.locked # prevent areas with unshuffled checks from being hinted
         ):
             top_level_locations.append(hint_area)
+
     if not top_level_locations:
         return None
+
     hint_area = random.choice(top_level_locations)
     item_count = 0
+
     for location in world.get_filled_locations():
+        shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations()))
+
         if HintArea.at(location) == hint_area:
             if (location.item.majoritem
                 # exclude locked items
@@ -1192,6 +1204,9 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
                     or world.settings.shuffle_ganon_bosskey == 'stones' or world.settings.shuffle_ganon_bosskey == 'medallions'
                     or world.settings.shuffle_ganon_bosskey == 'dungeons' or world.settings.shuffle_ganon_bosskey == 'tokens'))):
                 item_count = item_count + 1
+
+            if location in shuffled_locations_in_region and len(shuffled_locations_in_region) == 1:
+                mark_checked(checked, location.name)
 
     mark_checked(checked, hint_area, CheckedKind.IMPORTANT_CHECK)
 

--- a/Hints.py
+++ b/Hints.py
@@ -1158,8 +1158,9 @@ def get_junk_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, 
 def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, set[CheckedKind]]) -> HintReturn:
     top_level_locations = []
     empty_dungeons = [dungeon for dungeon in world.precompleted_dungeons if world.precompleted_dungeons[dungeon]]
+    locations = {location for location in world.get_filled_locations()}
 
-    for location in world.get_filled_locations():
+    for location in locations:
         hint_area = HintArea.at(location)
 
         if (
@@ -1169,7 +1170,7 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
             and hint_area.dungeon_name not in empty_dungeons # prevent pre-completed dungeons from being hinted
             and not location.locked # prevent areas with unshuffled checks from being hinted
         ):
-            shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations()))
+            shuffled_locations_in_region = set(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, locations))
 
             # Don't hint areas with all locations already hinted
             if shuffled_locations_in_region and all(map(lambda loc: is_checked([loc], checked), shuffled_locations_in_region)):
@@ -1182,10 +1183,9 @@ def get_important_check_hint(spoiler: Spoiler, world: World, checked: dict[HintA
     hint_area = random.choice(top_level_locations)
     item_count = 0
 
-    for location in world.get_filled_locations():
-
+    for location in locations:
         if HintArea.at(location) == hint_area:
-            shuffled_locations_in_region = list(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, world.get_filled_locations()))
+            shuffled_locations_in_region = set(filter(lambda loc: HintArea.at(loc) == hint_area and not loc.locked, locations))
 
             if (location.item.majoritem
                 # exclude locked items


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
Closes #2501 if accepted

This PR does a couple things. First, a check has been added to ensure that areas that have all locations already hinted cannot be selected for an important check hint. Once the hinted location has been selected, it is then added to the `checked` dict directly (in addition to `HintArea` being added as well) to ensure that other hint types cannot hint that location.
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. -->

- Added `'Wasteland Chest'` as an always hint on S9 settings. Checked to make sure that `HintArea.HAUNTED_WASTELAND` was not added to `top_level_locations`. Turned Overworld Skulls on and re-ran test to make sure `HintArea.HAUNTED_WASTELAND` was now included.
- Forced the hint area to be `HintArea.HAUNTED_WASTELAND` with normal S9 settings without Wasteland being hinted already. Checked to make sure that `'Wasteland Chest'` was marked in `checked` dict.