### PR TITLE
Enable setting DEBUG_MODE for C through build.py

### DIFF
--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -8,6 +8,10 @@ CFLAGS = -O1 -G0 -fno-reorder-blocks -march=vr4300 -mtune=vr4300 -mabi=32 -mno-g
 	-mexplicit-relocs
 CPPFLAGS = -DF3DEX_GBI_2
 
+ifdef DEBUG_MODE
+  CFLAGS += -DDEBUG_MODE=1
+endif
+
 OUTDIR := build
 OBJDIR := build/bin
 SRCDIR := c

--- a/ASM/build.py
+++ b/ASM/build.py
@@ -18,6 +18,7 @@ parser.add_argument('--no-compile-c', action='store_true', help="Do not recompil
 parser.add_argument('--dump-obj', action='store_true', help="Dumps extra object info for debugging purposes. Does nothing with --no-compile-c")
 parser.add_argument('--diff-only', action='store_true', help="Creates diff output without running armips")
 parser.add_argument('--mips-binutils-prefix', type=str, default="mips64-", help="Use a different prefix for N64 toolchain")
+parser.add_argument('--debug-c', action='store_true', help="Define DEBUG_MODE 1 for C modules")
 
 args = parser.parse_args()
 pj64_sym_path = args.pj64sym
@@ -25,6 +26,7 @@ compile_c = not args.no_compile_c
 dump_obj = args.dump_obj
 diff_only = args.diff_only
 mips_binutils_prefix = args.mips_binutils_prefix
+debug_c = args.debug_c
 
 root_dir = os.path.dirname(os.path.realpath(__file__))
 tools_dir = os.path.join(root_dir, 'tools')
@@ -47,6 +49,8 @@ if base_rom_size != 0x400_0000:
 if compile_c:
     clist = ['make']
     clist.append(f'MIPS_BINUTILS_PREFIX={mips_binutils_prefix}')
+    if debug_c:
+        clist.append(f'DEBUG_MODE=1')
     if dump_obj:
         clist.append('RUN_OBJDUMP=1')
     try:

--- a/ASM/c/debug.h
+++ b/ASM/c/debug.h
@@ -1,7 +1,9 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
+#ifndef DEBUG_MODE
 #define DEBUG_MODE 0
+#endif
 
 #include "z64.h"
 #include "gfx.h"


### PR DESCRIPTION
`DEBUG_MODE` is defined in debug.h and must be manually changed in the file when switching between debug and non-debug build. It's tedious and tampers with the file. It would be helpful to be able to change when building.

Here, by running build.py --debug-c, `DEBUG_MODE` is set to 1 in the Makefile, so the C is compiled with `DEBUG_MODE` set. If `DEBUG_MODE` isn't externally defined, it is still defined as 0 by debug.h.

## Testing

I compiled with and without --debug-c with the vanilla build.py and Makefile as far as I could (I need some changes to compile with my compiler).