### PR TITLE
Debug menu v3.1 bugfix

### DIFF
--- a/ASM/c/main.c
+++ b/ASM/c/main.c
@@ -49,6 +49,9 @@ void before_game_state_update() {
     manage_music_changes();
     manage_uninvert_yaxis();
     display_misc_messages();
+#if DEBUG_MODE
+    manage_debug_inputs();
+#endif
 }
 
 void after_game_state_update() {


### PR DESCRIPTION
When pushing #2528, i forgot the changes in main.c that handle ignoring the in game inputs while the menu is open.
This new function was added in debug.c but actually never called so it was completely useless.
