### PR TITLE
Adding in 2 missing locations

### DIFF
--- a/LocationList.py
+++ b/LocationList.py
@@ -2503,6 +2503,9 @@ location_table: dict[str, tuple[str, Optional[int], LocationDefault, LocationAdd
     ("Ganons Castle MQ Water Trial Silver Rupee Red Ice",            ("SilverRupee", 0x0D, (3,0,10), None,                       'Silver Rupee (Ganons Castle Water Trial)', ("Ganon's Castle MQ", "Master Quest", "Silver Rupees",))),
     ("Ganons Castle MQ Water Trial Silver Rupee Above Void",         ("SilverRupee", 0x0D, (3,0,11), None,                       'Silver Rupee (Ganons Castle Water Trial)', ("Ganon's Castle MQ", "Master Quest", "Silver Rupees",))),
 
+    # Ganon's Castle MQ Wonderitems
+    ("Ganons Castle MQ Shadow Trial Explosives Wonderitem",            ("Wonderitem",   0x0D,  (12,0,13), None,                   'Deku Nuts (5)',                         ("Ganon's Castle MQ", "Master Quest", "Wonderitems",))),
+
     # Ganon's Castle Shared
     ("Ganons Tower Boss Key Chest",                                  ("Chest",        0x0A,  0x0B, None,                            'Boss Key (Ganons Castle)',              ("Ganon's Tower", "Vanilla Dungeons", "Master Quest", "Chests",))),
 
@@ -2545,6 +2548,7 @@ location_table: dict[str, tuple[str, Optional[int], LocationDefault, LocationAdd
     ("Fairy Pot",                                                    ("Drop",         None,  None, None,                            'Fairy',                                 None)),
     ("Free Fairies",                                                 ("Drop",         None,  None, None,                            'Fairy',                                 None)),
     ("Wall Fairy",                                                   ("Drop",         None,  None, None,                            'Fairy',                                 None)),
+    ("Bombable Fairy",                                               ("Drop",         None,  None, None,                            'Fairy',                                 None)),
     ("Butterfly Fairy",                                              ("Drop",         None,  None, None,                            'Fairy',                                 None)),
     ("Gossip Stone Fairy",                                           ("Drop",         None,  None, None,                            'Fairy',                                 None)),
     ("Bean Plant Fairy",                                             ("Drop",         None,  None, None,                            'Fairy',                                 None)),

--- a/data/Glitched World/Ganons Castle MQ.json
+++ b/data/Glitched World/Ganons Castle MQ.json
@@ -138,8 +138,7 @@
             "Ganons Castle MQ Shadow Trial Silver Rupee Bomb Flower": "True",
             "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True",
             "Ganons Castle MQ Shadow Trial Explosives Wonderitem": "
-                at('Ganons Castle Shadow Trial', can_use(Bow)) or
-                has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire) or can_gdv"
+                Bow or has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire) or can_gdv"
         },
         "exits": {
             "Ganons Castle Shadow Trial Second Gap": "Hover_Boots or has_fire_source or logic_shadow_trial_mq"

--- a/data/Glitched World/Ganons Castle MQ.json
+++ b/data/Glitched World/Ganons Castle MQ.json
@@ -136,7 +136,10 @@
         "locations": {
             "Ganons Castle MQ Shadow Trial Silver Rupee Moving Platform": "True",
             "Ganons Castle MQ Shadow Trial Silver Rupee Bomb Flower": "True",
-            "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True"
+            "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True",
+            "Ganons Castle MQ Shadow Trial Explosives Wonderitem": "
+                at('Ganons Castle Shadow Trial', can_use(Bow)) or
+                has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire) or can_gdv",
         },
         "exits": {
             "Ganons Castle Shadow Trial Second Gap": "Hover_Boots or has_fire_source or logic_shadow_trial_mq"

--- a/data/Glitched World/Ganons Castle MQ.json
+++ b/data/Glitched World/Ganons Castle MQ.json
@@ -139,7 +139,7 @@
             "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True",
             "Ganons Castle MQ Shadow Trial Explosives Wonderitem": "
                 at('Ganons Castle Shadow Trial', can_use(Bow)) or
-                has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire) or can_gdv",
+                has_explosives or Progressive_Strength_Upgrade or can_use(Dins_Fire) or can_gdv"
         },
         "exits": {
             "Ganons Castle Shadow Trial Second Gap": "Hover_Boots or has_fire_source or logic_shadow_trial_mq"

--- a/data/Glitched World/Jabu Jabus Belly MQ.json
+++ b/data/Glitched World/Jabu Jabus Belly MQ.json
@@ -105,7 +105,8 @@
             "Jabu Jabus Belly MQ Falling Like Like Room Pot 1": "True",
             "Jabu Jabus Belly MQ Falling Like Like Room Pot 2": "True",
             "Jabu Jabus Belly MQ Hallway Small Crate 1": "True",
-            "Jabu Jabus Belly MQ Hallway Small Crate 2": "True"
+            "Jabu Jabus Belly MQ Hallway Small Crate 2": "True",
+            "Bombable Fairy": "has_bottle and has_explosives"
         },
         "exits": {
             "Jabu Jabus After Right Tentacle": "Jabu_Jabus_Belly_Right_Tentacle_Cleared"

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -116,7 +116,7 @@
             "Ganons Castle MQ Shadow Trial Silver Rupee Bomb Flower": "True",
             "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True",
             "Ganons Castle MQ Shadow Trial Explosives Wonderitem": "
-                has_explosives or Bow or Progressive_Strength_Upgrade or can_use(Dins_Fire)",
+                has_explosives or Bow or Progressive_Strength_Upgrade or can_use(Dins_Fire)"
         },
         "exits": {
             "Ganons Castle Shadow Trial Second Gap": "Hover_Boots or has_fire_source or logic_shadow_trial_mq"

--- a/data/World/Ganons Castle MQ.json
+++ b/data/World/Ganons Castle MQ.json
@@ -114,7 +114,9 @@
         "locations": {
             "Ganons Castle MQ Shadow Trial Silver Rupee Moving Platform": "True",
             "Ganons Castle MQ Shadow Trial Silver Rupee Bomb Flower": "True",
-            "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True"
+            "Ganons Castle MQ Shadow Trial Silver Rupee First Beamos": "True",
+            "Ganons Castle MQ Shadow Trial Explosives Wonderitem": "
+                has_explosives or Bow or Progressive_Strength_Upgrade or can_use(Dins_Fire)",
         },
         "exits": {
             "Ganons Castle Shadow Trial Second Gap": "Hover_Boots or has_fire_source or logic_shadow_trial_mq"

--- a/data/World/Jabu Jabus Belly MQ.json
+++ b/data/World/Jabu Jabus Belly MQ.json
@@ -100,7 +100,8 @@
             "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 2": "has_explosives",
             "Jabu Jabus Belly MQ Falling Like-Like Room Explosives Wonderitem 3": "has_explosives",
             "Jabu Jabus Belly MQ Hallway Small Crate 1": "True",
-            "Jabu Jabus Belly MQ Hallway Small Crate 2": "True"
+            "Jabu Jabus Belly MQ Hallway Small Crate 2": "True",
+            "Bombable Fairy": "has_bottle"
         },
         "exits": {
             "Jabu Jabus Belly Past Big Octo": "Sticks or (can_use(Dins_Fire) and Kokiri_Sword)"


### PR DESCRIPTION
While doing work on Dev-Rob, I noticed 2 locations were missing from main dev that ought to be here: the shadow trial MQ wonder item, and a spawnable fairy collectible from MQ jabu. Adding these in just as they were over there.
