### PR TITLE
Adjust file select version line shortening

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -355,8 +355,22 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
 
     line_len = 21
     version_str = "version " + __version__
-    if len(version_str) > line_len:
-        version_str = "ver. " + __version__
+    if version_str.endswith('.0 Release'):
+        if len(version_str) > line_len:
+            version_str = "version " + __version__[:-len('.0 Release')] + " Release"
+        if len(version_str) > line_len:
+            version_str = "ver. " + __version__[:-len('.0 Release')] + " Release"
+        if len(version_str) > line_len:
+            version_str = "v. " + __version__[:-len('.0 Release')] + " Release"
+        if len(version_str) > line_len:
+            version_str = "v" + __version__[:-len('.0 Release')] + " Release"
+    else:
+        if len(version_str) > line_len:
+            version_str = "ver. " + __version__
+        if len(version_str) > line_len:
+            version_str = "v. " + __version__
+        if len(version_str) > line_len:
+            version_str = "v" + __version__
     rom.write_bytes(rom.sym('VERSION_STRING_TXT'), make_bytes(version_str, 25))
 
     if world.settings.create_spoiler:


### PR DESCRIPTION
With the next major release adding an extra digit, the version info on the file select screen will exceed the 21-character limit. Before this PR, this would result in the version info being shortened to `ver. 10.0.0 Release`. With this PR, it's shortened to `version 10.0 Release` instead, omitting the patch number, which is also consistent with how we refer to releases on [ootrandomizer.com](https://ootrandomizer.com/) and in announcements.

Additionally, for both releases and Dev versions, this adds version display variants that are shortened even further in case the shortened version still doesn't fit: `version ` → `ver. ` → `v. ` → `v` (the last one with no space). These are very unlikely to matter for main any time soon, but are useful for forks, which tend to have longer version info due to including the branch name and supplementary versions and such.

## Testing

Tested with an unmodified `__version__` string (`9.0.2 f.LUM`) as well as `10.0.0 Release` and `255.255.255 Fenhl-255`:

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/0219101a-f15f-4ebc-a430-e23f0564af1b" />

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/1f2433a4-ec93-4ee4-9674-9e3d43b2c50c" />

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/47222855-19ca-4c2a-bddb-38b99342e9de" />
