### PR TITLE
Ageless items

### DIFF
--- a/Patches.py
+++ b/Patches.py
@@ -1837,6 +1837,60 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
                 text_codes.append(code)
         update_message_by_id(messages, message_id, ''.join(code.get_string() for code in text_codes))
 
+    # Remove age requirements on most equipment and items
+    # More information at https://wiki.cloudmodding.com/oot/Item_Usability_Table
+    if world.settings.no_age_limits:
+        # Item usability
+        rom.write_byte(0xBC7794 + 0x00, 0x09) # Deku Sticks
+        rom.write_byte(0xBC7794 + 0x0C, 0x09) # Boomerang
+        rom.write_byte(0xBC7794 + 0x0F, 0x09) # Megaton Hammer
+        rom.write_byte(0xBC7794 + 0x16, 0x09) # Adult Trade Item
+        rom.write_byte(0xBC7794 + 0x17, 0x09) # Child Trade Item
+        rom.write_byte(0xBC7794 + 0x19, 0x09) # Kokiri Sword
+        rom.write_byte(0xBC7794 + 0x1B, 0x09) # Biggoron Sword
+        rom.write_byte(0xBC7794 + 0x1D, 0x09) # Deku Shield
+        rom.write_byte(0xBC7794 + 0x1F, 0x09) # Mirror Shield
+        rom.write_byte(0xBC7794 + 0x22, 0x09) # Goron Tunic
+        rom.write_byte(0xBC7794 + 0x23, 0x09) # Zora Tunic
+        rom.write_byte(0xBC7794 + 0x26, 0x09) # Iron Boots
+        rom.write_byte(0xBC7794 + 0x27, 0x09) # Hover Boots
+        # Pause menu appearance
+        rom.write_byte(0xBC7794 + 0x28, 0x09) # Deku Sticks
+        rom.write_byte(0xBC7794 + 0x36, 0x09) # Boomerang
+        rom.write_byte(0xBC7794 + 0x39, 0x09) # Megaton Hammer
+        rom.write_byte(0xBC7794 + 0x63, 0x09) # Kokiri Sword
+        rom.write_byte(0xBC7794 + 0x65, 0x09) # Biggoron Sword
+        rom.write_byte(0xBC7794 + 0x66, 0x09) # Deku Shield
+        rom.write_byte(0xBC7794 + 0x68, 0x09) # Mirror Shield
+        rom.write_byte(0xBC7794 + 0x6A, 0x09) # Goron Tunic
+        rom.write_byte(0xBC7794 + 0x6B, 0x09) # Zora Tunic
+        rom.write_byte(0xBC7794 + 0x6D, 0x09) # Iron Boots
+        rom.write_byte(0xBC7794 + 0x6E, 0x09) # Hover Boots
+        rom.write_byte(0xBC7794 + 0x49, 0x09) # Child Trade Items
+        rom.write_byte(0xBC7794 + 0x4A, 0x09)
+        rom.write_byte(0xBC7794 + 0x4B, 0x09)
+        rom.write_byte(0xBC7794 + 0x4C, 0x09)
+        rom.write_byte(0xBC7794 + 0x4D, 0x09)
+        rom.write_byte(0xBC7794 + 0x4E, 0x09)
+        rom.write_byte(0xBC7794 + 0x4F, 0x09)
+        rom.write_byte(0xBC7794 + 0x50, 0x09)
+        rom.write_byte(0xBC7794 + 0x51, 0x09)
+        rom.write_byte(0xBC7794 + 0x52, 0x09)
+        rom.write_byte(0xBC7794 + 0x53, 0x09)
+        rom.write_byte(0xBC7794 + 0x55, 0x09) # Adult Trade Items
+        rom.write_byte(0xBC7794 + 0x56, 0x09)
+        rom.write_byte(0xBC7794 + 0x57, 0x09)
+        rom.write_byte(0xBC7794 + 0x58, 0x09)
+        rom.write_byte(0xBC7794 + 0x59, 0x09)
+        rom.write_byte(0xBC7794 + 0x5A, 0x09)
+        rom.write_byte(0xBC7794 + 0x5B, 0x09)
+        rom.write_byte(0xBC7794 + 0x5C, 0x09)
+        rom.write_byte(0xBC7794 + 0x5D, 0x09)
+        rom.write_byte(0xBC7794 + 0x5E, 0x09)
+        rom.write_byte(0xBC7794 + 0x5F, 0x09)
+        # D-pad boots as both ages
+        rom.write_byte(rom.sym('CFG_AGELESS_BOOTS'), 0x01)
+
     permutation = None
 
     # text shuffle

--- a/Patches.py
+++ b/Patches.py
@@ -1888,8 +1888,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
         rom.write_byte(0xBC7794 + 0x5D, 0x09)
         rom.write_byte(0xBC7794 + 0x5E, 0x09)
         rom.write_byte(0xBC7794 + 0x5F, 0x09)
-        # D-pad boots as both ages
-        rom.write_byte(rom.sym('CFG_AGELESS_BOOTS'), 0x01)
 
     permutation = None
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -4090,6 +4090,21 @@ class SettingInfos:
         shared         = True,
     )
 
+    no_age_limits = Checkbutton(
+        gui_text       = 'Disable Item Age Checks',
+        gui_tooltip    = '''\
+            Make most items usable as both ages.
+            Exceptions are the bow and magic arrows
+            as child, hookshot as child, and magic
+            beans as adult.
+
+            Not considered by logic. It may be possible
+            to softlock yourself if you are not careful.
+        ''',
+        default        = False,
+        shared         = True,
+    )
+
     starting_tod = Combobox(
         gui_text       = 'Starting Time of Day',
         default        = 'default',

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -400,6 +400,7 @@
             "fix_broken_drops",
             "tcg_requires_lens",
             "no_collectible_hearts",
+            "no_age_limits",
             "one_item_per_dungeon"
           ]
         },


### PR DESCRIPTION
Removes age checks on item usability for all items and equipment except hookshot/longshot. Basically a free equip swap.

I believe child Hookshot was implemented for OoTMM, but I can't remember the details. That may be portable to this project.

Logic is not currently implemented for either Glitchless or Advanced. I'm looking for someone willing to put that together, including base development, trick development, and review responses. I personally don't have the time or interest.

## Testing

Worked as expected back on 7.1.
