### PR TITLE
fix tiny var bug

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -261,7 +261,7 @@ def generate_wad(wad_file: str, rom_file: str, output_file: str, channel_title: 
         with open(wad_file, 'rb') as wad_stream:
             wad_buffer = bytearray(wad_stream.read(0xFC0))
     except FileNotFoundError as ex:
-            raise FileNotFoundError(f'Invalid path to Base WAD: "{input_file}"')
+            raise FileNotFoundError(f'Invalid path to Base WAD: "{wad_file}"')
 
     wad_app1_sha1_usa = [
         [0x76, 0x3D, 0x4D, 0x3D, 0x07, 0x13, 0xE4, 0xD1, 0x0E, 0x44, 0x54, 0x0C, 0xCF, 0xA3, 0x25, 0x5E, 0x19, 0xF2, 0x8A, 0xF7], # US Wad App1


### PR DESCRIPTION
I was just looking through the repo to understand it better and noticed this error is using the wrong var

## Testing
I did not test the thrown exception, and in fact I don't think this exception can even trigger due to the check on line 257, but for some reason the undefined var ref bothered me enough to bring attention to this lol. 

The only reason I didn't remove the try catch in my PR is because if memory serves Windows can have os.path.isfile return true but still fail to open the file with a file not found error if the file path is too long or something
