### PR TITLE
Fast Goron vase

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -164,6 +164,10 @@ def patch_cutscenes(rom: Rom, songs_as_items: bool, settings: Settings) -> None:
         rom.write_int16(0x020B1A0A, 0x01D4)
         rom.write_int16(0x020B1A16, 0x01D4)
 
+    # Goron vase (z_bg_spot18_basket)
+    rom.write_int32(0xE476D4, 0x00000000) # Delete cutscene
+    rom.write_int16(0xE47872, 0x0001) # Stop spinning at frame 1
+
     # Play Sarias Song to Darunia
     delete_cutscene(rom, 0x22769E0)
 


### PR DESCRIPTION
In child Goron City, removes the cutscene of the vase spinning when throwing a bomb in it, and makes the item drop instantly instead of waiting for the vase to spin.


https://github.com/user-attachments/assets/644999bf-e505-4ced-a4ce-93ab1e848b27



## Testing
Tested that it worked (Retroarch) as can be seen on the video above. Here is a test patch of main dev + this change.
Starting in goron city as child with bombs/dins/magic/sticks.
[OotR_test_fast_goron_vase.zip](https://github.com/user-attachments/files/24958463/OotR_test_fast_goron_vase.zip)
