### PR TITLE
Update release cycle docs for #dev-announcements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,6 @@ Regular releases of the randomizer roughly follow this schedule:
 * Full freeze also lasts at least one week and may take longer if beta tester activity is low.
 * If no critical issues are found during beta testing, the release is published and any PRs labelled “waiting for release” are merged to start off the next release cycle.
 
-The current state of the release cycle is pinned in the #dev-public-talk Discord channel.
+Updates to the state of the release cycle will be posted to the #dev-announcements Discord channel.
 
 There may also be hotfix releases which bypass this procedure, e.g. in case of a severe bug that wasn't caught in beta testing or in case of changes to racing presets.


### PR DESCRIPTION
Updates the release cycle section of the contributing doc to reflect the fact that we now have the #dev-announcements Discord channel, which was created so things like release cycle updates don't get lost between other conversations in #dev-public-talk. With a dedicated announcements channel, I'd say pinning the status should no longer be necessary.