### PR TITLE
Advanced Logic - Water Temple MQ Typo

### DIFF
--- a/data/Glitched World/Water Temple MQ.json
+++ b/data/Glitched World/Water Temple MQ.json
@@ -55,7 +55,7 @@
                 (Hookshot or adv_water_hop)",
             "Water Temple Before Boss Lower": "can_use(Longshot) or
                 (adv_hovers_recoil and can_use(Hover_Boots) and Megaton_Hammer) or
-                (adv_water_hop and can_use(Iron_Boots) and Raise_Water_Level) or
+                (adv_water_hop and can_use(Iron_Boots) and Reset_Water_Level) or
                 ((can_mega or can_hess or can_superslide) and can_use(Hover_Boots)) or
                 can_hover",
             "Water Temple After Waterfall Room": "


### PR DESCRIPTION
[Discord #setup-support](https://discord.com/channels/274180765816848384/476723801032491008/1536190160419688623)

typo found for MQ water, raise_water_level is named in vanilla / reset_water_level for MQ. There was an undefined mention in MQ 

## Testing

Confirmed it raised the same error
<img width="551" height="297" alt="Screenshot 2026-08-10 at 10 12 03 AM" src="https://github.com/user-attachments/assets/b2361f02-7860-4895-b57c-780edff47e62" />
 of undefined helper

Confirmed fix by running 5 seeds with advanced logic preset and all MQ.

<img width="566" height="282" alt="Screenshot 2026-08-10 at 10 12 52 AM" src="https://github.com/user-attachments/assets/6f5a5d19-0f40-47b3-a95d-546f45d9fd1e" />

