### PR TITLE
Add hint distro option to upgrade eligible Goal hints to WotH

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -695,14 +695,17 @@ def get_goal_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, 
     goal.weight = 0
 
     location_text = HintArea.at(location).text(world.settings.clearer_hints)
-    if world_id == world.id:
-        player_text = "the"
-        goal_text = goal.hint_text
+    if goal.name in world.hint_dist_user.get('upgrade_goals_to_woth', []) and location in spoiler.required_locations[world.id]:
+        return GossipText('%s is on the way of the hero.' % location_text, ['Light Blue'], [location.name], [location.item.name]), [location]
     else:
-        player_text = "Player %s's" % (world_id + 1)
-        goal_text = spoiler.goal_categories[world_id][goal_category.name].get_goal(goal.name).hint_text
+        if world_id == world.id:
+            player_text = "the"
+            goal_text = goal.hint_text
+        else:
+            player_text = "Player %s's" % (world_id + 1)
+            goal_text = spoiler.goal_categories[world_id][goal_category.name].get_goal(goal.name).hint_text
 
-    return GossipText('%s is on %s %s.' % (location_text, player_text, goal_text), ['Light Blue', goal.color], [location.name], [location.item.name]), [location]
+        return GossipText('%s is on %s %s.' % (location_text, player_text, goal_text), ['Light Blue', goal.color], [location.name], [location.item.name]), [location]
 
 
 def get_barren_hint(spoiler: Spoiler, world: World, checked: dict[HintArea | str, set[CheckedKind]]) -> HintReturn:


### PR DESCRIPTION
This adds a new entry `upgrade_goals_to_woth` to hint distributions which can be set to a list of goal names for which Goal hints should be upgraded to WotH hints if the hinted location is woth (logically required to complete the seed). The entry is optional and defaults to the empty list.

This functions similarly to the `upgrade_hints` entry which controls Sometimes/Always/etc hints being upgraded to dual hints: An upgraded WotH hint is not checked against the hint exclusions for WotH hints (only those for Goal hints) and does not count towards the `dungeons_woth_limit`.

This is primarily intended for Triforce Hunt, where it allows distinguishing between woth (required to collect enough pieces to meet the goal count) and non-woth path (unlocks pieces but not enough to be strictly required) without affecting the total number of hints per type or prioritizing one over the other.

## Testing

Rolled a seed with the multiworld tournament preset modified to enable Triforce Hunt and `"upgrade_goals_to_woth": ["gold"]` added to the hint distro. Confirmed that locations in the woth list use WotH wording, while others use Goal wording.