### PR TITLE
Enable overriding rainbow tunics

### DIFF
--- a/Cosmetics.py
+++ b/Cosmetics.py
@@ -107,6 +107,10 @@ def patch_tunic_colors(rom: Rom, settings: Settings, log: CosmeticsLog, symbols:
     tunic_color_list = Colors.get_tunic_colors()
     rainbow_error = None
 
+    # Clear all rainbow tunic bits so that it can be overridden.
+    if 'CFG_RAINBOW_TUNIC_ENABLED' in symbols:
+        rom.write_byte(symbols['CFG_RAINBOW_TUNIC_ENABLED'], 0)
+
     for tunic, tunic_setting, address in tunics:
         tunic_option = getattr(settings, tunic_setting)
 


### PR DESCRIPTION
This PR fixes a bug where, if a seed is generated with rainbow tunics, then the tunic colors cannot be overridden. This happened because the rainbow tunic bits that are set by the person generating the seed could never be unset. Fix is simply to 0 out the rainbow tunic bits before applying the selected cosmetics.

## Testing

Generated patch files before and after the change, and verified that post-change it's possible to override rainbow tunics.
