### PR TITLE
Fix switching from advanced to glitchless keeping tricks cached.

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -80,10 +80,10 @@ def resolve_settings(settings: Settings) -> Optional[Rom]:
     if settings.logic_rules == 'advanced':
         for trick in advanced_logic_tricks.values():
             settings.settings_dict[trick['name']] = trick['name'] in settings.advanced_allowed_tricks
-    else: 
+    else:
         for trick in advanced_logic_tricks.values():
             settings.settings_dict[trick['name']] = False
-    
+
 
     # we load the rom before creating the seed so that errors get caught early
     outputting_specific_world = settings.create_uncompressed_rom or settings.create_compressed_rom or settings.create_wad_file

--- a/Main.py
+++ b/Main.py
@@ -65,11 +65,11 @@ def resolve_settings(settings: Settings) -> Optional[Rom]:
     old_tricks = settings.allowed_tricks
     old_advanced_tricks = settings.advanced_allowed_tricks
     settings.load_distribution()
+    settings.remove_disabled()
 
     # compare pointers to lists rather than contents, so even if the two are identical
     # we'll still log the error and note the dist file overrides completely.
-    if old_tricks and (old_tricks is not settings.allowed_tricks
-                    or old_advanced_tricks is not settings.advanced_allowed_tricks):
+    if (old_tricks and old_tricks is not settings.allowed_tricks) or (old_advanced_tricks and old_advanced_tricks is not settings.advanced_allowed_tricks):
         logger.error('Tricks are set in two places! Using only the tricks from the distribution file.')
 
     for trick in logic_tricks.values():
@@ -107,7 +107,6 @@ def resolve_settings(settings: Settings) -> Optional[Rom]:
         settings.hint_dist = 'custom'
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)
-    settings.remove_disabled()
     logger.info('(Original) Settings string: %s\n', settings.settings_string)
     random.seed(settings.numeric_seed)
     settings.resolve_random_settings(cosmetic=False)

--- a/Main.py
+++ b/Main.py
@@ -75,8 +75,9 @@ def resolve_settings(settings: Settings) -> Optional[Rom]:
     for trick in logic_tricks.values():
         settings.settings_dict[trick['name']] = trick['name'] in settings.allowed_tricks
 
-    for trick in advanced_logic_tricks.values():
-        settings.settings_dict[trick['name']] = trick['name'] in settings.advanced_allowed_tricks
+    if settings.logic_rules == 'advanced':
+        for trick in advanced_logic_tricks.values():
+            settings.settings_dict[trick['name']] = trick['name'] in settings.advanced_allowed_tricks
 
     # we load the rom before creating the seed so that errors get caught early
     outputting_specific_world = settings.create_uncompressed_rom or settings.create_compressed_rom or settings.create_wad_file

--- a/Main.py
+++ b/Main.py
@@ -65,19 +65,25 @@ def resolve_settings(settings: Settings) -> Optional[Rom]:
     old_tricks = settings.allowed_tricks
     old_advanced_tricks = settings.advanced_allowed_tricks
     settings.load_distribution()
-    settings.remove_disabled()
 
     # compare pointers to lists rather than contents, so even if the two are identical
     # we'll still log the error and note the dist file overrides completely.
     if (old_tricks and old_tricks is not settings.allowed_tricks) or (old_advanced_tricks and old_advanced_tricks is not settings.advanced_allowed_tricks):
         logger.error('Tricks are set in two places! Using only the tricks from the distribution file.')
 
+    # flag tricks based on settings
+    # special case advanced so that if another logic is selected, all tricks are set to False
+    # this is a failsafe for disabled_default
     for trick in logic_tricks.values():
         settings.settings_dict[trick['name']] = trick['name'] in settings.allowed_tricks
 
     if settings.logic_rules == 'advanced':
         for trick in advanced_logic_tricks.values():
             settings.settings_dict[trick['name']] = trick['name'] in settings.advanced_allowed_tricks
+    else: 
+        for trick in advanced_logic_tricks.values():
+            settings.settings_dict[trick['name']] = False
+    
 
     # we load the rom before creating the seed so that errors get caught early
     outputting_specific_world = settings.create_uncompressed_rom or settings.create_compressed_rom or settings.create_wad_file
@@ -108,6 +114,7 @@ def resolve_settings(settings: Settings) -> Optional[Rom]:
         settings.hint_dist = 'custom'
 
     logger.info('OoT Randomizer Version %s  -  Seed: %s', __version__, settings.seed)
+    settings.remove_disabled()
     logger.info('(Original) Settings string: %s\n', settings.settings_string)
     random.seed(settings.numeric_seed)
     settings.resolve_random_settings(cosmetic=False)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3218,7 +3218,8 @@ class SettingInfos:
             and MAY be required to complete the game.
 
             Tricks in the left column are NEVER required.
-        '''
+        ''',
+        disabled_default = []
     )
 
     # Starting Inventory


### PR DESCRIPTION
Issues have been popping up of otherwise impossible glitchless seeds nonetheless being generated. After extensive testing using a plando file to force Jabu Jabu's Belly into Water Temple with otherwise S9 settings, I tracked the issue down to either the GUI or the settings, world, or main not properly updating the distribution file before creating the seed.

In resolve_settings in Main.py, it came to my attention that the tricks were being rechecked on top of the old distribution file, which didn't properly flush the list if one of the trick lists was disabled. Up until the creation of advanced logic this was not an issue, as the only way to disable a trick list otherwise to enable No Logic, which already ignores them by setting the logic to every location simply to True.

By just moving the call to the remove_disabled() method to before the trick lists are populated again, the issue is resolved.

This PR also includes setting a disabled_default to the advanced_allowed_tricks list and updating the error check for duplicated trick lists to check glitchless and advanced tricks separately.