### PR TITLE
Hookshot and Climb Anywhere

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -293,6 +293,20 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
     rom.write_int32s(0x14B9CB8, [0x00000000, 0x00000000, 0x00000000, 0x00000000])  # Boss Key (Key)
     rom.write_int32s(0x14B9F20, [0x00000000, 0x00000000, 0x00000000, 0x00000000])  # Boss Key (Gem)
 
+    if world.settings.climb_anywhere:
+        # Delete the check for SurfaceType_IsHookshotSurface from the hookshot actor
+        rom.write_int32(0xCADAF8, 0x00000000)
+        # Override default wall flags to add climbable surface flag
+        # See D_80119D90, SurfaceType wall properties in z_bgcheck.c in decomp
+        for idx in range(32):
+            if idx == 2:
+                # 3rd entry is for ladders, which have a different flag that
+                # centers link horizontally on the climbable surface
+                continue
+            wall_flags = rom.read_int32(0xB61F80 + idx * 4)
+            wall_flags = wall_flags | 0x00000008
+            rom.write_int32(0xB61F80 + idx*4, wall_flags)
+
     # Force language to be English in the event a Japanese rom was submitted
     rom.write_byte(0x3E, 0x45)
     rom.force_patch.append(0x3E)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4348,7 +4348,8 @@ class SettingInfos:
     climb_anywhere = Checkbutton(
         gui_text       = 'Climb Anywhere',
         gui_tooltip    = '''\
-            Make all surfaces climbable and hookshot-able.
+            Make all vertical surfaces climbable and
+            most surfaces hookshot-able.
         ''',
         shared         = True,
         default        = False,

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4345,6 +4345,15 @@ class SettingInfos:
         shared         = True,
     )
 
+    climb_anywhere = Checkbutton(
+        gui_text       = 'Climb Anywhere',
+        gui_tooltip    = '''\
+            Make all surfaces climbable and hookshot-able.
+        ''',
+        shared         = True,
+        default        = False,
+    )
+
     # Cosmetics
 
     default_targeting = Combobox(

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -395,6 +395,7 @@
             "text_shuffle",
             "damage_multiplier",
             "deadly_bonks",
+            "climb_anywhere",
             "starting_tod",
             "blue_fire_arrows",
             "fix_broken_drops",


### PR DESCRIPTION
Implements two features under one setting:

1. Hookshot and Longshot can attach to any surface.
2. All wall-type surfaces are made climbable.

Logic is not currently implemented for either Glitchless or Advanced. I'm looking for someone willing to put that together, including base development, trick development, and review responses. I personally don't have the time or interest.

## Testing

Worked as expected back on 7.1.

There is a quirk with doors where getting too close to a door will make you start climbing it, when you probably want to open it instead. The feature doesn't prevent opening doors.
