### PR TITLE
logic bugfix for entering botw

### DIFF
--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -2378,6 +2378,14 @@ advanced_logic_tricks: dict[str, dict[str, str | tuple[str, ...]]] = {
                     Drop a chu, then perform a ledgeclip from the edge near windmill
                     entrance to clip into BotW as adult. Alternative to Odie clip.
                     '''},
+    '(Glitch) BotW Cucco Dive': {
+        'name'    : 'glitch_botw_cucco_dive',
+        'tags'    : ("Glitch","Child","Bottom of the Well",),
+        'tooltip' : '''\
+                    Using ISG (individual trick not required) or Nuts, you can trigger
+                    the angry cucco cutscene as you enter the water, allowing Link to
+                    fall through it and enter the Bottom of the Well.
+                    '''},
     '(Glitch) BotW Blank A': {
         'name'    : 'glitch_botw_blank_a',
         'tags'    : ("Glitch","Child","Bottom of the Well",),

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1971,7 +1971,9 @@
                 or
                 (is_child and
                     ( (glitch_navi_dive and can_jumpslash)
-                    or (at_day and (can_isg or Nuts))
+                    or (at_day and glitch_botw_cucco_dive and 
+                        (Nuts or (can_shield and (Sticks or Kokiri_Sword or can_use(Megaton_Hammer))))
+                        )
                     )
                 )
                 or

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -1971,7 +1971,7 @@
                 or
                 (is_child and
                     ( (glitch_navi_dive and can_jumpslash)
-                    or (at_day and glitch_botw_cucco_dive and 
+                    or (at_day and glitch_botw_cucco_dive and
                         (Nuts or (can_shield and (Sticks or Kokiri_Sword or can_use(Megaton_Hammer))))
                         )
                     )


### PR DESCRIPTION
for advanced logic
cucco dive with just Nuts was in logic erroneously. now gated it is behind a trick

example seed: https://ootrandomizer.com/seed/get?id=2059884

Ocarinas in RFT and Botw, no tricks, no glitches, no ER, base advanced logic, ocarina required for bridge (6 med + shadow temple), ALR on
