### PR TITLE
Fix "Remove" silver rupees setting

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -910,8 +910,13 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
             if shuffle_setting is not None and dungeon_collection is not None and not shuffle_item:
                 if shuffle_setting in ('remove', 'startwith'):
                     world.state.collect(ItemFactory(item, world))
-                    item = get_junk_item()[0]
-                    shuffle_item = True
+                    if location.type == 'SilverRupee':
+                        # Silver rupees handled differently since removing them actually removes their locations from the world
+                        item = IGNORE_LOCATION
+                        shuffle_item = False
+                    else:
+                        item = get_junk_item()[0]
+                        shuffle_item = True
                 elif shuffle_setting in ('any_dungeon', 'overworld', 'keysanity', 'regional', 'anywhere') and not world.precompleted_dungeons.get(dungeon.name, False):
                     shuffle_item = True
                 elif shuffle_item is None:


### PR DESCRIPTION
Fixes #2541 

Basically, the "remove" silver rupee setting was working like other remove settings, such as small keys: The items are given to the player automatically, but the locations are still open for filling with items. But silver rupee "remove" is different in that it actually removes the locations from the game, so obviously nothing should be shuffled onto these locations. Fixed by checking if the location type is silver rupee in the "remove" logic and, if so, setting it to not be shuffled and ignoring the location.

## Testing
[OoT_FBB47_49XAF4DK8K_Spoiler.json](https://github.com/user-attachments/files/26480029/OoT_FBB47_49XAF4DK8K_Spoiler.json)

After this change, spoiler logs with silver rupees set to remove no longer list silver rupee locations as having items in them. I also noted a lack of silver rupee items in the location pool when inspecting the code while it was running.
