### PR TITLE
Remove FTR and Tunic checks from Bolero>Fire

### DIFF
--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -34,7 +34,6 @@ logic_tricks: dict[str, dict[str, str | tuple[str, ...]]] = {
                     "Child", "Adult",),
         'tooltip' : '''\
                     Allows the following possible without Tunics:
-                    - Enter Fire Temple as adult.
                     - Zora's Fountain bottom Freestandings. You
                     might not have enough time to resurface, and
                     you may need to make multiple trips.

--- a/SettingsListTricks.py
+++ b/SettingsListTricks.py
@@ -37,6 +37,8 @@ logic_tricks: dict[str, dict[str, str | tuple[str, ...]]] = {
                     - Zora's Fountain bottom Freestandings. You
                     might not have enough time to resurface, and
                     you may need to make multiple trips.
+                    - Enter Fire Temple from Goron City, the grotto,
+                    or the great fairy fountain.
                     - Traverse the first floor of the Fire Temple,
                     except the elevator room and Volvagia.
                     - Go underwater in the Water Temple. (The area

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -2773,9 +2773,7 @@
                 is_adult and (Hover_Boots or Hookshot or here(can_plant_bean) or plant_beans or (can_hover and can_use(Goron_Tunic)))",
             "DMC Upper Nearby": "is_adult and (here(can_plant_bean) or plant_beans)",
             # Check boulder color
-            "DMC Fire Temple Entrance": "
-                (is_child and shuffle_dungeon_entrances) or
-                (is_adult and (logic_fewer_tunic_requirements or Goron_Tunic))",
+            "DMC Fire Temple Entrance": "is_adult or shuffle_dungeon_entrances",
             "DMC Pierre Platform": "can_use(Distant_Scarecrow)"
         }
     },

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2453,8 +2453,7 @@
             "DMC Lower Nearby": "
                 is_adult and (Hover_Boots or Hookshot or here(can_plant_bean) or plant_beans)",
             "DMC Upper Nearby": "is_adult and (here(can_plant_bean) or plant_beans)",
-            "DMC Fire Temple Entrance": "
-                (is_adult or shuffle_dungeon_entrances) and (logic_fewer_tunic_requirements or can_use(Goron_Tunic)",
+            "DMC Fire Temple Entrance": "is_adult or shuffle_dungeon_entrances",
             "DMC Pierre Platform": "can_use(Distant_Scarecrow)"
         }
     },

--- a/data/World/Overworld.json
+++ b/data/World/Overworld.json
@@ -2454,8 +2454,7 @@
                 is_adult and (Hover_Boots or Hookshot or here(can_plant_bean) or plant_beans)",
             "DMC Upper Nearby": "is_adult and (here(can_plant_bean) or plant_beans)",
             "DMC Fire Temple Entrance": "
-                (is_child and shuffle_dungeon_entrances) or
-                (is_adult and (logic_fewer_tunic_requirements or Goron_Tunic))",
+                (is_adult or shuffle_dungeon_entrances) and (logic_fewer_tunic_requirements or can_use(Goron_Tunic)",
             "DMC Pierre Platform": "can_use(Distant_Scarecrow)"
         }
     },


### PR DESCRIPTION
It makes very little sense that child can be required to enter fire temple's entrance to pick up a tunic for adult to use that entrance, despite it objectively being harder for child to use this entrance than adult, due to the slower speed.

This requires child to have FTR enabled to logically use this entrance. It also slightly simplifies the way the logic is written.

This is a draft PR because I literally wrote this in 5 minutes before work, and I still need to check the rest of the repository for changes that need to accompany it. I also need to add in a parenthesis I just noticed I missed (but can't easily change from right here and don't have time to change right now).

## Testing
I didn't test anything yet. I'll download a copy tonight to make the change, I just wanted to actually get this made so I didn't keep forgetting.