### PR TITLE
Include random starting items in effective starting items

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -1834,10 +1834,7 @@ def build_misc_item_hints(world: World, messages: list[Message], allow_duplicate
     for hint_type, data in misc_item_hint_table.items():
         if hint_type in world.settings.misc_hints:
             item = world.misc_hint_items[hint_type]
-            if (
-                (item in world.distribution.effective_starting_items and world.distribution.effective_starting_items[item].count > 0) or
-                (item in world.distribution.randomized_starting_items and world.distribution.randomized_starting_items[item] > 0)
-            ):
+            if item in world.distribution.effective_starting_items and world.distribution.effective_starting_items[item].count > 0:
                 if item == data['default_item']:
                     text = data['default_item_text'].format(area='#your pocket#')
                 else:

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -1043,7 +1043,6 @@ def get_pool_core(world: World) -> tuple[list[str], dict[str, Item]]:
         world.randomized_starting_items[selected_item] = world.randomized_starting_items.get(selected_item, 0) + 1
         pool.remove(selected_item)
         pool.extend(get_junk_item())
-    add_random_starting_items_ammo(world.randomized_starting_items)
     for item, count in world.randomized_starting_items.items():
         if item in REWARD_COLORS and count > 0:
             world.hinted_dungeon_reward_locations[item] = None
@@ -1136,10 +1135,3 @@ def configure_random_starting_items_pool(world: World, pool: list[str]) -> list[
         exclude_list.extend(ItemInfo.junk_weight)
 
     return sorted({item for item in pool if item not in exclude_list and ItemInfo.items[item].type != 'Shop'}) # give each item the same weight regardless of how many copies there are
-
-
-def add_random_starting_items_ammo(randomized_starting_items: dict[str, int]) -> None:
-    for item in StartingItems.inventory.values():
-        if item.item_name in randomized_starting_items and item.ammo:
-            for ammo, qty in item.ammo.items():
-                randomized_starting_items[ammo] = qty[randomized_starting_items[item.item_name] - 1]

--- a/Patches.py
+++ b/Patches.py
@@ -2000,7 +2000,6 @@ def patch_rom(spoiler: Spoiler, world: World, rom: Rom) -> Rom:
 
     # actually write the save table to rom
     world.distribution.give_items(world, save_context)
-    world.distribution.give_randomized_items(world, save_context)
     if world.settings.starting_age == 'adult':
         # When starting as adult, the pedestal doesn't handle child default equips when going back child the first time, so we have to equip them ourselves
         save_context.equip_default_items('child')

--- a/Plandomizer.py
+++ b/Plandomizer.py
@@ -1050,10 +1050,6 @@ class WorldDistribution:
                 continue
             save_context.give_item(world, name, record.count)
 
-    def give_randomized_items(self, world: World, save_context: SaveContext) -> None:
-        for item, count in world.randomized_starting_items.items():
-            save_context.give_item(world, item, count)
-
     def get_starting_item(self, item: str) -> int:
         items = self.starting_items
         if item in items:
@@ -1081,6 +1077,9 @@ class WorldDistribution:
 
     def configure_effective_starting_items(self, worlds: list[World], world: World) -> None:
         items = {item_name: record.copy() for item_name, record in self.starting_items.items()}
+
+        for item, count in world.randomized_starting_items.items():
+            add_starting_item_with_ammo(items, item, count)
 
         if world.settings.start_with_rupees:
             add_starting_item_with_ammo(items, 'Rupees', 999)


### PR DESCRIPTION
This implements an alternative to #2503 originally suggested in https://github.com/OoTRandomizer/OoT-Randomizer/pull/2503#issuecomment-3838654424. Compared to #2503, this PR also covers other parts of the codebase that refer to effective starting items, such as altar hints.

## Testing

The following plando fails on Dev if a dungeon reward is selected as a random starting item, but succeeds on this PR:

```json
{
    "settings": {
        "add_random_starting_items": true,
        "random_starting_items_exclude": [
            "songs",
            "bombchus",
            "shields",
            "deku_upgrades",
            "health_upgrades",
            "junk"
        ],
        "random_starting_items_count": 10,
        "shuffle_dungeon_rewards": "anywhere"
    }
}
```

Also repeated the test from #2503 to confirm the text output of the Ganondorf hint in a debugger.