### PR TITLE
Improve cross-platform ASM toolchain discovery and Apple Silicon / arm64 support

### DIFF
--- a/ASM/README.md
+++ b/ASM/README.md
@@ -1,4 +1,4 @@
-Advanced modifications to the Randomzier source require a bit more software than what is needed for running it.
+Advanced modifications to the Randomizer source require a bit more software than what is needed for running it.
 
 ## Assembly: armips
 ### Windows Prerequisite
@@ -8,8 +8,13 @@ Advanced modifications to the Randomzier source require a bit more software than
 ### Running
 - Download the armips assembler: <https://github.com/Kingcom/armips>
   - [Windows automated builds](https://buildbot.orphis.net/armips/)
-  - On other platforms you'll need either `clang` or `gcc`, `cmake`, and either `ninja` or `make` installed. All of these should be available in the package repositories of every major Linux distribution and Homebrew on macOS. After, follow the [building from source instructions](https://github.com/Kingcom/armips#22-building-from-source).
-- Put the armips executable in the `tools` directory, or somewhere in your PATH.
+  - On macOS or Linux with Homebrew, the OoTRandomizer tap can install it with:
+
+        brew tap ootrandomizer/tap
+        brew install --HEAD ootrandomizer/tap/armips
+
+  - To compile armips yourself, install either `clang` or `gcc`, `cmake`, and either `ninja` or `make`, then follow the [building from source instructions](https://github.com/Kingcom/armips#22-building-from-source).
+- Put the armips executable directly in `tools`, or install it somewhere already in your `PATH`.
 - Put the ROM you want to patch at `roms/base.z64`. This needs to be an uncompressed ROM; OoTRandomizer will produce one at ZOOTDEC.z64 when you run it with a compressed ROM.
 - Run `python build.py --no-compile-c`, which will:
   - create `roms/patched.z64`
@@ -37,15 +42,39 @@ Recompiling the C code for randomizer requires the N64 development tools to be i
   - **Using WSL**: Install the latest Debian Linux from the Windows Store and follow the below instructions for Debian.
 - **Debian**: [Follow this how-to](https://practicerom.com/public/packages/debian/howto.txt) on adding the toolchain's package repository and installing the pre-built binaries.
   - You will also need to run `apt install build-essential` or `apt install make` if `make` is not installed.
-- **Any platform with a gcc compiler**: Build from source from the [glankk/n64](https://github.com/glankk/n64) repository. Simply follow the readme.
+- **macOS (Intel or Apple Silicon)**:
+  - The simplest system-wide installation is the OoTRandomizer Homebrew tap:
+
+        brew tap ootrandomizer/tap
+        brew install --HEAD ootrandomizer/tap/n64
+
+  - To keep the toolchain inside this checkout, build the patched n64 source with `ASM/tools` as its installation prefix. On macOS, `./install_deps` installs GNU Make as `gmake`:
+
+        cd /path/to/n64
+        ./install_deps
+        ./configure --prefix="/absolute/path/to/OoT-Randomizer/ASM/tools"
+        gmake toolchain-all
+        gmake toolchain-install
+
+    This installs `mips64-gcc`, `mips64-ld`, `mips64-objdump`, and `mips64-objcopy` in `ASM/tools/bin`, where `build.py` finds them automatically. Using `ASM/tools/n64` as the prefix is also supported.
+  - The patched n64 build detects Homebrew under both `/opt/homebrew` and `/usr/local`, including the GMP, MPFR, MPC, zlib, Lua, libusb, GNU sed, and texinfo paths needed by native Apple Silicon builds. No permanent shell PATH change is required.
+- **Any platform with a C/C++ compiler**: Build from the n64 source after applying the macOS compatibility patch, then follow the included readme. The upstream project is [glankk/n64](https://github.com/glankk/n64).
   - The dependency install script may not install all the necessary libraries depending on your OS version. Take a look at the output from the configure step to see if anything is missing.
-  - It is easiest if you use `--prefix=/the/path/to/OoT-Randomizer/ASM/tools` for the `./configure` step. This will install all the toolchain in a way the build script can use, however this is inconvenient if you plan to use the toolchain for other projects as well.
+  - It is easiest if you use `--prefix=/the/path/to/OoT-Randomizer/ASM/tools` for the `./configure` step. This installs the toolchain in a location used directly by the build script, although a system-wide prefix may be more convenient when sharing the toolchain with other projects.
+  - Keep any explicitly selected `BINUTILS_VERSION`, `GCC_VERSION`, `NEWLIB_VERSION`, and `GDB_VERSION` archive stems unchanged. The patched n64 build still supports its automatic version selection and conditional newlib patches.
   - If you are trying to update the toolchain this way, it is easiest to just delete your local copy of the repository and clone it again to ensure all the packages get updated and are compatible.
 
 
-You can substitute using the `tools` folder with adding the `n64/bin` folder to your environment PATH if you need an advanced setup.
+`build.py` searches `ASM/tools`, `ASM/tools/bin`, and `ASM/tools/n64/bin` before the existing environment `PATH`. This supports a single executable copied into `tools`, a toolchain installed with `ASM/tools` as its prefix, a complete prefix copied to `ASM/tools/n64`, and normal system-wide installations without platform-specific build logic.
+On POSIX hosts, `build.py` uses the platform-neutral `ASM/tools/toolchain` directory for compiler launchers so GCC and its assembler are selected from the same prefix. Apple Silicon uses the same layout and only adds an isolated environment for `as`, preventing MacPorts or Conda entries from replacing the assembler selected by GCC. Windows continues to use the discovered executables directly. Set `OOTR_N64_PREFIX=/absolute/path/to/n64-prefix` to select a local installation explicitly.
 ### Running
-To recompile the C modules, use `python build.py` in this directory, or adjust the path to `build.py` relative to your terminal's working directory.
+Before building, verify the ROM, project files, armips, make, and every required MIPS executable:
+
+    python3 build.py --check-toolchains
+
+The check prints every required project file separately with its expected absolute path and actual location. For each executable it prints the project-local candidate paths, whether each candidate exists, the command selected from `PATH`, its resolved target and version, and the assembler selected internally by GCC. Missing or invalid entries produce `Result: FAILED` and exit status 1.
+
+To recompile the C modules, run `python build.py` in this directory, or run `python ASM/build.py` from the repository root (`python3` may be required on macOS and Linux). The default `mips64-` prefix matches a toolchain built from the n64 source; use `--mips-binutils-prefix` only for packages that intentionally use another target prefix.
 
 ## Debugging Symbols for Project64
 To generate symbols for the Project64 debugger, use the `--pj64sym` option:

--- a/ASM/build.py
+++ b/ASM/build.py
@@ -5,8 +5,11 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 
 import argparse
 import json
+import platform
 import re
-from subprocess import check_call as call, CalledProcessError
+import shlex
+import shutil
+from subprocess import check_call as call, check_output, CalledProcessError, DEVNULL
 from rom_diff import create_diff
 from ntype import BigStream
 from crc import calculate_crc
@@ -19,6 +22,7 @@ parser.add_argument('--dump-obj', action='store_true', help="Dumps extra object 
 parser.add_argument('--diff-only', action='store_true', help="Creates diff output without running armips")
 parser.add_argument('--mips-binutils-prefix', type=str, default="mips64-", help="Use a different prefix for N64 toolchain")
 parser.add_argument('--debug-c', action='store_true', help="Define DEBUG_MODE 1 for C modules")
+parser.add_argument('--check-toolchains', action='store_true', help="Show the expected and selected path for every required ASM file and tool, then exit")
 
 args = parser.parse_args()
 pj64_sym_path = args.pj64sym
@@ -27,14 +31,322 @@ dump_obj = args.dump_obj
 diff_only = args.diff_only
 mips_binutils_prefix = args.mips_binutils_prefix
 debug_c = args.debug_c
+check_toolchains = args.check_toolchains
 
 root_dir = os.path.dirname(os.path.realpath(__file__))
 tools_dir = os.path.join(root_dir, 'tools')
-# Makes it possible to use the "tools" directory as the prefix for the toolchain
+# Supported project-local layouts:
+#   ASM/tools/<tool>
+#   ASM/tools/bin/<tool>
+#   ASM/tools/n64/bin/<tool>
 tools_bin_dir = os.path.join(tools_dir, 'bin')
-# Makes it possible to copy the full toolchain prefix into the "tools" directory
-n64_bin_dir = os.path.join(tools_dir, "n64", "bin")
-os.environ['PATH'] = os.pathsep.join([tools_dir, tools_bin_dir, n64_bin_dir, os.environ['PATH']])
+n64_bin_dir = os.path.join(tools_dir, 'n64', 'bin')
+# Generated POSIX compiler launchers use one platform-neutral location.
+toolchain_dir = os.path.join(tools_dir, 'toolchain')
+toolchain_bin_dir = os.path.join(toolchain_dir, 'bin')
+toolchain_driver_dir = os.path.join(toolchain_dir, 'gcc-driver')
+
+
+def is_executable(path):
+    return bool(path and os.path.isfile(path) and os.access(path, os.X_OK))
+
+
+def prepend_path(*directories):
+    current = os.environ.get('PATH', '').split(os.pathsep)
+    ordered = []
+    for directory in directories:
+        if directory and directory not in ordered:
+            ordered.append(directory)
+    for directory in current:
+        if directory and directory not in ordered:
+            ordered.append(directory)
+    os.environ['PATH'] = os.pathsep.join(ordered)
+
+
+def find_toolchain_prefix(tool_prefix):
+    """Find a complete N64 prefix without changing the normal tool search order."""
+    gcc_name = tool_prefix + 'gcc'
+    candidates = [
+        os.environ.get('OOTR_N64_PREFIX'),
+        os.path.join(tools_dir, 'n64'),
+    ]
+
+    # A local executable or symlink can reveal the complete installation prefix.
+    for gcc_path in (
+        os.path.join(tools_dir, gcc_name),
+        os.path.join(tools_bin_dir, gcc_name),
+        os.path.join(n64_bin_dir, gcc_name),
+        shutil.which(gcc_name),
+    ):
+        if gcc_path and os.path.exists(gcc_path):
+            real_gcc = os.path.realpath(gcc_path)
+            candidates.append(os.path.dirname(os.path.dirname(real_gcc)))
+
+    # Homebrew exposes every tap formula named n64 through the same opt prefix.
+    # Adding these normal installation paths avoids embedding brew-specific
+    # command handling in the build script and also handles PATH shadowing.
+    if platform.system() == 'Darwin':
+        candidates.extend(('/opt/homebrew/opt/n64', '/usr/local/opt/n64'))
+
+    required = ('gcc', 'as', 'ld', 'objdump', 'objcopy')
+    checked = set()
+    for candidate in candidates:
+        if not candidate:
+            continue
+        candidate = os.path.realpath(os.path.expanduser(candidate))
+        if candidate in checked:
+            continue
+        checked.add(candidate)
+        bindir = os.path.join(candidate, 'bin')
+        if all(is_executable(os.path.join(bindir, tool_prefix + tool)) for tool in required):
+            return candidate
+    return None
+
+
+def write_executable(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', newline='\n') as stream:
+        stream.write(content)
+    os.chmod(path, 0o755)
+
+
+def prepare_toolchain(tool_prefix):
+    """Prepare one consistent toolchain path on every supported platform."""
+    prepend_path(tools_dir, tools_bin_dir, n64_bin_dir)
+
+    prefix = find_toolchain_prefix(tool_prefix)
+    if not prefix:
+        return None
+
+    real_bin = os.path.join(prefix, 'bin')
+    prepend_path(real_bin, tools_dir, tools_bin_dir, n64_bin_dir)
+
+    # Windows toolchains are executable files and continue to run directly.
+    # POSIX hosts use the same tools/toolchain layout so GCC and its assembler
+    # always come from one prefix. Apple Silicon adds only the environment
+    # isolation that was required by the native Homebrew toolchain.
+    if os.name != 'nt':
+        real_gcc = os.path.join(real_bin, tool_prefix + 'gcc')
+        real_gxx = os.path.join(real_bin, tool_prefix + 'g++')
+        real_as = os.path.join(real_bin, tool_prefix + 'as')
+        driver_as = os.path.join(toolchain_driver_dir, 'as')
+        isolate_assembler = platform.system() == 'Darwin' and platform.machine() == 'arm64'
+
+        if isolate_assembler:
+            assembler_script = '\n'.join([
+                '#!/bin/sh',
+                'set -eu',
+                'exec /usr/bin/env -i \\',
+                '  PATH="/usr/bin:/bin" \\',
+                '  HOME="${HOME:-/tmp}" \\',
+                '  TMPDIR="${TMPDIR:-/tmp}" \\',
+                '  LANG=C \\',
+                '  LC_ALL=C \\',
+                '  ' + shlex.quote(real_as) + ' "$@"',
+                '',
+            ])
+        else:
+            assembler_script = '\n'.join([
+                '#!/bin/sh',
+                'set -eu',
+                'exec ' + shlex.quote(real_as) + ' "$@"',
+                '',
+            ])
+        write_executable(driver_as, assembler_script)
+
+        for name, compiler in (
+            (tool_prefix + 'gcc', real_gcc),
+            (tool_prefix + 'g++', real_gxx),
+        ):
+            if not is_executable(compiler):
+                continue
+            compiler_script = '\n'.join([
+                '#!/bin/sh',
+                'set -eu',
+                'exec ' + shlex.quote(compiler) + ' -B' + shlex.quote(toolchain_driver_dir + os.sep) + ' "$@"',
+                '',
+            ])
+            write_executable(os.path.join(toolchain_bin_dir, name), compiler_script)
+
+        # Expose the remaining tools from the same prefix in the same generated
+        # directory. This keeps Linux and macOS layouts identical and prevents
+        # another installation earlier in PATH from supplying ld or objcopy.
+        os.makedirs(toolchain_bin_dir, exist_ok=True)
+        wrapper_names = {tool_prefix + 'gcc', tool_prefix + 'g++'}
+        for name in os.listdir(real_bin):
+            if not name.startswith(tool_prefix) or name in wrapper_names:
+                continue
+            source = os.path.join(real_bin, name)
+            target = os.path.join(toolchain_bin_dir, name)
+            if not is_executable(source):
+                continue
+            if os.path.lexists(target):
+                os.unlink(target)
+            os.symlink(os.path.realpath(source), target)
+
+        prepend_path(toolchain_bin_dir, real_bin, tools_dir, tools_bin_dir, n64_bin_dir)
+        if isolate_assembler:
+            os.environ.pop('COMPILER_PATH', None)
+            os.environ.pop('GCC_EXEC_PREFIX', None)
+            print(f'build.py: isolated assembler: {driver_as}')
+
+    print(f'build.py: toolchain prefix: {prefix}')
+    return prefix
+
+
+def command_version(path, *args):
+    try:
+        output = check_output([path, *args], text=True, stderr=DEVNULL).strip()
+        return output.splitlines()[0] if output else 'version unavailable'
+    except (CalledProcessError, OSError):
+        return 'version unavailable'
+
+
+def display_path_check(label, expected_path, exists, actual_path=None, detail=None):
+    status = 'OK' if exists else 'MISSING'
+    print(f'  [{status}] {label}')
+    print(f'       expected: {expected_path}')
+    print(f'       actual:   {actual_path if actual_path else "not found"}')
+    if detail:
+        print(f'       detail:   {detail}')
+
+
+def local_command_candidates(name, is_mips=False):
+    candidates = [
+        os.path.join(tools_dir, name),
+        os.path.join(tools_bin_dir, name),
+        os.path.join(n64_bin_dir, name),
+    ]
+    if is_mips:
+        candidates.append(os.path.join(toolchain_bin_dir, name))
+        prefix = os.environ.get('OOTR_N64_PREFIX')
+        if prefix:
+            candidates.append(os.path.join(prefix, 'bin', name))
+    return candidates
+
+
+def display_command_check(name, version_args, include_project_paths=True, is_mips=False):
+    selected = shutil.which(name)
+    valid = is_executable(selected)
+    print(f'  [{"OK" if valid else "MISSING"}] {name}')
+
+    if include_project_paths:
+        candidates = local_command_candidates(name, is_mips)
+        print('       expected:')
+        for candidate in candidates:
+            state = 'present' if is_executable(candidate) else 'absent'
+            print(f'         - [{state}] {candidate}')
+        print('         - [environment] PATH')
+    else:
+        print('       expected: executable available in PATH')
+
+    print(f'       selected: {selected if selected else "not found"}')
+    if valid:
+        real_path = os.path.realpath(selected)
+        if real_path != selected:
+            print(f'       resolved: {real_path}')
+        print(f'       version:  {command_version(selected, *version_args)}')
+    return valid, selected
+
+
+def check_toolchain_requirements(tool_prefix):
+    print('OoTR ASM toolchain check')
+    print(f'  host: {platform.system()} {platform.machine()}')
+    print(f'  ASM directory: {root_dir}')
+    print(f'  MIPS prefix: {tool_prefix}')
+    prefix_override = os.environ.get('OOTR_N64_PREFIX')
+    print(f'  OOTR_N64_PREFIX: {prefix_override if prefix_override else "not set"}')
+    ok = True
+
+    required_files = [
+        'Makefile',
+        'linker_script.ld',
+        'ootSymbols.ld',
+        os.path.join('src', 'build.asm'),
+        os.path.join('src', 'addresses.asm'),
+        os.path.join('src', 'boot.asm'),
+        os.path.join('c', 'util.c'),
+    ]
+    print('Project files:')
+    for relative in required_files:
+        expected = os.path.abspath(os.path.join(root_dir, relative))
+        exists = os.path.isfile(expected)
+        display_path_check(relative, expected, exists, expected if exists else None)
+        ok = ok and exists
+
+    print('Base ROM:')
+    rom_path = os.path.abspath(os.path.join(root_dir, 'roms', 'base.z64'))
+    if os.path.isfile(rom_path):
+        size = os.path.getsize(rom_path)
+        valid = size == 0x4000000
+        status = 'OK' if valid else 'INVALID'
+        print(f'  [{status}] roms/base.z64')
+        print(f'       expected: {rom_path}')
+        print(f'       actual:   {rom_path}')
+        print(f'       size:     {size:#x} bytes; expected 0x4000000 bytes (64 MiB)')
+        ok = ok and valid
+    else:
+        display_path_check('roms/base.z64', rom_path, False)
+        ok = False
+
+    print('Executables:')
+    command_specs = [
+        ('armips', ['--version'], True, False),
+        ('make', ['--version'], False, False),
+        (tool_prefix + 'gcc', ['--version'], True, True),
+        (tool_prefix + 'as', ['--version'], True, True),
+        (tool_prefix + 'ld', ['--version'], True, True),
+        (tool_prefix + 'objdump', ['--version'], True, True),
+        (tool_prefix + 'objcopy', ['--version'], True, True),
+    ]
+    resolved = {}
+    for name, version_args, include_project_paths, is_mips in command_specs:
+        valid, selected = display_command_check(name, version_args, include_project_paths, is_mips)
+        resolved[name] = selected
+        ok = ok and valid
+
+    print('GCC assembler selection:')
+    gcc_name = tool_prefix + 'gcc'
+    gcc_path = resolved.get(gcc_name)
+    if gcc_path:
+        try:
+            reported = check_output([gcc_path, '-print-prog-name=as'], text=True, stderr=DEVNULL).strip()
+            assembler = reported
+            if assembler and not os.path.isabs(assembler):
+                assembler = shutil.which(assembler) or assembler
+            valid = is_executable(assembler)
+            print(f'  [{"OK" if valid else "INVALID"}] assembler selected by {gcc_name}')
+            print(f'       query:    {gcc_path} -print-prog-name=as')
+            print(f'       reported: {reported if reported else "not reported"}')
+            print(f'       actual:   {assembler if assembler else "not found"}')
+            if valid:
+                real_assembler = os.path.realpath(assembler)
+                if real_assembler != assembler:
+                    print(f'       resolved: {real_assembler}')
+            ok = ok and valid
+        except (CalledProcessError, OSError):
+            print(f'  [INVALID] assembler selected by {gcc_name}')
+            print(f'       query:    {gcc_path} -print-prog-name=as')
+            print('       actual:   query failed')
+            ok = False
+    else:
+        print(f'  [MISSING] assembler selected by {gcc_name}')
+        print(f'       query:    unavailable because {gcc_name} was not found')
+        print('       actual:   not found')
+        ok = False
+
+    print(f'Result: {"OK" if ok else "FAILED"}')
+    return ok
+
+
+if compile_c or check_toolchains:
+    prepare_toolchain(mips_binutils_prefix)
+else:
+    prepend_path(tools_dir, tools_bin_dir, n64_bin_dir)
+
+if check_toolchains:
+    sys.exit(0 if check_toolchain_requirements(mips_binutils_prefix) else 1)
+
 
 run_dir = root_dir
 
@@ -148,15 +460,15 @@ for (name, sym) in symbols.items():
         else:
             patch_symbols[name] = addr
 
-with open('../data/generated/symbols.json', 'w', newline='\n') as f:
+with open('../data/generated/symbols.json', 'w+', newline='\n') as f:
     json.dump(data_symbols, f, indent=4, sort_keys=True)
 
-with open('../data/generated/patch_symbols.json', 'w', newline='\n') as f:
+with open('../data/generated/patch_symbols.json', 'w+', newline='\n') as f:
     json.dump(patch_symbols, f, indent=4, sort_keys=True)
 
 if pj64_sym_path:
     pj64_sym_path = os.path.realpath(pj64_sym_path)
-    with open(pj64_sym_path, 'w') as f:
+    with open(pj64_sym_path, 'w+') as f:
         key = lambda pair: pair[1]['address']
         for sym_name, sym in sorted(symbols.items(), key=key):
             f.write('{0},{1},{2}\n'.format(sym['address'], sym['type'], sym_name))


### PR DESCRIPTION
## Improve cross-platform ASM toolchain discovery and Apple Silicon support

This PR updates the ASM build script to support the Apple Silicon n64 toolchain without changing the existing Windows, Linux, or Intel macOS workflows.

Before this, both of these need to be merged:
* https://github.com/glankk/n64/pull/32
* https://github.com/OoTRandomizer/homebrew-tap/pull/5
### Changes

* Add common MIPS toolchain discovery for:

  * project-local tools
  * `OOTR_N64_PREFIX`
  * standard Homebrew n64 prefixes
  * the system `PATH`
* Place generated toolchain wrappers under the shared `ASM/tools/toolchain` directory.
* Ensure GCC, assembler, linker, objdump, and objcopy are selected from the same toolchain prefix.
* Add an isolated assembler launch environment on Apple Silicon to avoid interference from Conda, MacPorts, or inherited compiler variables.
* Clear `COMPILER_PATH` and `GCC_EXEC_PREFIX` before invoking the toolchain.
* Add optional `mips64-g++` support.
* Add:

```text
python3 build.py --check-toolchains
```

This command reports the expected path, detected path, resolved path, version, ROM size, and GCC-selected assembler for every required file and executable.

* Preserve existing build behavior on other platforms.
* Support both the existing fixed payload layout and branches that use a configurable payload start, depending on the selected patch version.

### Compatibility

The Apple Silicon-specific behavior is enabled only when running on Darwin arm64. Other platforms continue to use the existing direct tool execution path.